### PR TITLE
perf(web): flutter web load time optimizations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ COPY frontend/ ./
 RUN dart run build_runner build --delete-conflicting-outputs
 ARG RAILWAY_GIT_COMMIT_SHA=dev
 ARG ENABLE_FEEDBACK=false
-RUN flutter build web --release --dart-define=API_URL= --dart-define=GIT_SHA=${RAILWAY_GIT_COMMIT_SHA} --dart-define=ENABLE_FEEDBACK=${ENABLE_FEEDBACK} --no-pub --no-wasm-dry-run
+RUN flutter build web --release --dart-define=API_URL= --dart-define=GIT_SHA=${RAILWAY_GIT_COMMIT_SHA} --dart-define=ENABLE_FEEDBACK=${ENABLE_FEEDBACK} --no-pub --tree-shake-icons --wasm
+RUN rm -f build/web/assets/NOTICES
 
 # Stage 2: Python/Django runtime
 FROM python:3.13-slim AS runtime

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ frontend-run-html:
 	cd frontend && flutter run -d web-server --web-port 3001 --web-hostname 0.0.0.0 --dart-define=ENABLE_FEEDBACK=$(ENABLE_FEEDBACK) --dart-define=GIT_SHA=$(shell git rev-parse --short HEAD)
 
 frontend-build:
-	cd frontend && flutter build web --dart-define=API_URL=$(API_URL) --dart-define=ENABLE_FEEDBACK=$(ENABLE_FEEDBACK) --dart-define=GIT_SHA=$(shell git rev-parse --short HEAD)
+	cd frontend && flutter build web --dart-define=API_URL=$(API_URL) --dart-define=ENABLE_FEEDBACK=$(ENABLE_FEEDBACK) --dart-define=GIT_SHA=$(shell git rev-parse --short HEAD) --tree-shake-icons --wasm
 
 frontend-codegen:
 	cd frontend && dart run build_runner build --delete-conflicting-outputs

--- a/frontend/lib/router/app_router.dart
+++ b/frontend/lib/router/app_router.dart
@@ -8,32 +8,43 @@ import 'package:pda/screens/auth/magic_login_screen.dart';
 import 'package:pda/screens/auth/onboarding_screen.dart';
 import 'package:pda/screens/auth/new_password_screen.dart';
 import 'package:pda/screens/calendar_screen.dart';
-import 'package:pda/screens/event_management_screen.dart';
 import 'package:pda/screens/home_screen.dart';
-import 'package:pda/screens/join_requests_screen.dart';
 import 'package:pda/screens/join_screen.dart';
 import 'package:pda/screens/join_success_screen.dart';
-import 'package:pda/screens/members_screen.dart';
 import 'package:pda/screens/faq_screen.dart';
 import 'package:pda/screens/guidelines_screen.dart';
 import 'package:pda/screens/event_detail_screen.dart';
 import 'package:pda/screens/donate_screen.dart';
 import 'package:pda/screens/install_app_screen.dart';
-import 'package:pda/screens/settings_screen.dart';
-import 'package:pda/screens/volunteer_screen.dart';
-import 'package:pda/screens/admin_screen.dart';
-import 'package:pda/screens/join_form_config_screen.dart';
-import 'package:pda/screens/survey_admin_screen.dart';
-import 'package:pda/screens/survey_builder_screen.dart';
-import 'package:pda/screens/survey_responses_screen.dart';
-import 'package:pda/screens/survey_screen.dart';
-import 'package:pda/screens/docs_screen.dart';
-import 'package:pda/screens/doc_detail_screen.dart';
-import 'package:pda/screens/whatsapp_config_screen.dart';
-import 'package:pda/screens/profile_screen.dart';
-import 'package:pda/screens/member_profile_screen.dart';
 import 'package:pda/config/constants.dart';
 import 'package:pda/services/route_tracker.dart';
