### PR TITLE
fix(auth): generate magic link resets password and sets needs_onboarding

### DIFF
--- a/backend/tests/test_users.py
+++ b/backend/tests/test_users.py
@@ -410,3 +410,48 @@ class TestResetPassword:
         assert len(data["magic_link_token"]) == 36  # UUID format
         other_user.refresh_from_db()
         assert not other_user.has_usable_password()
+
+
+# ---------------------------------------------------------------------------
+# TestGenerateMagicLink
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestGenerateMagicLink:
+    def test_generate_magic_link_success(self, api_client, manage_users_headers, other_user):
+        response = api_client.post(
+            f"/api/auth/users/{other_user.pk}/magic-link/",
+            **manage_users_headers,
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data["magic_link_token"]) == 36  # UUID format
+
+    def test_generate_magic_link_sets_needs_onboarding(
+        self, api_client, manage_users_headers, other_user
+    ):
+        other_user.needs_onboarding = False
+        other_user.save(update_fields=["needs_onboarding"])
+        response = api_client.post(
+            f"/api/auth/users/{other_user.pk}/magic-link/",
+            **manage_users_headers,
+        )
+        assert response.status_code == 200
+        other_user.refresh_from_db()
+        assert other_user.needs_onboarding
+        assert not other_user.has_usable_password()
+
+    def test_generate_magic_link_not_found(self, api_client, manage_users_headers):
+        response = api_client.post(
+            "/api/auth/users/00000000-0000-0000-0000-000000000000/magic-link/",
+            **manage_users_headers,
+        )
+        assert response.status_code == 404
+
+    def test_generate_magic_link_requires_permission(self, api_client, auth_headers, other_user):
+        response = api_client.post(
+            f"/api/auth/users/{other_user.pk}/magic-link/",
+            **auth_headers,
+        )
+        assert response.status_code == 403

--- a/backend/users/_management.py
+++ b/backend/users/_management.py
@@ -394,6 +394,9 @@ def generate_magic_link(request, user_id: str):
         user = User.objects.get(pk=user_id)
     except User.DoesNotExist:
         return Status(404, ErrorOut(detail="User not found."))
+    user.set_unusable_password()
+    user.needs_onboarding = True
+    user.save(update_fields=["password", "needs_onboarding"])
     magic_token = _create_magic_token(user)
     audit_log(
         logging.INFO,

--- a/frontend/lib/screens/calendar/event_login_gate.dart
+++ b/frontend/lib/screens/calendar/event_login_gate.dart
@@ -82,7 +82,12 @@ class _EventAdminActionsState extends ConsumerState<EventAdminActions> {
         data: result.data,
       );
       if (result.photo != null) {
-        await uploadEventPhoto(ref, widget.event.id, result.photo!, oldPhotoUrl: widget.event.photoUrl);
+        await uploadEventPhoto(
+          ref,
+          widget.event.id,
+          result.photo!,
+          oldPhotoUrl: widget.event.photoUrl,
+        );
       } else if (result.removePhoto) {
         await deleteEventPhoto(ref, widget.event.id);
       }

--- a/frontend/lib/screens/event_management_row.dart
+++ b/frontend/lib/screens/event_management_row.dart
@@ -31,7 +31,12 @@ class EventManagementRow extends ConsumerWidget {
       final api = ref.read(apiClientProvider);
       await api.patch('/api/community/events/${event.id}/', data: result.data);
       if (result.photo != null) {
-        await uploadEventPhoto(ref, event.id, result.photo!, oldPhotoUrl: event.photoUrl);
+        await uploadEventPhoto(
+          ref,
+          event.id,
+          result.photo!,
+          oldPhotoUrl: event.photoUrl,
+        );
       } else if (result.removePhoto) {
         await deleteEventPhoto(ref, event.id);
       }


### PR DESCRIPTION
## Summary

- `generate_magic_link` now calls `set_unusable_password()` and sets `needs_onboarding=True` before creating the token, matching what `reset_password` already does
- Adds `TestGenerateMagicLink` test class with 4 tests covering success, state changes, permission check, and 404

## Why

Users created before magic links existed had real temp passwords set. When an admin generated a magic link for them, the endpoint only created a token — it left `needs_onboarding` unchanged and the old password still valid. This caused the magic login flow to land in an inconsistent state.

Now any user receiving a magic link is always routed through the onboarding/new-password flow.

Closes #237