### PR TITLE
feat(ci): move Docker builds to GitHub Actions with GHCR layer caching

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,8 +1,6 @@
 name: CI & Build
 
 on:
-  push:
-    branches: [main, staging]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -12,9 +12,6 @@ jobs:
   backend-ci:
     name: Backend CI
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: backend
     steps:
       - uses: actions/checkout@v6
 
@@ -27,29 +24,26 @@ jobs:
           python-version: "3.13"
 
       - name: Install dependencies
-        run: uv sync --locked
+        run: cd backend && uv sync --locked
 
       - name: Lint
-        run: uv run ruff check . && uv run ruff format --check .
+        run: make lint-check
 
       - name: Django checks
-        run: uv run python manage.py check
+        run: make check
 
       - name: Tests
-        run: uv run python -m pytest tests/ -q
+        run: make test
 
       - name: Type check
-        run: uv run ty check .
+        run: make typecheck
 
       - name: Complexity
-        run: uvx --with flake8-cognitive-complexity flake8 --max-cognitive-complexity 10 --select CCR001 .
+        run: make complexity
 
   frontend-ci:
     name: Frontend CI
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: frontend
     steps:
       - uses: actions/checkout@v6
 
@@ -59,16 +53,13 @@ jobs:
           cache: true
 
       - name: Install dependencies
-        run: flutter pub get
+        run: make frontend-install
 
-      - name: Format check
-        run: dart format --set-exit-if-changed lib/ test/
-
-      - name: Analyze
-        run: dart analyze
+      - name: Lint
+        run: make frontend-lint
 
       - name: Tests
-        run: flutter test
+        run: make frontend-test
 
       - name: Cache pub global packages
         uses: actions/cache@v4
@@ -77,7 +68,7 @@ jobs:
           key: pub-global-${{ runner.os }}-dart-code-metrics
 
       - name: Complexity
-        run: dart pub global activate dart_code_metrics 2>/dev/null; dart pub global run dart_code_metrics:metrics analyze lib/ --disable-sunset-warning --set-exit-on-violation-level=warning
+        run: make frontend-complexity
 
   build-and-push:
     name: Build & Push Image

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -3,6 +3,7 @@ name: CI & Build
 on:
   push:
     branches: [main, staging]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -1,0 +1,114 @@
+name: CI & Build
+
+on:
+  push:
+    branches: [main, staging]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  backend-ci:
+    name: Backend CI
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          version: "latest"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --locked
+
+      - name: Lint
+        run: uv run ruff check . && uv run ruff format --check .
+
+      - name: Django checks
+        run: uv run python manage.py check
+
+      - name: Tests
+        run: uv run python -m pytest tests/ -q
+
+      - name: Type check
+        run: uv run ty check .
+
+      - name: Complexity
+        run: uvx --with flake8-cognitive-complexity flake8 --max-cognitive-complexity 10 --select CCR001 .
+
+  frontend-ci:
+    name: Frontend CI
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: "3.41.4"
+          cache: true
+
+      - name: Install dependencies
+        run: flutter pub get
+
+      - name: Format check
+        run: dart format --set-exit-if-changed lib/ test/
+
+      - name: Analyze
+        run: dart analyze
+
+      - name: Tests
+        run: flutter test
+
+      - name: Cache pub global packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: pub-global-${{ runner.os }}-dart-code-metrics
+
+      - name: Complexity
+        run: dart pub global activate dart_code_metrics 2>/dev/null; dart pub global run dart_code_metrics:metrics analyze lib/ --disable-sunset-warning --set-exit-on-violation-level=warning
+
+  build-and-push:
+    name: Build & Push Image
+    needs: [backend-ci, frontend-ci]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help install run test lint format typecheck lint-file typecheck-file check migrate \
+.PHONY: help install run test lint lint-check format typecheck lint-file typecheck-file check migrate \
         createsuperuser seed db-start db-stop ci dev build-dev complexity \
         frontend-install frontend-run frontend-run-html frontend-build frontend-codegen frontend-lint \
         frontend-format frontend-test frontend-fix frontend-complexity
@@ -47,6 +47,9 @@ test:
 
 lint:
 	cd backend && uv run ruff check --fix . && uv run ruff format .
+
+lint-check:
+	cd backend && uv run ruff check . && uv run ruff format --check .
 
 format:
 	cd backend && uv run ruff format .
@@ -114,7 +117,7 @@ frontend-complexity:
 	dart pub global activate dart_code_metrics 2>/dev/null; dart pub global run dart_code_metrics:metrics analyze frontend/lib/ --disable-sunset-warning --set-exit-on-violation-level=warning
 
 # CI (run before every commit)
-ci: lint check test typecheck complexity frontend-lint frontend-test frontend-complexity
+ci: lint-check check test typecheck complexity frontend-lint frontend-test frontend-complexity
 
 # Install deps, codegen, migrate, then run dev
 build-dev: install frontend-codegen migrate dev


### PR DESCRIPTION
## Summary

Moves Docker image builds from Railway to GitHub Actions with GHCR for reliable layer caching, cutting build times when lockfiles haven't changed.

## Changes

- **`.github/workflows/ci-build.yml`** — New workflow with 3 parallel/sequential jobs:
  - `backend-ci`: Python 3.13 + uv, runs lint-check, check, test, typecheck, complexity
  - `frontend-ci`: Flutter 3.41.4, runs frontend-lint, frontend-test, frontend-complexity
  - `build-and-push`: needs both CI jobs; builds Dockerfile and pushes to `ghcr.io/leahpeker/pda` with SHA + branch tags and GHA layer caching
- **`Makefile`** — Adds `lint-check` target (`ruff check . && ruff format --check .`) for CI use (no file writes); `make ci` now uses `lint-check` instead of `lint`

## Out of scope

- Railway deploy trigger (separate follow-up — Railway still builds from Dockerfile)
- PR CI checks

Closes #87

<em>🤖 Co-created with Claude</em>