+import 'package:pda/widgets/deferred_screen.dart';
+// Deferred screen imports — kept out of the initial JS bundle
+import 'package:pda/screens/event_management_screen.dart'
+    deferred as event_management_screen;
+import 'package:pda/screens/join_requests_screen.dart'
+    deferred as join_requests_screen;
+import 'package:pda/screens/members_screen.dart' deferred as members_screen;
+import 'package:pda/screens/settings_screen.dart' deferred as settings_screen;
+import 'package:pda/screens/volunteer_screen.dart' deferred as volunteer_screen;
+import 'package:pda/screens/admin_screen.dart' deferred as admin_screen;
+import 'package:pda/screens/join_form_config_screen.dart'
+    deferred as join_form_config_screen;
+import 'package:pda/screens/survey_admin_screen.dart'
+    deferred as survey_admin_screen;
+import 'package:pda/screens/survey_builder_screen.dart'
+    deferred as survey_builder_screen;
+import 'package:pda/screens/survey_responses_screen.dart'
+    deferred as survey_responses_screen;
+import 'package:pda/screens/survey_screen.dart' deferred as survey_screen;
+import 'package:pda/screens/docs_screen.dart' deferred as docs_screen;
+import 'package:pda/screens/doc_detail_screen.dart'
+    deferred as doc_detail_screen;
+import 'package:pda/screens/whatsapp_config_screen.dart'
+    deferred as whatsapp_config_screen;
+import 'package:pda/screens/profile_screen.dart' deferred as profile_screen;
+import 'package:pda/screens/member_profile_screen.dart'
+    deferred as member_profile_screen;
 
 final _log = Logger('Router');
 
