### PR TITLE
fix(fe): disable RSVP, invites, calendar, and poll on past events (#295)

### DIFF
--- a/frontend/lib/models/event.dart
+++ b/frontend/lib/models/event.dart
@@ -67,3 +67,7 @@ abstract class Event with _$Event {
 
   factory Event.fromJson(Map<String, dynamic> json) => _$EventFromJson(json);
 }
+
+extension EventHelpers on Event {
+  bool get isPast => !(endDatetime ?? startDatetime).isAfter(DateTime.now());
+}

--- a/frontend/lib/screens/calendar/event_detail_panel.dart
+++ b/frontend/lib/screens/calendar/event_detail_panel.dart
@@ -248,8 +248,10 @@ class EventDetailContent extends ConsumerWidget {
                 ),
               ),
               const SizedBox(width: 8),
-              CalendarMenuChip(event: liveEvent),
-              const SizedBox(width: 4),
+              if (!liveEvent.isPast) ...[
+                CalendarMenuChip(event: liveEvent),
+                const SizedBox(width: 4),
+              ],
               EventActionChip(
                 tooltip: 'share event',
                 icon: AppIcons.share,

--- a/frontend/lib/screens/calendar/event_member_section.dart
+++ b/frontend/lib/screens/calendar/event_member_section.dart
@@ -232,7 +232,8 @@ class EventMemberSection extends ConsumerWidget {
               ),
             ),
           ],
-          if (event.status != EventStatus.cancelled &&
+          if (!event.isPast &&
+              event.status != EventStatus.cancelled &&
               (isCoHost ||
                   event.invitePermission == InvitePermission.allMembers)) ...[
             const SizedBox(height: 12),
@@ -247,7 +248,7 @@ class EventMemberSection extends ConsumerWidget {
               ),
             ),
           ],
-          if (event.rsvpEnabled && event.status != EventStatus.cancelled) ...[
+          if (!event.isPast && event.rsvpEnabled && event.status != EventStatus.cancelled) ...[
             const SizedBox(height: 12),
             EventSectionCard(
               label: EventDetailLabel.rsvp,

--- a/frontend/lib/widgets/embedded_event_poll.dart
+++ b/frontend/lib/widgets/embedded_event_poll.dart
@@ -78,7 +78,8 @@ class EmbeddedEventPoll extends ConsumerWidget {
           );
         }
 
-        final canManage = _canManagePoll(user);
+        final isPast = event.isPast;
+        final canManage = !isPast && _canManagePoll(user);
         final hasVoted = poll.myVotes.isNotEmpty;
         final sortedOptions = [...poll.options]
           ..sort((a, b) => b.totalCount.compareTo(a.totalCount));
@@ -90,6 +91,7 @@ class EmbeddedEventPoll extends ConsumerWidget {
           sortedOptions,
           hasVoted,
           canManage,
+          isPast: isPast,
         );
       },
     );
