### PR TITLE
feat: feedback uses user id, admin search matches id prefix

### DIFF
--- a/backend/community/_feedback.py
+++ b/backend/community/_feedback.py
@@ -36,7 +36,6 @@ class ErrorReportOut(BaseModel):
 class FeedbackMetadataIn(BaseModel):
     route: str = Field(default="", max_length=500)
     user_agent: str = Field(default="", max_length=500)
-    user_display_name: str = Field(default="", max_length=100)
     app_version: str = Field(default="", max_length=50)
 
 
@@ -76,10 +75,6 @@ def _build_feedback_metadata(meta: FeedbackMetadataIn) -> str:
         lines.append(f"- **Route:** `{meta.route}`")
     if meta.user_agent:
         lines.append(f"- **User Agent:** {meta.user_agent}")
-    if meta.user_display_name:
-        first_name = meta.user_display_name.split()[0] if meta.user_display_name.split() else ""
-        if first_name:
-            lines.append(f"- **User:** {first_name}")
     if meta.app_version:
         lines.append(f"- **App Version:** {meta.app_version}")
     return "\n".join(lines) if len(lines) > 2 else ""
@@ -128,10 +123,8 @@ def _build_issue_body(payload: FeedbackIn, auth_user) -> str:
         if metadata_section:
             parts.append(metadata_section)
 
-    if not isinstance(auth_user, AnonymousUser) and auth_user.display_name:
-        first_name = auth_user.display_name.split()[0] if auth_user.display_name.split() else ""
-        if first_name:
-            parts.append(f"\n_Submitted by {first_name}_")
+    if not isinstance(auth_user, AnonymousUser):
+        parts.append(f"\n_Submitted by user id: `{auth_user.id}`_")
 
     return "\n\n".join(parts)
 

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -141,10 +141,10 @@ class TestFeedback:
         )
         assert response.status_code == 422
 
-    def test_feedback_issue_body_uses_first_name_and_omits_phone(
+    def test_feedback_issue_body_uses_user_id_and_omits_name_and_phone(
         self, api_client, settings, monkeypatch
     ):
-        """Submitter identity in issue body should be just the first word of display name."""
+        """Submitter identity in issue body should be the user's UUID, not name or phone."""
         import json
 
         for k, v in _APP_SETTINGS.items():
@@ -171,7 +171,7 @@ class TestFeedback:
             {
                 "title": "something broke",
                 "description": "details",
-                "metadata": {"user_display_name": "alice smith"},
+                "metadata": {},
             },
             content_type="application/json",
             **headers,
@@ -181,13 +181,15 @@ class TestFeedback:
         issue_request = captured["calls"][-1]
         body_payload = json.loads(issue_request.data.decode())
         issue_body = body_payload["body"]
-        assert "alice" in issue_body
+        assert str(user.id) in issue_body
+        assert "alice" not in issue_body
         assert "smith" not in issue_body
         assert "+15551239999" not in issue_body
         assert "Phone" not in issue_body
+        assert "User:" not in issue_body
 
-    def test_feedback_schema_rejects_user_phone_field(self, api_client, settings, monkeypatch):
-        """user_phone was intentionally removed — extra fields should not break anything."""
+    def test_feedback_schema_ignores_removed_fields(self, api_client, settings, monkeypatch):
+        """user_phone and user_display_name were removed — extra fields should be ignored, not break."""
         for k, v in _APP_SETTINGS.items():
             setattr(settings, k, v)
         monkeypatch.setattr(
@@ -200,7 +202,10 @@ class TestFeedback:
             {
                 "title": "t",
                 "description": "d",
-                "metadata": {"user_phone": "+15551234567"},
+                "metadata": {
+                    "user_phone": "+15551234567",
+                    "user_display_name": "alice smith",
+                },
             },
             content_type="application/json",
         )

--- a/frontend/src/api/feedback.test.ts
+++ b/frontend/src/api/feedback.test.ts
@@ -37,7 +37,6 @@ describe('useSubmitFeedback', () => {
       metadata: {
         route: '/calendar',
         userAgent: 'jsdom',
-        userDisplayName: 'alice',
         appVersion: '',
       },
     });
@@ -50,7 +49,6 @@ describe('useSubmitFeedback', () => {
       metadata: {
         route: '/calendar',
         user_agent: 'jsdom',
-        user_display_name: 'alice',
         app_version: '',
       },
     });
@@ -67,7 +65,6 @@ describe('useSubmitFeedback', () => {
       metadata: {
         route: '/',
         userAgent: '',
-        userDisplayName: '',
         appVersion: '',
       },
     });
@@ -93,7 +90,6 @@ describe('useSubmitFeedback', () => {
         metadata: {
           route: '/',
           userAgent: '',
-          userDisplayName: '',
           appVersion: '',
         },
       }),

--- a/frontend/src/api/feedback.ts
+++ b/frontend/src/api/feedback.ts
@@ -16,7 +16,6 @@ export interface SubmitFeedbackPayload {
   metadata: {
     route: string;
     userAgent: string;
-    userDisplayName: string;
     appVersion: string;
   };
 }
@@ -35,7 +34,6 @@ export function useSubmitFeedback() {
         metadata: {
           route: payload.metadata.route,
           user_agent: payload.metadata.userAgent,
-          user_display_name: payload.metadata.userDisplayName,
           app_version: payload.metadata.appVersion,
         },
       });