@@ -206,25 +217,38 @@ final routerProvider = Provider<GoRouter>((ref) {
         path: '/members',
         name: 'members',
         caseSensitive: false,
-        builder: (_, __) => const MembersScreen(),
+        builder: (_, __) => DeferredScreen(
+          loader: members_screen.loadLibrary,
+          builder: () => members_screen.MembersScreen(),
+        ),
       ),
       GoRoute(
         path: '/join-requests',
         name: 'join-requests',
         caseSensitive: false,
-        builder: (_, __) => const JoinRequestsScreen(),
+        builder: (_, __) => DeferredScreen(
+          loader: join_requests_screen.loadLibrary,
+          builder: () => join_requests_screen.JoinRequestsScreen(),
+        ),
       ),
       GoRoute(
         path: '/events/mine',
         name: 'my-events',
         caseSensitive: false,
-        builder: (_, __) => const EventManagementScreen(myEventsOnly: true),
+        builder: (_, __) => DeferredScreen(
+          loader: event_management_screen.loadLibrary,
+          builder: () =>
+              event_management_screen.EventManagementScreen(myEventsOnly: true),
+        ),
       ),
       GoRoute(
         path: '/events/manage',
         name: 'manage-events',
         caseSensitive: false,
-        builder: (_, __) => const EventManagementScreen(),
+        builder: (_, __) => DeferredScreen(
+          loader: event_management_screen.loadLibrary,
+          builder: () => event_management_screen.EventManagementScreen(),
+        ),
       ),
       GoRoute(
         path: '/guidelines',
@@ -242,7 +266,10 @@ final routerProvider = Provider<GoRouter>((ref) {
         path: '/settings',
         name: 'settings',
         caseSensitive: false,
-        builder: (_, __) => const SettingsScreen(),
+        builder: (_, __) => DeferredScreen(
+          loader: settings_screen.loadLibrary,
+          builder: () => settings_screen.SettingsScreen(),
+        ),
       ),
       GoRoute(
         path: '/donate',
@@ -260,78 +287,118 @@ final routerProvider = Provider<GoRouter>((ref) {
         path: '/volunteer',
         name: 'volunteer',
         caseSensitive: false,
-        builder: (_, __) => const VolunteerScreen(),
+        builder: (_, __) => DeferredScreen(
+          loader: volunteer_screen.loadLibrary,
+          builder: () => volunteer_screen.VolunteerScreen(),
+        ),
       ),
       GoRoute(
         path: '/admin',
         name: 'admin',
         caseSensitive: false,
-        builder: (_, __) => const AdminScreen(),
+        builder: (_, __) => DeferredScreen(
+          loader: admin_screen.loadLibrary,
+          builder: () => admin_screen.AdminScreen(),
+        ),
       ),
       GoRoute(
         path: '/admin/join-form',
         name: 'join-form-config',
         caseSensitive: false,
-        builder: (_, __) => const JoinFormConfigScreen(),
+        builder: (_, __) => DeferredScreen(
+          loader: join_form_config_screen.loadLibrary,
+          builder: () => join_form_config_screen.JoinFormConfigScreen(),
+        ),
       ),
       GoRoute(
         path: '/admin/surveys',
         name: 'survey-admin',
         caseSensitive: false,
-        builder: (_, __) => const SurveyAdminScreen(),
+        builder: (_, __) => DeferredScreen(
+          loader: survey_admin_screen.loadLibrary,
+          builder: () => survey_admin_screen.SurveyAdminScreen(),
+        ),
       ),
       GoRoute(
         path: '/admin/surveys/:id',
         name: 'survey-builder',
         caseSensitive: false,
-        builder: (_, state) =>
-            SurveyBuilderScreen(surveyId: state.pathParameters['id']!),
+        builder: (_, state) => DeferredScreen(
+          loader: survey_builder_screen.loadLibrary,
+          builder: () => survey_builder_screen.SurveyBuilderScreen(
+            surveyId: state.pathParameters['id']!,
+          ),
+        ),
       ),
       GoRoute(
         path: '/admin/surveys/:id/responses',
         name: 'survey-responses',
         caseSensitive: false,
-        builder: (_, state) =>
-            SurveyResponsesScreen(surveyId: state.pathParameters['id']!),
+        builder: (_, state) => DeferredScreen(
+          loader: survey_responses_screen.loadLibrary,
+          builder: () => survey_responses_screen.SurveyResponsesScreen(
+            surveyId: state.pathParameters['id']!,
+          ),
+        ),
       ),
       GoRoute(
         path: '/admin/whatsapp',
         name: 'whatsapp-config',
         caseSensitive: false,
-        builder: (_, __) => const WhatsAppConfigScreen(),
+        builder: (_, __) => DeferredScreen(
+          loader: whatsapp_config_screen.loadLibrary,
+          builder: () => whatsapp_config_screen.WhatsAppConfigScreen(),
+        ),
       ),
       GoRoute(
         path: '/docs',
         name: 'docs',
         caseSensitive: false,
-        builder: (_, __) => const DocsScreen(),
+        builder: (_, __) => DeferredScreen(
+          loader: docs_screen.loadLibrary,
+          builder: () => docs_screen.DocsScreen(),
+        ),
       ),
       GoRoute(
         path: '/docs/:id',
         name: 'doc-detail',
         caseSensitive: false,
-        builder: (_, state) =>
-            DocDetailScreen(docId: state.pathParameters['id']!),
+        builder: (_, state) => DeferredScreen(
+          loader: doc_detail_screen.loadLibrary,
+          builder: () => doc_detail_screen.DocDetailScreen(
+            docId: state.pathParameters['id']!,
+          ),
+        ),
       ),
       GoRoute(
         path: '/profile',
         name: 'profile',
         caseSensitive: false,
-        builder: (_, __) => const ProfileScreen(),
+        builder: (_, __) => DeferredScreen(
+          loader: profile_screen.loadLibrary,
+          builder: () => profile_screen.ProfileScreen(),
+        ),
       ),
       GoRoute(
         path: '/members/:id',
         name: 'member-profile',
         caseSensitive: false,
-        builder: (_, state) =>
-            MemberProfileScreen(userId: state.pathParameters['id']!),
+        builder: (_, state) => DeferredScreen(
+          loader: member_profile_screen.loadLibrary,
+          builder: () => member_profile_screen.MemberProfileScreen(
+            userId: state.pathParameters['id']!,
+          ),
+        ),
       ),
       GoRoute(
         path: '/surveys/:slug',
         name: 'survey',
         caseSensitive: false,
-        builder: (_, state) =>
-            SurveyScreen(slug: state.pathParameters['slug']!),
+        builder: (_, state) => DeferredScreen(
+          loader: survey_screen.loadLibrary,
+          builder: () =>
+              survey_screen.SurveyScreen(slug: state.pathParameters['slug']!),
+        ),
       ),
       GoRoute(
         path: '/events/:id',

--- a/frontend/lib/widgets/deferred_screen.dart
+++ b/frontend/lib/widgets/deferred_screen.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+
+/// Generic wrapper that loads a deferred Dart library before building a screen.
+///
+/// Usage in GoRouter route builders:
+/// ```dart
+/// import 'package:pda/screens/foo_screen.dart' deferred as foo_screen;
+///
+/// builder: (_, __) => DeferredScreen(
+///   loader: foo_screen.loadLibrary,
+///   builder: () => const foo_screen.FooScreen(),
+/// ),
+/// ```
+class DeferredScreen extends StatefulWidget {
+  const DeferredScreen({
+    super.key,
+    required this.loader,
+    required this.builder,
+  });
+
+  final Future<void> Function() loader;
+  final Widget Function() builder;
+
+  @override
+  State<DeferredScreen> createState() => _DeferredScreenState();
+}
+
+class _DeferredScreenState extends State<DeferredScreen> {
+  bool _loaded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.loader().then((_) {
+      if (mounted) setState(() => _loaded = true);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (!_loaded) {
+      return const Scaffold(body: Center(child: CircularProgressIndicator()));
+    }
+    return widget.builder();
+  }
+}

--- a/frontend/pubspec.lock
+++ b/frontend/pubspec.lock
@@ -65,14 +65,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.13.0"
-  bloc:
-    dependency: transitive
-    description:
-      name: bloc
-      sha256: a48653a82055a900b88cd35f92429f068c5a8057ae9b136d197b3d56c57efb81
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.2.0"
   boolean_selector:
     dependency: transitive
     description:
@@ -374,14 +366,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_bloc:
-    dependency: transitive
-    description:
-      name: flutter_bloc
-      sha256: cf51747952201a455a1c840f8171d273be009b932c75093020f9af64f2123e38
-      url: "https://pub.dev"
-    source: hosted
-    version: "9.1.1"
   flutter_colorpicker:
     dependency: transitive
     description:
@@ -869,14 +853,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.17.6"
-  nested:
-    dependency: transitive
-    description:
-      name: nested
-      sha256: "03bac4c528c64c95c722ec99280375a6f2fc708eec17c7b3f07253b626cd2a20"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.0"
   node_preamble:
     dependency: transitive
     description:
@@ -893,14 +869,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.3.0"
-  omni_datetime_picker:
-    dependency: "direct main"
-    description:
-      name: omni_datetime_picker
-      sha256: bb360790e76109ea2e53b45643cdaab779649c4bf1a9d2794d3a135bfe9746e1
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.3.1"
   package_config:
     dependency: transitive
     description:
@@ -1005,14 +973,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.5.0"
-  provider:
-    dependency: transitive
-    description:
-      name: provider
-      sha256: "4e82183fa20e5ca25703ead7e05de9e4cceed1fbd1eadc1ac3cb6f565a09f272"
-      url: "https://pub.dev"
-    source: hosted
-    version: "6.1.5+1"
   pub_semver:
     dependency: transitive
     description:
@@ -1133,14 +1093,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
-  rxdart:
-    dependency: transitive
-    description:
-      name: rxdart
-      sha256: "5c3004a4a8dbb94bd4bf5412a4def4acdaa12e12f269737a5751369e12d1a962"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.28.0"
   share_plus:
     dependency: "direct main"
     description:

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -23,7 +23,6 @@ dependencies:
   cupertino_icons: ^1.0.8
   flutter_web_plugins:
     sdk: flutter
-  omni_datetime_picker: ^2.3.1
   url_launcher: ^6.3.2
   web: ^1.1.0
   share_plus: ^12.0.0


### PR DESCRIPTION
## Summary

- **Tree-shake Material Icons** (`--tree-shake-icons`): strips unused glyphs from the font, ~1.5MB → ~50KB
- **Remove `assets/NOTICES`** post-build in Dockerfile: 1.4MB of license text with no licenses page in the app
- **Drop dead dependency** `omni_datetime_picker`: listed in pubspec but never imported anywhere
- **Defer 16 screens** behind `deferred as` imports via a new reusable `DeferredScreen` widget — admin, survey, docs, settings, profile, and other secondary screens are now separate JS chunks loaded on first navigation rather than at startup
- **WASM build** (`--wasm`): Dart compiles to WebAssembly for Chrome/Edge/Firefox; automatic JS fallback for Safari

## Test plan

- [ ] CI passes (lint, tests, type checks, frontend lint/test)
- [ ] Deploy to Railway and verify initial load time
- [ ] Navigate to a deferred screen (e.g. `/settings`, `/admin`) and confirm it loads correctly
- [ ] Verify no icon flash or missing icons after tree-shaking
- [ ] Check browser devtools Network tab for `.wasm` build artifacts