### PR TITLE
fix(events): preserve photo crop ratio on detail view + form preview

### DIFF
--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -29,7 +29,7 @@ export default function EventDetailScreen() {
         <img
           src={event.photoUrl}
           alt=""
-          className="mb-4 aspect-video w-full rounded-lg object-cover"
+          className="mb-4 h-auto max-h-[70vh] w-full rounded-lg"
           loading="lazy"
         />
       ) : null}

--- a/frontend/src/screens/events/form/EventFormPhoto.tsx
+++ b/frontend/src/screens/events/form/EventFormPhoto.tsx
@@ -102,15 +102,17 @@ export function EventFormPhoto({ photoUrl, photoUpdatedAt, onCrop, onDelete, dis
         disabled={locked}
         aria-label={hasPhoto ? 'change cover photo' : 'add a cover photo'}
         className={cn(
-          'group relative aspect-video w-full overflow-hidden rounded-[var(--radius-md)]',
+          'group relative w-full overflow-hidden rounded-[var(--radius-md)]',
           'focus-visible:ring-brand-300 focus-visible:ring-2 focus-visible:outline-none',
-          hasPhoto ? 'bg-surface-raised' : 'border-brand-200 bg-brand-50 border-2 border-dashed',
+          hasPhoto
+            ? 'bg-surface-raised'
+            : 'border-brand-200 bg-brand-50 aspect-video border-2 border-dashed',
           locked && 'cursor-not-allowed opacity-60',
         )}
       >
         {hasPhoto ? (
           <>
-            <img src={displayUrl} alt="" className="absolute inset-0 h-full w-full object-cover" />
+            <img src={displayUrl} alt="" className="block h-auto max-h-[70vh] w-full" />
             <div className="absolute inset-0 flex items-end justify-end bg-gradient-to-t from-black/40 via-transparent to-transparent p-3 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
               <span className="text-foreground rounded-full bg-white/90 px-3 py-1 text-xs font-medium">
                 change photo


### PR DESCRIPTION
## Summary
Event cover photos were hard-coded to aspect-video 16:9 with object-cover, which silently re-cropped whatever ratio the user chose in the cropper. Fix: display at natural aspect, capped at max-h-[70vh].

- \`EventDetailScreen\`: drop \`aspect-video object-cover\`, use \`h-auto max-h-[70vh]\`
- \`EventFormPhoto\`: same treatment when a photo is present; keep aspect-video on the empty-state placeholder so the "add a cover photo" target stays a nice rectangle

The cropper is already free-form (\`shape=\"rect\"\`, no locked aspect), so this just lets the chosen crop show through.

## Test plan
- [ ] Upload a landscape photo (e.g. 16:9) — displays at that ratio
- [ ] Upload a portrait photo — displays tall, capped at 70% viewport height
- [ ] Upload a square — displays square
- [ ] Empty state "add a cover photo" button is still a nice rectangle