### PR TITLE
fix: replace event 'archive' with 'delete'

### DIFF
--- a/frontend/src/api/eventWrites.ts
+++ b/frontend/src/api/eventWrites.ts
@@ -13,7 +13,7 @@ import { mapEvent, type WireEvent } from './eventMapper';
 import type { Event } from '@/models/event';
 import { fromCashAppUrl, fromVenmoUrl, toCashAppUrl, toVenmoUrl } from '@/utils/paymentHandle';
 
-export type EventStatus = 'active' | 'draft' | 'cancelled';
+export type EventStatus = 'active' | 'draft' | 'cancelled' | 'deleted';
 
 export type VisibilityChoice = 'official' | 'public' | 'members_only' | 'invite_only';
 
@@ -139,11 +139,9 @@ function kebabToCamel(s: string): string {
   return s.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
 }
 
-// Archive (a.k.a. cancel) an event. The backend has no DELETE route for
-// events — the only destructive path is PATCH status=cancelled. We always
-// send notify_attendees=true so RSVPs get pinged; the backend no-ops the
-// notification on draft→cancelled transitions.
-export function useArchiveEvent(eventId: string) {
+// Cancel an event (active → cancelled). Notifies attendees; the backend
+// no-ops notifications on draft→cancelled transitions.
+export function useCancelEvent(eventId: string) {
   const qc = useQueryClient();
   const isAuthed = useAuthStore((s) => s.status === 'authed');
   return useMutation({
@@ -152,6 +150,24 @@ export function useArchiveEvent(eventId: string) {
         status: 'cancelled' satisfies EventStatus,
         notify_attendees: true,
       };
+      const { data } = await apiClient.patch<WireEvent>(`/api/community/events/${eventId}/`, body);
+      return mapEvent(data);
+    },
+    onSuccess: (event) => {
+      qc.setQueryData(eventKeys.detail(event.id, isAuthed), event);
+      void qc.invalidateQueries({ queryKey: eventKeys.list(isAuthed) });
+    },
+  });
+}
+
+// Delete an event. PATCHes status=deleted, which the backend accepts from
+// draft/active/cancelled. Active events with attendees must be cancelled first.
+export function useDeleteEvent(eventId: string) {
+  const qc = useQueryClient();
+  const isAuthed = useAuthStore((s) => s.status === 'authed');
+  return useMutation({
+    mutationFn: async () => {
+      const body: WireBody = { status: 'deleted' satisfies EventStatus };
       const { data } = await apiClient.patch<WireEvent>(`/api/community/events/${eventId}/`, body);
       return mapEvent(data);
     },

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -17,6 +17,7 @@ export const EventStatus = {
   Active: 'active',
   Cancelled: 'cancelled',
   Draft: 'draft',
+  Deleted: 'deleted',
 } as const;
 
 export const InvitePermission = {

--- a/frontend/src/screens/events/EventAdminActions.test.tsx
+++ b/frontend/src/screens/events/EventAdminActions.test.tsx
@@ -11,7 +11,8 @@ import type { User } from '@/models/user';
 // Mock network-touching dependencies
 vi.mock('@/api/eventWrites', () => ({
   useUpdateEvent: vi.fn().mockReturnValue({ mutateAsync: vi.fn(), isPending: false }),
-  useArchiveEvent: vi.fn().mockReturnValue({ mutateAsync: vi.fn(), isPending: false }),
+  useCancelEvent: vi.fn().mockReturnValue({ mutateAsync: vi.fn(), isPending: false }),
+  useDeleteEvent: vi.fn().mockReturnValue({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
 import { EventAdminActions } from './EventAdminActions';
@@ -104,7 +105,7 @@ beforeEach(() => {
 });
 
 describe('EventAdminActions', () => {
-  it('creator sees edit and cancel (no archive) for active upcoming event with attendees', () => {
+  it('creator sees edit and cancel (no delete) for active upcoming event with attendees', () => {
     const creator = makeUser(CREATOR_ID);
     useAuthStore.setState({ status: 'authed', user: creator, accessToken: 'tok' });
 
@@ -112,12 +113,12 @@ describe('EventAdminActions', () => {
 
     expect(screen.getByRole('button', { name: /^edit$/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /cancel event/i })).toBeInTheDocument();
-    // With attendees, the event must be cancelled before it can be archived.
-    expect(screen.queryByRole('button', { name: /^archive$/i })).not.toBeInTheDocument();
+    // With attendees, the event must be cancelled before it can be deleted.
+    expect(screen.queryByRole('button', { name: /^delete$/i })).not.toBeInTheDocument();
   });
 
-  // With no one RSVP'd, skip the cancel-then-archive two-step: show archive outright.
-  it('creator sees archive (no cancel) for active upcoming event with no attendees', () => {
+  // With no one RSVP'd, skip the cancel-then-delete two-step: show delete outright.
+  it('creator sees delete (no cancel) for active upcoming event with no attendees', () => {
     const creator = makeUser(CREATOR_ID);
     useAuthStore.setState({ status: 'authed', user: creator, accessToken: 'tok' });
 
@@ -125,11 +126,11 @@ describe('EventAdminActions', () => {
     renderActions(emptyEvent);
 
     expect(screen.getByRole('button', { name: /^edit$/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /^archive$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /cancel event/i })).not.toBeInTheDocument();
   });
 
-  it('creator sees archive for draft event', () => {
+  it('creator sees delete for draft event', () => {
     const creator = makeUser(CREATOR_ID);
     useAuthStore.setState({ status: 'authed', user: creator, accessToken: 'tok' });
 
@@ -138,7 +139,7 @@ describe('EventAdminActions', () => {
 
     expect(screen.getByRole('button', { name: /^edit$/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /^publish$/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /^archive$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument();
   });
 
   it('co-host sees edit and cancel buttons for upcoming event', () => {
@@ -149,8 +150,8 @@ describe('EventAdminActions', () => {
 
     expect(screen.getByRole('button', { name: /^edit$/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /cancel event/i })).toBeInTheDocument();
-    // Co-host is not the creator, so no archive button (canArchive = isCreator || canManage)
-    expect(screen.queryByRole('button', { name: /^archive$/i })).not.toBeInTheDocument();
+    // Co-host is not the creator, so no delete button (canDelete = isCreator || canManage)
+    expect(screen.queryByRole('button', { name: /^delete$/i })).not.toBeInTheDocument();
   });
 
   it('creator sees no cancel button for a past event', () => {
@@ -161,10 +162,10 @@ describe('EventAdminActions', () => {
     const cancelledEvent: Event = { ...BASE_EVENT, status: EventStatus.Cancelled };
     renderActions(cancelledEvent);
 
-    // Edit and archive present, but no cancel-event button for already-cancelled events
+    // Edit and delete present, but no cancel-event button for already-cancelled events
     expect(screen.getByRole('button', { name: /^edit$/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /cancel event/i })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /^archive$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument();
   });
 
   it('regular member (not creator, not co-host) sees no admin action buttons', () => {
@@ -175,7 +176,7 @@ describe('EventAdminActions', () => {
 
     expect(screen.queryByRole('button', { name: /^edit$/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /cancel event/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /^archive$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^delete$/i })).not.toBeInTheDocument();
   });
 
   it('unauthenticated user sees no admin action buttons', () => {
@@ -185,13 +186,12 @@ describe('EventAdminActions', () => {
 
     expect(screen.queryByRole('button', { name: /^edit$/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /cancel event/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /^archive$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^delete$/i })).not.toBeInTheDocument();
   });
 
-  // Flutter gated delete on attendees count. React gates archive on status
-  // (draft/cancelled) and ignores attendees. This locks that behavior in:
-  // a draft event with attendees still shows archive.
-  it('creator sees archive for draft event regardless of attendees count', () => {
+  // A draft event with attendees still shows delete: drafts haven't been
+  // published, so there's nothing to cancel — users can delete directly.
+  it('creator sees delete for draft event regardless of attendees count', () => {
     const creator = makeUser(CREATOR_ID);
     useAuthStore.setState({ status: 'authed', user: creator, accessToken: 'tok' });
 
@@ -202,13 +202,13 @@ describe('EventAdminActions', () => {
     };
     renderActions(draftWithAttendees);
 
-    expect(screen.getByRole('button', { name: /^archive$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument();
   });
 
-  // Past events can't be edited (would change historical record). Archive is
+  // Past events can't be edited (would change historical record). Delete is
   // still allowed on cancelled past events; cancel button hidden since it's
   // already cancelled.
-  it('creator sees only archive (no edit) for a past cancelled event', () => {
+  it('creator sees only delete (no edit) for a past cancelled event', () => {
     const creator = makeUser(CREATOR_ID);
     useAuthStore.setState({ status: 'authed', user: creator, accessToken: 'tok' });
 
@@ -220,7 +220,7 @@ describe('EventAdminActions', () => {
     renderActions(pastCancelled);
 
     expect(screen.queryByRole('button', { name: /^edit$/i })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /^archive$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /cancel event/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/events/EventAdminActions.tsx
+++ b/frontend/src/screens/events/EventAdminActions.tsx
@@ -1,11 +1,10 @@
-// Admin actions for events: edit, duplicate, cancel, archive. Visible only
-// to the creator, a co-host, or a user with manage_events. Matches
-// EventAdminActions from the flutter app.
+// Admin actions for events: edit, publish (drafts), cancel, delete.
+// Visible only to the creator, a co-host, or a user with manage_events.
 
 import { isAxiosError } from 'axios';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useArchiveEvent, useUpdateEvent } from '@/api/eventWrites';
+import { useCancelEvent, useDeleteEvent, useUpdateEvent } from '@/api/eventWrites';
 import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
@@ -47,24 +46,25 @@ function AdminActionRow({
   const navigate = useNavigate();
   const [cancelOpen, setCancelOpen] = useState(false);
   const [cancelError, setCancelError] = useState<string | null>(null);
-  const [archiveOpen, setArchiveOpen] = useState(false);
-  const [archiveError, setArchiveError] = useState<string | null>(null);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const update = useUpdateEvent(event.id);
-  const archive = useArchiveEvent(event.id);
+  const cancelMut = useCancelEvent(event.id);
+  const deleteMut = useDeleteEvent(event.id);
   const [publishError, setPublishError] = useState<string | null>(null);
 
   const isCancelled = event.status === EventStatus.Cancelled;
   const isDraft = event.status === EventStatus.Draft;
   const hasNoAttendees = event.attendingCount === 0;
-  const canArchive = (isCreator || canManage) && (isDraft || isCancelled || hasNoAttendees);
+  const canDelete = (isCreator || canManage) && (isDraft || isCancelled || hasNoAttendees);
   const showCancel = !isCancelled && !isDraft && !hasNoAttendees;
   const canEditEvent = !event.isPast;
 
   async function onCancel() {
     setCancelError(null);
     try {
-      await archive.mutateAsync();
+      await cancelMut.mutateAsync();
       setCancelOpen(false);
     } catch (err) {
       setCancelError(extractMutationError(err));
@@ -80,13 +80,13 @@ function AdminActionRow({
     }
   }
 
-  async function onArchive() {
-    setArchiveError(null);
+  async function onDelete() {
+    setDeleteError(null);
     try {
-      await archive.mutateAsync();
+      await deleteMut.mutateAsync();
       void navigate('/calendar', { replace: true });
     } catch (err) {
-      setArchiveError(extractMutationError(err));
+      setDeleteError(extractMutationError(err));
     }
   }
 
@@ -118,15 +118,15 @@ function AdminActionRow({
             cancel event
           </Button>
         ) : null}
-        {canArchive ? (
+        {canDelete ? (
           <Button
             variant="secondary"
             onClick={() => {
-              setArchiveOpen(true);
+              setDeleteOpen(true);
             }}
             className="border-red-300 text-red-700 hover:bg-red-50"
           >
-            archive
+            delete
           </Button>
         ) : null}
       </div>
@@ -146,7 +146,7 @@ function AdminActionRow({
       >
         <p className="text-foreground-secondary text-sm">
           mark this event as cancelled? attendees will get a notification and see a cancelled badge
-          — you can't un-cancel from the React app yet.
+          — you can't un-cancel from the react app yet.
         </p>
         {cancelError ? (
           <p role="alert" className="mt-3 text-sm text-red-600">
@@ -167,48 +167,48 @@ function AdminActionRow({
             onClick={() => {
               void onCancel();
             }}
-            disabled={archive.isPending}
+            disabled={cancelMut.isPending}
           >
-            {archive.isPending ? 'cancelling…' : 'cancel event'}
+            {cancelMut.isPending ? 'cancelling…' : 'cancel event'}
           </Button>
         </div>
       </Dialog>
 
       <Dialog
-        open={archiveOpen}
+        open={deleteOpen}
         onClose={() => {
-          setArchiveOpen(false);
-          setArchiveError(null);
+          setDeleteOpen(false);
+          setDeleteError(null);
         }}
-        title="archive event"
+        title="delete event"
       >
         <p className="text-foreground-secondary text-sm">
-          archive this event? it will be marked cancelled and hidden from the active calendar. This
-          cannot be undone from the React app yet.
+          delete this event? it will be removed from the calendar and can't be recovered from the
+          react app.
         </p>
-        {archiveError ? (
+        {deleteError ? (
           <p role="alert" className="mt-3 text-sm text-red-600">
-            {archiveError}
+            {deleteError}
           </p>
         ) : null}
         <div className="mt-4 flex justify-end gap-2">
           <Button
             variant="ghost"
             onClick={() => {
-              setArchiveOpen(false);
-              setArchiveError(null);
+              setDeleteOpen(false);
+              setDeleteError(null);
             }}
-            disabled={archive.isPending}
+            disabled={deleteMut.isPending}
           >
             back
           </Button>
           <Button
             onClick={() => {
-              void onArchive();
+              void onDelete();
             }}
-            disabled={archive.isPending}
+            disabled={deleteMut.isPending}
           >
-            {archive.isPending ? 'archiving…' : 'archive'}
+            {deleteMut.isPending ? 'deleting…' : 'delete'}
           </Button>
         </div>
       </Dialog>


### PR DESCRIPTION
## Summary

The event \"archive\" button was PATCHing \`status=cancelled\`, which the backend rejects for past events with \"past events cannot be cancelled — use delete instead\". Archive was never a distinct concept — the backend only has \`cancelled\` and \`deleted\`. This replaces the confusingly-named archive with a proper delete path.

- New \`useDeleteEvent\` PATCHes \`status=deleted\`
- Old \`useArchiveEvent\` renamed to \`useCancelEvent\` (it was always doing cancel)
- UI button is now \"delete\" with matching dialog copy
- \`EventStatus\` type + const gains \`deleted\`

## Files touched

- \`frontend/src/api/eventWrites.ts\` — split into \`useCancelEvent\` and \`useDeleteEvent\`
- \`frontend/src/models/event.ts\` — \`EventStatus.Deleted\`
- \`frontend/src/screens/events/EventAdminActions.tsx\` — button + dialog rewrite
- \`frontend/src/screens/events/EventAdminActions.test.tsx\` — matching assertion updates

## Test plan

- [ ] past event: delete button works (was broken before)
- [ ] cancelled event: delete button works
- [ ] active event with 0 attendees: delete button works
- [ ] active event with attendees: only cancel shown, cancel still works
- [ ] draft event: delete button works