### PR TITLE
fix: max-attendees validation, no-past datepicker, misc fe cleanup

### DIFF
--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -16,6 +16,18 @@ from community.models import (
 )
 
 
+def _validate_max_attendees(v: int | None) -> int | None:
+    """Accept null (unlimited) or an integer >= 1. Reject 0 and negatives."""
+    if v is None:
+        return v
+    if v < 1:
+        raise ValidationException(
+            ValidationCode.MAX_ATTENDEES_MUST_BE_AT_LEAST_ONE,
+            field="max_attendees",
+        )
+    return v
+
+
 def _require_path(url: str, field: str) -> str:
     """Validate that a URL has a non-trivial path (not bare domain)."""
     if not url:
@@ -277,6 +289,11 @@ class EventIn(BaseModel):
     def validate_other(cls, v: str) -> str:
         return _validate_generic_url(v or "", field="other_link")
 
+    @field_validator("max_attendees", mode="after")
+    @classmethod
+    def validate_max_attendees(cls, v: int | None) -> int | None:
+        return _validate_max_attendees(v)
+
 
 class EventPatchIn(BaseModel):
     title: str | None = Field(default=None, max_length=FieldLimit.TITLE)
@@ -325,6 +342,11 @@ class EventPatchIn(BaseModel):
         if v is None:
             return None
         return _validate_generic_url(v, field="other_link")
+
+    @field_validator("max_attendees", mode="after")
+    @classmethod
+    def validate_max_attendees(cls, v: int | None) -> int | None:
+        return _validate_max_attendees(v)
 
 
 _MAX_EVENT_PHOTO_SIZE = 10 * 1024 * 1024  # 10 MB

--- a/backend/community/_validation.py
+++ b/backend/community/_validation.py
@@ -20,6 +20,7 @@ class ValidationCode:
 
     # Event form
     START_DATETIME_REQUIRED_UNLESS_TBD = "start_datetime_required_unless_tbd"
+    MAX_ATTENDEES_MUST_BE_AT_LEAST_ONE = "max_attendees_must_be_at_least_one"
     URL_INVALID = "url_invalid"
     URL_PATH_REQUIRED = "url_path_required"
     URL_SCHEME_MUST_BE_HTTP_OR_HTTPS = "url_scheme_must_be_http_or_https"

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,5 +1,24 @@
+from datetime import timedelta
+
 import pytest
 from django.test import Client
+from django.utils import timezone
+
+
+def future_iso(days: int = 30, hours: int = 0, minutes: int = 0) -> str:
+    """ISO 8601 string N days/hours/minutes ahead of now.
+
+    Use this anywhere a test needs a valid future start/end datetime instead
+    of hardcoding a year like "2026-06-01T18:00:00Z" — those strings silently
+    rot as time passes and the `check_past` validator starts rejecting them.
+    """
+    return (timezone.now() + timedelta(days=days, hours=hours, minutes=minutes)).isoformat()
+
+
+def past_iso(days: int = 1) -> str:
+    """ISO 8601 string N days in the past. Use for testing stale-draft scenarios,
+    retroactive data, etc. — never for normal create/edit flows (those are rejected)."""
+    return (timezone.now() - timedelta(days=days)).isoformat()
 
 
 @pytest.fixture(autouse=True)

--- a/backend/tests/test_cohost_notifications.py
+++ b/backend/tests/test_cohost_notifications.py
@@ -10,6 +10,8 @@ from notifications.models import Notification, NotificationType
 from notifications.service import create_cohost_added_notifications
 from users.models import User
 
+from tests.conftest import future_iso
+
 # ─── Helpers ─────────────────────────────────────────────────────────────────
 
 
@@ -44,8 +46,8 @@ def another_user(db) -> User:
 def sample_event(adder) -> Event:
     return Event.objects.create(
         title="Test Event",
-        start_datetime="2026-06-01T18:00:00Z",
-        end_datetime="2026-06-01T20:00:00Z",
+        start_datetime=future_iso(days=30),
+        end_datetime=future_iso(days=30, hours=2),
         created_by=adder,
     )
 
