### PR TITLE
expand bottom nav to 5 items (members + my events)

### DIFF
--- a/backend/community/management/commands/seed.py
+++ b/backend/community/management/commands/seed.py
@@ -19,6 +19,8 @@ class SeedUser:
     phone_number: str
     display_name: str
     is_superuser: bool
+    email: str = ""
+    bio: str = ""
 
 
 @dataclass
@@ -54,11 +56,35 @@ SEED_USERS = [
         phone_number="+17025550001",
         display_name="Seed Admin",
         is_superuser=True,
+        email="admin@pda.test",
+        bio="org admin — ping me if anything's broken 🌿",
     ),
     SeedUser(
         phone_number="+17025550002",
         display_name="Seed Member",
         is_superuser=False,
+        email="member@pda.test",
+        bio="vegan six years, big into potlucks and mutual aid.",
+    ),
+    SeedUser(
+        phone_number="+17025550003",
+        display_name="Jamie Okafor",
+        is_superuser=False,
+        email="jamie@pda.test",
+        bio="food not bombs volunteer. cook, eat, organize.",
+    ),
+    SeedUser(
+        phone_number="+17025550004",
+        display_name="Rin Takahashi",
+        is_superuser=False,
+        email="rin@pda.test",
+    ),
+    SeedUser(
+        phone_number="+17025550005",
+        display_name="Ash Morales",
+        is_superuser=False,
+        email="ash@pda.test",
+        bio="plant-based chef, always down to swap recipes.",
     ),
 ]
 
@@ -236,9 +262,28 @@ class Command(BaseCommand):
         self._seed_content()
         self._print_summary()
 
+    def _backfill_user(self, user: User, data: "SeedUser") -> None:
+        """Fill in email/bio on existing users so reseeding picks up changes."""
+        updates: dict[str, str] = {}
+        if data.email and not user.email:
+            updates["email"] = data.email
+        if data.bio and not user.bio:
+            updates["bio"] = data.bio
+        if not updates:
+            self.stdout.write(f"  Already exists: {user.display_name}")
+            return
+        for k, v in updates.items():
+            setattr(user, k, v)
+        user.save(update_fields=list(updates.keys()))
+        self.stdout.write(f"  Backfilled {', '.join(updates)}: {user.display_name}")
+
     def _create_or_skip_user(self, data, admin_role, member_role) -> tuple[User, bool]:
         """Create user from seed data or return existing. Returns (user, created)."""
-        defaults: dict[str, object] = {"display_name": data.display_name}
+        defaults: dict[str, object] = {
+            "display_name": data.display_name,
+            "email": data.email,
+            "bio": data.bio,
+        }
         if data.is_superuser:
             defaults["is_superuser"] = True
             defaults["is_staff"] = True
@@ -251,7 +296,7 @@ class Command(BaseCommand):
             user.roles.add(admin_role if data.is_superuser else member_role)
             self.stdout.write(f"  Created user: {user.display_name}")
         else:
-            self.stdout.write(f"  Already exists: {user.display_name}")
+            self._backfill_user(user, data)
         return user, created
 
     def _seed_users(self) -> User:

--- a/backend/tests/test_seed.py
+++ b/backend/tests/test_seed.py
@@ -19,7 +19,7 @@ def test_seed_is_idempotent():
     call_command("seed")
     call_command("seed")
 
-    assert User.objects.filter(phone_number__startswith="+1702555").count() == 2
+    assert User.objects.filter(phone_number__startswith="+1702555").count() == 5
     assert Event.objects.count() == 4
     assert JoinRequest.objects.count() == 8
 

