### PR TITLE
feat(phone): format phone numbers for display

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,6 +34,7 @@
     "country-flag-icons": "^1.6.16",
     "date-fns": "^4.1.0",
     "dompurify": "^3.4.0",
+    "libphonenumber-js": "^1.12.42",
     "react": "^19.2.5",
     "react-big-calendar": "^1.19.4",
     "react-day-picker": "^9.14.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       dompurify:
         specifier: ^3.4.0
         version: 3.4.0
+      libphonenumber-js:
+        specifier: ^1.12.42
+        version: 1.12.42
       react:
         specifier: ^19.2.5
         version: 19.2.5
@@ -1820,8 +1823,8 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
-  libphonenumber-js@1.12.41:
-    resolution: {integrity: sha512-lsmMmGXBxXIK/VMLEj0kL6MtUs1kBGj1nTCzi6zgQoG1DEwqwt2DQyHxcLykceIxAnfE3hya7NuIh6PpC6S3fA==}
+  libphonenumber-js@1.12.42:
+    resolution: {integrity: sha512-oKQFPTibqQwZZkChCDVMFVJXMZdyJNqDWZWYNn8BgyAaK/6yFJEowxCY0RVFirRyWP63hMRuKlkSEd9qlvbWXg==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -4468,7 +4471,7 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
-  libphonenumber-js@1.12.41: {}
+  libphonenumber-js@1.12.42: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -4850,7 +4853,7 @@ snapshots:
       classnames: 2.5.1
       country-flag-icons: 1.6.16
       input-format: 0.3.14(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
-      libphonenumber-js: 1.12.41
+      libphonenumber-js: 1.12.42
       prop-types: 15.8.1
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)

--- a/frontend/src/components/MemberPicker.tsx
+++ b/frontend/src/components/MemberPicker.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { useUserSearch, type MemberSearchResult } from '@/api/userSearch';
 import { TextField } from './ui/TextField';
 import { cn } from '@/utils/cn';
+import { formatPhone } from '@/utils/formatPhone';
 
 interface Props {
   label: string;
@@ -54,7 +55,7 @@ export function MemberPicker({ label, selected, onChange, hint, excludeIds = [] 
                 className="hover:bg-background flex w-full items-center justify-between px-3 py-2 text-start text-sm"
               >
                 <span>{m.displayName}</span>
-                <span className="text-muted text-xs">{m.phoneNumber}</span>
+                <span className="text-muted text-xs">{formatPhone(m.phoneNumber)}</span>
               </button>
             </li>
           ))}

--- a/frontend/src/screens/admin/ApprovalCredentialsDialog.tsx
+++ b/frontend/src/screens/admin/ApprovalCredentialsDialog.tsx
@@ -6,6 +6,7 @@
 import { useState } from 'react';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
+import { formatPhone } from '@/utils/formatPhone';
 import { buildMagicLinkUrl, buildSmsHref, buildWelcomeMessage } from '@/utils/welcomeMessage';
 
 interface Props {
@@ -41,7 +42,7 @@ export function ApprovalCredentialsDialog({
   return (
     <Dialog open={open} onClose={onClose} title={`welcome ${displayName}`}>
       <p className="text-foreground-secondary text-sm">
-        share this one-time login link with {phoneNumber}. it won't be shown again.
+        share this one-time login link with {formatPhone(phoneNumber)}. it won't be shown again.
       </p>
       <div className="bg-surface-dim mt-3 overflow-x-auto rounded-md px-3 py-2 font-mono text-xs break-all">
         {magicLinkUrl}

--- a/frontend/src/screens/admin/BulkCreateDialog.tsx
+++ b/frontend/src/screens/admin/BulkCreateDialog.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import { Textarea } from '@/components/ui/Textarea';
 import { useBulkCreateUsers, type BulkCreateResponse, type BulkCreateResult } from '@/api/users';
+import { formatPhone } from '@/utils/formatPhone';
 import { buildMagicLinkUrl, buildSmsHref, buildWelcomeMessage } from '@/utils/welcomeMessage';
 
 interface Props {
@@ -119,7 +120,7 @@ function ResultsView({
           <ul className="flex flex-col gap-1">
             {failures.map((r) => (
               <li key={r.row} className="text-sm text-red-700">
-                {r.phoneNumber} — {r.error ?? 'unknown error'}
+                {formatPhone(r.phoneNumber)} — {r.error ?? 'unknown error'}
               </li>
             ))}
           </ul>
@@ -150,7 +151,9 @@ function MagicLinkRow({ result }: { result: BulkCreateResult }) {
   return (
     <div className="flex flex-col gap-1 rounded-md border border-neutral-200 bg-white p-2">
       <div className="flex items-center justify-between gap-2">
-        <span className="truncate text-sm font-medium text-neutral-900">{result.phoneNumber}</span>
+        <span className="truncate text-sm font-medium text-neutral-900">
+          {formatPhone(result.phoneNumber)}
+        </span>
         <div className="flex gap-2">
           <Button variant="secondary" onClick={() => void copy()}>
             {copied ? 'copied ✓' : 'copy link'}

--- a/frontend/src/screens/admin/JoinRequestsScreen.tsx
+++ b/frontend/src/screens/admin/JoinRequestsScreen.tsx
@@ -12,6 +12,7 @@ import { Button } from '@/components/ui/Button';
 import { useConfirm } from '@/components/ui/useConfirm';
 import { SegmentedControl } from '@/components/ui/SegmentedControl';
 import { cn } from '@/utils/cn';
+import { formatPhone } from '@/utils/formatPhone';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 import { ApprovalCredentialsDialog } from './ApprovalCredentialsDialog';
 
@@ -47,7 +48,7 @@ export default function JoinRequestsScreen() {
   if (isError) return <ContentError message="couldn't load join requests — try refreshing" />;
 
   async function decideRequest(request: JoinRequestSummary, status: 'approved' | 'rejected') {
-    const name = request.displayName || request.phoneNumber;
+    const name = request.displayName || formatPhone(request.phoneNumber);
     const message =
       status === 'approved'
         ? `approve ${name}? once you approve someone you can't un-approve them — are you sure?`
@@ -76,7 +77,7 @@ export default function JoinRequestsScreen() {
   }
 
   async function unrejectRequest(request: JoinRequestSummary) {
-    const name = request.displayName || request.phoneNumber;
+    const name = request.displayName || formatPhone(request.phoneNumber);
     const ok = await confirm({
       title: 'un-reject request',
       message: `un-reject ${name}? this will move them back to pending review.`,
@@ -168,7 +169,7 @@ function JoinRequestCard({
         <div>
           <h2 className="text-base font-medium">{request.displayName}</h2>
           <p className="text-muted text-xs">
-            {request.phoneNumber} · submitted{' '}
+            {formatPhone(request.phoneNumber)} · submitted{' '}
             {format(new Date(request.submittedAt), 'MMM d, h:mm a')}
           </p>
         </div>

--- a/frontend/src/screens/admin/MemberCreateDialog.tsx
+++ b/frontend/src/screens/admin/MemberCreateDialog.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import { TextField } from '@/components/ui/TextField';
 import { useCreateUser, type CreateUserResult } from '@/api/users';
+import { formatPhone } from '@/utils/formatPhone';
 import { buildMagicLinkUrl, buildSmsHref, buildWelcomeMessage } from '@/utils/welcomeMessage';
 
 interface Props {
@@ -102,7 +103,7 @@ function CredentialsView({
   onClose: () => void;
 }) {
   const magicLinkUrl = buildMagicLinkUrl(result.magicLinkToken);
-  const greeting = result.displayName || result.phoneNumber;
+  const greeting = result.displayName || formatPhone(result.phoneNumber);
   const welcomeMessage = buildWelcomeMessage(result.displayName, magicLinkUrl);
   const smsHref = buildSmsHref(result.phoneNumber, welcomeMessage);
 
@@ -117,7 +118,8 @@ function CredentialsView({
   return (
     <Dialog open={open} onClose={onClose} title={`welcome ${greeting}`}>
       <p className="text-sm text-neutral-700">
-        share this one-time login link with {result.phoneNumber}. it won't be shown again.
+        share this one-time login link with {formatPhone(result.phoneNumber)}. it won't be shown
+        again.
       </p>
       <div className="mt-3 overflow-x-auto rounded-md bg-neutral-100 px-3 py-2 font-mono text-xs break-all">
         {magicLinkUrl}

--- a/frontend/src/screens/admin/MemberDetailScreen.tsx
+++ b/frontend/src/screens/admin/MemberDetailScreen.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/Button';
 import { useConfirm } from '@/components/ui/useConfirm';
 import { TextField } from '@/components/ui/TextField';
 import { Toggle } from '@/components/ui/Toggle';
+import { formatPhone } from '@/utils/formatPhone';
 import {
   useArchiveUser,
   useSendMemberMagicLink,
@@ -45,7 +46,7 @@ function MemberDetailView({ member }: { member: Member }) {
   async function onArchive() {
     const confirmed = await confirm({
       title: 'archive member',
-      message: `archive ${member.displayName || member.phoneNumber}? they'll lose access immediately — you can restore them later by approving a new join request.`,
+      message: `archive ${member.displayName || formatPhone(member.phoneNumber)}? they'll lose access immediately — you can restore them later by approving a new join request.`,
       confirmLabel: 'archive',
       destructive: true,
     });
@@ -72,9 +73,9 @@ function MemberDetailView({ member }: { member: Member }) {
         <MemberAvatar member={member} />
         <div className="flex flex-col items-center gap-1">
           <h1 className="text-2xl font-medium tracking-tight">
-            {member.displayName || member.phoneNumber}
+            {member.displayName || formatPhone(member.phoneNumber)}
           </h1>
-          <p className="text-sm text-neutral-600">{member.phoneNumber}</p>
+          <p className="text-sm text-neutral-600">{formatPhone(member.phoneNumber)}</p>
           {member.email ? <p className="text-sm text-neutral-600">{member.email}</p> : null}
           {member.isPaused ? (
             <span className="mt-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-800">

--- a/frontend/src/screens/admin/MembersTab.tsx
+++ b/frontend/src/screens/admin/MembersTab.tsx
@@ -9,6 +9,7 @@ import { Button } from '@/components/ui/Button';
 import { Select } from '@/components/ui/Select';
 import { TextField } from '@/components/ui/TextField';
 import { ContentError, ContentLoading } from '@/screens/public/ContentContainer';
+import { formatPhone } from '@/utils/formatPhone';
 import { BulkCreateDialog } from './BulkCreateDialog';
 import { MemberCreateDialog } from './MemberCreateDialog';
 
@@ -334,9 +335,11 @@ function MemberRow({ member }: { member: Member }) {
       )}
       <div className="min-w-0 flex-1">
         <p className="text-foreground truncate text-sm font-medium">
-          {member.displayName || member.phoneNumber}
+          {member.displayName || formatPhone(member.phoneNumber)}
         </p>
-        <p className="text-foreground-tertiary truncate text-xs">{member.phoneNumber}</p>
+        <p className="text-foreground-tertiary truncate text-xs">
+          {formatPhone(member.phoneNumber)}
+        </p>
       </div>
       <div className="flex shrink-0 flex-wrap justify-end gap-1">
         {member.roles.map((role) => (

--- a/frontend/src/screens/members/MemberProfileScreen.tsx
+++ b/frontend/src/screens/members/MemberProfileScreen.tsx
@@ -5,6 +5,7 @@
 import { useParams } from 'react-router-dom';
 import { useMemberProfile, type MemberProfile } from '@/api/users';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
+import { formatPhone } from '@/utils/formatPhone';
 
 export default function MemberProfileScreen() {
   const { userId = '' } = useParams<{ userId: string }>();
@@ -61,7 +62,7 @@ function ContactLines({ member }: { member: MemberProfile }) {
           href={`sms:${member.phoneNumber}`}
           className="text-foreground-secondary text-sm hover:underline"
         >
-          {member.phoneNumber}
+          {formatPhone(member.phoneNumber)}
         </a>
       ) : null}
       {hasEmail ? (

--- a/frontend/src/screens/members/MembersDirectoryScreen.tsx
+++ b/frontend/src/screens/members/MembersDirectoryScreen.tsx
@@ -7,6 +7,7 @@ import { Link } from 'react-router-dom';
 import { useMembersDirectory, type DirectoryMember } from '@/api/users';
 import { TextField } from '@/components/ui/TextField';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
+import { formatPhone } from '@/utils/formatPhone';
 
 export default function MembersDirectoryScreen() {
   const { data = [], isPending, isError } = useMembersDirectory();
@@ -86,7 +87,7 @@ function DirectoryRow({ member }: { member: DirectoryMember }) {
         </p>
         {member.phoneNumber || member.email ? (
           <p className="text-foreground-tertiary truncate text-xs">
-            {member.phoneNumber || member.email}
+            {member.phoneNumber ? formatPhone(member.phoneNumber) : member.email}
           </p>
         ) : null}
       </div>

--- a/frontend/src/screens/settings/SettingsScreen.tsx
+++ b/frontend/src/screens/settings/SettingsScreen.tsx
@@ -11,6 +11,7 @@ import { ContentContainer } from '@/screens/public/ContentContainer';
 import { AvatarUpload } from './AvatarUpload';
 import { ChangePasswordDialog } from './ChangePasswordDialog';
 import { cn } from '@/utils/cn';
+import { formatPhone } from '@/utils/formatPhone';
 
 export default function SettingsScreen() {
   const user = useAuthStore((s) => s.user);
@@ -37,7 +38,7 @@ export default function SettingsScreen() {
           value={user.displayName}
           onSave={(v) => updateProfile({ displayName: v })}
         />
-        <ReadOnly label="phone number" value={user.phoneNumber} />
+        <ReadOnly label="phone number" value={formatPhone(user.phoneNumber)} />
         <InlineText
           label="email"
           value={user.email}

--- a/frontend/src/utils/formatPhone.test.ts
+++ b/frontend/src/utils/formatPhone.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { formatPhone } from './formatPhone';
+
+describe('formatPhone', () => {
+  it('formats US numbers as (xxx) xxx-xxxx with no country code', () => {
+    expect(formatPhone('+12125551234')).toBe('(212) 555-1234');
+  });
+
+  it('formats UK numbers in international style', () => {
+    expect(formatPhone('+442079460958')).toBe('+44 20 7946 0958');
+  });
+
+  it('formats Canadian numbers in international style (not confused with US)', () => {
+    // +1 416 is Toronto — same country code as US but parser distinguishes.
+    expect(formatPhone('+14165550100')).toBe('+1 416 555 0100');
+  });
+
+  it('formats German numbers in international style', () => {
+    expect(formatPhone('+493012345678')).toBe('+49 30 12345678');
+  });
+
+  it('returns the raw input for an unparseable string', () => {
+    expect(formatPhone('not-a-number')).toBe('not-a-number');
+  });
+
+  it('returns an empty string as-is', () => {
+    expect(formatPhone('')).toBe('');
+  });
+
+  it('returns the raw input when missing a leading "+" (no country context)', () => {
+    // Stored numbers are always E.164 with a "+"; if somehow we get a bare
+    // digit string, we pass through rather than guessing the country.
+    expect(formatPhone('12125551234')).toBe('12125551234');
+  });
+});

--- a/frontend/src/utils/formatPhone.ts
+++ b/frontend/src/utils/formatPhone.ts
@@ -1,0 +1,14 @@
+// Format a phone number for display. US numbers render as `(xxx) xxx-xxxx`
+// (country code dropped since the user base is primarily US); everything else
+// falls back to the international format (`+44 20 7946 0958`). Invalid or
+// empty input passes through unchanged so we never hide data from admins.
+
+import { parsePhoneNumberFromString } from 'libphonenumber-js';
+
+export function formatPhone(raw: string): string {
+  if (!raw) return raw;
+  const parsed = parsePhoneNumberFromString(raw);
+  if (!parsed) return raw;
+  if (parsed.country === 'US') return parsed.formatNational();
+  return parsed.formatInternational();
+}


### PR DESCRIPTION
Closes #364.

## Summary
Phone numbers now render in a friendlier format:
- **US** (\`+1\` with US region): \`(212) 555-1234\` — matches the issue example, country code dropped since the user base is primarily US
- **Canada** and everything else: international format via libphonenumber-js (\`+1 416 555 0100\`, \`+44 20 7946 0958\`, \`+49 30 12345678\`, etc.)
- **Unparseable / empty**: passes through unchanged

Display-only — input fields (login, settings edit, admin create, bulk create) still take raw digits, and storage stays E.164.

## Dependency
Adds \`libphonenumber-js\` (~13 KB gzipped, full country coverage).

## Touched (display sites)
- \`MemberDetailScreen\` header + archive confirmation
- \`MembersTab\` row (main + fallback)
- \`MemberCreateDialog\` success greeting + share message
- \`BulkCreateDialog\` success rows + failure lines
- \`MemberPicker\` search-result rows
- \`JoinRequestsScreen\` request row + approve/reject/un-reject confirmation messages
- \`ApprovalCredentialsDialog\` share message
- \`MembersDirectoryScreen\` row subtext
- \`MemberProfileScreen\` sms link
- \`SettingsScreen\` read-only phone

## Test plan
- [ ] Settings screen: your US phone shows as \`(xxx) xxx-xxxx\`
- [ ] Admin members list: US member → formatted; if anyone has a non-US phone, it shows international
- [ ] Join requests: pending row shows formatted phone; approve confirmation message also formatted
- [ ] Bulk create with a mix of valid + invalid rows: success rows formatted, failure rows show the raw (unparseable) input