### PR TITLE
feat: machine-readable validation errors for event schema

### DIFF
--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -6,6 +6,7 @@ from urllib.parse import urlparse
 from pydantic import BaseModel, Field, field_validator, model_validator
 
 from community._field_limits import FieldLimit
+from community._validation import ValidationCode, ValidationException
 from community.models import (
     AttendanceStatus,
     EventStatus,
@@ -15,23 +16,20 @@ from community.models import (
 )
 
 
-def _require_path(url: str, domain_hint: str) -> str:
-    """Validate that a URL has a non-trivial path (not bare domain).
-
-    Returns the normalized https:// URL, or raises ValueError.
-    """
+def _require_path(url: str, field: str) -> str:
+    """Validate that a URL has a non-trivial path (not bare domain)."""
     if not url:
         return url
     normalized = url if url.startswith(("http://", "https://")) else f"https://{url}"
     try:
         parsed = urlparse(normalized)
     except ValueError:
-        raise ValueError("enter a valid URL")
+        raise ValidationException(ValidationCode.URL_INVALID, field=field)
     if not parsed.netloc:
-        raise ValueError("enter a valid URL")
+        raise ValidationException(ValidationCode.URL_INVALID, field=field)
     path = parsed.path.rstrip("/")
     if not path:
-        raise ValueError(f"link must point to a specific page, not just {domain_hint}")
+        raise ValidationException(ValidationCode.URL_PATH_REQUIRED, field=field)
     return normalized
 
 
@@ -43,34 +41,38 @@ def _strip_www(host: str) -> str:
     return host.removeprefix("www.")
 
 
-def _validate_whatsapp_url(url: str) -> str:
+def _validate_whatsapp_url(url: str, field: str) -> str:
     known_hosts = {"chat.whatsapp.com", "wa.me", "whats.app"}
     if not url:
         return url
     try:
         parsed = urlparse(_normalize_url(url))
     except ValueError:
-        raise ValueError("enter a valid URL")
+        raise ValidationException(ValidationCode.URL_INVALID, field=field)
     host = _strip_www(parsed.netloc.lower())
     if host not in known_hosts:
-        raise ValueError("must be a WhatsApp link (chat.whatsapp.com, wa.me, or whats.app)")
-    return _require_path(url, "whatsapp.com")
+        raise ValidationException(
+            ValidationCode.WHATSAPP_URL_NOT_RECOGNIZED,
+            field=field,
+            params={"allowed_hosts": sorted(known_hosts)},
+        )
+    return _require_path(url, field=field)
 
 
-def _validate_partiful_url(url: str) -> str:
+def _validate_partiful_url(url: str, field: str) -> str:
     if not url:
         return url
     try:
         parsed = urlparse(_normalize_url(url))
     except ValueError:
-        raise ValueError("enter a valid URL")
+        raise ValidationException(ValidationCode.URL_INVALID, field=field)
     host = _strip_www(parsed.netloc.lower())
     if "partiful.com" not in host:
-        raise ValueError("must be a Partiful link (partiful.com/...)")
-    return _require_path(url, "partiful.com")
+        raise ValidationException(ValidationCode.PARTIFUL_URL_NOT_RECOGNIZED, field=field)
+    return _require_path(url, field=field)
 
 
-def _validate_generic_url(url: str) -> str:
+def _validate_generic_url(url: str, field: str) -> str:
     # Accepts either a bare domain (fast.com) or a full URL and normalizes to
     # a full https:// URL on the way in. We don't require a path — "other_link"
     # is commonly used for landing pages and flyers.
@@ -80,11 +82,11 @@ def _validate_generic_url(url: str) -> str:
     try:
         parsed = urlparse(normalized)
     except ValueError:
-        raise ValueError("enter a valid URL")
+        raise ValidationException(ValidationCode.URL_INVALID, field=field)
     if not parsed.netloc or "." not in parsed.netloc:
-        raise ValueError("enter a valid URL")
+        raise ValidationException(ValidationCode.URL_INVALID, field=field)
     if parsed.scheme not in ("http", "https"):
-        raise ValueError("URL must use http or https")
+        raise ValidationException(ValidationCode.URL_SCHEME_MUST_BE_HTTP_OR_HTTPS, field=field)
     return normalized
 
 
@@ -211,7 +213,11 @@ class AttendanceIn(BaseModel):
     def validate_attendance(cls, v: str) -> str:
         valid = {AttendanceStatus.UNKNOWN, AttendanceStatus.ATTENDED, AttendanceStatus.NO_SHOW}
         if v not in valid:
-            raise ValueError(f"attendance must be one of: {', '.join(sorted(valid))}")
+            raise ValidationException(
+                ValidationCode.ATTENDANCE_INVALID_CHOICE,
+                field="attendance",
+                params={"allowed": sorted(valid)},
+            )
         return v
 
 
@@ -245,24 +251,31 @@ class EventIn(BaseModel):
 
     @model_validator(mode="after")
     def require_start_datetime_unless_tbd(self) -> "EventIn":
+        # Drafts are intentionally saveable with incomplete info; the
+        # "needs a date" rule only applies when publishing.
+        if self.status == EventStatus.DRAFT:
+            return self
         if not self.datetime_tbd and self.start_datetime is None:
-            raise ValueError("start_datetime is required when datetime_tbd is false")
+            raise ValidationException(
+                ValidationCode.START_DATETIME_REQUIRED_UNLESS_TBD,
+                field="start_datetime",
+            )
         return self
 
     @field_validator("whatsapp_link", mode="before")
     @classmethod
     def validate_whatsapp(cls, v: str) -> str:
-        return _validate_whatsapp_url(v or "")
+        return _validate_whatsapp_url(v or "", field="whatsapp_link")
 
     @field_validator("partiful_link", mode="before")
     @classmethod
     def validate_partiful(cls, v: str) -> str:
-        return _validate_partiful_url(v or "")
+        return _validate_partiful_url(v or "", field="partiful_link")
 
     @field_validator("other_link", mode="before")
     @classmethod
     def validate_other(cls, v: str) -> str:
-        return _validate_generic_url(v or "")
+        return _validate_generic_url(v or "", field="other_link")
 
 
 class EventPatchIn(BaseModel):
@@ -297,21 +310,21 @@ class EventPatchIn(BaseModel):
     def validate_whatsapp(cls, v: str | None) -> str | None:
         if v is None:
             return None
-        return _validate_whatsapp_url(v)
+        return _validate_whatsapp_url(v, field="whatsapp_link")
 
     @field_validator("partiful_link", mode="before")
     @classmethod
     def validate_partiful(cls, v: str | None) -> str | None:
         if v is None:
             return None
-        return _validate_partiful_url(v)
+        return _validate_partiful_url(v, field="partiful_link")
 
     @field_validator("other_link", mode="before")
     @classmethod
     def validate_other(cls, v: str | None) -> str | None:
         if v is None:
             return None
-        return _validate_generic_url(v)
+        return _validate_generic_url(v, field="other_link")
 
 
 _MAX_EVENT_PHOTO_SIZE = 10 * 1024 * 1024  # 10 MB

--- a/backend/community/_events.py
+++ b/backend/community/_events.py
@@ -270,14 +270,16 @@ def create_event(request, payload: EventIn):
     if _is_invalid_official_visibility(payload.event_type, payload.visibility):
         return Status(400, ErrorOut(detail="Official events must be public."))
 
-    dt_error = _validate_event_datetimes(
-        payload.start_datetime,
-        payload.end_datetime,
-        payload.datetime_tbd,
-        check_past=payload.status != EventStatus.DRAFT,
-    )
-    if dt_error:
-        return Status(400, ErrorOut(detail=dt_error))
+    # Drafts are intentionally saveable incomplete — skip the date checks.
+    if payload.status != EventStatus.DRAFT:
+        dt_error = _validate_event_datetimes(
+            payload.start_datetime,
+            payload.end_datetime,
+            payload.datetime_tbd,
+            check_past=True,
+        )
+        if dt_error:
+            return Status(400, ErrorOut(detail=dt_error))
 
     event = Event.objects.create(
         title=payload.title,

--- a/backend/community/_validation.py
+++ b/backend/community/_validation.py
@@ -1,0 +1,53 @@
+"""Machine-readable validation errors.
+
+Validators raise ``ValidationException(code, field, params?)`` instead of
+``ValueError("free text")``. The global Ninja handler (see ``config/urls.py``)
+catches both ``ValidationException`` and Pydantic ``ValidationError`` and
+reshapes them to ``{ detail: [{code, field, params?}, ...] }`` so the frontend
+owns the UI copy.
+
+Adding a new validation error:
+  1. Add a constant to ``ValidationCode`` (stable string — don't rename once shipped).
+  2. Raise ``ValidationException(ValidationCode.YOUR_CODE, field="foo")``.
+  3. Add a case in the frontend's ``validationCodes.ts`` messageForCode().
+"""
+
+from typing import Any
+
+
+class ValidationCode:
+    """Stable error codes. Strings are part of the API contract — don't rename."""
+
+    # Event form
+    START_DATETIME_REQUIRED_UNLESS_TBD = "start_datetime_required_unless_tbd"
+    URL_INVALID = "url_invalid"
+    URL_PATH_REQUIRED = "url_path_required"
+    URL_SCHEME_MUST_BE_HTTP_OR_HTTPS = "url_scheme_must_be_http_or_https"
+    WHATSAPP_URL_NOT_RECOGNIZED = "whatsapp_url_not_recognized"
+    PARTIFUL_URL_NOT_RECOGNIZED = "partiful_url_not_recognized"
+
+    # Event attendance
+    ATTENDANCE_INVALID_CHOICE = "attendance_invalid_choice"
+
+
+class ValidationException(Exception):
+    """Raised by validators to signal a machine-readable error.
+
+    ``field`` is the dotted field name (e.g. ``"start_datetime"`` or
+    ``"whatsapp_link"``). Leave ``None`` for model-level errors that don't
+    belong to a single field.
+
+    ``params`` lets the frontend interpolate values into the rendered
+    message (e.g. a list of allowed hosts). Keep them JSON-serializable.
+    """
+
+    def __init__(
+        self,
+        code: str,
+        field: str | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> None:
+        super().__init__(code)
+        self.code = code
+        self.field = field
+        self.params = params or {}

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -7,6 +7,7 @@ from notifications.sse import notification_stream
 from users.api import router as auth_router
 
 from config.media_proxy import serve_media
+from config.validation_handlers import register_validation_handlers
 
 
 class NoCacheTemplateView(TemplateView):
@@ -19,6 +20,7 @@ class NoCacheTemplateView(TemplateView):
 
 
 api = NinjaAPI(title="PDA API", version="1.0.0")
+register_validation_handlers(api)
 api.add_router("/auth/", auth_router, tags=["auth"])
 api.add_router("/community/", community_router, tags=["community"])
 api.add_router("/notifications/", notifications_router, tags=["notifications"])

--- a/backend/config/validation_handlers.py
+++ b/backend/config/validation_handlers.py
@@ -1,0 +1,90 @@
+"""Global Ninja exception handlers that reshape validation errors to
+``{ detail: [{code, field, params?}, ...] }`` so the frontend owns UI copy.
+
+Two cases:
+  1. ``ValidationException`` raised by our own validators — direct pass-through.
+  2. ``ninja.errors.ValidationError`` — Ninja's wrapper around Pydantic
+     errors during request parsing. Covers missing fields, type mismatches,
+     and nested validator failures. If a validator raised a
+     ``ValidationException``, pull its code out of ``ctx.error``.
+"""
+
+from typing import Any
+
+from community._validation import ValidationException
+from django.http import HttpRequest, HttpResponse
+from ninja import NinjaAPI
+from ninja.errors import ValidationError as NinjaValidationError
+
+_GENERIC_FIELD_INVALID = "field_invalid"
+_GENERIC_FIELD_REQUIRED = "field_required"
+
+
+def register_validation_handlers(api: NinjaAPI) -> None:
+    @api.exception_handler(ValidationException)
+    def _handle_validation_exception(
+        request: HttpRequest, exc: ValidationException
+    ) -> HttpResponse:
+        return api.create_response(
+            request,
+            {"detail": [_serialize_validation_exception(exc)]},
+            status=422,
+        )
+
+    @api.exception_handler(NinjaValidationError)
+    def _handle_ninja_validation_error(
+        request: HttpRequest, exc: NinjaValidationError
+    ) -> HttpResponse:
+        return api.create_response(
+            request,
+            {"detail": [_serialize_pydantic_error(e) for e in exc.errors]},
+            status=422,
+        )
+
+
+def _serialize_validation_exception(exc: ValidationException) -> dict[str, Any]:
+    out: dict[str, Any] = {"code": exc.code, "field": exc.field}
+    if exc.params:
+        out["params"] = exc.params
+    return out
+
+
+def _serialize_pydantic_error(err: dict[str, Any]) -> dict[str, Any]:
+    # When a validator raised a ValidationException, Pydantic's message takes
+    # the form "Value error, <str(exc)>". Since str(ValidationException) is the
+    # bare code (see __init__), we can recover it by stripping the prefix.
+    # (Ninja stringifies ctx.error at the main.py level so we can't grab the
+    # exception instance directly.)
+    msg = err.get("msg", "") or ""
+    if msg.startswith("Value error, "):
+        code_candidate = msg.removeprefix("Value error, ").strip()
+        if _looks_like_validation_code(code_candidate):
+            return {"code": code_candidate, "field": _loc_to_field(err)}
+
+    # Default Pydantic errors (type mismatches, missing, etc.) — map the most
+    # common types to generic codes. The frontend falls back to a generic
+    # message for anything it doesn't recognize.
+    err_type = err.get("type", "")
+    code = _GENERIC_FIELD_REQUIRED if err_type == "missing" else _GENERIC_FIELD_INVALID
+    return {"code": code, "field": _loc_to_field(err)}
+
+
+def _looks_like_validation_code(s: str) -> bool:
+    # Stable codes are snake_case identifiers. This guards against matching
+    # arbitrary free-text ValueErrors that slip through uncaptured.
+    return bool(s) and s.replace("_", "").isalnum() and "_" in s and s.islower()
+
+
+_NINJA_SOURCE_NAMES = frozenset({"body", "query", "path", "header", "form", "cookie", "file"})
+
+
+def _loc_to_field(err: dict[str, Any]) -> str | None:
+    # Ninja's loc looks like ("body", "<param-name>", "<field>", ...). Strip
+    # the source prefix if present, then strip the handler's param name (one
+    # element). What's left is the user-visible field path.
+    loc = list(err.get("loc") or ())
+    if loc and str(loc[0]) in _NINJA_SOURCE_NAMES:
+        loc.pop(0)
+    if loc:
+        loc.pop(0)  # drop the handler's param variable name
+    return ".".join(str(p) for p in loc) if loc else None

--- a/backend/tests/test_validation_codes.py
+++ b/backend/tests/test_validation_codes.py
@@ -1,0 +1,120 @@
+"""End-to-end tests for machine-readable validation errors.
+
+Validators now raise ``ValidationException(code, field)`` instead of
+``ValueError("free text")``. The global Ninja handler reshapes both those
+and stock Pydantic errors into ``{ detail: [{code, field, params?}, ...] }``
+so the frontend owns UI copy.
+"""
+
+import pytest
+from community._validation import ValidationCode
+
+BASE_EVENT = {
+    "title": "Validation Test Event",
+    "start_datetime": "2026-06-01T18:00:00Z",
+}
+
+
+@pytest.fixture
+def manage_events_headers(db):
+    from ninja_jwt.tokens import RefreshToken
+    from users.models import User
+    from users.permissions import PermissionKey
+    from users.roles import Role
+
+    user = User.objects.create_user(
+        phone_number="+14155559010",
+        password="validationcodepass123",
+        display_name="Validation Codes Manager",
+    )
+    role = Role.objects.create(name="val_mgr", permissions=[PermissionKey.MANAGE_EVENTS])
+    user.roles.add(role)
+    refresh = RefreshToken.for_user(user)
+    return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
+
+
+@pytest.mark.django_db
+class TestValidationCodesShape:
+    def test_start_datetime_missing_returns_code_and_field(self, api_client, manage_events_headers):
+        payload = {"title": "No date"}  # missing start_datetime, not tbd, not draft
+        resp = api_client.post(
+            "/api/community/events/",
+            payload,
+            content_type="application/json",
+            **manage_events_headers,
+        )
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert isinstance(detail, list)
+        assert any(
+            e["code"] == ValidationCode.START_DATETIME_REQUIRED_UNLESS_TBD
+            and e["field"] == "start_datetime"
+            for e in detail
+        )
+        # Defensive: no Pydantic-flavored strings leak through.
+        for e in detail:
+            assert "msg" not in e
+            assert not any("Value error" in str(v) for v in e.values())
+
+    def test_draft_without_start_datetime_is_allowed(self, api_client, manage_events_headers):
+        payload = {"title": "Draft no date", "status": "draft"}
+        resp = api_client.post(
+            "/api/community/events/",
+            payload,
+            content_type="application/json",
+            **manage_events_headers,
+        )
+        assert resp.status_code == 201
+
+    def test_invalid_whatsapp_host_returns_code_with_field(self, api_client, manage_events_headers):
+        resp = api_client.post(
+            "/api/community/events/",
+            {**BASE_EVENT, "whatsapp_link": "https://notwhatsapp.com/x"},
+            content_type="application/json",
+            **manage_events_headers,
+        )
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        match = next(e for e in detail if e["code"] == ValidationCode.WHATSAPP_URL_NOT_RECOGNIZED)
+        assert match["field"] == "whatsapp_link"
+        assert "allowed_hosts" in match["params"]
+
+    def test_bare_whatsapp_domain_returns_url_path_required(
+        self, api_client, manage_events_headers
+    ):
+        resp = api_client.post(
+            "/api/community/events/",
+            {**BASE_EVENT, "whatsapp_link": "https://chat.whatsapp.com/"},
+            content_type="application/json",
+            **manage_events_headers,
+        )
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert any(
+            e["code"] == ValidationCode.URL_PATH_REQUIRED and e["field"] == "whatsapp_link"
+            for e in detail
+        )
+
+    def test_generic_pydantic_error_gets_fallback_code(self, api_client, manage_events_headers):
+        # max_attendees expects int | None — a string triggers a default
+        # Pydantic type error, not one of our ValidationCodes.
+        resp = api_client.post(
+            "/api/community/events/",
+            {**BASE_EVENT, "max_attendees": "not a number"},
+            content_type="application/json",
+            **manage_events_headers,
+        )
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert any(e["code"] == "field_invalid" for e in detail)
+
+    def test_missing_title_gets_field_required(self, api_client, manage_events_headers):
+        resp = api_client.post(
+            "/api/community/events/",
+            {"start_datetime": "2026-06-01T18:00:00Z"},
+            content_type="application/json",
+            **manage_events_headers,
+        )
+        assert resp.status_code == 422
+        detail = resp.json()["detail"]
+        assert any(e["code"] == "field_required" and e["field"] == "title" for e in detail)

--- a/frontend/src/api/eventWrites.ts
+++ b/frontend/src/api/eventWrites.ts
@@ -10,6 +10,7 @@ import { apiClient } from './client';
 import { useAuthStore } from '@/auth/store';
 import { eventKeys } from './events';
 import { mapEvent, type WireEvent } from './eventMapper';
+import { messagesFromFieldErrors, type FieldError } from './validationCodes';
 import type { Event } from '@/models/event';
 import { fromCashAppUrl, fromVenmoUrl, toCashAppUrl, toVenmoUrl } from '@/utils/paymentHandle';
 
@@ -221,12 +222,16 @@ export function extractEventError(err: unknown): string {
     }
     const data = err.response?.data as Record<string, unknown> | undefined;
     if (data) {
-      // Django Ninja returns { detail: [{ type, loc, msg, ctx }, ...] }
-      // for validation errors.
+      // Backend returns one of two shapes:
+      //   { detail: "free-text" } — unhandled 4xx from route handlers
+      //   { detail: [{ code, field, params? }, ...] } — validation errors
       if (typeof data.detail === 'string') return data.detail;
       if (Array.isArray(data.detail)) {
-        const msgs = (data.detail as { msg?: string }[]).map((e) => e.msg).filter(Boolean);
-        if (msgs.length > 0) return msgs.join(', ');
+        const fieldErrors = data.detail.filter(
+          (e): e is FieldError =>
+            typeof e === 'object' && e !== null && typeof (e as FieldError).code === 'string',
+        );
+        if (fieldErrors.length > 0) return messagesFromFieldErrors(fieldErrors);
       }
     }
   }

--- a/frontend/src/api/validationCodes.test.ts
+++ b/frontend/src/api/validationCodes.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ValidationCode,
+  messageForCode,
+  messagesFromFieldErrors,
+  type FieldError,
+} from './validationCodes';
+
+describe('messageForCode', () => {
+  it('returns friendly copy for known event-form codes', () => {
+    expect(
+      messageForCode({
+        code: ValidationCode.StartDatetimeRequiredUnlessTbd,
+        field: 'start_datetime',
+      }),
+    ).toBe('pick a start time, or mark the time as tbd');
+  });
+
+  it('uses the field name for generic fallback codes', () => {
+    expect(messageForCode({ code: ValidationCode.FieldRequired, field: 'title' })).toContain(
+      'title',
+    );
+    expect(messageForCode({ code: ValidationCode.FieldInvalid, field: 'max_attendees' })).toContain(
+      'max attendees',
+    );
+  });
+
+  it('returns a safe fallback for unknown codes', () => {
+    expect(messageForCode({ code: 'something_the_fe_doesnt_know', field: null })).toMatch(
+      /double-check/i,
+    );
+  });
+});
+
+describe('messagesFromFieldErrors', () => {
+  it('joins multiple distinct errors with a middle dot', () => {
+    const errors: FieldError[] = [
+      { code: ValidationCode.FieldRequired, field: 'title' },
+      { code: ValidationCode.StartDatetimeRequiredUnlessTbd, field: 'start_datetime' },
+    ];
+    const out = messagesFromFieldErrors(errors);
+    expect(out).toContain('title');
+    expect(out).toContain('start time');
+    expect(out).toContain(' · ');
+  });
+
+  it('deduplicates repeated messages', () => {
+    const errors: FieldError[] = [
+      { code: ValidationCode.UrlInvalid, field: 'whatsapp_link' },
+      { code: ValidationCode.UrlInvalid, field: 'whatsapp_link' },
+    ];
+    const out = messagesFromFieldErrors(errors);
+    // one message, no separator
+    expect(out).toBe('enter a valid url');
+  });
+});

--- a/frontend/src/api/validationCodes.ts
+++ b/frontend/src/api/validationCodes.ts
@@ -1,0 +1,78 @@
+// Machine-readable validation error codes from the backend.
+// The backend raises ValidationException(code, field, params?) and a global
+// Ninja handler reshapes those (and generic Pydantic errors) into
+// { detail: [{ code, field, params? }, ...] }. UI copy lives here.
+//
+// To add a new code:
+//   1. Add the constant to the backend ValidationCode class (same string).
+//   2. Add it to ValidationCode below.
+//   3. Add a case in messageForCode().
+//
+// Unknown codes fall back to a generic "something's not right" message —
+// safe, if unhelpful. Never display the raw code to users.
+
+export const ValidationCode = {
+  // Event form
+  StartDatetimeRequiredUnlessTbd: 'start_datetime_required_unless_tbd',
+  UrlInvalid: 'url_invalid',
+  UrlPathRequired: 'url_path_required',
+  UrlSchemeMustBeHttpOrHttps: 'url_scheme_must_be_http_or_https',
+  WhatsappUrlNotRecognized: 'whatsapp_url_not_recognized',
+  PartifulUrlNotRecognized: 'partiful_url_not_recognized',
+
+  // Event attendance
+  AttendanceInvalidChoice: 'attendance_invalid_choice',
+
+  // Generic fallbacks emitted by the handler for Pydantic errors without
+  // a custom code (type mismatches, missing fields, etc.).
+  FieldRequired: 'field_required',
+  FieldInvalid: 'field_invalid',
+} as const;
+
+export type ValidationCodeValue = (typeof ValidationCode)[keyof typeof ValidationCode];
+
+export interface FieldError {
+  code: string;
+  field: string | null;
+  params?: Record<string, unknown>;
+}
+
+/** Return user-facing copy for a single field error. */
+export function messageForCode(err: FieldError): string {
+  switch (err.code) {
+    case ValidationCode.StartDatetimeRequiredUnlessTbd:
+      return 'pick a start time, or mark the time as tbd';
+    case ValidationCode.UrlInvalid:
+      return 'enter a valid url';
+    case ValidationCode.UrlPathRequired:
+      return 'link must point to a specific page, not just a homepage';
+    case ValidationCode.UrlSchemeMustBeHttpOrHttps:
+      return 'url must start with http:// or https://';
+    case ValidationCode.WhatsappUrlNotRecognized:
+      return 'whatsapp link must be from chat.whatsapp.com, wa.me, or whats.app';
+    case ValidationCode.PartifulUrlNotRecognized:
+      return 'link must be a partiful.com url';
+    case ValidationCode.AttendanceInvalidChoice:
+      return 'pick a valid attendance option';
+    case ValidationCode.FieldRequired:
+      return err.field ? `${err.field.replace(/_/g, ' ')} is required` : 'this field is required';
+    case ValidationCode.FieldInvalid:
+      return err.field ? `${err.field.replace(/_/g, ' ')} is not valid` : 'this field is not valid';
+    default:
+      return "something's not right — double-check your entries";
+  }
+}
+
+/** Join multiple field errors into a single human-readable sentence. */
+export function messagesFromFieldErrors(errors: FieldError[]): string {
+  const msgs = errors.map(messageForCode);
+  // Dedup while preserving order — backend sometimes emits two errors for
+  // the same underlying mistake (type coerce + validator).
+  const seen = new Set<string>();
+  const uniq = msgs.filter((m) => {
+    if (seen.has(m)) return false;
+    seen.add(m);
+    return true;
+  });
+  return uniq.join(' · ');
+}


### PR DESCRIPTION
## Summary

Validators now raise ``ValidationException(code, field, params?)`` instead of ``ValueError(\"free text\")``. A global Ninja handler reshapes both our custom exceptions and standard Pydantic errors into

\`\`\`
{ detail: [{ code, field, params? }, ...] }
\`\`\`

so the **frontend** owns UI copy. No more \"Value error, start_datetime is required when datetime_tbd is false\" leaking to users.

## Scope

- Event create/edit schemas (\`EventIn\`, \`EventPatchIn\`, \`AttendanceIn\`) migrated.
- Drafts are now saveable without a start_datetime (FE already allowed this; BE was rejecting).
- Other schemas still raise \`ValueError\` — they fall through the fallback path and show a generic message. Migrate as we touch them.

## Files

- \`backend/community/_validation.py\` — \`ValidationCode\` constants + \`ValidationException\`.
- \`backend/config/validation_handlers.py\` — global Ninja handlers.
- \`backend/community/_event_schemas.py\` — all URL/event validators migrated.
- \`backend/community/_events.py\` — create_event skips date check on drafts.
- \`frontend/src/api/validationCodes.ts\` — mirror of codes + \`messageForCode()\` dispatcher.
- \`frontend/src/api/eventWrites.ts\` — \`extractEventError\` now reads codes.
- Tests on both sides.

## Test plan

- [x] backend: new \`test_validation_codes.py\` covers code shape, draft carve-out, whatsapp host, fallbacks
- [x] frontend: \`validationCodes.test.ts\` covers known codes, fallback, dedup
- [x] \`make agent-ci\` green (all 691 BE + 362 FE tests pass)
- [ ] manual: try save an event with no title — confirm user-friendly message
- [ ] manual: try save a draft with no date — confirm success (was rejected before)