### PR TITLE
fix(infra): invalidate browser cache on new builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY frontend/ ./
 RUN dart run build_runner build --delete-conflicting-outputs
 ARG RAILWAY_GIT_COMMIT_SHA=dev
 ARG ENABLE_FEEDBACK=false
-RUN flutter build web --release --dart-define=API_URL= --dart-define=GIT_SHA=${RAILWAY_GIT_COMMIT_SHA} --dart-define=ENABLE_FEEDBACK=${ENABLE_FEEDBACK} --no-pub --tree-shake-icons --wasm
+RUN flutter build web --release --pwa-strategy=none --dart-define=API_URL= --dart-define=GIT_SHA=${RAILWAY_GIT_COMMIT_SHA} --dart-define=ENABLE_FEEDBACK=${ENABLE_FEEDBACK} --no-pub --tree-shake-icons --wasm
 RUN rm -f build/web/assets/NOTICES
 
 # Stage 2: Python/Django runtime

--- a/Makefile
+++ b/Makefile
@@ -98,7 +98,7 @@ frontend-run-html:
 	cd frontend && flutter run -d web-server --web-port 3001 --web-hostname 0.0.0.0 --dart-define=ENABLE_FEEDBACK=$(ENABLE_FEEDBACK) --dart-define=GIT_SHA=$(shell git rev-parse --short HEAD)
 
 frontend-build:
-	cd frontend && flutter build web --dart-define=API_URL=$(API_URL) --dart-define=ENABLE_FEEDBACK=$(ENABLE_FEEDBACK) --dart-define=GIT_SHA=$(shell git rev-parse --short HEAD) --tree-shake-icons --wasm
+	cd frontend && flutter build web --pwa-strategy=none --dart-define=API_URL=$(API_URL) --dart-define=ENABLE_FEEDBACK=$(ENABLE_FEEDBACK) --dart-define=GIT_SHA=$(shell git rev-parse --short HEAD) --tree-shake-icons --wasm
 
 frontend-codegen:
 	cd frontend && dart run build_runner build --delete-conflicting-outputs

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -99,7 +99,7 @@ MEDIA_ROOT = BASE_DIR / "media"
 
 if IS_PRODUCTION:
     WHITENOISE_ROOT = STATIC_ROOT / "flutter"
-    WHITENOISE_MAX_AGE = 31536000  # 1 year — safe because WhiteNoise uses content-hashed filenames
+    WHITENOISE_MAX_AGE = 60
 
 STORAGES: dict[str, dict[str, object]] = {
     "default": {"BACKEND": "django.core.files.storage.FileSystemStorage"},

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -8,6 +8,16 @@ from users.api import router as auth_router
 
 from config.media_proxy import serve_media
 
+
+class NoCacheTemplateView(TemplateView):
+    """TemplateView that sets Cache-Control: no-cache so browsers always revalidate."""
+
+    def dispatch(self, request, *args, **kwargs):
+        response = super().dispatch(request, *args, **kwargs)
+        response["Cache-Control"] = "no-cache"
+        return response
+
+
 api = NinjaAPI(title="PDA API", version="1.0.0")
 api.add_router("/auth/", auth_router, tags=["auth"])
 api.add_router("/community/", community_router, tags=["community"])
@@ -20,8 +30,9 @@ urlpatterns = [
     # Media proxy — streams files from storage backend (local disk or B2)
     re_path(r"^media/(?P<path>.+)$", serve_media),
     # Flutter SPA catch-all (MUST BE LAST)
+    # no-cache ensures browsers always check for new builds after deploys
     re_path(
         r"^(?!.*\.(js|css|json|wasm|png|jpg|ico|svg|ttf|otf|woff|woff2|map)$).*$",
-        TemplateView.as_view(template_name="flutter/index.html"),
+        NoCacheTemplateView.as_view(template_name="flutter/index.html"),
     ),
 ]

--- a/backend/tests/test_cache_headers.py
+++ b/backend/tests/test_cache_headers.py
@@ -1,0 +1,32 @@
+import pytest
+from django.test import Client, override_settings
+
+
+@pytest.fixture
+def flutter_template_dir(tmp_path):
+    """Create a minimal flutter/index.html template for the catch-all view."""
+    template_dir = tmp_path / "templates"
+    flutter_dir = template_dir / "flutter"
+    flutter_dir.mkdir(parents=True)
+    (flutter_dir / "index.html").write_text("<html><body>test</body></html>")
+    return str(template_dir)
+
+
+@pytest.mark.unit
+class TestSPACacheHeaders:
+    def test_spa_catchall_sets_no_cache_header(self, flutter_template_dir):
+        """index.html responses must include Cache-Control: no-cache to prevent stale deploys."""
+        with override_settings(
+            TEMPLATES=[
+                {
+                    "BACKEND": "django.template.backends.django.DjangoTemplates",
+                    "DIRS": [flutter_template_dir],
+                    "APP_DIRS": True,
+                    "OPTIONS": {"context_processors": []},
+                }
+            ]
+        ):
+            client = Client()
+            response = client.get("/")
+            assert response.status_code == 200
+            assert response["Cache-Control"] == "no-cache"

--- a/frontend/web/index.html
+++ b/frontend/web/index.html
@@ -79,14 +79,17 @@
     });
   </script>
 
-  <!--
-    You can customize the "flutter_bootstrap.js" script.
-    This is useful to provide a custom configuration to the Flutter loader
-    or to give the user feedback during the initialization process.
-
-    For more details:
-    * https://docs.flutter.dev/platform-integration/web/initialization
-  -->
+  <!-- Unregister any previously-installed Flutter service worker.
+       flutter build web used to register one by default (now disabled via
+       --pwa-strategy=none). This one-time cleanup ensures existing users
+       stop being served stale cached assets. -->
+  <script>
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.getRegistrations().then(function(registrations) {
+        for (var r of registrations) { r.unregister(); }
+      });
+    }
+  </script>
   <script src="flutter_bootstrap.js" async></script>
 </body>
 </html>


### PR DESCRIPTION
## What

Fixes stale browser caching after deploying new Flutter web builds. Users previously had to hard-refresh to see changes.

## Why

Two reinforcing caching issues:
1. **Flutter's default service worker** aggressively caches all assets — new builds enter "waiting" state and won't activate until all tabs close
2. **No `Cache-Control` on `index.html`** — browsers apply heuristic caching, preventing revalidation of new `flutter_bootstrap.js` references

## Changes

- **Disable Flutter service worker** — `--pwa-strategy=none` in `Dockerfile` and `Makefile` build commands
- **Unregister existing service workers** — JS snippet in `index.html` for one-time cleanup of previously-installed workers
- **`Cache-Control: no-cache` on `index.html`** — browser always revalidates the entry point via custom catch-all view
- **Explicit `WHITENOISE_MAX_AGE=60`** in settings
- **Regression test** verifying cache-control header on SPA catch-all responses

Closes #245

<em>🤖 Co-created with Claude</em>