### PR TITLE
ci: run agent-ci on PRs and pushes to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,69 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# Cancel older runs of the same branch when a new push arrives — the latest
+# commit is the one we care about.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  backend:
+    name: Backend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v8
+        with:
+          enable-cache: true
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --locked
+
+      - name: Run backend CI
+        run: make agent-backend-ci
+
+      # agent-lint auto-fixes with ruff; fail if anything was reformatted so
+      # contributors format locally instead of relying on CI to silently fix.
+      - name: Fail if the working tree is dirty
+        run: git diff --exit-code
+
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 10.33.0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: cd frontend && pnpm install --frozen-lockfile
+
+      - name: Run frontend CI
+        run: make agent-frontend-ci
+
+      # agent-frontend-format auto-writes with prettier; fail on diff so
+      # formatting is enforced on PRs rather than silently absorbed.
+      - name: Fail if the working tree is dirty
+        run: git diff --exit-code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: astral-sh/setup-uv@v8
+      - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
 
@@ -47,7 +47,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@v6
         with:
           version: 10.33.0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,29 @@ jobs:
   backend:
     name: Backend
     runs-on: ubuntu-latest
+
+    # Postgres 16 — matches docker-compose.yml for local dev. SQLite doesn't
+    # support JSONField `contains` lookups or pg_notify (SSE), so a handful
+    # of tests only pass against Postgres.
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: pda
+          POSTGRES_PASSWORD: pda
+          POSTGRES_DB: pda
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://pda:pda@localhost:5432/pda
+      SECRET_KEY: ci-only-not-used-in-prod
+
     steps:
       - uses: actions/checkout@v6
 

--- a/frontend/src/api/validationCodes.test.ts
+++ b/frontend/src/api/validationCodes.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  Code,
-  messageForCode,
-  messagesFromFieldErrors,
-  type FieldError,
-} from './validationCodes';
+import { Code, messageForCode, messagesFromFieldErrors, type FieldError } from './validationCodes';
 
 describe('messageForCode', () => {
   it('returns friendly copy for known event-form codes', () => {
@@ -17,12 +12,10 @@ describe('messageForCode', () => {
   });
 
   it('uses the field name for generic fallback codes', () => {
-    expect(messageForCode({ code: Code.Generic.FieldRequired, field: 'title' })).toContain(
-      'title',
+    expect(messageForCode({ code: Code.Generic.FieldRequired, field: 'title' })).toContain('title');
+    expect(messageForCode({ code: Code.Generic.FieldInvalid, field: 'max_attendees' })).toContain(
+      'max attendees',
     );
-    expect(
-      messageForCode({ code: Code.Generic.FieldInvalid, field: 'max_attendees' }),
-    ).toContain('max attendees');
   });
 
   it('interpolates params for password errors', () => {

--- a/frontend/src/api/validationCodes.ts
+++ b/frontend/src/api/validationCodes.ts
@@ -204,7 +204,7 @@ export function messageForCode(err: FieldError): string {
     case Code.Event.OfficialMustBePublic:
       return 'official events must be public';
     case Code.Event.InvalidCreateStatus:
-      return "new events can only be saved as active or draft";
+      return 'new events can only be saved as active or draft';
     case Code.Event.DateLockedByPoll:
       return "can't edit the date while a poll is active — finalize the poll first";
     case Code.Event.InviteOnly:
@@ -234,7 +234,7 @@ export function messageForCode(err: FieldError): string {
     case Code.Event.RsvpsClosedPast:
       return 'rsvps are closed for past events';
     case Code.Event.NoPlusOneSpots:
-      return "no spots available for a +1";
+      return 'no spots available for a +1';
     case Code.Event.RsvpNotFound:
       return 'rsvp not found';
     case Code.Event.AttendanceOpensLater:
@@ -434,7 +434,7 @@ export function messageForCode(err: FieldError): string {
     case Code.JoinRequest.OnlyRejectedCanBeUnRejected:
       return 'only rejected requests can be un-rejected';
     case Code.JoinRequest.PhoneAlreadyInvited:
-      return "that number is already in the community — try logging in instead";
+      return 'that number is already in the community — try logging in instead';
     case Code.JoinRequest.PhoneAlreadyPending:
       return "a request for this number is already pending — we'll be in touch soon";
     case Code.JoinRequest.AnswerRequired: {

--- a/frontend/src/screens/events/poll/PollManageDialog.tsx
+++ b/frontend/src/screens/events/poll/PollManageDialog.tsx
@@ -85,12 +85,7 @@ export function PollManageDialog({ open, onClose, poll }: Props) {
           <span className="text-sm font-medium">add an option</span>
           <div className="flex items-end gap-2">
             <div className="flex-1">
-              <DateTimePicker
-                label="date & time"
-                value={newIso}
-                onChange={setNewIso}
-                disablePast
-              />
+              <DateTimePicker label="date & time" value={newIso} onChange={setNewIso} disablePast />
             </div>
             <Button
               variant="secondary"


### PR DESCRIPTION
## Summary

Restores the CI workflow that went missing when the default branch switched from staging to main — the old `.github/workflows/ci-build.yml` and `promote-staging-to-main.yml` were deleted at the same time (PR #207) and a replacement never landed. #371 and #372 currently have no automated checks running against them.

## What runs

Two parallel jobs, each mirroring a local `make` target so the CI gate and local pre-commit loop stay in lockstep:

- **Backend** → `make agent-backend-ci` (ruff, django check, pytest, ty, complexity/file-size, `check-codes` once #372 lands)
- **Frontend** → `make agent-frontend-ci` (eslint, prettier, vitest, tsc)

## Triggers

- `pull_request` against `main`
- `push` to `main` (status on merge)
- Concurrency cancels older PR runs on the same branch; leaves push-to-main runs alone so deploy-facing history is complete.

## Auto-fix gotcha

`agent-lint` runs `ruff check --fix` and `agent-frontend-format` runs `prettier --write`. On a read-only CI runner they succeed silently after rewriting files. A trailing `git diff --exit-code` fails the job if anything was reformatted, so PRs land on already-formatted code rather than letting CI absorb the fix.

## Notes

- `permissions: contents: read` — nothing writes back to the repo.
- Deliberately separate from #371/#372 so the workflow itself is reviewable in isolation. Once this merges, #371 and #372 will pick it up on their next push.

## Test plan

- [ ] After merge, the CI workflow appears on open PRs (#371 / #372) and runs green
- [ ] A PR that introduces a formatting violation fails at \"Fail if the working tree is dirty\"