### PR TITLE
fix(events): prevent creating or updating events with past start dates

### DIFF
--- a/backend/community/_events.py
+++ b/backend/community/_events.py
@@ -7,6 +7,7 @@ from uuid import UUID
 from config.audit import audit_log
 from config.media_proxy import media_path
 from django.db.models import Q
+from django.utils import timezone
 from ninja import File, Router
 from ninja.files import UploadedFile
 from ninja.responses import Status
@@ -57,6 +58,17 @@ def _can_edit_event(user, event: Event) -> bool:
 def _is_invalid_official_visibility(event_type: str, visibility: str) -> bool:
     """Official events must have public visibility."""
     return event_type == EventType.OFFICIAL and visibility != PageVisibility.PUBLIC
+
+
+def _validate_event_datetimes(
+    start, end, datetime_tbd: bool, *, check_past: bool = True
+) -> str | None:
+    """Return an error message if datetime fields are invalid, else None."""
+    if end is not None and end <= start:
+        return "end_datetime must be after start_datetime."
+    if check_past and not datetime_tbd and start < timezone.now():
+        return "Start date must be in the future."
+    return None
 
 
 @router.get("/events/", response={200: list[EventListOut]}, auth=_optional_jwt)
@@ -159,8 +171,11 @@ def create_event(request, payload: EventIn):
     if _is_invalid_official_visibility(payload.event_type, payload.visibility):
         return Status(400, ErrorOut(detail="Official events must be public."))
 
-    if payload.end_datetime is not None and payload.end_datetime <= payload.start_datetime:
-        return Status(400, ErrorOut(detail="end_datetime must be after start_datetime."))
+    dt_error = _validate_event_datetimes(
+        payload.start_datetime, payload.end_datetime, payload.datetime_tbd
+    )
+    if dt_error:
+        return Status(400, ErrorOut(detail=dt_error))
 
     event = Event.objects.create(
         title=payload.title,
@@ -252,8 +267,15 @@ def update_event(request, event_id: UUID, payload: EventPatchIn):
         return Status(400, ErrorOut(detail="Official events must be public."))
     effective_start = updates.get("start_datetime", event.start_datetime)
     effective_end = updates.get("end_datetime", event.end_datetime)
-    if effective_end is not None and effective_end <= effective_start:
-        return Status(400, ErrorOut(detail="end_datetime must be after start_datetime."))
+    effective_tbd = updates.get("datetime_tbd", event.datetime_tbd)
+    dt_error = _validate_event_datetimes(
+        effective_start,
+        effective_end,
+        effective_tbd,
+        check_past="start_datetime" in updates,
+    )
+    if dt_error:
+        return Status(400, ErrorOut(detail=dt_error))
     co_host_ids = updates.pop("co_host_ids", None)
     invited_user_ids = updates.pop("invited_user_ids", None)
     for field, value in updates.items():

--- a/backend/tests/test_event_management.py
+++ b/backend/tests/test_event_management.py
@@ -254,6 +254,63 @@ class TestEventManagement:
         assert response.status_code == 400
         assert "end_datetime" in response.json()["detail"]
 
+    def test_create_event_in_past_returns_400(self, api_client, manage_events_headers):
+        response = api_client.post(
+            "/api/community/events/",
+            {
+                "title": "Past Event",
+                "start_datetime": "2020-01-01T18:00:00Z",
+            },
+            content_type="application/json",
+            **manage_events_headers,
+        )
+        assert response.status_code == 400
+        assert "future" in response.json()["detail"]
+
+    def test_create_event_in_past_allowed_when_datetime_tbd(
+        self, api_client, manage_events_headers
+    ):
+        response = api_client.post(
+            "/api/community/events/",
+            {
+                "title": "TBD Event",
+                "start_datetime": "2020-01-01T18:00:00Z",
+                "datetime_tbd": True,
+            },
+            content_type="application/json",
+            **manage_events_headers,
+        )
+        assert response.status_code == 201
+
+    def test_update_event_start_to_past_returns_400(
+        self, api_client, manage_events_headers, sample_event
+    ):
+        response = api_client.patch(
+            f"/api/community/events/{sample_event.id}/",
+            {"start_datetime": "2020-01-01T18:00:00Z"},
+            content_type="application/json",
+            **manage_events_headers,
+        )
+        assert response.status_code == 400
+        assert "future" in response.json()["detail"]
+
+    def test_update_event_non_date_fields_on_past_event(
+        self, api_client, manage_events_headers, db
+    ):
+        """Updating non-date fields on a past event should succeed."""
+        past_event = Event.objects.create(
+            title="Old Meetup",
+            start_datetime="2020-01-01T18:00:00Z",
+        )
+        response = api_client.patch(
+            f"/api/community/events/{past_event.id}/",
+            {"title": "Updated Old Meetup"},
+            content_type="application/json",
+            **manage_events_headers,
+        )
+        assert response.status_code == 200
+        assert response.json()["title"] == "Updated Old Meetup"
+
     def test_update_event_clear_end_datetime(self, api_client, manage_events_headers, sample_event):
         response = api_client.patch(
             f"/api/community/events/{sample_event.id}/",

--- a/frontend/lib/screens/calendar/event_form_dialog.dart
+++ b/frontend/lib/screens/calendar/event_form_dialog.dart
@@ -124,9 +124,12 @@ class _EventFormDialogState extends ConsumerState<EventFormDialog> {
       _venmoLink = TextEditingController();
       _cashappLink = TextEditingController();
       _zelleInfo = TextEditingController();
-      final base = widget.initialDate ?? DateTime.now();
       final now = DateTime.now();
-      _start = DateTime(base.year, base.month, base.day, now.hour + 1);
+      final base = widget.initialDate ?? now;
+      final candidate = DateTime(base.year, base.month, base.day, now.hour + 1);
+      _start = candidate.isBefore(now)
+          ? DateTime(now.year, now.month, now.day, now.hour + 1)
+          : candidate;
       _end = null;
       _rsvpEnabled = false;
       _allowPlusOnes = false;

--- a/frontend/lib/screens/calendar/event_form_when_section.dart
+++ b/frontend/lib/screens/calendar/event_form_when_section.dart
@@ -114,7 +114,7 @@ class _EventFormWhenSectionState extends State<EventFormWhenSection> {
               setState(() => _dateSetByPoll = false);
               widget.onStartChanged(dt);
             },
-            firstDate: DateTime(2000),
+            firstDate: DateTime.now(),
             lastDate: DateTime(2100),
             mode: _startPickerMode!,
           ),
@@ -192,7 +192,7 @@ class _EventFormWhenSectionState extends State<EventFormWhenSection> {
               setState(() => _dateSetByPoll = false);
               widget.onEndChanged(dt);
             },
-            firstDate: DateTime(2000),
+            firstDate: DateTime.now(),
             lastDate: DateTime(2100),
             mode: _endPickerMode!,
           ),


### PR DESCRIPTION
Add backend validation rejecting start_datetime in the past (skipped when datetime_tbd is true). Extract shared _validate_event_datetimes helper to keep update_event under the return-statement lint limit. Clamp frontend date pickers to DateTime.now() and ensure the default start for new events is never in the past.