### PR TITLE
fix(validation): allow Unicode names, hyphens, apostrophes in display name

### DIFF
--- a/backend/community/_join_requests.py
+++ b/backend/community/_join_requests.py
@@ -13,7 +13,7 @@ from ninja_jwt.authentication import JWTAuth
 from pydantic import BaseModel
 from users.permissions import PermissionKey
 
-from community._shared import DISPLAY_NAME_RE, ErrorOut, _validate_phone, logger
+from community._shared import ErrorOut, _validate_phone, logger, validate_display_name
 from community.models import (
     JoinFormQuestion,
     JoinFormQuestionType,
@@ -349,13 +349,9 @@ def reorder_join_form_questions(request, payload: JoinFormQuestionOrderIn):
 @router.post("/join-request/", response={201: JoinRequestOut, 400: ErrorOut}, auth=None)
 def submit_join_request(request, payload: JoinRequestIn):
     display_name = payload.display_name.strip()
-    if not display_name:
-        return Status(400, ErrorOut(detail="display_name is required."))
-    if not DISPLAY_NAME_RE.match(display_name) or len(display_name) > 64:
-        return Status(
-            400,
-            ErrorOut(detail="Display name must contain only letters and spaces (max 64 chars)."),
-        )
+    name_error = validate_display_name(display_name)
+    if name_error:
+        return Status(400, ErrorOut(detail=name_error))
 
     try:
         validated_phone = _validate_phone(payload.phone_number)

--- a/backend/community/_shared.py
+++ b/backend/community/_shared.py
@@ -38,7 +38,25 @@ class ErrorOut(BaseModel):
     detail: str
 
 
-DISPLAY_NAME_RE = re.compile(r"^[a-zA-Z ]+$")
+_DISPLAY_NAME_REJECT_RE = re.compile(r'[\d@#$%^&*()+=\[\]{}<>|\\/:;!?~`"]')
+
+
+def validate_display_name(name: str) -> str | None:
+    """Return an error message if the display name is invalid, or None if valid.
+
+    Allows Unicode letters, combining marks, apostrophes, hyphens, spaces, and periods.
+    Rejects digits, email/URL characters, and names that contain no letters.
+    """
+    stripped = name.strip()
+    if not stripped:
+        return "display name is required"
+    if len(stripped) > 64:
+        return "display name must be at most 64 characters"
+    if _DISPLAY_NAME_REJECT_RE.search(stripped):
+        return "display name contains invalid characters — no numbers or symbols"
+    if all(c in " '-." for c in stripped):
+        return "display name must contain at least one letter"
+    return None
 
 
 def _validate_phone(raw: str) -> str:

--- a/backend/tests/test_join_requests.py
+++ b/backend/tests/test_join_requests.py
@@ -211,6 +211,63 @@ class TestJoinRequestSubmission:
         )
         assert response.status_code == 400
 
