### PR TITLE
chore(rules): default PRs to staging base branch

### DIFF
--- a/.claude/rules/pull-requests.md
+++ b/.claude/rules/pull-requests.md
@@ -1,0 +1,22 @@
+---
+paths:
+  - ".github/**"
+---
+
+# Pull Request Conventions
+
+## Base Branch
+
+**All PRs default to `staging` as the base branch**, not `main`.
+
+```bash
+gh pr create --draft --base staging
+```
+
+Only target `main` directly for hotfixes that must go to production immediately — and only with explicit confirmation.
+
+## Other Conventions
+
+- Always open in draft mode
+- Titles use conventional commit format: `type(scope): description`
+- Check for PR templates at `.github/PULL_REQUEST_TEMPLATE.md` before writing the description


### PR DESCRIPTION
## Description
Adds a project rule documenting that all new PRs should target `staging` as the base branch, not `main`.

## Tasks
- Add `.claude/rules/pull-requests.md` with base branch convention, draft mode reminder, and the exception for production hotfixes