--- a/backend/tests/users/test_member_directory.py
+++ b/backend/tests/users/test_member_directory.py
@@ -1,0 +1,63 @@
+"""Tests for the authed member directory endpoint."""
+
+import pytest
+from django.utils import timezone
+
+
+@pytest.mark.django_db
+class TestMemberDirectory:
+    def test_requires_auth(self, api_client):
+        response = api_client.get("/api/auth/users/directory/")
+        assert response.status_code == 401
+
+    def test_authed_caller_sees_directory(self, api_client, auth_headers, other_user):
+        response = api_client.get("/api/auth/users/directory/", **auth_headers)
+        assert response.status_code == 200
+        ids = [u["id"] for u in response.json()]
+        assert str(other_user.pk) in ids
+
+    def test_excludes_paused_users(self, api_client, auth_headers, other_user):
+        other_user.is_paused = True
+        other_user.save(update_fields=["is_paused"])
+        response = api_client.get("/api/auth/users/directory/", **auth_headers)
+        assert response.status_code == 200
+        ids = [u["id"] for u in response.json()]
+        assert str(other_user.pk) not in ids
+
+    def test_excludes_archived_users(self, api_client, auth_headers, other_user):
+        other_user.archived_at = timezone.now()
+        other_user.save(update_fields=["archived_at"])
+        response = api_client.get("/api/auth/users/directory/", **auth_headers)
+        assert response.status_code == 200
+        ids = [u["id"] for u in response.json()]
+        assert str(other_user.pk) not in ids
+
+    def test_excludes_onboarding_pending_users(self, api_client, auth_headers, other_user):
+        other_user.needs_onboarding = True
+        other_user.save(update_fields=["needs_onboarding"])
+        response = api_client.get("/api/auth/users/directory/", **auth_headers)
+        assert response.status_code == 200
+        ids = [u["id"] for u in response.json()]
+        assert str(other_user.pk) not in ids
+
+    def test_redacts_phone_when_user_hid_it(self, api_client, auth_headers, other_user):
+        other_user.show_phone = False
+        other_user.save(update_fields=["show_phone"])
+        response = api_client.get("/api/auth/users/directory/", **auth_headers)
+        assert response.status_code == 200
+        entry = next(u for u in response.json() if u["id"] == str(other_user.pk))
+        assert entry["phone_number"] == ""
+
+    def test_redacts_email_when_user_hid_it(self, api_client, auth_headers, other_user):
+        other_user.email = "hidden@example.com"
+        other_user.show_email = False
+        other_user.save(update_fields=["email", "show_email"])
+        response = api_client.get("/api/auth/users/directory/", **auth_headers)
+        assert response.status_code == 200
+        entry = next(u for u in response.json() if u["id"] == str(other_user.pk))
+        assert entry["email"] == ""
+
+    def test_shows_phone_when_user_opted_in(self, api_client, auth_headers, other_user):
+        response = api_client.get("/api/auth/users/directory/", **auth_headers)
+        entry = next(u for u in response.json() if u["id"] == str(other_user.pk))
+        assert entry["phone_number"] == other_user.phone_number

--- a/backend/users/_auth.py
+++ b/backend/users/_auth.py
@@ -26,6 +26,7 @@ from users.schemas import (
     ErrorOut,
     LoginIn,
     LogoutOut,
+    MemberDirectoryOut,
     MemberProfileOut,
     MePatchIn,
     OnboardingIn,
@@ -281,6 +282,34 @@ def delete_photo(request):
         logging.INFO, "profile_photo_deleted", request, target_type="user", target_id=str(user.pk)
     )
     return Status(200, UserOut.from_user(user))
+
+
+@router.get(
+    "/users/directory/",
+    response={200: list[MemberDirectoryOut]},
+    auth=JWTAuth(),
+)
+def list_member_directory(request):
+    """Authed-only member directory. Respects each user's show_phone/show_email flags."""
+    users = User.objects.filter(
+        is_active=True,
+        is_paused=False,
+        archived_at__isnull=True,
+        needs_onboarding=False,
+    ).order_by("display_name", "phone_number")
+    return Status(
+        200,
+        [
+            MemberDirectoryOut(
+                id=str(u.id),
+                display_name=u.display_name or u.phone_number,
+                phone_number=u.phone_number if u.show_phone else "",
+                email=(u.email or "") if u.show_email else "",
+                profile_photo_url=media_path(u.profile_photo),
+            )
+            for u in users
+        ],
+    )
 
 
 @router.get(

--- a/backend/users/schemas.py
+++ b/backend/users/schemas.py
@@ -102,6 +102,14 @@ class MemberProfileOut(BaseModel):
     login_link_requested: bool = False
 
 
+class MemberDirectoryOut(BaseModel):
+    id: str
+    display_name: str
+    phone_number: str = ""
+    email: str = ""
+    profile_photo_url: str = ""
+
+
 class UserCreateIn(BaseModel):
     phone_number: str = Field(max_length=FieldLimit.PHONE)
     display_name: str = Field(default="", max_length=FieldLimit.DISPLAY_NAME)

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -307,6 +307,41 @@ function fromWireProfile(w: WireMemberProfile): MemberProfile {
   };
 }
 
