### PR TITLE
perf: add preload hints for main.dart.js and canvaskit.wasm

### DIFF
--- a/frontend/test/accessibility/photo_crop_dialog_a11y_test.dart
+++ b/frontend/test/accessibility/photo_crop_dialog_a11y_test.dart
@@ -102,7 +102,7 @@ void main() {
         );
 
         await tester.tap(find.text('open'));
-        await tester.pump();
+        await tester.pumpAndSettle();
 
         await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
         handle.dispose();
@@ -121,7 +121,7 @@ void main() {
         );
 
         await tester.tap(find.text('open'));
-        await tester.pump();
+        await tester.pumpAndSettle();
 
         await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
         handle.dispose();
@@ -147,7 +147,7 @@ void main() {
         );
 
         await tester.tap(find.text('open'));
-        await tester.pump();
+        await tester.pumpAndSettle();
 
         await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
         handle.dispose();
@@ -171,7 +171,7 @@ void main() {
         );
 
         await tester.tap(find.text('open'));
-        await tester.pump();
+        await tester.pumpAndSettle();
 
         await expectLater(tester, meetsGuideline(androidTapTargetGuideline));
         handle.dispose();

--- a/frontend/test/widgets/photo_crop_dialog_test.dart
+++ b/frontend/test/widgets/photo_crop_dialog_test.dart
@@ -43,7 +43,7 @@ void main() {
       );
 
       await tester.tap(find.text('open'));
-      await tester.pump();
+      await tester.pumpAndSettle();
 
       expect(find.text('crop profile photo'), findsOneWidget);
       expect(find.text('cancel'), findsOneWidget);
@@ -73,7 +73,7 @@ void main() {
       );
 
       await tester.tap(find.text('open'));
-      await tester.pump();
+      await tester.pumpAndSettle();
 
       expect(find.text('crop event photo'), findsOneWidget);
       expect(find.text('cancel'), findsOneWidget);
@@ -100,7 +100,7 @@ void main() {
       );
 
       await tester.tap(find.text('open'));
-      await tester.pump();
+      await tester.pumpAndSettle();
 
       expect(find.text('pinch to zoom, drag to reposition'), findsOneWidget);
     });
@@ -130,7 +130,7 @@ void main() {
       );
 
       await tester.tap(find.text('open'));
-      await tester.pump();
+      await tester.pumpAndSettle();
 
       await tester.tap(find.text('cancel'));
       await tester.pumpAndSettle();
@@ -164,7 +164,7 @@ void main() {
       );
 
       await tester.tap(find.text('open'));
-      await tester.pump();
+      await tester.pumpAndSettle();
 
       await tester.tap(find.text('cancel'));
       await tester.pumpAndSettle();
@@ -192,7 +192,7 @@ void main() {
       );
 
       await tester.tap(find.text('open'));
-      await tester.pump();
+      await tester.pumpAndSettle();
 
       // The crop area is wrapped in a Semantics widget for screen readers.
       expect(find.byType(Semantics), findsWidgets);

--- a/frontend/web/index.html
+++ b/frontend/web/index.html
@@ -33,6 +33,10 @@
   <!-- Preload Material Icons font to avoid icon flash on load -->
   <link rel="preload" href="assets/fonts/MaterialIcons-Regular.otf" as="font" type="font/otf" crossorigin="anonymous"/>
 
+  <!-- Preload critical Flutter assets so the browser starts downloading immediately -->
+  <link rel="preload" href="main.dart.js" as="script"/>
+  <link rel="preload" href="canvaskit/canvaskit.wasm" as="fetch" type="application/wasm" crossorigin="anonymous"/>
+
   <title>pda</title>
   <link rel="manifest" href="manifest.json">
 


### PR DESCRIPTION
## Summary
- Add `<link rel="preload">` hints for `main.dart.js` and `canvaskit/canvaskit.wasm` so the browser starts downloading them immediately instead of waiting for JS to request them
- Fix crop dialog tests that broke from the deferred `crop_your_image` import (need `pumpAndSettle` to let `loadLibrary()` future resolve)

## Test plan
- [ ] `make ci` passes
- [ ] Deploy to staging, check Network tab in incognito — preload requests should appear early in the waterfall
- [ ] Crop dialog still works (circle + rectangle modes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)