### PR TITLE
fix: in-app confirm dialog (unblocks mobile) + version footer

### DIFF
--- a/backend/community/_version.py
+++ b/backend/community/_version.py
@@ -1,0 +1,25 @@
+"""Build/version info endpoint — exposes the deployed commit SHA for traceability."""
+
+import os
+
+from ninja import Router
+from pydantic import BaseModel
+
+router = Router()
+
+
+class VersionOut(BaseModel):
+    commit_sha: str
+    commit_sha_short: str
+    environment: str
+
+
+@router.get("/version/", response={200: VersionOut}, auth=None)
+def get_version(request):
+    sha = os.environ.get("RAILWAY_GIT_COMMIT_SHA") or "dev"
+    environment = os.environ.get("RAILWAY_ENVIRONMENT_NAME") or "local"
+    return 200, VersionOut(
+        commit_sha=sha,
+        commit_sha_short=sha[:7],
+        environment=environment,
+    )

--- a/backend/community/api.py
+++ b/backend/community/api.py
@@ -27,6 +27,7 @@ from community._pages import router as pages_router
 from community._polls import router as polls_router
 from community._surveys import router as surveys_router
 from community._surveys_public import router as surveys_public_router
+from community._version import router as version_router
 from community._whatsapp import router as whatsapp_router
 
 router = Router()
@@ -48,3 +49,4 @@ router.add_router("", surveys_router)
 router.add_router("", surveys_public_router)
 router.add_router("", docs_router)
 router.add_router("", geocode_router)
+router.add_router("", version_router)

--- a/backend/tests/test_version.py
+++ b/backend/tests/test_version.py
@@ -1,0 +1,32 @@
+import pytest
+
+
+@pytest.mark.django_db
+class TestGetVersion:
+    def test_get_version_unauthenticated(self, api_client):
+        response = api_client.get("/api/community/version/")
+        assert response.status_code == 200
+        data = response.json()
+        assert "commit_sha" in data
+        assert "commit_sha_short" in data
+        assert "environment" in data
+
+    def test_get_version_local_fallback(self, api_client, monkeypatch):
+        monkeypatch.delenv("RAILWAY_GIT_COMMIT_SHA", raising=False)
+        monkeypatch.delenv("RAILWAY_ENVIRONMENT_NAME", raising=False)
+        response = api_client.get("/api/community/version/")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["commit_sha"] == "dev"
+        assert data["commit_sha_short"] == "dev"
+        assert data["environment"] == "local"
+
+    def test_get_version_from_railway_env(self, api_client, monkeypatch):
+        monkeypatch.setenv("RAILWAY_GIT_COMMIT_SHA", "abc1234def5678")
+        monkeypatch.setenv("RAILWAY_ENVIRONMENT_NAME", "staging")
+        response = api_client.get("/api/community/version/")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["commit_sha"] == "abc1234def5678"
+        assert data["commit_sha_short"] == "abc1234"
+        assert data["environment"] == "staging"

--- a/frontend/src/api/version.ts
+++ b/frontend/src/api/version.ts
@@ -1,0 +1,29 @@
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from './client';
+
+export interface VersionInfo {
+  commitSha: string;
+  commitShaShort: string;
+  environment: string;
+}
+
+interface WireVersion {
+  commit_sha: string;
+  commit_sha_short: string;
+  environment: string;
+}
+
+export function useVersion() {
+  return useQuery({
+    queryKey: ['version'] as const,
+    queryFn: async () => {
+      const { data } = await apiClient.get<WireVersion>('/api/community/version/');
+      return {
+        commitSha: data.commit_sha,
+        commitShaShort: data.commit_sha_short,
+        environment: data.environment,
+      } satisfies VersionInfo;
+    },
+    staleTime: Infinity,
+  });
+}

