### PR TITLE
fix: apple calendar add uses https, not webcal subscription

### DIFF
--- a/frontend/src/screens/events/EventActions.tsx
+++ b/frontend/src/screens/events/EventActions.tsx
@@ -6,7 +6,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import type { Event } from '@/models/event';
-import { googleCalendarUrl, icsUrl, webcalUrl, shareEventUrl } from '@/utils/eventCalendar';
+import { appleCalendarUrl, googleCalendarUrl, icsUrl, shareEventUrl } from '@/utils/eventCalendar';
 
 interface Props {
   event: Event;
@@ -97,7 +97,7 @@ function CalendarMenu({ event }: { event: Event }) {
             </a>
           ) : null}
           <a
-            href={webcalUrl(event.id)}
+            href={appleCalendarUrl(event.id)}
             role="menuitem"
             className="text-foreground hover:bg-surface-dim block px-3 py-2"
             onClick={() => {

--- a/frontend/src/utils/eventCalendar.ts
+++ b/frontend/src/utils/eventCalendar.ts
@@ -26,14 +26,13 @@ export function icsUrl(eventId: string): string {
   return `/api/community/events/${eventId}/ics/`;
 }
 
-// Apple Calendar on iOS/macOS won't open a plain https://foo.ics link —
-// Safari saves it as a file instead. The webcal:// scheme is the official
-// hand-off: the OS recognizes it and asks Calendar.app to subscribe /
-// import. We convert our relative ics path to an absolute webcal:// URL.
-export function webcalUrl(eventId: string): string {
-  const path = icsUrl(eventId);
-  const absolute = new URL(path, window.location.origin);
-  absolute.protocol = 'webcal:';
+// Apple Calendar single-event add: we used to use webcal:// here, but that's
+// a *subscription* scheme — iOS/macOS treats the URL as an auto-refreshing
+// feed and creates a calendar subscription, not a one-off add. For a single
+// event that's the wrong UX. A plain https:// link to the .ics endpoint
+// prompts the OS to open Calendar.app and add the event once.
+export function appleCalendarUrl(eventId: string): string {
+  const absolute = new URL(icsUrl(eventId), window.location.origin);
   return absolute.toString();
 }
 


### PR DESCRIPTION
## Summary
`webcal://` is a *subscription* scheme — iOS/macOS treats that URL as a calendar feed it should auto-refresh, and creates a "Calendar Subscriptions" entry for it. For a single-event "add to calendar" that's the wrong UX: one event shows up once, the subscription sits around forever re-fetching the same single-event feed, and if anything goes wrong the event quietly disappears from the calendar.

A plain `https://` link to `/api/community/events/{id}/ics/` triggers Apple's native .ics open flow — Calendar.app prompts to add the event once and is done.

- renamed `webcalUrl()` → `appleCalendarUrl()` in `utils/eventCalendar.ts`
- `EventActions.tsx` consumes the new helper
- no backend change; the existing `/ics/` endpoint was already correct

The per-user multi-event subscription feed at `/api/community/calendar/feed/?token=...` still uses `webcal://` where subscriptions actually make sense — this PR only changes the single-event add button.

## Test plan
- [ ] on iOS / macOS: tap "apple calendar" on an event → Calendar.app opens with "Add Event" (not "Subscribe")
- [ ] the event shows up once in the main calendar, not under "Other" / "Subscriptions"
- [ ] no new entry appears in Settings → Calendar → Accounts → Subscribed Calendars
- [ ] google calendar + download .ics options still work