+    def test_submit_display_name_with_email_rejected(self, api_client, why_join_id):
+        response = api_client.post(
+            "/api/community/join-request/",
+            {
+                "display_name": "user@example.com",
+                "phone_number": "+12025550705",
+                "answers": {why_join_id: "I care"},
+            },
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+    def test_submit_display_name_with_url_rejected(self, api_client, why_join_id):
+        response = api_client.post(
+            "/api/community/join-request/",
+            {
+                "display_name": "http://evil.com",
+                "phone_number": "+12025550706",
+                "answers": {why_join_id: "I care"},
+            },
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+
+    @pytest.mark.parametrize(
+        "name,phone",
+        [
+            ("José O'Brien", "+12025550707"),
+            ("Müller-Schmidt", "+12025550709"),
+            ("Юлия К", "+12025550710"),
+            ("田中 太郎", "+12025550711"),
+        ],
+    )
+    def test_submit_display_name_unicode_accepted(self, api_client, why_join_id, name, phone):
+        response = api_client.post(
+            "/api/community/join-request/",
+            {
+                "display_name": name,
+                "phone_number": phone,
+                "answers": {why_join_id: "Collective liberation."},
+            },
+            content_type="application/json",
+        )
+        assert response.status_code == 201, f"Expected 201 for name: {name!r}"
+
+    def test_submit_display_name_hyphen_apostrophe_accepted(self, api_client, why_join_id):
+        response = api_client.post(
+            "/api/community/join-request/",
+            {
+                "display_name": "Mary-Jane O'Brien",
+                "phone_number": "+12025550708",
+                "answers": {why_join_id: "Collective liberation."},
+            },
+            content_type="application/json",
+        )
+        assert response.status_code == 201
+
     def test_default_status_is_pending(self, api_client, why_join_id):
         response = api_client.post(
             "/api/community/join-request/",

--- a/backend/users/_auth.py
+++ b/backend/users/_auth.py
@@ -2,6 +2,7 @@
 
 import logging
 
+from community._shared import validate_display_name
 from config.audit import audit_log
 from config.media_proxy import media_path
 from ninja import File, Router
@@ -133,7 +134,10 @@ def update_me(request, payload: MePatchIn):
     user = User.objects.prefetch_related("roles").get(pk=request.auth.pk)
     changed = []
     if payload.display_name is not None:
-        user.display_name = payload.display_name
+        name_error = validate_display_name(payload.display_name)
+        if name_error:
+            return Status(400, ErrorOut(detail=name_error))
+        user.display_name = payload.display_name.strip()
         changed.append("display_name")
     if payload.email is not None:
         user.email = payload.email
@@ -220,6 +224,9 @@ def complete_onboarding(request, payload: OnboardingIn):
         return Status(400, ErrorOut(detail="New password must be at least 8 characters."))
     user = User.objects.prefetch_related("roles").get(pk=request.auth.pk)
     if payload.display_name is not None:
+        name_error = validate_display_name(payload.display_name)
+        if name_error:
+            return Status(400, ErrorOut(detail=name_error))
         user.display_name = payload.display_name.strip()
     if payload.email:
         user.email = payload.email

--- a/backend/users/_management.py
+++ b/backend/users/_management.py
@@ -3,6 +3,7 @@
 import logging
 import re
 
+from community._shared import validate_display_name
 from config.audit import audit_log
 from django.db import models as dj_models
 from ninja import Router
@@ -50,6 +51,11 @@ def create_user(request, payload: UserCreateIn):
             details={"endpoint": "create_user", "required_permission": PermissionKey.CREATE_USER},
         )
         return Status(403, ErrorOut(detail="Permission denied."))
+
+    if payload.display_name:
+        name_error = validate_display_name(payload.display_name)
+        if name_error:
+            return Status(400, ErrorOut(detail=name_error))
 
     try:
         user, magic_token = _create_user_with_role(
@@ -248,19 +254,30 @@ def update_user(request, user_id: str, payload: UserPatchIn):
     return Status(200, UserOut.from_user(user))
 
 
+def _patch_phone(user: User, user_id: str, phone_number: str) -> str | None:
+    """Validate and apply a phone number change. Returns error string or None."""
+    if User.objects.exclude(pk=user_id).filter(phone_number=phone_number).exists():
+        return "A user with that phone number already exists."
+    try:
+        user.phone_number = _validate_phone(phone_number)
+    except ValueError as e:
+        return str(e)
+    return None
+
+
 def _apply_user_patch(
     user: User, user_id: str, payload: UserPatchIn, requester_id: str
 ) -> str | None:
     """Apply UserPatchIn fields to user. Returns an error message string on failure, else None."""
     if payload.phone_number is not None:
-        if User.objects.exclude(pk=user_id).filter(phone_number=payload.phone_number).exists():
-            return "A user with that phone number already exists."
-        try:
-            user.phone_number = _validate_phone(payload.phone_number)
-        except ValueError as e:
-            return str(e)
+        err = _patch_phone(user, user_id, payload.phone_number)
+        if err:
+            return err
     if payload.display_name is not None:
-        user.display_name = payload.display_name
+        err = validate_display_name(payload.display_name)
+        if err:
+            return err
+        user.display_name = payload.display_name.strip()
     if payload.email is not None:
         user.email = payload.email
     if payload.is_paused and requester_id == str(user.pk):

--- a/frontend/lib/screens/auth/onboarding_screen.dart
+++ b/frontend/lib/screens/auth/onboarding_screen.dart
@@ -101,9 +101,7 @@ class _OnboardingScreenState extends ConsumerState<OnboardingScreen> {
                         ),
                         textInputAction: TextInputAction.next,
                         onFieldSubmitted: (_) => _emailFocusNode.requestFocus(),
-                        validator: (v) => (v == null || v.trim().isEmpty)
-                            ? 'Display name is required'
-                            : null,
+                        validator: v.displayName(),
                       ),
                       const SizedBox(height: 12),
                       TextFormField(

--- a/frontend/lib/screens/join_screen.dart
+++ b/frontend/lib/screens/join_screen.dart
@@ -126,9 +126,7 @@ class _JoinScreenState extends ConsumerState<JoinScreen> {
                         decoration: const InputDecoration(
                           labelText: 'display name *',
                           hintText: 'e.g. Alex R',
-                          helperText:
-                              'letters and spaces only; at least first name + '
-                              'last initial',
+                          helperText: 'at least first name + last initial',
                           border: OutlineInputBorder(),
                         ),
                         validator: v.displayName(),

--- a/frontend/lib/screens/members/add_member_dialog.dart
+++ b/frontend/lib/screens/members/add_member_dialog.dart
@@ -62,7 +62,7 @@ class _AddMemberDialogState extends State<AddMemberDialog> {
                     labelText: 'Display name (optional)',
                     border: OutlineInputBorder(),
                   ),
-                  validator: v.maxLength(64),
+                  validator: v.optionalDisplayName(),
                   onFieldSubmitted: (_) {
                     if (!_formKey.currentState!.validate()) return;
                     Navigator.of(context).pop({

--- a/frontend/lib/utils/validators.dart
+++ b/frontend/lib/utils/validators.dart
@@ -42,13 +42,25 @@ Validator minLength(int min, [String? message]) {
   };
 }
 
-/// Letters and spaces only (matches backend display name rule).
+/// Unicode letters, combining marks, apostrophes, hyphens, spaces, and periods.
+/// Rejects digits and symbols (emails, phone numbers, URLs).
 Validator displayName() {
-  final re = RegExp(r'^[a-zA-Z ]+$');
+  final re = RegExp(r"^[\p{L}\p{M}' \-\.]+$", unicode: true);
   return all([
     required(),
-    (v) => (v != null && !re.hasMatch(v.trim()))
-        ? 'Letters and spaces only'
+    (v) => (v != null && v.trim().isNotEmpty && !re.hasMatch(v.trim()))
+        ? 'letters, spaces, hyphens, and apostrophes only'
+        : null,
+    maxLength(64),
+  ]);
+}
+
+/// Optional display name: skips format check if empty, same rules if provided.
+Validator optionalDisplayName() {
+  final re = RegExp(r"^[\p{L}\p{M}' \-\.]+$", unicode: true);
+  return all([
+    (v) => (v != null && v.trim().isNotEmpty && !re.hasMatch(v.trim()))
+        ? 'letters, spaces, hyphens, and apostrophes only'
         : null,
     maxLength(64),
   ]);

--- a/frontend/test/unit/validators_test.dart
+++ b/frontend/test/unit/validators_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pda/utils/validators.dart' as v;
+
+void main() {
+  group('displayName()', () {
+    final validator = v.displayName();
+
+    test('accepts ASCII name', () {
+      expect(validator('Alex R'), isNull);
+    });
+
+    test('accepts name with hyphen', () {
+      expect(validator('Mary-Jane'), isNull);
+    });
+
+    test("accepts name with apostrophe", () {
+      expect(validator("O'Brien"), isNull);
+    });
+
+    test('accepts name with period (initial)', () {
+      expect(validator('Alex R.'), isNull);
+    });
+
+    test('accepts accented Latin characters', () {
+      expect(validator('José Müller'), isNull);
+    });
+
+    test('accepts Cyrillic characters', () {
+      expect(validator('Юлия К'), isNull);
+    });
+
+    test('accepts CJK characters', () {
+      expect(validator('田中 太郎'), isNull);
+    });
+
+    test('rejects empty string', () {
+      expect(validator(''), isNotNull);
+    });
+
+    test('rejects whitespace only', () {
+      expect(validator('   '), isNotNull);
+    });
+
+    test('rejects name with digits', () {
+      expect(validator('Alice2'), isNotNull);
+    });
+
+    test('rejects email address', () {
+      expect(validator('user@example.com'), isNotNull);
+    });
+
+    test('rejects URL', () {
+      expect(validator('http://evil.com'), isNotNull);
+    });
+
+    test('rejects phone number', () {
+      expect(validator('5551234567'), isNotNull);
+    });
+
+    test('rejects names over 64 characters', () {
+      expect(validator('A' * 65), isNotNull);
+    });
+  });
+
+  group('optionalDisplayName()', () {
+    final validator = v.optionalDisplayName();
+
+    test('accepts empty/null (optional field)', () {
+      expect(validator(''), isNull);
+      expect(validator(null), isNull);
+      expect(validator('   '), isNull);
+    });
+
+    test('accepts valid Unicode name when provided', () {
+      expect(validator("Mary-Jane O'Brien"), isNull);
+    });
+
+    test('rejects invalid name when provided', () {
+      expect(validator('user@example.com'), isNotNull);
+      expect(validator('Alice2'), isNotNull);
+    });
+
+    test('rejects names over 64 characters', () {
+      expect(validator('A' * 65), isNotNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Replaces ASCII-only `^[a-zA-Z ]+$` with Unicode-aware validation — allows any Unicode letters, hyphens, apostrophes, spaces, and periods
- Backend uses a blocklist (rejects digits, `@`, URL chars); frontend uses a Unicode allowlist (`\p{L}\p{M}`) via Dart's `unicode: true` flag
- Adds format validation to 4 endpoints that previously skipped it (`PATCH /me/`, `POST /complete-onboarding/`, `POST /create-user/`, `PATCH /users/:id/`)
- Updates onboarding screen and add-member dialog to use the shared validator for consistency

## Test plan
- [ ] `make ci` passes (385 backend tests + new Dart validator unit tests)
- [ ] Enter "Mary-Jane O'Brien", "José", "Юлия К" on join form → accepted
- [ ] Enter "user@example.com", "5551234567", "http://foo.com" → rejected

Closes #229