--- a/frontend/src/components/ui/ConfirmDialog.tsx
+++ b/frontend/src/components/ui/ConfirmDialog.tsx
@@ -1,0 +1,46 @@
+// In-app replacement for window.confirm. Native confirm() is silently
+// suppressed by some mobile browsers (especially iOS Safari in PWA mode
+// and popup-blocker heuristics), so admin screens must use this instead.
+
+import { Button } from '@/components/ui/Button';
+import { Dialog } from '@/components/ui/Dialog';
+
+interface Props {
+  open: boolean;
+  title: string;
+  message: string;
+  confirmLabel: string;
+  cancelLabel: string;
+  destructive: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  confirmLabel,
+  cancelLabel,
+  destructive,
+  onCancel,
+  onConfirm,
+}: Props) {
+  return (
+    <Dialog open={open} onClose={onCancel} title={title}>
+      <p className="text-foreground-secondary text-sm whitespace-pre-wrap">{message}</p>
+      <div className="mt-5 flex justify-end gap-2">
+        <Button variant="secondary" onClick={onCancel}>
+          {cancelLabel}
+        </Button>
+        <Button
+          variant={destructive ? 'secondary' : 'primary'}
+          onClick={onConfirm}
+          className={destructive ? 'text-destructive border-destructive' : undefined}
+        >
+          {confirmLabel}
+        </Button>
+      </div>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/ui/useConfirm.tsx
+++ b/frontend/src/components/ui/useConfirm.tsx
@@ -1,0 +1,53 @@
+import { useCallback, useRef, useState } from 'react';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
+
+interface ConfirmOptions {
+  title?: string;
+  message: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  destructive?: boolean;
+}
+
+interface ConfirmState extends ConfirmOptions {
+  resolve: (ok: boolean) => void;
+}
+
+export function useConfirm() {
+  const [state, setState] = useState<ConfirmState | null>(null);
+  const pendingRef = useRef<ConfirmState | null>(null);
+
+  const confirm = useCallback((options: ConfirmOptions) => {
+    return new Promise<boolean>((resolve) => {
+      const next: ConfirmState = { ...options, resolve };
+      pendingRef.current = next;
+      setState(next);
+    });
+  }, []);
+
+  const close = useCallback((ok: boolean) => {
+    const current = pendingRef.current;
+    pendingRef.current = null;
+    setState(null);
+    current?.resolve(ok);
+  }, []);
+
+  const element = state ? (
+    <ConfirmDialog
+      open
+      title={state.title ?? 'are you sure?'}
+      message={state.message}
+      confirmLabel={state.confirmLabel ?? 'confirm'}
+      cancelLabel={state.cancelLabel ?? 'cancel'}
+      destructive={state.destructive ?? false}
+      onCancel={() => {
+        close(false);
+      }}
+      onConfirm={() => {
+        close(true);
+      }}
+    />
+  ) : null;
+
+  return { confirm, element };
+}

--- a/frontend/src/screens/admin/JoinFormAdminScreen.tsx
+++ b/frontend/src/screens/admin/JoinFormAdminScreen.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import type { JoinQuestion } from '@/api/join';
 import { useDeleteJoinQuestion, useJoinQuestions, useReorderJoinQuestions } from '@/api/join';
 import { Button } from '@/components/ui/Button';
+import { useConfirm } from '@/components/ui/useConfirm';
 import { SortableList } from '@/components/SortableList';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 import { JoinQuestionDialog } from './JoinQuestionDialog';
@@ -16,6 +17,7 @@ export default function JoinFormAdminScreen() {
   const del = useDeleteJoinQuestion();
   const [editing, setEditing] = useState<JoinQuestion | null>(null);
   const [creating, setCreating] = useState(false);
+  const { confirm, element: confirmElement } = useConfirm();
 
   if (isPending) return <ContentLoading />;
   if (isError) return <ContentError message="couldn't load questions — try refreshing" />;
@@ -24,10 +26,14 @@ export default function JoinFormAdminScreen() {
     reorder.mutate(nextIds);
   }
 
-  function askDelete(q: JoinQuestion) {
-    // Small inline confirm instead of a full dialog — non-destructive-ish
-    // (deleting a question doesn't invalidate prior submissions).
-    if (!window.confirm(`delete "${q.label}"?`)) return;
+  async function askDelete(q: JoinQuestion) {
+    const ok = await confirm({
+      title: 'delete question',
+      message: `delete "${q.label}"?`,
+      confirmLabel: 'delete',
+      destructive: true,
+    });
+    if (!ok) return;
     del.mutate(q.id);
   }
 
@@ -83,7 +89,7 @@ export default function JoinFormAdminScreen() {
                   variant="ghost"
                   aria-label={`delete ${q.label}`}
                   onClick={() => {
-                    askDelete(q);
+                    void askDelete(q);
                   }}
                   className="!px-2"
                 >
@@ -108,6 +114,8 @@ export default function JoinFormAdminScreen() {
         }}
         existing={editing ?? undefined}
       />
+
+      {confirmElement}
     </ContentContainer>
   );
 }

--- a/frontend/src/screens/admin/JoinRequestsScreen.tsx
+++ b/frontend/src/screens/admin/JoinRequestsScreen.tsx
@@ -9,6 +9,7 @@ import {
   type JoinRequestSummary,
 } from '@/api/join';
 import { Button } from '@/components/ui/Button';
+import { useConfirm } from '@/components/ui/useConfirm';
 import { SegmentedControl } from '@/components/ui/SegmentedControl';
 import { cn } from '@/utils/cn';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
@@ -27,6 +28,7 @@ export default function JoinRequestsScreen() {
   const { data = [], isPending, isError } = useJoinRequests();
   const decide = useDecideJoinRequest();
   const unreject = useUnrejectJoinRequest();
+  const { confirm, element: confirmElement } = useConfirm();
 
   const [filter, setFilter] = useState<Filter>('pending');
   const [error, setError] = useState<string | null>(null);
@@ -50,7 +52,13 @@ export default function JoinRequestsScreen() {
       status === 'approved'
         ? `approve ${name}? once you approve someone you can't un-approve them — are you sure?`
         : `reject ${name}? once you reject someone you can't un-reject them — are you sure?`;
-    if (!window.confirm(message)) return;
+    const ok = await confirm({
+      title: status === 'approved' ? 'approve request' : 'reject request',
+      message,
+      confirmLabel: status === 'approved' ? 'approve' : 'reject',
+      destructive: status === 'rejected',
+    });
+    if (!ok) return;
 
     setError(null);
     try {
@@ -69,7 +77,12 @@ export default function JoinRequestsScreen() {
 
   async function unrejectRequest(request: JoinRequestSummary) {
     const name = request.displayName || request.phoneNumber;
-    if (!window.confirm(`un-reject ${name}? this will move them back to pending review.`)) return;
+    const ok = await confirm({
+      title: 'un-reject request',
+      message: `un-reject ${name}? this will move them back to pending review.`,
+      confirmLabel: 'un-reject',
+    });
+    if (!ok) return;
 
     setError(null);
     try {
@@ -131,6 +144,7 @@ export default function JoinRequestsScreen() {
           magicLinkToken={credsFor.magicLinkToken}
         />
       ) : null}
+      {confirmElement}
     </ContentContainer>
   );
 }

--- a/frontend/src/screens/admin/MemberDetailScreen.tsx
+++ b/frontend/src/screens/admin/MemberDetailScreen.tsx
@@ -7,6 +7,7 @@ import { Link, useNavigate, useParams } from 'react-router-dom';
 import { isAxiosError } from 'axios';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/Button';
+import { useConfirm } from '@/components/ui/useConfirm';
 import { TextField } from '@/components/ui/TextField';
 import { Toggle } from '@/components/ui/Toggle';
 import {
@@ -39,11 +40,15 @@ function MemberDetailView({ member }: { member: Member }) {
   const [editing, setEditing] = useState(false);
   const navigate = useNavigate();
   const archive = useArchiveUser();
+  const { confirm, element: confirmElement } = useConfirm();
 
   async function onArchive() {
-    const confirmed = window.confirm(
-      `archive ${member.displayName || member.phoneNumber}? they'll lose access immediately — you can restore them later by approving a new join request.`,
-    );
+    const confirmed = await confirm({
+      title: 'archive member',
+      message: `archive ${member.displayName || member.phoneNumber}? they'll lose access immediately — you can restore them later by approving a new join request.`,
+      confirmLabel: 'archive',
+      destructive: true,
+    });
     if (!confirmed) return;
     try {
       await archive.mutateAsync(member.id);
@@ -121,6 +126,8 @@ function MemberDetailView({ member }: { member: Member }) {
           </Button>
         </div>
       )}
+
+      {confirmElement}
     </ContentContainer>
   );
 }

--- a/frontend/src/screens/admin/RolesTab.tsx
+++ b/frontend/src/screens/admin/RolesTab.tsx
@@ -6,6 +6,7 @@ import { isAxiosError } from 'axios';
 import { toast } from 'sonner';
 import { useDeleteRole, useRoles, type Role } from '@/api/roles';
 import { Button } from '@/components/ui/Button';
+import { useConfirm } from '@/components/ui/useConfirm';
 import { ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 import { RoleFormDialog } from './RoleFormDialog';
 
@@ -16,6 +17,7 @@ export function RolesTab() {
   const deleteRole = useDeleteRole();
   const [editing, setEditing] = useState<Role | null>(null);
   const [creating, setCreating] = useState(false);
+  const { confirm, element: confirmElement } = useConfirm();
 
   async function onDelete(role: Role) {
     if (PROTECTED_ROLE_NAMES.has(role.name)) return;
@@ -23,7 +25,12 @@ export function RolesTab() {
       role.userCount > 0
         ? `${String(role.userCount)} member${role.userCount === 1 ? ' has' : 's have'} the "${role.name}" role — deleting will remove it from ${role.userCount === 1 ? 'them' : 'all of them'}. continue?`
         : `delete the "${role.name}" role? this cannot be undone.`;
-    const confirmed = window.confirm(warning);
+    const confirmed = await confirm({
+      title: 'delete role',
+      message: warning,
+      confirmLabel: 'delete',
+      destructive: true,
+    });
     if (!confirmed) return;
     try {
       await deleteRole.mutateAsync(role.id);
@@ -119,6 +126,8 @@ export function RolesTab() {
           }}
         />
       ) : null}
+
+      {confirmElement}
     </>
   );
 }

--- a/frontend/src/screens/admin/SurveyAdminListScreen.tsx
+++ b/frontend/src/screens/admin/SurveyAdminListScreen.tsx
@@ -10,6 +10,7 @@ import {
   type SurveySummary,
 } from '@/api/surveyAdmin';
 import { Button } from '@/components/ui/Button';
+import { useConfirm } from '@/components/ui/useConfirm';
 import { Dialog } from '@/components/ui/Dialog';
 import { Select } from '@/components/ui/Select';
 import { TextField } from '@/components/ui/TextField';
@@ -21,12 +22,19 @@ export default function SurveyAdminListScreen() {
   const { data = [], isPending, isError } = useAdminSurveys();
   const del = useDeleteSurvey();
   const [creating, setCreating] = useState(false);
+  const { confirm, element: confirmElement } = useConfirm();
 
   if (isPending) return <ContentLoading />;
   if (isError) return <ContentError message="couldn't load surveys — try refreshing" />;
 
-  function askDelete(s: SurveySummary) {
-    if (!window.confirm(`delete "${s.title}"? this also deletes responses.`)) return;
+  async function askDelete(s: SurveySummary) {
+    const ok = await confirm({
+      title: 'delete survey',
+      message: `delete "${s.title}"? this also deletes responses.`,
+      confirmLabel: 'delete',
+      destructive: true,
+    });
+    if (!ok) return;
     del.mutate(s.id);
   }
 
@@ -49,7 +57,12 @@ export default function SurveyAdminListScreen() {
         <ul className="flex flex-col gap-2">
           {data.map((s) => (
             <li key={s.id}>
-              <SurveyRow survey={s} onDelete={askDelete} />
+              <SurveyRow
+                survey={s}
+                onDelete={(survey) => {
+                  void askDelete(survey);
+                }}
+              />
             </li>
           ))}
         </ul>
@@ -61,6 +74,8 @@ export default function SurveyAdminListScreen() {
           setCreating(false);
         }}
       />
+
+      {confirmElement}
     </ContentContainer>
   );
 }

--- a/frontend/src/screens/admin/SurveyBuilderScreen.tsx
+++ b/frontend/src/screens/admin/SurveyBuilderScreen.tsx
@@ -8,6 +8,7 @@ import {
   type SurveyQuestion,
 } from '@/api/surveyAdmin';
 import { Button } from '@/components/ui/Button';
+import { useConfirm } from '@/components/ui/useConfirm';
 import { SortableList } from '@/components/SortableList';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 import { SurveyQuestionDialog } from './SurveyQuestionDialog';
@@ -22,6 +23,7 @@ export default function SurveyBuilderScreen() {
 
   const [editing, setEditing] = useState<SurveyQuestion | null>(null);
   const [creating, setCreating] = useState(false);
+  const { confirm, element: confirmElement } = useConfirm();
 
   if (isPending) return <ContentLoading />;
   if (isError) return <ContentError message="couldn't load survey — try refreshing" />;
@@ -32,8 +34,14 @@ export default function SurveyBuilderScreen() {
     reorder.mutate(nextIds);
   }
 
-  function askDelete(q: SurveyQuestion) {
-    if (!window.confirm(`delete "${q.label}"? this also deletes responses to it.`)) return;
+  async function askDelete(q: SurveyQuestion) {
+    const ok = await confirm({
+      title: 'delete question',
+      message: `delete "${q.label}"? this also deletes responses to it.`,
+      confirmLabel: 'delete',
+      destructive: true,
+    });
+    if (!ok) return;
     del.mutate(q.id);
   }
 
@@ -125,7 +133,7 @@ export default function SurveyBuilderScreen() {
                   <Button
                     variant="ghost"
                     onClick={() => {
-                      askDelete(q);
+                      void askDelete(q);
                     }}
                   >
                     delete
@@ -152,6 +160,8 @@ export default function SurveyBuilderScreen() {
         }}
         existing={editing ?? undefined}
       />
+
+      {confirmElement}
     </ContentContainer>
   );
 }

--- a/frontend/src/screens/docs/DocsScreen.tsx
+++ b/frontend/src/screens/docs/DocsScreen.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/api/docs';
 import { SortableList } from '@/components/SortableList';
 import { Button } from '@/components/ui/Button';
+import { useConfirm } from '@/components/ui/useConfirm';
 import { TextField } from '@/components/ui/TextField';
 import { hasPermission, Permission } from '@/models/permissions';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
@@ -34,6 +35,7 @@ export default function DocsScreen() {
   const [newFolderName, setNewFolderName] = useState('');
   const [newDocTitle, setNewDocTitle] = useState('');
   const [newDocFolderId, setNewDocFolderId] = useState('');
+  const { confirm, element: confirmElement } = useConfirm();
 
   const flatFolders = useMemo(() => (data ? flattenFolders(data) : []), [data]);
   const defaultDocFolderId = flatFolders[0]?.id ?? '';
@@ -151,10 +153,13 @@ export default function DocsScreen() {
               deleteFolder={deleteFolder}
               deleteDoc={deleteDoc}
               reorderDocs={reorderDocs}
+              confirm={confirm}
             />
           ))}
         </div>
       )}
+
+      {confirmElement}
     </ContentContainer>
   );
 }
@@ -172,6 +177,7 @@ function flattenFolders(folders: DocFolder[], prefix = ''): { id: string; label:
 type DeleteFolder = ReturnType<typeof useDeleteDocFolder>;
 type DeleteDoc = ReturnType<typeof useDeleteDocument>;
 type ReorderDocs = ReturnType<typeof useReorderDocuments>;
+type Confirm = ReturnType<typeof useConfirm>['confirm'];
 
 function FolderView({
   folder,
@@ -180,6 +186,7 @@ function FolderView({
   deleteFolder,
   deleteDoc,
   reorderDocs,
+  confirm,
 }: {
   folder: DocFolder;
   depth: number;
@@ -187,6 +194,7 @@ function FolderView({
   deleteFolder: DeleteFolder;
   deleteDoc: DeleteDoc;
   reorderDocs: ReorderDocs;
+  confirm: Confirm;
 }) {
   const Heading: ElementType = depth === 0 ? 'h2' : 'h3';
   return (
@@ -207,12 +215,19 @@ function FolderView({
             variant="ghost"
             className="text-muted text-xs"
             onClick={() => {
-              const ok = window.confirm(`delete folder "${folder.name}" and everything inside?`);
-              if (!ok) return;
-              void deleteFolder.mutateAsync(folder.id).then(
-                () => toast.success('folder deleted'),
-                () => toast.error("couldn't delete folder"),
-              );
+              void (async () => {
+                const ok = await confirm({
+                  title: 'delete folder',
+                  message: `delete folder "${folder.name}" and everything inside?`,
+                  confirmLabel: 'delete',
+                  destructive: true,
+                });
+                if (!ok) return;
+                await deleteFolder.mutateAsync(folder.id).then(
+                  () => toast.success('folder deleted'),
+                  () => toast.error("couldn't delete folder"),
+                );
+              })();
             }}
           >
             delete folder
@@ -235,12 +250,19 @@ function FolderView({
                 doc={d}
                 canManage
                 onDelete={() => {
-                  const ok = window.confirm(`delete "${d.title}"?`);
-                  if (!ok) return;
-                  void deleteDoc.mutateAsync(d.id).then(
-                    () => toast.success('document deleted'),
-                    () => toast.error("couldn't delete"),
-                  );
+                  void (async () => {
+                    const ok = await confirm({
+                      title: 'delete document',
+                      message: `delete "${d.title}"?`,
+                      confirmLabel: 'delete',
+                      destructive: true,
+                    });
+                    if (!ok) return;
+                    await deleteDoc.mutateAsync(d.id).then(
+                      () => toast.success('document deleted'),
+                      () => toast.error("couldn't delete"),
+                    );
+                  })();
                 }}
               />
             )}
@@ -254,12 +276,19 @@ function FolderView({
                     doc={d}
                     canManage
                     onDelete={() => {
-                      const ok = window.confirm(`delete "${d.title}"?`);
-                      if (!ok) return;
-                      void deleteDoc.mutateAsync(d.id).then(
-                        () => toast.success('document deleted'),
-                        () => toast.error("couldn't delete"),
-                      );
+                      void (async () => {
+                        const ok = await confirm({
+                          title: 'delete document',
+                          message: `delete "${d.title}"?`,
+                          confirmLabel: 'delete',
+                          destructive: true,
+                        });
+                        if (!ok) return;
+                        await deleteDoc.mutateAsync(d.id).then(
+                          () => toast.success('document deleted'),
+                          () => toast.error("couldn't delete"),
+                        );
+                      })();
                     }}
                   />
                 ) : (
@@ -281,6 +310,7 @@ function FolderView({
               deleteFolder={deleteFolder}
               deleteDoc={deleteDoc}
               reorderDocs={reorderDocs}
+              confirm={confirm}
             />
           ))}
         </div>

--- a/frontend/src/screens/settings/SettingsScreen.tsx
+++ b/frontend/src/screens/settings/SettingsScreen.tsx
@@ -6,6 +6,7 @@ import { TextField } from '@/components/ui/TextField';
 import { useAuthStore } from '@/auth/store';
 import { useAccessibilityStore, type ThemeMode, type TextScale } from '@/accessibility/store';
 import { useCalendarToken, useRegenerateCalendarToken } from '@/api/calendar';
+import { useVersion } from '@/api/version';
 import { ContentContainer } from '@/screens/public/ContentContainer';
 import { AvatarUpload } from './AvatarUpload';
 import { ChangePasswordDialog } from './ChangePasswordDialog';
@@ -79,6 +80,8 @@ export default function SettingsScreen() {
         <DyslexiaToggle checked={dyslexiaFont} onChange={toggleDyslexiaFont} />
         <TextScaleToggle value={textScale} onChange={setTextScale} />
       </Section>
+
+      <BuildInfo />
 
       <ChangePasswordDialog
         open={pwOpen}
@@ -174,6 +177,17 @@ function CalendarFeedSubscription() {
         </Button>
       )}
     </div>
+  );
+}
+
+function BuildInfo() {
+  const versionQ = useVersion();
+  if (!versionQ.data) return null;
+  const { commitShaShort, environment } = versionQ.data;
+  return (
+    <p className="text-muted mb-6 text-center text-xs">
+      build {commitShaShort} · {environment}
+    </p>
   );
 }
 


### PR DESCRIPTION
## Summary

- Replace `window.confirm()` across all admin screens with a new in-app `ConfirmDialog` built on the existing `Dialog` primitive. Native `confirm()` is silently suppressed by some mobile browsers (iOS Safari PWA, popup-blocker heuristics), which was why the approve/reject buttons on `/admin/join-requests` didn't work on phones.
- Add `/api/version` endpoint (commit sha + environment) and surface it as a small build-info footer on the settings screen.

## Files touched

**New**
- `frontend/src/components/ui/ConfirmDialog.tsx` — presentational dialog
- `frontend/src/components/ui/useConfirm.tsx` — hook returning `{ confirm, element }`
- `backend/community/_version.py` + `backend/tests/test_version.py`
- `frontend/src/api/version.ts`

**Migrated (7 screens)**
JoinRequestsScreen, RolesTab, MemberDetailScreen, JoinFormAdminScreen, SurveyAdminListScreen, SurveyBuilderScreen, DocsScreen.

**Touched for version footer**
backend/community/api.py, frontend/src/screens/settings/SettingsScreen.tsx.

## Test plan

- [ ] on mobile: open /admin/join-requests → approve a pending request → confirm dialog appears → approve → works
- [ ] on mobile: reject flow works
- [ ] on desktop: approve/reject still behave the same
- [ ] delete flows in roles / members / join form / surveys / docs all show the new confirm
- [ ] settings screen shows build footer (e.g. "build abc1234 · staging")
- [ ] /api/version returns commit sha + environment