--- a/frontend/src/components/FeedbackButton.test.tsx
+++ b/frontend/src/components/FeedbackButton.test.tsx
@@ -155,7 +155,6 @@ describe('FeedbackButton', () => {
       metadata: {
         route: '/events/mine',
         userAgent: 'jsdom-test-agent',
-        userDisplayName: 'alice',
       },
     });
     await waitFor(() => {
@@ -166,7 +165,7 @@ describe('FeedbackButton', () => {
     });
   });
 
-  it('sends only the first word of the display name and never sends phone', async () => {
+  it('never sends user display name, phone, or id from the client — backend derives identity from auth', async () => {
     useAuthStore.setState({
       status: 'authed',
       user: makeUser({ displayName: 'alice smith' }),
@@ -185,8 +184,9 @@ describe('FeedbackButton', () => {
     });
     const payload = submitFeedbackMock.mock.calls[0]?.[0] as { metadata?: Record<string, unknown> };
     const metadata = payload.metadata ?? {};
-    expect(metadata.userDisplayName).toBe('alice');
+    expect(metadata).not.toHaveProperty('userDisplayName');
     expect(metadata).not.toHaveProperty('userPhone');
+    expect(metadata).not.toHaveProperty('userId');
   });
 
   it('exposes the github issue url in the success toast action', async () => {

--- a/frontend/src/components/FeedbackButton.tsx
+++ b/frontend/src/components/FeedbackButton.tsx
@@ -20,7 +20,6 @@ const DESCRIPTION_MAX = 2000;
 
 export function FeedbackButton() {
   const isAuthed = useAuthStore((s) => s.status === 'authed');
-  const user = useAuthStore((s) => s.user);
   const location = useLocation();
   const { mutateAsync, isPending } = useSubmitFeedback();
 
@@ -86,7 +85,6 @@ export function FeedbackButton() {
         metadata: {
           route: location.pathname,
           userAgent: typeof navigator !== 'undefined' ? navigator.userAgent : '',
-          userDisplayName: (user?.displayName ?? '').split(' ')[0] ?? '',
           appVersion: '',
         },
       });

--- a/frontend/src/screens/admin/MembersScreen.test.tsx
+++ b/frontend/src/screens/admin/MembersScreen.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -117,6 +118,22 @@ describe('MembersScreen', () => {
 
     expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
     expect(screen.getByText('Grace Hopper')).toBeInTheDocument();
+  });
+
+  it('filters members by user id prefix when searching', async () => {
+    mockUsersResult({
+      data: [
+        makeMember({ id: 'abc12345-aaaa-bbbb-cccc-dddddddddddd', displayName: 'Ada Lovelace' }),
+        makeMember({ id: 'def67890-eeee-ffff-1111-222222222222', displayName: 'Grace Hopper' }),
+      ],
+    });
+
+    renderScreen();
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/^search$/i), 'abc12');
+
+    expect(screen.getByText('Ada Lovelace')).toBeInTheDocument();
+    expect(screen.queryByText('Grace Hopper')).not.toBeInTheDocument();
   });
 
   it('shows the empty state when there are no members', () => {

--- a/frontend/src/screens/admin/MembersTab.tsx
+++ b/frontend/src/screens/admin/MembersTab.tsx
@@ -62,7 +62,7 @@ export function MembersTab() {
         <div className="flex-1">
           <TextField
             label="search"
-            placeholder="name, phone, or email"
+            placeholder="name, phone, email, or user id"
             value={query}
             maxLength={100}
             onChange={(e) => {
@@ -291,7 +291,8 @@ function filterAndSort(
       (m) =>
         m.displayName.toLowerCase().includes(q) ||
         m.phoneNumber.toLowerCase().includes(q) ||
-        m.email.toLowerCase().includes(q),
+        m.email.toLowerCase().includes(q) ||
+        m.id.toLowerCase().startsWith(q),
     );
   }
   if (selectedRoles.size > 0) {


### PR DESCRIPTION
## Summary

### feedback
- drop `user_display_name` from `FeedbackMetadataIn` (backend) and `SubmitFeedbackPayload` (frontend)
- backend writes user id (uuid) into the issue body trailer, derived from `request.auth` — client can't spoof another user's identity
- no client-sent identity fields at all (display name, phone, id all gone)

### admin members search
- extend the existing name/phone/email search to also match user id via `startsWith`, so UUID prefixes copy-pasted from GH issues find the member immediately
- update placeholder text

## Test plan
- [ ] Submit feedback while logged in — the created GH issue has a \`_Submitted by user id: \`<uuid>\`_\` trailer and no name/phone metadata
- [ ] Copy the uuid from that GH issue → paste the first 6-8 chars into the admin members search → member appears
- [ ] Search still works with names, phones, and emails