@@ -118,13 +120,15 @@ class EmbeddedEventPoll extends ConsumerWidget {
     EventPoll poll,
     List<EventPollOption> sortedOptions,
     bool hasVoted,
-    bool canManage,
-  ) {
+    bool canManage, {
+    bool isPast = false,
+  }) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        if (hasVoted) ...[
-          Text('you voted ✓', style: theme.textTheme.labelLarge),
+        if (hasVoted || isPast) ...[
+          if (!isPast) Text('you voted ✓', style: theme.textTheme.labelLarge),
+          if (isPast) Text('poll closed', style: theme.textTheme.labelLarge),
           const SizedBox(height: 4),
           ...sortedOptions.map(
             (option) => PollOptionResult(
@@ -132,26 +136,28 @@ class EmbeddedEventPoll extends ConsumerWidget {
               onVotersTap: () => _showVoters(context, option),
             ),
           ),
-          const SizedBox(height: 8),
-          Row(
-            children: [
-              Semantics(
-                button: true,
-                label: 'edit your poll response',
-                child: OutlinedButton(
-                  onPressed: () => _openVoteDialog(context, poll),
-                  child: const Text('edit response'),
+          if (!isPast) ...[
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Semantics(
+                  button: true,
+                  label: 'edit your poll response',
+                  child: OutlinedButton(
+                    onPressed: () => _openVoteDialog(context, poll),
+                    child: const Text('edit response'),
+                  ),
                 ),
-              ),
-              if (canManage) ...[
-                const SizedBox(width: 8),
-                TextButton(
-                  onPressed: () => _showFinalizeSheet(context, poll),
-                  child: const Text('choose winner'),
-                ),
+                if (canManage) ...[
+                  const SizedBox(width: 8),
+                  TextButton(
+                    onPressed: () => _showFinalizeSheet(context, poll),
+                    child: const Text('choose winner'),
+                  ),
+                ],
               ],
-            ],
-          ),
+            ),
+          ],
         ] else ...[
           Text('time poll open', style: theme.textTheme.labelLarge),
           const SizedBox(height: 4),

--- a/frontend/test/unit/event_is_past_test.dart
+++ b/frontend/test/unit/event_is_past_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pda/models/event.dart';
+
+Event _makeEvent({DateTime? start, DateTime? end}) => Event(
+  id: 'test-id',
+  title: 'Test Event',
+  description: '',
+  startDatetime: start ?? DateTime.now(),
+  endDatetime: end,
+  location: '',
+);
+
+void main() {
+  group('Event.isPast', () {
+    test('returns true when endDatetime is in the past', () {
+      final event = _makeEvent(
+        start: DateTime.now().subtract(const Duration(hours: 3)),
+        end: DateTime.now().subtract(const Duration(hours: 1)),
+      );
+      expect(event.isPast, isTrue);
+    });
+
+    test('returns true when only startDatetime exists and is in the past', () {
+      final event = _makeEvent(
+        start: DateTime.now().subtract(const Duration(hours: 1)),
+      );
+      expect(event.isPast, isTrue);
+    });
+
+    test('returns false when endDatetime is in the future', () {
+      final event = _makeEvent(
+        start: DateTime.now().subtract(const Duration(hours: 1)),
+        end: DateTime.now().add(const Duration(hours: 1)),
+      );
+      expect(event.isPast, isFalse);
+    });
+
+    test(
+      'returns false when only startDatetime exists and is in the future',
+      () {
+        final event = _makeEvent(
+          start: DateTime.now().add(const Duration(hours: 1)),
+        );
+        expect(event.isPast, isFalse);
+      },
+    );
+
+    test(
+      'returns false when event is currently happening (start past, end future)',
+      () {
+        final event = _makeEvent(
+          start: DateTime.now().subtract(const Duration(hours: 1)),
+          end: DateTime.now().add(const Duration(hours: 2)),
+        );
+        expect(event.isPast, isFalse);
+      },
+    );
+  });
+}

--- a/frontend/test/widgets/event_detail_panel_test.dart
+++ b/frontend/test/widgets/event_detail_panel_test.dart
@@ -163,6 +163,82 @@ void main() {
     expect(find.text('cancel event'), findsOneWidget);
   });
 
+  testWidgets('RSVP hidden on past event for authenticated member', (
+    tester,
+  ) async {
+    tester.view.physicalSize = _kTestSize;
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final pastEvent = _baseEvent.copyWith(
+      startDatetime: DateTime.now().subtract(const Duration(days: 7)),
+      endDatetime: DateTime.now()
+          .subtract(const Duration(days: 7))
+          .add(const Duration(hours: 2)),
+    );
+
+    await tester.pumpWidget(
+      _buildSubject(
+        pastEvent,
+        authNotifier: _MemberAuthNotifier(userId: 'u-member'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text("i'm going"), findsNothing);
+    expect(find.text('maybe'), findsNothing);
+    expect(find.text("can't make it"), findsNothing);
+  });
+
+  testWidgets('invite friends hidden on past event', (tester) async {
+    tester.view.physicalSize = _kTestSize;
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final pastEvent = _baseEvent.copyWith(
+      startDatetime: DateTime.now().subtract(const Duration(days: 7)),
+      endDatetime: DateTime.now()
+          .subtract(const Duration(days: 7))
+          .add(const Duration(hours: 2)),
+    );
+
+    await tester.pumpWidget(
+      _buildSubject(
+        pastEvent,
+        authNotifier: _MemberAuthNotifier(userId: 'u-creator'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.text('invite friends'), findsNothing);
+  });
+
+  testWidgets('calendar menu hidden on past event', (tester) async {
+    tester.view.physicalSize = _kTestSize;
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+
+    final pastEvent = _baseEvent.copyWith(
+      startDatetime: DateTime.now().subtract(const Duration(days: 7)),
+      endDatetime: DateTime.now()
+          .subtract(const Duration(days: 7))
+          .add(const Duration(hours: 2)),
+    );
+
+    await tester.pumpWidget(
+      _buildSubject(
+        pastEvent,
+        authNotifier: _MemberAuthNotifier(userId: 'u-member'),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byTooltip('add to calendar'), findsNothing);
+  });
+
   testWidgets('admin actions hidden for non-creator member', (tester) async {
     tester.view.physicalSize = _kTestSize;
     tester.view.devicePixelRatio = 1.0;


### PR DESCRIPTION
Add isPast extension getter on Event model using the existing (endDatetime ?? startDatetime).isAfter(now) pattern from list_view.dart.

Guard four interactive sections behind isPast:
- CalendarMenuChip hidden on past events
- Invite friends button hidden on past events
- RSVP section hidden on past events
- Poll voting shows read-only results on past events

Changes linted and tested (238 tests pass).

<em>🤖 Co-created with Claude</em>