@@ -102,8 +104,8 @@ class TestCohostNotificationIntegration:
     def test_create_event_with_cohost_notifies(self, api_client, adder, cohost):
         payload = {
             "title": "Cohost Party",
-            "start_datetime": "2026-07-01T18:00:00Z",
-            "end_datetime": "2026-07-01T20:00:00Z",
+            "start_datetime": future_iso(days=60),
+            "end_datetime": future_iso(days=60, hours=2),
             "co_host_ids": [str(cohost.pk)],
         }
         response = api_client.post(
@@ -123,8 +125,8 @@ class TestCohostNotificationIntegration:
     def test_create_event_does_not_notify_creator(self, api_client, adder):
         payload = {
             "title": "Solo Host",
-            "start_datetime": "2026-07-01T18:00:00Z",
-            "end_datetime": "2026-07-01T20:00:00Z",
+            "start_datetime": future_iso(days=60),
+            "end_datetime": future_iso(days=60, hours=2),
             "co_host_ids": [str(adder.pk)],
         }
         api_client.post(

--- a/backend/tests/test_event_cancel.py
+++ b/backend/tests/test_event_cancel.py
@@ -5,6 +5,8 @@ from community.models import Event, EventStatus
 from users.permissions import PermissionKey
 from users.roles import Role
 
+from tests.conftest import future_iso, past_iso
+
 
 @pytest.fixture
 def manage_events_user(db):
@@ -38,8 +40,8 @@ def upcoming_event_with_rsvp(db, manage_events_user, test_user):
     event = Event.objects.create(
         title="Cancellable Event",
         description="Has attendees",
-        start_datetime="2027-04-01T18:00:00Z",
-        end_datetime="2027-04-01T20:00:00Z",
+        start_datetime=future_iso(days=180),
+        end_datetime=future_iso(days=180, hours=2),
         location="The Vegan Cafe",
         created_by=manage_events_user,
         rsvp_enabled=True,
@@ -54,8 +56,8 @@ def upcoming_event_no_attendees(db, manage_events_user):
     return Event.objects.create(
         title="Empty Event",
         description="No one invited",
-        start_datetime="2027-04-01T18:00:00Z",
-        end_datetime="2027-04-01T20:00:00Z",
+        start_datetime=future_iso(days=180),
+        end_datetime=future_iso(days=180, hours=2),
         location="The Vegan Cafe",
         created_by=manage_events_user,
     )
@@ -66,8 +68,8 @@ def past_event(db, manage_events_user):
     return Event.objects.create(
         title="Past Event",
         description="Already happened",
-        start_datetime="2020-01-01T18:00:00Z",
-        end_datetime="2020-01-01T20:00:00Z",
+        start_datetime=past_iso(days=90),
+        end_datetime=past_iso(days=90),
         location="History",
         created_by=manage_events_user,
     )

--- a/backend/tests/test_event_capacity.py
+++ b/backend/tests/test_event_capacity.py
@@ -4,6 +4,8 @@ import pytest
 from community.models import Event, EventRSVP, RSVPStatus
 from users.models import User
 
+from tests.conftest import future_iso
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -65,12 +67,13 @@ def headers4(user4):
 
 
 @pytest.fixture
-def capped_event(db):
+def capped_event(db, test_user):
     return Event.objects.create(
         title="Capped Event",
-        start_datetime="2026-06-01T18:00:00Z",
+        start_datetime=future_iso(days=30),
         rsvp_enabled=True,
         max_attendees=2,
+        created_by=test_user,
     )
 
 
@@ -78,7 +81,7 @@ def capped_event(db):
 def unlimited_event(db):
     return Event.objects.create(
         title="Unlimited Event",
-        start_datetime="2026-06-01T18:00:00Z",
+        start_datetime=future_iso(days=30),
         rsvp_enabled=True,
     )
 
@@ -316,3 +319,79 @@ class TestCapacityCounts:
         event_data = next(e for e in resp.json() if e["id"] == str(capped_event.id))
         assert event_data["attending_count"] == 1
         assert event_data["max_attendees"] == 2
+
+
+# ---------------------------------------------------------------------------
+# TestMaxAttendeesValidation (#362)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestMaxAttendeesValidation:
+    @staticmethod
+    def _future_iso(days: int = 30) -> str:
+        from datetime import timedelta
+
+        from django.utils import timezone
+
+        return (timezone.now() + timedelta(days=days)).isoformat()
+
+    def test_create_rejects_zero_max_attendees(self, api_client, auth_headers):
+        import json
+
+        resp = api_client.post(
+            "/api/community/events/",
+            data=json.dumps(
+                {
+                    "title": "No Seats",
+                    "start_datetime": self._future_iso(),
+                    "rsvp_enabled": True,
+                    "max_attendees": 0,
+                }
+            ),
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert resp.status_code == 422
+        assert any(e["code"] == "max_attendees_must_be_at_least_one" for e in resp.json()["detail"])
+
+    def test_create_accepts_null_max_attendees(self, api_client, auth_headers):
+        import json
+
+        resp = api_client.post(
+            "/api/community/events/",
+            data=json.dumps(
+                {
+                    "title": "Unlimited",
+                    "start_datetime": self._future_iso(),
+                    "rsvp_enabled": True,
+                    "max_attendees": None,
+                }
+            ),
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert resp.status_code == 201
+
+    def test_patch_rejects_zero_max_attendees(self, api_client, capped_event, auth_headers):
+        import json
+
+        resp = api_client.patch(
+            f"/api/community/events/{capped_event.id}/",
+            data=json.dumps({"max_attendees": 0}),
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert resp.status_code == 422
+        assert any(e["code"] == "max_attendees_must_be_at_least_one" for e in resp.json()["detail"])
+
+    def test_patch_accepts_null_max_attendees(self, api_client, capped_event, auth_headers):
+        import json
+
+        resp = api_client.patch(
+            f"/api/community/events/{capped_event.id}/",
+            data=json.dumps({"max_attendees": None}),
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert resp.status_code == 200

--- a/backend/tests/test_event_drafts.py
+++ b/backend/tests/test_event_drafts.py
@@ -5,6 +5,8 @@ import json
 import pytest
 from community.models import Event, EventStatus
 
+from tests.conftest import future_iso, past_iso
+
 
 @pytest.fixture
 def creator(db):
@@ -78,7 +80,7 @@ def invitee(db):
 def sample_draft(db, creator):
     return Event.objects.create(
         title="Draft BBQ",
-        start_datetime="2027-06-01T18:00:00Z",
+        start_datetime=future_iso(days=180),
         created_by=creator,
         status=EventStatus.DRAFT,
     )
@@ -88,7 +90,7 @@ def sample_draft(db, creator):
 def future_active_event(db, creator):
     return Event.objects.create(
         title="Active BBQ",
-        start_datetime="2027-06-01T18:00:00Z",
+        start_datetime=future_iso(days=180),
         created_by=creator,
         status=EventStatus.ACTIVE,
     )
@@ -100,7 +102,7 @@ class TestCreateDraft:
         response = api_client.post(
             "/api/community/events/",
             data=json.dumps(
-                {"title": "My Draft", "start_datetime": "2027-06-01T18:00:00Z", "status": "draft"}
+                {"title": "My Draft", "start_datetime": future_iso(days=180), "status": "draft"}
             ),
             content_type="application/json",
             **creator_headers,
@@ -112,7 +114,7 @@ class TestCreateDraft:
         response = api_client.post(
             "/api/community/events/",
             data=json.dumps(
-                {"title": "Past Draft", "start_datetime": "2020-01-01T12:00:00Z", "status": "draft"}
+                {"title": "Past Draft", "start_datetime": past_iso(days=90), "status": "draft"}
             ),
             content_type="application/json",
             **creator_headers,
@@ -126,7 +128,7 @@ class TestCreateDraft:
             data=json.dumps(
                 {
                     "title": "Past Active",
-                    "start_datetime": "2020-01-01T12:00:00Z",
+                    "start_datetime": past_iso(days=90),
                     "status": "active",
                 }
             ),
@@ -141,7 +143,7 @@ class TestCreateDraft:
             data=json.dumps(
                 {
                     "title": "Bad Status",
-                    "start_datetime": "2027-06-01T18:00:00Z",
+                    "start_datetime": future_iso(days=180),
                     "status": "cancelled",
                 }
             ),
@@ -158,7 +160,7 @@ class TestCreateDraft:
             data=json.dumps(
                 {
                     "title": "Draft With Invitee",
-                    "start_datetime": "2027-06-01T18:00:00Z",
+                    "start_datetime": future_iso(days=180),
                     "status": "draft",
                     "invited_user_ids": [str(invitee.pk)],
                 }
@@ -178,7 +180,7 @@ class TestCreateDraft:
             data=json.dumps(
                 {
                     "title": "Draft With Cohost",
-                    "start_datetime": "2027-06-01T18:00:00Z",
+                    "start_datetime": future_iso(days=180),
                     "status": "draft",
                     "co_host_ids": [str(cohost.pk)],
                 }
@@ -193,7 +195,7 @@ class TestCreateDraft:
     def test_create_event_unauthenticated(self, api_client):
         response = api_client.post(
             "/api/community/events/",
-            data=json.dumps({"title": "Anon", "start_datetime": "2027-06-01T18:00:00Z"}),
+            data=json.dumps({"title": "Anon", "start_datetime": future_iso(days=180)}),
             content_type="application/json",
         )
         assert response.status_code == 401
@@ -264,7 +266,7 @@ class TestPatchDraft:
     def test_patch_draft_past_datetime_rejected(self, api_client, sample_draft, creator_headers):
         response = api_client.patch(
             f"/api/community/events/{sample_draft.id}/",
-            data=json.dumps({"start_datetime": "2020-01-01T12:00:00Z"}),
+            data=json.dumps({"start_datetime": past_iso(days=90)}),
             content_type="application/json",
             **creator_headers,
         )
@@ -278,7 +280,7 @@ class TestPatchDraft:
         date is updated — even if the user only touches the title."""
         stale = Event.objects.create(
             title="Old Draft",
-            start_datetime="2020-01-01T12:00:00Z",
+            start_datetime=past_iso(days=90),
             created_by=creator,
             status=EventStatus.DRAFT,
         )
@@ -366,7 +368,7 @@ class TestPublishDraft:
     def test_publish_draft_past_start_rejected(self, api_client, creator_headers, creator):
         draft = Event.objects.create(
             title="Past Draft",
-            start_datetime="2020-01-01T12:00:00Z",
+            start_datetime=past_iso(days=90),
             created_by=creator,
             status=EventStatus.DRAFT,
         )
@@ -382,7 +384,7 @@ class TestPublishDraft:
         """datetime_tbd=True drafts skip the future-date check on publish."""
         draft = Event.objects.create(
             title="TBD Draft",
-            start_datetime="2020-01-01T12:00:00Z",
+            start_datetime=past_iso(days=90),
             datetime_tbd=True,
             created_by=creator,
             status=EventStatus.DRAFT,

--- a/backend/tests/test_event_flags.py
+++ b/backend/tests/test_event_flags.py
@@ -8,6 +8,8 @@ from users.models import User
 from users.permissions import PermissionKey
 from users.roles import Role
 
+from tests.conftest import future_iso
+
 # ─── Fixtures ─────────────────────────────────────────────────────────────────
 
 
@@ -46,8 +48,8 @@ def admin_user(db) -> User:
 def sample_event(db) -> Event:
     return Event.objects.create(
         title="Community Potluck",
-        start_datetime="2026-06-01T18:00:00Z",
-        end_datetime="2026-06-01T20:00:00Z",
+        start_datetime=future_iso(days=30),
+        end_datetime=future_iso(days=30, hours=2),
         location="The Vegan Cafe",
     )
 

--- a/backend/tests/test_event_link_validation.py
+++ b/backend/tests/test_event_link_validation.py
@@ -9,10 +9,14 @@ Validates that:
 
 import pytest
 
-BASE_EVENT = {
-    "title": "Link Test Event",
-    "start_datetime": "2026-06-01T18:00:00Z",
-}
+from tests.conftest import future_iso
+
+
+def base_event() -> dict:
+    return {
+        "title": "Link Test Event",
+        "start_datetime": future_iso(days=30),
+    }
 
 
 @pytest.fixture
@@ -38,7 +42,7 @@ class TestWhatsappLinkValidation:
     def _post(self, api_client, headers, whatsapp_link):
         return api_client.post(
             "/api/community/events/",
-            {**BASE_EVENT, "whatsapp_link": whatsapp_link},
+            {**base_event(), "whatsapp_link": whatsapp_link},
             content_type="application/json",
             **headers,
         )
@@ -75,7 +79,7 @@ class TestPartifulLinkValidation:
     def _post(self, api_client, headers, partiful_link):
         return api_client.post(
             "/api/community/events/",
-            {**BASE_EVENT, "partiful_link": partiful_link},
+            {**base_event(), "partiful_link": partiful_link},
             content_type="application/json",
             **headers,
         )
@@ -106,7 +110,7 @@ class TestOtherLinkValidation:
     def _post(self, api_client, headers, other_link):
         return api_client.post(
             "/api/community/events/",
-            {**BASE_EVENT, "other_link": other_link},
+            {**base_event(), "other_link": other_link},
             content_type="application/json",
             **headers,
         )
@@ -135,7 +139,7 @@ class TestLinkValidationOnPatch:
     def _create_event(self, api_client, headers):
         resp = api_client.post(
             "/api/community/events/",
-            BASE_EVENT,
+            base_event(),
             content_type="application/json",
             **headers,
         )

--- a/backend/tests/test_event_management.py
+++ b/backend/tests/test_event_management.py
@@ -5,6 +5,8 @@ from community.models import Event
 from users.permissions import PermissionKey
 from users.roles import Role
 
+from tests.conftest import future_iso, past_iso
+
 
 @pytest.fixture
 def manage_events_user(db):
@@ -34,8 +36,8 @@ def sample_event(db):
     return Event.objects.create(
         title="Community Meetup",
         description="Monthly gathering",
-        start_datetime="2026-04-01T18:00:00Z",
-        end_datetime="2026-04-01T20:00:00Z",
+        start_datetime=future_iso(days=7),
+        end_datetime=future_iso(days=7, hours=2),
         location="The Vegan Cafe",
     )
 
@@ -50,8 +52,8 @@ class TestEventManagement:
             {
                 "title": "New Event",
                 "description": "A great event",
-                "start_datetime": "2026-05-01T18:00:00Z",
-                "end_datetime": "2026-05-01T20:00:00Z",
+                "start_datetime": future_iso(days=14),
+                "end_datetime": future_iso(days=14, hours=2),
                 "location": "Online",
             },
             content_type="application/json",
@@ -69,8 +71,8 @@ class TestEventManagement:
             "/api/community/events/",
             {
                 "title": "Named Event",
-                "start_datetime": "2026-05-01T18:00:00Z",
-                "end_datetime": "2026-05-01T20:00:00Z",
+                "start_datetime": future_iso(days=14),
+                "end_datetime": future_iso(days=14, hours=2),
             },
             content_type="application/json",
             **manage_events_headers,
@@ -95,8 +97,8 @@ class TestEventManagement:
             "/api/community/events/",
             {
                 "title": "Member Event",
-                "start_datetime": "2026-05-01T18:00:00Z",
-                "end_datetime": "2026-05-01T20:00:00Z",
+                "start_datetime": future_iso(days=14),
+                "end_datetime": future_iso(days=14, hours=2),
             },
             content_type="application/json",
             **headers,
@@ -108,8 +110,8 @@ class TestEventManagement:
             "/api/community/events/",
             {
                 "title": "Unauthenticated Event",
-                "start_datetime": "2026-05-01T18:00:00Z",
-                "end_datetime": "2026-05-01T20:00:00Z",
+                "start_datetime": future_iso(days=14),
+                "end_datetime": future_iso(days=14, hours=2),
             },
             content_type="application/json",
         )
@@ -120,8 +122,8 @@ class TestEventManagement:
             "/api/community/events/",
             {
                 "title": "Minimal Event",
-                "start_datetime": "2026-06-01T10:00:00Z",
-                "end_datetime": "2026-06-01T11:00:00Z",
+                "start_datetime": future_iso(days=30),
+                "end_datetime": future_iso(days=30, hours=1),
             },
             content_type="application/json",
             **manage_events_headers,
@@ -162,8 +164,8 @@ class TestEventManagement:
         event = Event.objects.create(
             title="My Event",
             description="Created by member",
-            start_datetime="2026-07-01T18:00:00Z",
-            end_datetime="2026-07-01T20:00:00Z",
+            start_datetime=future_iso(days=60),
+            end_datetime=future_iso(days=60, hours=2),
             location="Online",
             created_by=test_user,
         )
@@ -181,8 +183,8 @@ class TestEventManagement:
         event = Event.objects.create(
             title="Someone Else's Event",
             description="Created by manager",
-            start_datetime="2026-07-01T18:00:00Z",
-            end_datetime="2026-07-01T20:00:00Z",
+            start_datetime=future_iso(days=60),
+            end_datetime=future_iso(days=60, hours=2),
             location="Online",
             created_by=manage_events_user,
         )
@@ -232,7 +234,7 @@ class TestEventManagement:
             "/api/community/events/",
             {
                 "title": "Open-ended Event",
-                "start_datetime": "2026-05-01T18:00:00Z",
+                "start_datetime": future_iso(days=14),
             },
             content_type="application/json",
             **manage_events_headers,
@@ -245,8 +247,8 @@ class TestEventManagement:
             "/api/community/events/",
             {
                 "title": "Bad Event",
-                "start_datetime": "2026-05-01T20:00:00Z",
-                "end_datetime": "2026-05-01T18:00:00Z",
+                "start_datetime": future_iso(days=14, hours=2),
+                "end_datetime": future_iso(days=14),
             },
             content_type="application/json",
             **manage_events_headers,
@@ -259,7 +261,7 @@ class TestEventManagement:
             "/api/community/events/",
             {
                 "title": "Past Event",
-                "start_datetime": "2020-01-01T18:00:00Z",
+                "start_datetime": past_iso(days=90),
             },
             content_type="application/json",
             **manage_events_headers,
@@ -274,7 +276,7 @@ class TestEventManagement:
             "/api/community/events/",
             {
                 "title": "TBD Event",
-                "start_datetime": "2020-01-01T18:00:00Z",
+                "start_datetime": past_iso(days=90),
                 "datetime_tbd": True,
             },
             content_type="application/json",
@@ -287,7 +289,7 @@ class TestEventManagement:
     ):
         response = api_client.patch(
             f"/api/community/events/{sample_event.id}/",
-            {"start_datetime": "2020-01-01T18:00:00Z"},
+            {"start_datetime": past_iso(days=90)},
             content_type="application/json",
             **manage_events_headers,
         )
@@ -300,7 +302,7 @@ class TestEventManagement:
         """Updating non-date fields on a past event should succeed."""
         past_event = Event.objects.create(
             title="Old Meetup",
-            start_datetime="2020-01-01T18:00:00Z",
+            start_datetime=past_iso(days=90),
         )
         response = api_client.patch(
             f"/api/community/events/{past_event.id}/",
@@ -326,7 +328,7 @@ class TestEventManagement:
     ):
         response = api_client.patch(
             f"/api/community/events/{sample_event.id}/",
-            {"end_datetime": "2026-04-01T17:00:00Z"},
+            {"end_datetime": future_iso(days=6)},
             content_type="application/json",
             **manage_events_headers,
         )
@@ -338,7 +340,7 @@ class TestEventManagement:
             "/api/community/events/",
             {
                 "title": "Geocoded Meetup",
-                "start_datetime": "2026-07-01T18:00:00Z",
+                "start_datetime": future_iso(days=60),
                 "location": "The Vegan Cafe",
                 "latitude": 37.774929,
                 "longitude": -122.419416,
@@ -356,7 +358,7 @@ class TestEventManagement:
             "/api/community/events/",
             {
                 "title": "No Location Event",
-                "start_datetime": "2026-07-01T18:00:00Z",
+                "start_datetime": future_iso(days=60),
             },
             content_type="application/json",
             **manage_events_headers,
@@ -396,8 +398,8 @@ class TestEventManagement:
 
         event = Event.objects.create(
             title="Past Deletable Event",
-            start_datetime="2020-01-01T18:00:00Z",
-            end_datetime="2020-01-01T20:00:00Z",
+            start_datetime=past_iso(days=90),
+            end_datetime=past_iso(days=90),
             location="History",
             created_by=None,
         )
@@ -418,8 +420,8 @@ class TestEventManagement:
 
         event = Event.objects.create(
             title="My Past Event",
-            start_datetime="2020-08-01T18:00:00Z",
-            end_datetime="2020-08-01T20:00:00Z",
+            start_datetime=past_iso(days=60),
+            end_datetime=past_iso(days=60),
             location="Online",
             created_by=test_user,
         )
@@ -437,8 +439,8 @@ class TestEventManagement:
         """A member cannot delete an event they did not create."""
         event = Event.objects.create(
             title="Someone Else's Past Event",
-            start_datetime="2020-08-01T18:00:00Z",
-            end_datetime="2020-08-01T20:00:00Z",
+            start_datetime=past_iso(days=60),
+            end_datetime=past_iso(days=60),
             location="Online",
             created_by=manage_events_user,
         )
@@ -478,7 +480,7 @@ class TestEventRateLimiting:
         for i in range(10):
             resp = api_client.post(
                 "/api/community/events/",
-                {"title": f"Event {i}", "start_datetime": "2026-06-01T18:00:00Z"},
+                {"title": f"Event {i}", "start_datetime": future_iso(days=30)},
                 content_type="application/json",
                 **manage_events_headers,
             )
@@ -486,7 +488,7 @@ class TestEventRateLimiting:
         # 11th request should be rate limited
         resp = api_client.post(
             "/api/community/events/",
-            {"title": "One Too Many", "start_datetime": "2026-06-01T18:00:00Z"},
+            {"title": "One Too Many", "start_datetime": future_iso(days=30)},
             content_type="application/json",
             **manage_events_headers,
         )

--- a/backend/tests/test_in_app_notifications.py
+++ b/backend/tests/test_in_app_notifications.py
@@ -15,6 +15,8 @@ from users.models import User
 from users.permissions import PermissionKey
 from users.roles import Role
 
+from tests.conftest import future_iso
+
 # ─── Fixtures ────────────────────────────────────────────────────────────────
 
 
@@ -46,8 +48,8 @@ def another_user(db) -> User:
 def sample_event(inviter) -> Event:
     return Event.objects.create(
         title="Test Event",
-        start_datetime="2026-06-01T18:00:00Z",
-        end_datetime="2026-06-01T20:00:00Z",
+        start_datetime=future_iso(days=30),
+        end_datetime=future_iso(days=30, hours=2),
         created_by=inviter,
     )
 
@@ -244,8 +246,8 @@ class TestEventInviteIntegration:
     def test_create_event_with_invites_creates_notifications(self, api_client, inviter, invitee):
         payload = {
             "title": "Party",
-            "start_datetime": "2026-07-01T18:00:00Z",
-            "end_datetime": "2026-07-01T20:00:00Z",
+            "start_datetime": future_iso(days=60),
+            "end_datetime": future_iso(days=60, hours=2),
             "invited_user_ids": [str(invitee.pk)],
         }
         response = api_client.post(
@@ -260,8 +262,8 @@ class TestEventInviteIntegration:
     def test_create_event_inviter_not_notified(self, api_client, inviter):
         payload = {
             "title": "Solo",
-            "start_datetime": "2026-07-01T18:00:00Z",
-            "end_datetime": "2026-07-01T20:00:00Z",
+            "start_datetime": future_iso(days=60),
+            "end_datetime": future_iso(days=60, hours=2),
             "invited_user_ids": [str(inviter.pk)],
         }
         api_client.post(
@@ -301,8 +303,8 @@ class TestCanSeeInvited:
     ):
         event = Event.objects.create(
             title="Invite-only party",
-            start_datetime="2026-06-01T18:00:00Z",
-            end_datetime="2026-06-01T20:00:00Z",
+            start_datetime=future_iso(days=30),
+            end_datetime=future_iso(days=30, hours=2),
             created_by=inviter,
             visibility=PageVisibility.INVITE_ONLY,
         )
@@ -319,8 +321,8 @@ class TestCanSeeInvited:
     def test_host_can_see_invited_list_when_rsvp_disabled(self, api_client, inviter, invitee):
         event = Event.objects.create(
             title="No-rsvp party",
-            start_datetime="2026-06-01T18:00:00Z",
-            end_datetime="2026-06-01T20:00:00Z",
+            start_datetime=future_iso(days=30),
+            end_datetime=future_iso(days=30, hours=2),
             created_by=inviter,
             rsvp_enabled=False,
         )
@@ -339,8 +341,8 @@ class TestCanSeeInvited:
     ):
         event = Event.objects.create(
             title="Public with invites",
-            start_datetime="2026-06-01T18:00:00Z",
-            end_datetime="2026-06-01T20:00:00Z",
+            start_datetime=future_iso(days=30),
+            end_datetime=future_iso(days=30, hours=2),
             created_by=inviter,
             visibility=PageVisibility.PUBLIC,
         )
@@ -359,8 +361,8 @@ class TestCanSeeInvited:
     ):
         event = Event.objects.create(
             title="Invite-only party",
-            start_datetime="2026-06-01T18:00:00Z",
-            end_datetime="2026-06-01T20:00:00Z",
+            start_datetime=future_iso(days=30),
+            end_datetime=future_iso(days=30, hours=2),
             created_by=inviter,
             visibility=PageVisibility.INVITE_ONLY,
         )

--- a/backend/tests/test_photos.py
+++ b/backend/tests/test_photos.py
@@ -10,6 +10,8 @@ from users.models import User
 from users.permissions import PermissionKey
 from users.roles import Role
 
+from tests.conftest import future_iso
+
 
 def _make_test_image(fmt="JPEG", size=(20, 20)):
     buf = io.BytesIO()
@@ -53,7 +55,7 @@ def manager(db):
 def event(db, member):
     return Event.objects.create(
         title="Test Event",
-        start_datetime="2026-06-01T18:00:00Z",
+        start_datetime=future_iso(days=30),
         created_by=member,
     )
 

--- a/backend/tests/test_polls.py
+++ b/backend/tests/test_polls.py
@@ -6,6 +6,8 @@ import pytest
 from community.models import Event, EventPoll, PollAvailability, PollOption, PollVote
 from users.models import User  # noqa: F401 (imported for create_user side effect)
 
+from tests.conftest import future_iso
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -15,7 +17,7 @@ from users.models import User  # noqa: F401 (imported for create_user side effec
 def poll_event(db, test_user):
     return Event.objects.create(
         title="Poll Event",
-        start_datetime="2026-08-01T18:00:00Z",
+        start_datetime=future_iso(days=90),
         created_by=test_user,
     )
 
@@ -40,8 +42,8 @@ def other_headers(other_user):
 @pytest.fixture
 def poll_with_options(db, poll_event, test_user):
     poll = EventPoll.objects.create(event=poll_event, created_by=test_user)
-    PollOption.objects.create(poll=poll, datetime="2026-09-01T18:00:00Z", display_order=0)
-    PollOption.objects.create(poll=poll, datetime="2026-09-02T18:00:00Z", display_order=1)
+    PollOption.objects.create(poll=poll, datetime=future_iso(days=120), display_order=0)
+    PollOption.objects.create(poll=poll, datetime=future_iso(days=121), display_order=1)
     return poll
 
 
@@ -53,9 +55,7 @@ def poll_with_options(db, poll_event, test_user):
 @pytest.mark.django_db
 class TestCreatePoll:
     def test_create_poll_success(self, api_client, auth_headers, poll_event):
-        payload = {
-            "options": ["2026-09-01T18:00:00Z", "2026-09-02T18:00:00Z", "2026-09-03T18:00:00Z"]
-        }
+        payload = {"options": [future_iso(days=120), future_iso(days=121), future_iso(days=122)]}
         response = api_client.post(
             f"/api/community/events/{poll_event.id}/poll/",
             data=json.dumps(payload),
@@ -83,7 +83,7 @@ class TestCreatePoll:
         assert response.status_code == 400
 
     def test_create_poll_with_one_option_succeeds(self, api_client, auth_headers, poll_event):
-        payload = {"options": ["2026-09-01T18:00:00Z"]}
+        payload = {"options": [future_iso(days=120)]}
         response = api_client.post(
             f"/api/community/events/{poll_event.id}/poll/",
             data=json.dumps(payload),
@@ -95,7 +95,7 @@ class TestCreatePoll:
     def test_create_poll_duplicate_fails(
         self, api_client, auth_headers, poll_with_options, poll_event
     ):
-        payload = {"options": ["2026-10-01T18:00:00Z", "2026-10-02T18:00:00Z"]}
+        payload = {"options": [future_iso(days=150), future_iso(days=151)]}
         response = api_client.post(
             f"/api/community/events/{poll_event.id}/poll/",
             data=json.dumps(payload),
@@ -105,7 +105,7 @@ class TestCreatePoll:
         assert response.status_code == 400
 
     def test_create_poll_non_creator_forbidden(self, api_client, other_headers, poll_event):
-        payload = {"options": ["2026-09-01T18:00:00Z", "2026-09-02T18:00:00Z"]}
+        payload = {"options": [future_iso(days=120), future_iso(days=121)]}
         response = api_client.post(
             f"/api/community/events/{poll_event.id}/poll/",
             data=json.dumps(payload),
@@ -115,7 +115,7 @@ class TestCreatePoll:
         assert response.status_code == 403
 
     def test_create_poll_unauthenticated(self, api_client, poll_event):
-        payload = {"options": ["2026-09-01T18:00:00Z", "2026-09-02T18:00:00Z"]}
+        payload = {"options": [future_iso(days=120), future_iso(days=121)]}
         response = api_client.post(
             f"/api/community/events/{poll_event.id}/poll/",
             data=json.dumps(payload),
@@ -126,7 +126,7 @@ class TestCreatePoll:
     def test_create_poll_event_not_found(self, api_client, auth_headers):
         import uuid
 
-        payload = {"options": ["2026-09-01T18:00:00Z", "2026-09-02T18:00:00Z"]}
+        payload = {"options": [future_iso(days=120), future_iso(days=121)]}
         response = api_client.post(
             f"/api/community/events/{uuid.uuid4()}/poll/",
             data=json.dumps(payload),

--- a/backend/tests/test_rsvp.py
+++ b/backend/tests/test_rsvp.py
@@ -3,6 +3,8 @@
 import pytest
 from community.models import Event, EventRSVP, RSVPStatus
 
+from tests.conftest import future_iso
+
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
@@ -13,8 +15,8 @@ def rsvp_event(db, test_user):
     return Event.objects.create(
         title="RSVP Event",
         description="An event with RSVPs enabled",
-        start_datetime="2026-06-01T18:00:00Z",
-        end_datetime="2026-06-01T20:00:00Z",
+        start_datetime=future_iso(days=30),
+        end_datetime=future_iso(days=30, hours=2),
         location="Community Space",
         rsvp_enabled=True,
         created_by=test_user,
@@ -25,8 +27,8 @@ def rsvp_event(db, test_user):
 def no_rsvp_event(db):
     return Event.objects.create(
         title="No RSVP Event",
-        start_datetime="2026-06-02T18:00:00Z",
-        end_datetime="2026-06-02T20:00:00Z",
+        start_datetime=future_iso(days=31),
+        end_datetime=future_iso(days=31, hours=2),
         rsvp_enabled=False,
     )
 
@@ -249,8 +251,8 @@ class TestCreateEventWithCohosts:
             "/api/community/events/",
             {
                 "title": "Cohost Event",
-                "start_datetime": "2026-07-01T18:00:00Z",
-                "end_datetime": "2026-07-01T20:00:00Z",
+                "start_datetime": future_iso(days=60),
+                "end_datetime": future_iso(days=60, hours=2),
                 "co_host_ids": [str(other_user.pk)],
             },
             content_type="application/json",
@@ -266,8 +268,8 @@ class TestCreateEventWithCohosts:
             "/api/community/events/",
             {
                 "title": "RSVP Event",
-                "start_datetime": "2026-07-01T18:00:00Z",
-                "end_datetime": "2026-07-01T20:00:00Z",
+                "start_datetime": future_iso(days=60),
+                "end_datetime": future_iso(days=60, hours=2),
                 "rsvp_enabled": True,
             },
             content_type="application/json",
@@ -294,8 +296,8 @@ class TestCreateEventWithCohosts:
             "/api/community/events/",
             {
                 "title": "Cohost Phone Test",
-                "start_datetime": "2026-08-01T18:00:00Z",
-                "end_datetime": "2026-08-01T20:00:00Z",
+                "start_datetime": future_iso(days=90),
+                "end_datetime": future_iso(days=90, hours=2),
                 "rsvp_enabled": True,
                 "co_host_ids": [str(other_user.pk)],
             },

--- a/backend/tests/test_validation_codes.py
+++ b/backend/tests/test_validation_codes.py
@@ -9,10 +9,14 @@ so the frontend owns UI copy.
 import pytest
 from community._validation import ValidationCode
 
-BASE_EVENT = {
-    "title": "Validation Test Event",
-    "start_datetime": "2026-06-01T18:00:00Z",
-}
+from tests.conftest import future_iso
+
+
+def base_event() -> dict:
+    return {
+        "title": "Validation Test Event",
+        "start_datetime": future_iso(days=30),
+    }
 
 
 @pytest.fixture
@@ -69,7 +73,7 @@ class TestValidationCodesShape:
     def test_invalid_whatsapp_host_returns_code_with_field(self, api_client, manage_events_headers):
         resp = api_client.post(
             "/api/community/events/",
-            {**BASE_EVENT, "whatsapp_link": "https://notwhatsapp.com/x"},
+            {**base_event(), "whatsapp_link": "https://notwhatsapp.com/x"},
             content_type="application/json",
             **manage_events_headers,
         )
@@ -84,7 +88,7 @@ class TestValidationCodesShape:
     ):
         resp = api_client.post(
             "/api/community/events/",
-            {**BASE_EVENT, "whatsapp_link": "https://chat.whatsapp.com/"},
+            {**base_event(), "whatsapp_link": "https://chat.whatsapp.com/"},
             content_type="application/json",
             **manage_events_headers,
         )
@@ -100,7 +104,7 @@ class TestValidationCodesShape:
         # Pydantic type error, not one of our ValidationCodes.
         resp = api_client.post(
             "/api/community/events/",
-            {**BASE_EVENT, "max_attendees": "not a number"},
+            {**base_event(), "max_attendees": "not a number"},
             content_type="application/json",
             **manage_events_headers,
         )
@@ -111,7 +115,7 @@ class TestValidationCodesShape:
     def test_missing_title_gets_field_required(self, api_client, manage_events_headers):
         resp = api_client.post(
             "/api/community/events/",
-            {"start_datetime": "2026-06-01T18:00:00Z"},
+            {"start_datetime": future_iso(days=30)},
             content_type="application/json",
             **manage_events_headers,
         )

--- a/frontend/src/api/validationCodes.ts
+++ b/frontend/src/api/validationCodes.ts
@@ -14,6 +14,7 @@
 export const ValidationCode = {
   // Event form
   StartDatetimeRequiredUnlessTbd: 'start_datetime_required_unless_tbd',
+  MaxAttendeesMustBeAtLeastOne: 'max_attendees_must_be_at_least_one',
   UrlInvalid: 'url_invalid',
   UrlPathRequired: 'url_path_required',
   UrlSchemeMustBeHttpOrHttps: 'url_scheme_must_be_http_or_https',
@@ -42,6 +43,8 @@ export function messageForCode(err: FieldError): string {
   switch (err.code) {
     case ValidationCode.StartDatetimeRequiredUnlessTbd:
       return 'pick a start time, or mark the time as tbd';
+    case ValidationCode.MaxAttendeesMustBeAtLeastOne:
+      return 'max attendees must be at least 1 — leave blank for unlimited';
     case ValidationCode.UrlInvalid:
       return 'enter a valid url';
     case ValidationCode.UrlPathRequired:

--- a/frontend/src/components/ui/DateTimePicker.tsx
+++ b/frontend/src/components/ui/DateTimePicker.tsx
@@ -14,6 +14,8 @@ interface Props {
   disabled?: boolean;
   error?: string | undefined;
   optional?: boolean;
+  /** Disable calendar days before today (inclusive). For event start times. */
+  disablePast?: boolean;
 }
 
 function isoToDate(iso: string | null): Date | undefined {
@@ -28,10 +30,24 @@ function dateToIso(date: Date, hours: number, minutes: number): string {
   return copy.toISOString();
 }
 
-export function DateTimePicker({ label, value, onChange, disabled, error, optional }: Props) {
+export function DateTimePicker({
+  label,
+  value,
+  onChange,
+  disabled,
+  error,
+  optional,
+  disablePast,
+}: Props) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const selectedDate = isoToDate(value);
+  // Start-of-today so "today" itself is still selectable.
+  const todayStart = (() => {
+    const d = new Date();
+    d.setHours(0, 0, 0, 0);
+    return d;
+  })();
 
   // Close on outside click
   useEffect(() => {
@@ -108,6 +124,7 @@ export function DateTimePicker({ label, value, onChange, disabled, error, option
             }}
             defaultMonth={selectedDate ?? new Date()}
             locale={enUS}
+            {...(disablePast ? { disabled: { before: todayStart } } : {})}
           />
           <div className="border-border mt-2 flex items-center gap-2 border-t pt-2">
             <label htmlFor="dt-time" className="text-muted text-xs">

--- a/frontend/src/screens/events/form/EventFormBasics.tsx
+++ b/frontend/src/screens/events/form/EventFormBasics.tsx
@@ -110,6 +110,7 @@ export function EventFormBasics({
                   onChange({ startDatetime: iso });
                 }}
                 error={errors.startDatetime}
+                disablePast
               />
               <DateTimePicker
                 label="ends"

--- a/frontend/src/screens/events/form/validateEventForm.test.ts
+++ b/frontend/src/screens/events/form/validateEventForm.test.ts
@@ -134,17 +134,22 @@ describe('validateEventForm', () => {
   });
 
   describe('maxAttendees', () => {
-    it('rejects negative maxAttendees', () => {
-      const errors = validateEventForm(validValues({ maxAttendees: -1 }));
-      expect(errors.maxAttendees).toBe('must be 0 or more');
+    it('rejects zero maxAttendees (see #362 — 0 means "no rsvps possible")', () => {
+      const errors = validateEventForm(validValues({ maxAttendees: 0 }));
+      expect(errors.maxAttendees).toBe('must be 1 or more (leave blank for unlimited)');
     });
 
-    it('accepts zero maxAttendees', () => {
-      const errors = validateEventForm(validValues({ maxAttendees: 0 }));
+    it('rejects negative maxAttendees', () => {
+      const errors = validateEventForm(validValues({ maxAttendees: -1 }));
+      expect(errors.maxAttendees).toBe('must be 1 or more (leave blank for unlimited)');
+    });
+
+    it('accepts any positive maxAttendees', () => {
+      const errors = validateEventForm(validValues({ maxAttendees: 1 }));
       expect(errors.maxAttendees).toBeUndefined();
     });
 
-    it('accepts null maxAttendees', () => {
+    it('accepts null maxAttendees (= unlimited, user cleared the field)', () => {
       const errors = validateEventForm(validValues({ maxAttendees: null }));
       expect(errors.maxAttendees).toBeUndefined();
     });

--- a/frontend/src/screens/events/form/validateEventForm.ts
+++ b/frontend/src/screens/events/form/validateEventForm.ts
@@ -29,11 +29,13 @@ export function validateEventForm(values: EventFormValues): Errors {
     }
   }
 
+  // null = unlimited (leave the field blank). Otherwise must be a positive
+  // integer — 0 would let someone create an event nobody can rsvp to.
   if (
     values.maxAttendees !== null &&
-    (values.maxAttendees < 0 || !Number.isFinite(values.maxAttendees))
+    (values.maxAttendees < 1 || !Number.isFinite(values.maxAttendees))
   ) {
-    errors.maxAttendees = 'must be 0 or more';
+    errors.maxAttendees = 'must be 1 or more (leave blank for unlimited)';
   }
   return errors;
 }

--- a/frontend/src/screens/events/poll/PollCreateDialog.tsx
+++ b/frontend/src/screens/events/poll/PollCreateDialog.tsx
@@ -119,6 +119,7 @@ function PollCreateDialogBody({ onClose, eventId, onBuffer, initialOptions }: Pr
                     updateRow(idx, next);
                   }}
                   optional={false}
+                  disablePast
                 />
               </div>
               <button

--- a/frontend/src/screens/events/poll/PollManageDialog.tsx
+++ b/frontend/src/screens/events/poll/PollManageDialog.tsx
@@ -85,7 +85,12 @@ export function PollManageDialog({ open, onClose, poll }: Props) {
           <span className="text-sm font-medium">add an option</span>
           <div className="flex items-end gap-2">
             <div className="flex-1">
-              <DateTimePicker label="date & time" value={newIso} onChange={setNewIso} />
+              <DateTimePicker
+                label="date & time"
+                value={newIso}
+                onChange={setNewIso}
+                disablePast
+              />
             </div>
             <Button
               variant="secondary"
@@ -224,7 +229,7 @@ function OptionRow({
   return (
     <li className="border-border bg-surface flex items-end gap-2 rounded-md border p-2">
       <div className="flex-1">
-        <DateTimePicker label="date & time" value={iso} onChange={setIso} />
+        <DateTimePicker label="date & time" value={iso} onChange={setIso} disablePast />
       </div>
       <Button
         variant="ghost"

--- a/frontend/src/screens/profile/ProfileScreen.tsx
+++ b/frontend/src/screens/profile/ProfileScreen.tsx
@@ -10,6 +10,7 @@ import { useHasAnyAdminPermission } from '@/auth/useAuth';
 import { ContentContainer } from '@/screens/public/ContentContainer';
 import { AvatarUpload } from '@/screens/settings/AvatarUpload';
 import { cn } from '@/utils/cn';
+import { formatPhone } from '@/utils/formatPhone';
 import { BioEditDialog } from './BioEditDialog';
 
 export default function ProfileScreen() {
@@ -32,7 +33,7 @@ export default function ProfileScreen() {
         <AvatarUpload size="lg" />
         <div className="flex flex-col items-center gap-1">
           <h1 className="text-2xl font-medium tracking-tight">{user.displayName}</h1>
-          <ContactLine value={user.phoneNumber} visible={user.showPhone} />
+          <ContactLine value={formatPhone(user.phoneNumber)} visible={user.showPhone} />
           {user.email ? <ContactLine value={user.email} visible={user.showEmail} /> : null}
         </div>
       </header>


### PR DESCRIPTION
Closes #362.

Three related cleanups bundled into one PR (I know, I know — but they're all small):

## 1. max_attendees must be ≥ 1 (#362)
Reporter was able to create an event with max_attendees=0 and then RSVP to their own event → auto-waitlisted. Fix:

- **Backend**: new \`MAX_ATTENDEES_MUST_BE_AT_LEAST_ONE\` validation code. Shared \`_validate_max_attendees\` field validator on both \`EventIn\` and \`EventPatchIn\` — null = unlimited, anything ≥ 1 ok, 0 or negative rejected with a machine-readable code.
- **Frontend**: \`validateEventForm\` tightened to \`>= 1\` with "leave blank for unlimited" hint. Mapped the new code in \`validationCodes\`.

## 2. Block past dates in DateTimePicker
Since we reject past dates on save anyway, just prevent selecting them in the first place.

- New \`disablePast\` prop on \`DateTimePicker\` that greys out calendar days before today.
- Applied to the event form "starts" picker and both poll-create / poll-edit option pickers.
- NOT applied to "ends" (must be after start, may be before today if event already happened), or unrelated pickers.

## 3. ProfileScreen phone formatting
The only display site I missed in #365 — \`/profile\` header now passes the phone through \`formatPhone\`.

## 4. Test cleanup (housekeeping)
\`conftest.py\` now exports \`future_iso(days=N)\` and \`past_iso(days=N)\` helpers. Replaced ~80 hardcoded date strings across 13 test files so they don't silently rot once real-world time passes them and the \`check_past\` validator starts rejecting them. \`client_timestamp\` values left hardcoded — those are tested for pass-through, not validated.

## Test plan
- [ ] Try to create an event with max=0 → blocked with friendly error
- [ ] Try to create with max=1, max=5, null — all work
- [ ] Edit an existing capped event, set max=0 → blocked
- [ ] Open event create form, try to click a day before today in the "starts" picker → greyed out, can't select
- [ ] Same for poll create / edit date pickers
- [ ] "Ends" picker is unchanged (can still pick any future day, or in the past for already-happened events)
- [ ] /profile header phone shows formatted
- [ ] Full backend suite still green (697 tests)