+// --- Member directory (any authed user) -------------------------------------
+// Authed-only list with phone/email pre-redacted per target's privacy flags.
+
+export interface DirectoryMember {
+  id: string;
+  displayName: string;
+  phoneNumber: string;
+  email: string;
+  profilePhotoUrl: string;
+}
+
+interface WireDirectoryMember {
+  id: string;
+  display_name: string;
+  phone_number: string;
+  email: string;
+  profile_photo_url: string;
+}
+
+export function useMembersDirectory() {
+  return useQuery({
+    queryKey: ['members-directory'] as const,
+    queryFn: async () => {
+      const { data } = await apiClient.get<WireDirectoryMember[]>('/api/auth/users/directory/');
+      return data.map<DirectoryMember>((w) => ({
+        id: w.id,
+        displayName: w.display_name,
+        phoneNumber: w.phone_number,
+        email: w.email,
+        profilePhotoUrl: w.profile_photo_url,
+      }));
+    },
+  });
+}
+
 export function useMemberProfile(userId: string | undefined) {
   return useQuery({
     queryKey: ['member-profile', userId] as const,

--- a/frontend/src/layout/BottomNav.test.tsx
+++ b/frontend/src/layout/BottomNav.test.tsx
@@ -1,7 +1,6 @@
-// Unit tests for the bottom nav. Covers the three pieces Flutter's
-// CalendarScreen FAB-permission tests used to cover: all three
-// destinations render, the add-event button navigates to /events/add,
-// and the nav always mounts (no permission gate on the FAB).
+// Unit tests for the bottom nav. Covers all five destinations rendering,
+// the add-event button navigating to /events/add, and the nav always
+// mounting (no permission gate on the FAB).
 
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
@@ -33,12 +32,26 @@ function renderNav(initialPath = '/') {
 }
 
 describe('BottomNav', () => {
-  it('renders all three destinations: calendar, add event, profile', () => {
+  it('renders all five destinations: calendar, my events, add event, members, profile', () => {
     renderNav('/');
 
     expect(screen.getByRole('link', { name: /^calendar$/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /^my events$/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /^add event$/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /^members$/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /^profile$/i })).toBeInTheDocument();
+  });
+
+  it('my events link points at /events/mine', () => {
+    renderNav('/');
+    const link = screen.getByRole('link', { name: /^my events$/i });
+    expect(link).toHaveAttribute('href', '/events/mine');
+  });
+
+  it('members link points at /members', () => {
+    renderNav('/');
+    const link = screen.getByRole('link', { name: /^members$/i });
+    expect(link).toHaveAttribute('href', '/members');
   });
 
   it('add-event button navigates to /events/add', async () => {

--- a/frontend/src/layout/BottomNav.tsx
+++ b/frontend/src/layout/BottomNav.tsx
@@ -31,7 +31,7 @@ export function BottomNav() {
         </NavItem>
 
         <NavItem to="/events/mine" label="my events">
-          {({ active }) => <TicketIcon filled={active} />}
+          {({ active }) => <StarIcon filled={active} />}
         </NavItem>
 
         <div className="flex items-center justify-center">
@@ -123,8 +123,8 @@ function CalendarIcon({ filled }: { filled: boolean }) {
   );
 }
 
-function TicketIcon({ filled }: { filled: boolean }) {
-  // Ticket silhouette reads as "events you're on the list for".
+function StarIcon({ filled }: { filled: boolean }) {
+  // Star reads as "events i've starred / am part of".
   return (
     <svg
       width="22"
@@ -137,8 +137,7 @@ function TicketIcon({ filled }: { filled: boolean }) {
       strokeLinejoin="round"
       aria-hidden="true"
     >
-      <path d="M3 8a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v2a2 2 0 0 0 0 4v2a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-2a2 2 0 0 0 0-4V8z" />
-      <path d="M9 6v2M9 11v2M9 16v2" stroke={filled ? 'white' : 'currentColor'} />
+      <path d="M12 3l2.7 5.8 6.3.9-4.6 4.4 1.1 6.3L12 17.8 6.5 20.4l1.1-6.3L3 9.7l6.3-.9L12 3z" />
     </svg>
   );
 }

--- a/frontend/src/layout/BottomNav.tsx
+++ b/frontend/src/layout/BottomNav.tsx
@@ -1,4 +1,4 @@
-// Fixed bottom nav — calendar / +event / profile.
+// Fixed bottom nav — calendar / my events / +event / members / profile.
 //
 // Mirrors Flutter's NavigationBar with labelBehavior=alwaysHide: labels are
 // visually hidden but present in the accessible name so screen readers can
@@ -25,9 +25,13 @@ export function BottomNav() {
       aria-label="primary"
       className="border-border bg-surface fixed inset-x-0 bottom-0 z-20 border-t pb-[env(safe-area-inset-bottom)]"
     >
-      <div className="mx-auto grid h-14 max-w-6xl grid-cols-3">
+      <div className="mx-auto grid h-14 max-w-6xl grid-cols-5">
         <NavItem to="/calendar" label="calendar">
           {({ active }) => <CalendarIcon filled={active} />}
+        </NavItem>
+
+        <NavItem to="/events/mine" label="my events">
+          {({ active }) => <TicketIcon filled={active} />}
         </NavItem>
 
         <div className="flex items-center justify-center">
@@ -45,6 +49,10 @@ export function BottomNav() {
             <PlusIcon />
           </button>
         </div>
+
+        <NavItem to="/members" label="members">
+          {({ active }) => <MembersIcon filled={active} />}
+        </NavItem>
 
         <NavItem to="/profile" label="profile">
           {({ active }) =>
@@ -111,6 +119,48 @@ function CalendarIcon({ filled }: { filled: boolean }) {
     >
       <rect x="3" y="5" width="18" height="16" rx="2" fill={filled ? 'currentColor' : 'none'} />
       <path d="M8 3v4M16 3v4M3 10h18" stroke={filled ? 'white' : 'currentColor'} />
+    </svg>
+  );
+}
+
+function TicketIcon({ filled }: { filled: boolean }) {
+  // Ticket silhouette reads as "events you're on the list for".
+  return (
+    <svg
+      width="22"
+      height="22"
+      viewBox="0 0 24 24"
+      fill={filled ? 'currentColor' : 'none'}
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M3 8a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2v2a2 2 0 0 0 0 4v2a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-2a2 2 0 0 0 0-4V8z" />
+      <path d="M9 6v2M9 11v2M9 16v2" stroke={filled ? 'white' : 'currentColor'} />
+    </svg>
+  );
+}
+
+function MembersIcon({ filled }: { filled: boolean }) {
+  // Two-person silhouette — distinct from the single-person ProfileIcon.
+  return (
+    <svg
+      width="22"
+      height="22"
+      viewBox="0 0 24 24"
+      fill={filled ? 'currentColor' : 'none'}
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="9" cy="8" r="3.5" />
+      <circle cx="17" cy="9" r="2.5" />
+      <path d="M2.5 20c0-3.6 2.9-6.5 6.5-6.5s6.5 2.9 6.5 6.5" />
+      <path d="M16 14.5c3 .3 5.5 2.8 5.5 5.5" />
     </svg>
   );
 }

--- a/frontend/src/layout/NotificationBell.tsx
+++ b/frontend/src/layout/NotificationBell.tsx
@@ -187,7 +187,7 @@ function notificationTarget(n: AppNotification): string | null {
     case NotificationType.JoinRequest:
       return '/join-requests';
     case NotificationType.MagicLinkRequest:
-      return n.relatedUserId ? `/admin/members/${n.relatedUserId}` : '/members';
+      return n.relatedUserId ? `/admin/members/${n.relatedUserId}` : '/admin/members';
     default:
       return null;
   }

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -48,6 +48,7 @@ const SurveyResponses = lazyWithRetry(() => import('@/screens/admin/SurveyRespon
 const Members = lazyWithRetry(() => import('@/screens/admin/MembersScreen'));
 const MemberDetail = lazyWithRetry(() => import('@/screens/admin/MemberDetailScreen'));
 const MemberProfile = lazyWithRetry(() => import('@/screens/members/MemberProfileScreen'));
+const MembersDirectory = lazyWithRetry(() => import('@/screens/members/MembersDirectoryScreen'));
 
 const Stub = lazyWithRetry(() => import('@/screens/NotImplemented'));
 
@@ -92,6 +93,7 @@ export const router = createBrowserRouter([
               { path: '/events/mine', element: el(<MyEvents />) },
               { path: '/events/add', element: el(<EventCreate />) },
               { path: '/events/:id/edit', element: el(<EventEdit />) },
+              { path: '/members', element: el(<MembersDirectory />) },
               { path: '/members/:userId', element: el(<MemberProfile />) },
             ],
           },
@@ -107,7 +109,7 @@ export const router = createBrowserRouter([
           {
             element: <RequirePermission perm={Permission.ManageUsers} />,
             children: [
-              { path: '/members', element: el(<Members />) },
+              { path: '/admin/members', element: el(<Members />) },
               { path: '/admin/members/:id', element: el(<MemberDetail />) },
             ],
           },

--- a/frontend/src/screens/admin/AdminHubScreen.tsx
+++ b/frontend/src/screens/admin/AdminHubScreen.tsx
@@ -15,7 +15,7 @@ interface Tile {
 
 const TILES: Tile[] = [
   {
-    to: '/members',
+    to: '/admin/members',
     label: 'members',
     description: 'create, edit, pause, or reset accounts',
     perm: Permission.ManageUsers,

--- a/frontend/src/screens/admin/MemberDetailScreen.tsx
+++ b/frontend/src/screens/admin/MemberDetailScreen.tsx
@@ -48,7 +48,7 @@ function MemberDetailView({ member }: { member: Member }) {
     try {
       await archive.mutateAsync(member.id);
       toast.success('member archived ✓');
-      void navigate('/members');
+      void navigate('/admin/members');
     } catch (err) {
       toast.error(extractError(err));
     }
@@ -56,7 +56,10 @@ function MemberDetailView({ member }: { member: Member }) {
 
   return (
     <ContentContainer>
-      <Link to="/members" className="mb-4 inline-block text-sm text-neutral-500 hover:underline">
+      <Link
+        to="/admin/members"
+        className="mb-4 inline-block text-sm text-neutral-500 hover:underline"
+      >
         ← back to members
       </Link>
 
@@ -106,11 +109,7 @@ function MemberDetailView({ member }: { member: Member }) {
         />
       ) : (
         <div className="flex justify-between">
-          <Button
-            variant="secondary"
-            onClick={() => void onArchive()}
-            disabled={archive.isPending}
-          >
+          <Button variant="secondary" onClick={() => void onArchive()} disabled={archive.isPending}>
             {archive.isPending ? 'archiving…' : 'archive'}
           </Button>
           <Button

--- a/frontend/src/screens/events/MyEventsScreen.tsx
+++ b/frontend/src/screens/events/MyEventsScreen.tsx
@@ -108,7 +108,7 @@ export default function MyEventsScreen() {
       </div>
 
       {mine.length === 0 ? (
-        <p className="text-sm text-neutral-500">{EMPTY_COPY[filter]}</p>
+        <p className="text-muted text-sm">{EMPTY_COPY[filter]}</p>
       ) : (
         <ul className="flex flex-col gap-2">
           {mine.map((e) => (
@@ -126,11 +126,11 @@ function EventRow({ event }: { event: Event }) {
   return (
     <Link
       to={`/events/${event.id}`}
-      className="flex items-center justify-between gap-3 rounded-lg border border-neutral-200 bg-white p-3 hover:bg-neutral-50"
+      className="border-border bg-surface hover:bg-surface-dim flex items-center justify-between gap-3 rounded-lg border p-3 transition-colors"
     >
       <div className="min-w-0">
-        <p className="truncate text-sm font-medium text-neutral-800">{event.title}</p>
-        <p className="truncate text-xs text-neutral-500">
+        <p className="text-foreground truncate text-sm font-medium">{event.title}</p>
+        <p className="text-foreground-tertiary truncate text-xs">
           {event.datetimeTbd || !event.startDatetime
             ? 'tbd'
             : format(event.startDatetime, 'EEE MMM d, h:mm a').toLowerCase()}
@@ -139,17 +139,21 @@ function EventRow({ event }: { event: Event }) {
       </div>
       <div className="flex items-center gap-2 text-xs">
         {event.status === EventStatus.Cancelled ? (
-          <span className="rounded-full bg-neutral-200 px-2 py-0.5 text-neutral-700">
+          <span className="bg-surface-dim text-foreground-secondary rounded-full px-2 py-0.5">
             cancelled
           </span>
         ) : null}
         {event.status === EventStatus.Draft ? (
-          <span className="rounded-full bg-amber-100 px-2 py-0.5 text-amber-900">draft</span>
+          <span className="rounded-full bg-amber-100 px-2 py-0.5 text-amber-900 dark:bg-amber-900/40 dark:text-amber-200">
+            draft
+          </span>
         ) : null}
         {event.eventType === EventType.Official ? (
-          <span className="rounded-full bg-blue-100 px-2 py-0.5 text-blue-900">official</span>
+          <span className="rounded-full bg-blue-100 px-2 py-0.5 text-blue-900 dark:bg-blue-900/40 dark:text-blue-200">
+            official
+          </span>
         ) : null}
-        <span className="text-neutral-500">{String(event.attendingCount)} going</span>
+        <span className="text-foreground-tertiary">{String(event.attendingCount)} going</span>
       </div>
     </Link>
   );

--- a/frontend/src/screens/events/MyEventsScreen.tsx
+++ b/frontend/src/screens/events/MyEventsScreen.tsx
@@ -15,12 +15,18 @@ import { SegmentedControl } from '@/components/ui/SegmentedControl';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 
 type Filter = 'upcoming' | 'past' | 'drafts' | 'cancelled';
+type Scope = 'all' | 'hosting';
 
 const FILTERS: { value: Filter; label: string }[] = [
   { value: 'upcoming', label: 'upcoming' },
   { value: 'past', label: 'past' },
   { value: 'drafts', label: 'drafts' },
   { value: 'cancelled', label: 'cancelled' },
+];
+
+const SCOPES: { value: Scope; label: string }[] = [
+  { value: 'all', label: 'all' },
+  { value: 'hosting', label: 'hosting' },
 ];
 
 const EMPTY_COPY: Record<Filter, string> = {
@@ -44,6 +50,7 @@ function pickSourceQuery(
 export default function MyEventsScreen() {
   const userId = useAuthStore((s) => s.user?.id ?? null);
   const [filter, setFilter] = useState<Filter>('upcoming');
+  const [scope, setScope] = useState<Scope>('all');
 
   const activeQuery = useEvents();
   const draftsQuery = useEvents(EventStatus.Draft);
@@ -65,13 +72,11 @@ export default function MyEventsScreen() {
         (a, b) => (b.startDatetime?.getTime() ?? 0) - (a.startDatetime?.getTime() ?? 0),
       );
     }
-    const mineActive = sourceData.filter(
-      (e) =>
-        e.createdById === userId ||
-        e.coHostIds.includes(userId) ||
-        e.myRsvp === RsvpStatus.Attending ||
-        e.myRsvp === RsvpStatus.Maybe,
-    );
+    const isHost = (e: Event) => e.createdById === userId || e.coHostIds.includes(userId);
+    const mineActive = sourceData.filter((e) => {
+      if (scope === 'hosting') return isHost(e);
+      return isHost(e) || e.myRsvp === RsvpStatus.Attending || e.myRsvp === RsvpStatus.Maybe;
+    });
     if (filter === 'upcoming') {
       return mineActive
         .filter((e) => !e.isPast)
@@ -80,7 +85,7 @@ export default function MyEventsScreen() {
     return mineActive
       .filter((e) => e.isPast)
       .sort((a, b) => (b.startDatetime?.getTime() ?? 0) - (a.startDatetime?.getTime() ?? 0));
-  }, [sourceQuery.data, userId, filter, isHostOnlyTab]);
+  }, [sourceQuery.data, userId, filter, isHostOnlyTab, scope]);
 
   if (sourceQuery.isPending) return <ContentLoading />;
   if (sourceQuery.isError) return <ContentError message="couldn't load events — try refreshing" />;
@@ -107,17 +112,34 @@ export default function MyEventsScreen() {
         />
       </div>
 
-      {mine.length === 0 ? (
-        <p className="text-muted text-sm">{EMPTY_COPY[filter]}</p>
-      ) : (
-        <ul className="flex flex-col gap-2">
-          {mine.map((e) => (
-            <li key={e.id}>
-              <EventRow event={e} />
-            </li>
-          ))}
-        </ul>
-      )}
+      <div className={!isHostOnlyTab ? 'pb-24' : undefined}>
+        {mine.length === 0 ? (
+          <p className="text-muted text-sm">{EMPTY_COPY[filter]}</p>
+        ) : (
+          <ul className="flex flex-col gap-2">
+            {mine.map((e) => (
+              <li key={e.id}>
+                <EventRow event={e} />
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {!isHostOnlyTab ? (
+        <div
+          className="border-border bg-surface/95 fixed inset-x-0 z-10 flex justify-center border-t px-4 py-3 backdrop-blur"
+          style={{ bottom: 'calc(3.5rem + env(safe-area-inset-bottom))' }}
+        >
+          <SegmentedControl
+            name="my-events-scope"
+            ariaLabel="scope"
+            options={SCOPES}
+            value={scope}
+            onChange={setScope}
+          />
+        </div>
+      ) : null}
     </ContentContainer>
   );
 }
@@ -153,7 +175,6 @@ function EventRow({ event }: { event: Event }) {
             official
           </span>
         ) : null}
-        <span className="text-foreground-tertiary">{String(event.attendingCount)} going</span>
       </div>
     </Link>
   );

--- a/frontend/src/screens/events/MyEventsScreen.tsx
+++ b/frontend/src/screens/events/MyEventsScreen.tsx
@@ -10,7 +10,7 @@ import { Link } from 'react-router-dom';
 import { useEvents } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
-import { EventStatus, EventType } from '@/models/event';
+import { EventStatus, EventType, RsvpStatus } from '@/models/event';
 import { SegmentedControl } from '@/components/ui/SegmentedControl';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 
@@ -24,7 +24,7 @@ const FILTERS: { value: Filter; label: string }[] = [
 ];
 
 const EMPTY_COPY: Record<Filter, string> = {
-  upcoming: 'nothing coming up 🌿 — events you create or co-host will show up here',
+  upcoming: "nothing coming up 🌿 — events you're hosting or going to will show up here",
   past: 'no past events yet 🌿',
   drafts: 'no drafts saved 🌿 — start one and we\u2019ll keep it here until you publish',
   cancelled: 'no cancelled events 🌿',
@@ -66,7 +66,11 @@ export default function MyEventsScreen() {
       );
     }
     const mineActive = sourceData.filter(
-      (e) => e.createdById === userId || e.coHostIds.includes(userId),
+      (e) =>
+        e.createdById === userId ||
+        e.coHostIds.includes(userId) ||
+        e.myRsvp === RsvpStatus.Attending ||
+        e.myRsvp === RsvpStatus.Maybe,
     );
     if (filter === 'upcoming') {
       return mineActive

--- a/frontend/src/screens/members/MemberProfileScreen.tsx
+++ b/frontend/src/screens/members/MemberProfileScreen.tsx
@@ -58,7 +58,7 @@ function ContactLines({ member }: { member: MemberProfile }) {
     <div className="flex flex-col items-center gap-1">
       {hasPhone ? (
         <a
-          href={`tel:${member.phoneNumber}`}
+          href={`sms:${member.phoneNumber}`}
           className="text-foreground-secondary text-sm hover:underline"
         >
           {member.phoneNumber}

--- a/frontend/src/screens/members/MembersDirectoryScreen.tsx
+++ b/frontend/src/screens/members/MembersDirectoryScreen.tsx
@@ -1,0 +1,95 @@
+// Member-facing directory — all active members, searchable. Rows link to the
+// public /members/:userId profile. Backend redacts phone/email per each
+// target's show_phone / show_email flags, so we just check truthiness here.
+
+import { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useMembersDirectory, type DirectoryMember } from '@/api/users';
+import { TextField } from '@/components/ui/TextField';
+import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
+
+export default function MembersDirectoryScreen() {
+  const { data = [], isPending, isError } = useMembersDirectory();
+  const [query, setQuery] = useState('');
+
+  const visible = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return data;
+    return data.filter(
+      (m) =>
+        m.displayName.toLowerCase().includes(q) ||
+        m.phoneNumber.toLowerCase().includes(q) ||
+        m.email.toLowerCase().includes(q),
+    );
+  }, [data, query]);
+
+  if (isPending) return <ContentLoading />;
+  if (isError) return <ContentError message="couldn't load members — try refreshing" />;
+
+  return (
+    <ContentContainer>
+      <h1 className="mb-6 text-2xl font-medium tracking-tight">members</h1>
+
+      <div className="mb-4">
+        <TextField
+          label="search"
+          placeholder="name, phone, or email"
+          value={query}
+          maxLength={100}
+          onChange={(e) => {
+            setQuery(e.target.value);
+          }}
+        />
+      </div>
+
+      {visible.length === 0 ? (
+        <p className="text-muted text-sm">
+          {data.length === 0 ? 'no members yet 🌿' : `no one matches "${query}" 🌿`}
+        </p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {visible.map((m) => (
+            <li key={m.id}>
+              <DirectoryRow member={m} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </ContentContainer>
+  );
+}
+
+function DirectoryRow({ member }: { member: DirectoryMember }) {
+  const initials = (member.displayName || '?').slice(0, 2).toLowerCase();
+  return (
+    <Link
+      to={`/members/${member.id}`}
+      className="border-border bg-surface hover:bg-surface-dim flex items-center gap-3 rounded-lg border p-3 transition-colors"
+    >
+      {member.profilePhotoUrl ? (
+        <img
+          src={member.profilePhotoUrl}
+          alt=""
+          className="h-10 w-10 shrink-0 rounded-full object-cover"
+        />
+      ) : (
+        <span
+          aria-hidden="true"
+          className="bg-surface-dim text-foreground-secondary flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm"
+        >
+          {initials}
+        </span>
+      )}
+      <div className="min-w-0 flex-1">
+        <p className="text-foreground truncate text-sm font-medium">
+          {member.displayName || 'member'}
+        </p>
+        {member.phoneNumber || member.email ? (
+          <p className="text-foreground-tertiary truncate text-xs">
+            {member.phoneNumber || member.email}
+          </p>
+        ) : null}
+      </div>
+    </Link>
+  );
+}


### PR DESCRIPTION
## Summary
- new `/members` screen: member-facing directory backed by a new `/api/auth/users/directory/` endpoint (authed, privacy-aware — honors each user's `show_phone` / `show_email` flags)
- `/events/mine` now includes events you've rsvp'd to (attending/maybe), not just host/co-host
- bottom nav is now 5 items: `calendar | my events | +event (fab) | members | profile`
- admin members screen moved from `/members` → `/admin/members` to free up the natural path for the member directory

## Test plan
- [ ] sign in as a non-admin member — bottom nav shows 5 items, fab stays centered
- [ ] `/members` — list renders, search filters on name/phone/email, click a row → `/members/:userId` profile
- [ ] pause a test user locally — they disappear from `/members`
- [ ] toggle a user's `show_phone` off — their phone no longer appears in the directory
- [ ] `/events/mine` — rsvp 'going' to an event you don't host; it appears under "upcoming"
- [ ] admin user: `/admin` hub tile → `/admin/members` works; detail back-link works
- [ ] deep-link to `/admin/members` on hard refresh — resolves to the admin screen
- [ ] dark mode: toggle OS preference and confirm all new screens render cleanly