### PR TITLE
fix(events): drafts must have future start times, editable when stale

### DIFF
--- a/backend/community/_events.py
+++ b/backend/community/_events.py
@@ -107,13 +107,22 @@ def _validate_update_payload(request, event: Event, event_id, updates: dict) -> 
     effective_start = updates.get("start_datetime", event.start_datetime)
     effective_end = updates.get("end_datetime", event.end_datetime)
     effective_tbd = updates.get("datetime_tbd", event.datetime_tbd)
-    # Draft events may hold placeholder/past start times until published.
-    check_past = "start_datetime" in updates and not event.is_draft
-    dt_error = _validate_event_datetimes(
-        effective_start, effective_end, effective_tbd, check_past=check_past
-    )
-    if dt_error:
-        return Status(400, ErrorOut(detail=dt_error))
+    # Drafts can legitimately have no start yet (see #357) — don't enforce
+    # "start required" or past-check when a draft stays dateless. But if the
+    # draft has a start (existing or being set), it must be a future date.
+    if event.is_draft and effective_start is None:
+        pass
+    else:
+        # Past-check applies when start_datetime is being touched, or on any
+        # edit to a draft that already has a start (stale-draft guard). Non-
+        # draft past events keep being tweakable for non-date fields within
+        # the 6-hour grace window (enforced client-side).
+        check_past = "start_datetime" in updates or event.is_draft
+        dt_error = _validate_event_datetimes(
+            effective_start, effective_end, effective_tbd, check_past=check_past
+        )
+        if dt_error:
+            return Status(400, ErrorOut(detail=dt_error))
     return None
 
 
@@ -270,8 +279,12 @@ def create_event(request, payload: EventIn):
     if _is_invalid_official_visibility(payload.event_type, payload.visibility):
         return Status(400, ErrorOut(detail="Official events must be public."))
 
