### PR TITLE
fix(fe): remove dead isPast extension + fix CI lint/test failures

### DIFF
--- a/frontend/lib/models/event.dart
+++ b/frontend/lib/models/event.dart
@@ -67,7 +67,3 @@ abstract class Event with _$Event {
 
   factory Event.fromJson(Map<String, dynamic> json) => _$EventFromJson(json);
 }
-
-extension EventHelpers on Event {
-  bool get isPast => !(endDatetime ?? startDatetime).isAfter(DateTime.now());
-}

--- a/frontend/lib/screens/calendar/event_member_section.dart
+++ b/frontend/lib/screens/calendar/event_member_section.dart
@@ -248,7 +248,9 @@ class EventMemberSection extends ConsumerWidget {
               ),
             ),
           ],
-          if (!event.isPast && event.rsvpEnabled && event.status != EventStatus.cancelled) ...[
+          if (!event.isPast &&
+              event.rsvpEnabled &&
+              event.status != EventStatus.cancelled) ...[
             const SizedBox(height: 12),
             EventSectionCard(
               label: EventDetailLabel.rsvp,

--- a/frontend/test/unit/event_is_past_test.dart
+++ b/frontend/test/unit/event_is_past_test.dart
@@ -1,59 +1,36 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pda/models/event.dart';
 
-Event _makeEvent({DateTime? start, DateTime? end}) => Event(
+Event _makeEvent({required bool isPast}) => Event(
   id: 'test-id',
   title: 'Test Event',
   description: '',
-  startDatetime: start ?? DateTime.now(),
-  endDatetime: end,
+  startDatetime: DateTime.now(),
   location: '',
+  isPast: isPast,
 );
 
 void main() {
   group('Event.isPast', () {
-    test('returns true when endDatetime is in the past', () {
-      final event = _makeEvent(
-        start: DateTime.now().subtract(const Duration(hours: 3)),
-        end: DateTime.now().subtract(const Duration(hours: 1)),
-      );
+    test('is true when server marks event as past', () {
+      final event = _makeEvent(isPast: true);
       expect(event.isPast, isTrue);
     });
 
-    test('returns true when only startDatetime exists and is in the past', () {
-      final event = _makeEvent(
-        start: DateTime.now().subtract(const Duration(hours: 1)),
-      );
-      expect(event.isPast, isTrue);
-    });
-
-    test('returns false when endDatetime is in the future', () {
-      final event = _makeEvent(
-        start: DateTime.now().subtract(const Duration(hours: 1)),
-        end: DateTime.now().add(const Duration(hours: 1)),
-      );
+    test('is false when server marks event as not past', () {
+      final event = _makeEvent(isPast: false);
       expect(event.isPast, isFalse);
     });
 
-    test(
-      'returns false when only startDatetime exists and is in the future',
-      () {
-        final event = _makeEvent(
-          start: DateTime.now().add(const Duration(hours: 1)),
-        );
-        expect(event.isPast, isFalse);
-      },
-    );
-
-    test(
-      'returns false when event is currently happening (start past, end future)',
-      () {
-        final event = _makeEvent(
-          start: DateTime.now().subtract(const Duration(hours: 1)),
-          end: DateTime.now().add(const Duration(hours: 2)),
-        );
-        expect(event.isPast, isFalse);
-      },
-    );
+    test('defaults to false', () {
+      final event = Event(
+        id: 'test-id',
+        title: 'Test Event',
+        description: '',
+        startDatetime: DateTime.now(),
+        location: '',
+      );
+      expect(event.isPast, isFalse);
+    });
   });
 }

--- a/frontend/test/widget/event_detail_edit_button_test.dart
+++ b/frontend/test/widget/event_detail_edit_button_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:pda/config/constants.dart';
+import 'package:pda/models/event.dart';
+import 'package:pda/models/user.dart';
+import 'package:pda/providers/auth_provider.dart';
+import 'package:pda/providers/event_provider.dart';
+import 'package:pda/screens/calendar/event_detail_panel.dart';
+
+import '../helpers/provider_overrides.dart';
+
+const _kTestSize = Size(700, 900);
+
+final _testEvent = Event(
+  id: 'evt-1',
+  title: 'Movie Night',
+  description: 'Watch a great film.',
+  startDatetime: DateTime(2026, 4, 1, 19),
+  location: '',
+  createdById: 'u-host',
+  createdByName: 'Alice',
+  coHostIds: ['u-cohost'],
+  coHostNames: ['Bob'],
+);
+
+Widget _buildSubject({AuthNotifier? authNotifier}) {
+  final router = GoRouter(
+    routes: [
+      GoRoute(
+        path: '/',
+        builder: (_, __) =>
+            Scaffold(body: EventDetailContent(event: _testEvent)),
+      ),
+      GoRoute(path: '/events/:id', builder: (_, __) => const SizedBox()),
+      GoRoute(path: '/join', builder: (_, __) => const SizedBox()),
+    ],
+  );
+  return ProviderScope(
+    overrides: [
+      eventsProvider.overrideWith((_) async => [_testEvent]),
+      eventDetailProvider.overrideWith((ref, id) async => _testEvent),
+      authProvider.overrideWith(() => authNotifier ?? _GuestAuthNotifier()),
+      silentNotificationsOverride,
+    ],
+    child: MaterialApp.router(routerConfig: router),
+  );
+}
+
+void main() {
+  group('event detail admin actions visibility', () {
+    testWidgets('co-host sees edit and cancel buttons', (tester) async {
+      tester.view.physicalSize = _kTestSize;
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        _buildSubject(authNotifier: _UserAuthNotifier(userId: 'u-cohost')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('edit'), findsOneWidget);
+      expect(find.text('cancel event'), findsOneWidget);
+    });
+
+    testWidgets('regular member does NOT see edit or delete', (tester) async {
+      tester.view.physicalSize = _kTestSize;
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(
+        _buildSubject(authNotifier: _UserAuthNotifier(userId: 'u-nobody')),
+      );
+      await tester.pumpAndSettle();
+
+      expect(find.text('edit'), findsNothing);
+      expect(find.text('cancel event'), findsNothing);
+    });
+
+    testWidgets('unauthenticated user does NOT see edit or delete', (
+      tester,
+    ) async {
+      tester.view.physicalSize = _kTestSize;
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      await tester.pumpWidget(_buildSubject());
+      await tester.pumpAndSettle();
+
+      expect(find.text('edit'), findsNothing);
+      expect(find.text('cancel event'), findsNothing);
+    });
+  });
+}
+
+class _GuestAuthNotifier extends AuthNotifier {
+  @override
+  Future<User?> build() async => null;
+
+  @override
+  Future<void> logout() async {}
+}
+
+class _UserAuthNotifier extends AuthNotifier {
+  final String userId;
+  final List<String> permissions;
+
+  _UserAuthNotifier({required this.userId, this.permissions = const []});
+
+  @override
+  Future<User?> build() async => User(
+    id: userId,
+    phoneNumber: '+12025551234',
+    displayName: 'Test User',
+    roles: [
+      if (permissions.isNotEmpty)
+        Role(id: 'r-1', name: 'custom', permissions: permissions),
+    ],
+  );
+
+  @override
+  Future<void> logout() async {}
+}

--- a/frontend/test/widget/event_detail_edit_button_test.dart
+++ b/frontend/test/widget/event_detail_edit_button_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:go_router/go_router.dart';
-import 'package:pda/config/constants.dart';
 import 'package:pda/models/event.dart';
 import 'package:pda/models/user.dart';
 import 'package:pda/providers/auth_provider.dart';
@@ -107,20 +106,12 @@ class _GuestAuthNotifier extends AuthNotifier {
 
 class _UserAuthNotifier extends AuthNotifier {
   final String userId;
-  final List<String> permissions;
 
-  _UserAuthNotifier({required this.userId, this.permissions = const []});
+  _UserAuthNotifier({required this.userId});
 
   @override
-  Future<User?> build() async => User(
-    id: userId,
-    phoneNumber: '+12025551234',
-    displayName: 'Test User',
-    roles: [
-      if (permissions.isNotEmpty)
-        Role(id: 'r-1', name: 'custom', permissions: permissions),
-    ],
-  );
+  Future<User?> build() async =>
+      User(id: userId, phoneNumber: '+12025551234', displayName: 'Test User');
 
   @override
   Future<void> logout() async {}

--- a/frontend/test/widget/settings_accessibility_test.dart
+++ b/frontend/test/widget/settings_accessibility_test.dart
@@ -14,9 +14,9 @@ void main() {
       tester,
     ) async {
       await tester.pumpWidget(
-        ProviderScope(
+        const ProviderScope(
           child: MaterialApp(
-            home: Scaffold(body: const SettingsAccessibilitySection()),
+            home: Scaffold(body: SettingsAccessibilitySection()),
           ),
         ),
       );
@@ -30,9 +30,9 @@ void main() {
 
     testWidgets('tapping dark segment updates theme mode', (tester) async {
       await tester.pumpWidget(
-        ProviderScope(
+        const ProviderScope(
           child: MaterialApp(
-            home: Scaffold(body: const SettingsAccessibilitySection()),
+            home: Scaffold(body: SettingsAccessibilitySection()),
           ),
         ),
       );

--- a/frontend/test/widgets/event_detail_panel_test.dart
+++ b/frontend/test/widgets/event_detail_panel_test.dart
@@ -171,12 +171,7 @@ void main() {
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
 
-    final pastEvent = _baseEvent.copyWith(
-      startDatetime: DateTime.now().subtract(const Duration(days: 7)),
-      endDatetime: DateTime.now()
-          .subtract(const Duration(days: 7))
-          .add(const Duration(hours: 2)),
-    );
+    final pastEvent = _baseEvent.copyWith(isPast: true);
 
     await tester.pumpWidget(
       _buildSubject(
@@ -197,12 +192,7 @@ void main() {
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
 
-    final pastEvent = _baseEvent.copyWith(
-      startDatetime: DateTime.now().subtract(const Duration(days: 7)),
-      endDatetime: DateTime.now()
-          .subtract(const Duration(days: 7))
-          .add(const Duration(hours: 2)),
-    );
+    final pastEvent = _baseEvent.copyWith(isPast: true);
 
     await tester.pumpWidget(
       _buildSubject(
@@ -221,12 +211,7 @@ void main() {
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
 
-    final pastEvent = _baseEvent.copyWith(
-      startDatetime: DateTime.now().subtract(const Duration(days: 7)),
-      endDatetime: DateTime.now()
-          .subtract(const Duration(days: 7))
-          .add(const Duration(hours: 2)),
-    );
+    final pastEvent = _baseEvent.copyWith(isPast: true);
 
     await tester.pumpWidget(
       _buildSubject(


### PR DESCRIPTION
## What

Fixes all failing `make ci` checks: 5 test failures and 8 lint warnings.

### Root cause

Two implementations of `isPast` existed on the `Event` model:

1. **Freezed field** (`@Default(false) bool isPast`) — server-computed, added in e55da92
2. **Extension getter** (`EventHelpers.isPast`) — client-computed, added in 5f42fcf

Dart class members shadow extension methods, so the extension was dead code. Tests constructing events with past dates expected the extension to compute `isPast`, but always read the Freezed field default (`false`).

### Changes

- Remove dead `EventHelpers` extension from `event.dart`
- Rewrite `event_is_past_test.dart` to verify the server-computed field
- Update `event_detail_panel_test.dart` past-event tests to use `copyWith(isPast: true)`
- Fix lint: unused import/param in edit button test, const in settings test
- Add widget tests for co-host edit/delete visibility (#308)

<em>🤖 Co-created with Claude</em>