-    # Drafts are intentionally saveable incomplete — skip the date checks.
-    if payload.status != EventStatus.DRAFT:
+    # Drafts can save without a start_datetime (see #357). But if a start IS
+    # provided, the same rules apply as for any event — must be in the future,
+    # end must be after start.
+    if payload.status == EventStatus.DRAFT and payload.start_datetime is None:
+        pass
+    else:
         dt_error = _validate_event_datetimes(
             payload.start_datetime,
             payload.end_datetime,

--- a/backend/tests/test_event_drafts.py
+++ b/backend/tests/test_event_drafts.py
@@ -108,7 +108,7 @@ class TestCreateDraft:
         assert response.status_code == 201
         assert response.json()["status"] == "draft"
 
-    def test_create_draft_allows_past_start(self, api_client, creator_headers):
+    def test_create_draft_past_start_rejected(self, api_client, creator_headers):
         response = api_client.post(
             "/api/community/events/",
             data=json.dumps(
@@ -117,7 +117,8 @@ class TestCreateDraft:
             content_type="application/json",
             **creator_headers,
         )
-        assert response.status_code == 201
+        assert response.status_code == 400
+        assert "future" in response.json()["detail"].lower()
 
     def test_create_active_event_past_start_rejected(self, api_client, creator_headers):
         response = api_client.post(
@@ -260,10 +261,49 @@ class TestDraftDetail:
 
 @pytest.mark.django_db
 class TestPatchDraft:
-    def test_patch_draft_past_datetime_ok(self, api_client, sample_draft, creator_headers):
+    def test_patch_draft_past_datetime_rejected(self, api_client, sample_draft, creator_headers):
         response = api_client.patch(
             f"/api/community/events/{sample_draft.id}/",
             data=json.dumps({"start_datetime": "2020-01-01T12:00:00Z"}),
+            content_type="application/json",
+            **creator_headers,
+        )
+        assert response.status_code == 400
+        assert "future" in response.json()["detail"].lower()
+
+    def test_patch_stale_draft_rejects_unrelated_field_edits(
+        self, api_client, creator, creator_headers
+    ):
+        """A draft whose start slipped into the past can't be saved until the
+        date is updated — even if the user only touches the title."""
+        stale = Event.objects.create(
+            title="Old Draft",
+            start_datetime="2020-01-01T12:00:00Z",
+            created_by=creator,
+            status=EventStatus.DRAFT,
+        )
+        response = api_client.patch(
+            f"/api/community/events/{stale.id}/",
+            data=json.dumps({"title": "new title"}),
+            content_type="application/json",
+            **creator_headers,
+        )
+        assert response.status_code == 400
+        assert "future" in response.json()["detail"].lower()
+
+    def test_patch_startless_draft_title_succeeds(self, api_client, creator, creator_headers):
+        """A draft with no start_datetime at all should still be editable —
+        progress-capture drafts are allowed to be dateless (see #357)."""
+        startless = Event.objects.create(
+            title="Dateless Draft",
+            start_datetime=None,
+            datetime_tbd=False,
+            created_by=creator,
+            status=EventStatus.DRAFT,
+        )
+        response = api_client.patch(
+            f"/api/community/events/{startless.id}/",
+            data=json.dumps({"title": "new title"}),
             content_type="application/json",
             **creator_headers,
         )

--- a/frontend/src/screens/events/EventAdminActions.test.tsx
+++ b/frontend/src/screens/events/EventAdminActions.test.tsx
@@ -259,6 +259,24 @@ describe('EventAdminActions', () => {
     expect(screen.queryByRole('button', { name: /^edit$/i })).not.toBeInTheDocument();
   });
 
+  // Drafts bypass the grace window — a stale draft (start slipped into the
+  // past before publish) must remain editable so the user can update the date.
+  it('creator can edit a draft with a start time well in the past', () => {
+    const creator = makeUser(CREATOR_ID);
+    useAuthStore.setState({ status: 'authed', user: creator, accessToken: 'tok' });
+
+    const staleDraft: Event = {
+      ...BASE_EVENT,
+      status: EventStatus.Draft,
+      startDatetime: new Date(Date.now() - 7 * 24 * 60 * 60 * 1000), // a week ago
+      endDatetime: null,
+      isPast: true,
+    };
+    renderActions(staleDraft);
+
+    expect(screen.getByRole('button', { name: /^edit$/i })).toBeInTheDocument();
+  });
+
   it('creator uses endDatetime (not startDatetime) as the grace-window anchor', () => {
     const creator = makeUser(CREATOR_ID);
     useAuthStore.setState({ status: 'authed', user: creator, accessToken: 'tok' });

--- a/frontend/src/screens/events/EventAdminActions.tsx
+++ b/frontend/src/screens/events/EventAdminActions.tsx
@@ -59,7 +59,9 @@ function AdminActionRow({
   const hasNoAttendees = event.attendingCount === 0;
   const canDelete = (isCreator || canManage) && (isDraft || isCancelled || hasNoAttendees);
   const showCancel = !isCancelled && !isDraft && !hasNoAttendees;
-  const canEditEvent = isEditWindowOpen(event);
+  // Drafts are always editable — the edit-window cutoff protects the
+  // historical record of published events, which drafts don't have.
+  const canEditEvent = isDraft || isEditWindowOpen(event);
 
   async function onCancel() {
     setCancelError(null);

--- a/frontend/src/screens/events/form/EventForm.tsx
+++ b/frontend/src/screens/events/form/EventForm.tsx
@@ -86,7 +86,12 @@ export function EventForm({ existing }: Props) {
   );
   const [coHosts, setCoHosts] = useState<MemberSearchResult[]>([]);
   const [invited, setInvited] = useState<MemberSearchResult[]>([]);
-  const [errors, setErrors] = useState<Partial<Record<keyof EventFormValues, string>>>({});
+  // On edit, pre-run validation so issues in the loaded values (e.g. a stale
+  // draft whose start is now in the past) are visible immediately instead of
+  // waiting for the first save attempt.
+  const [errors, setErrors] = useState<Partial<Record<keyof EventFormValues, string>>>(() =>
+    existing ? validateEventForm(eventToFormValues(existing)) : {},
+  );
   const [serverError, setServerError] = useState<string | null>(null);
   const [pendingPhoto, setPendingPhoto] = useState<Blob | null>(null);
   const pendingPhotoUrl = useMemo(

--- a/frontend/src/screens/events/form/validateEventForm.test.ts
+++ b/frontend/src/screens/events/form/validateEventForm.test.ts
@@ -81,11 +81,18 @@ describe('validateEventForm', () => {
   });
 
   describe('startDatetime', () => {
-    it('requires startDatetime when not TBD and not draft', () => {
+    it('requires startDatetime on active events when not TBD', () => {
       const errors = validateEventForm(
         validValues({ startDatetime: '', datetimeTbd: false, status: 'active' }),
       );
       expect(errors.startDatetime).toBe('required');
+    });
+
+    it('does not require startDatetime on drafts (progress-capture)', () => {
+      const errors = validateEventForm(
+        validValues({ startDatetime: '', datetimeTbd: false, status: 'draft' }),
+      );
+      expect(errors.startDatetime).toBeUndefined();
     });
 
     it('does not require startDatetime when datetimeTbd is true', () => {
@@ -93,16 +100,15 @@ describe('validateEventForm', () => {
       expect(errors.startDatetime).toBeUndefined();
     });
 
-    it('does not require startDatetime for drafts', () => {
-      const errors = validateEventForm(
-        validValues({ startDatetime: '', datetimeTbd: false, status: 'draft' }),
-      );
-      expect(errors.startDatetime).toBeUndefined();
+    it('rejects startDatetime in the past for active events', () => {
+      const past = new Date(Date.now() - 5 * 60 * 1000).toISOString(); // 5 min ago
+      const errors = validateEventForm(validValues({ startDatetime: past, status: 'active' }));
+      expect(errors.startDatetime).toBe('start must be in the future');
     });
 
-    it('rejects startDatetime in the past', () => {
-      const past = new Date(Date.now() - 5 * 60 * 1000).toISOString(); // 5 min ago
-      const errors = validateEventForm(validValues({ startDatetime: past }));
+    it('rejects startDatetime in the past for drafts too (once a date is picked)', () => {
+      const past = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+      const errors = validateEventForm(validValues({ startDatetime: past, status: 'draft' }));
       expect(errors.startDatetime).toBe('start must be in the future');
     });
   });

--- a/frontend/src/screens/events/form/validateEventForm.ts
+++ b/frontend/src/screens/events/form/validateEventForm.ts
@@ -14,9 +14,12 @@ export function validateEventForm(values: EventFormValues): Errors {
   if (values.description.length > 2000) errors.description = 'too long';
   if (values.location.length > 300) errors.location = 'under 300 chars';
 
-  if (!values.datetimeTbd && values.status !== 'draft') {
-    if (!values.startDatetime) errors.startDatetime = 'required';
-    else if (new Date(values.startDatetime).getTime() < Date.now() - 60_000) {
+  // Drafts can save without a start date (progress-capture). Active events
+  // must have one. Either way, if a start is present it must be in the future.
+  if (!values.datetimeTbd) {
+    if (!values.startDatetime) {
+      if (values.status !== 'draft') errors.startDatetime = 'required';
+    } else if (new Date(values.startDatetime).getTime() < Date.now() - 60_000) {
       errors.startDatetime = 'start must be in the future';
     }
   }


### PR DESCRIPTION
Closes #349.

## Summary
A user reported they couldn't edit title/location/cost on a draft event but could still manage co-hosts/invites. Root cause: the draft's \`start_datetime\` had slipped into the past, so \`isEditWindowOpen\` (a 6h-past-end grace window on \`EventAdminActions\`) hid the **edit** button. Co-host/invite UI lives elsewhere and wasn't gated on that check.

## Policy change
- **Past starts are never valid** — at create time, always. When editing a draft, always. When editing \`start_datetime\` on any event, always.
- Published past events within the 6h grace window still allow non-date tweaks (typos, follow-up notes) — unchanged.

## Changes
**Backend** (\`_events.py\`):
- create: \`check_past=True\` always — drops the DRAFT exception
- edit: \`check_past = \"start_datetime\" in updates or event.is_draft\` — stale drafts must be re-dated before any save goes through

**Frontend**:
- \`validateEventForm\`: past-start check applies to drafts too
- \`EventForm\`: pre-run validation on mount when editing, so stale drafts show the inline start-date error immediately
- \`EventAdminActions\`: drafts bypass \`isEditWindowOpen\` so the user can always reach the edit form to fix the date

**Tests**:
- Flip two backend assertions that codified the old draft-past-start leniency; add a stale-draft test covering the \"save title without touching date\" path
- Update \`validateEventForm\` tests; add the draft past-start rejection case
- Add \`EventAdminActions\` test: creator can edit a draft with a week-old start time

## Test plan
- [ ] Create a draft with a future start time — works
- [ ] Try to create a draft with a past start — backend rejects (400)
- [ ] Open a draft whose start is now in the past — edit button shows; inline error appears on the start field immediately; can't save until the date is updated
- [ ] Active upcoming event — unchanged
- [ ] Active event that ended 2h ago (within grace) — can still tweak title/description (unchanged)