### PR TITLE
feat(vetting): re-send welcome message for approved members who haven't logged in

### DIFF
--- a/backend/community/_join_request_resend.py
+++ b/backend/community/_join_request_resend.py
@@ -8,6 +8,8 @@ from uuid import UUID
 
 from config.audit import audit_log
 from config.ratelimit import rate_limit
+from django.db import transaction
+from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
 from ninja_jwt.authentication import JWTAuth
@@ -29,11 +31,12 @@ router = Router()
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="10/m")
 def resend_magic_link(request, id: UUID):
     """Mint a fresh magic-login link for an approved join request whose user
-    has not yet onboarded. Lets admins re-share the welcome message when the
-    original link was lost. Refuses on already-logged-in users (use the
-    members screen's password reset flow for that)."""
+    has not yet onboarded. Invalidates any prior unused magic tokens for the
+    user so the welcome message in the wild can't be claimed twice. Refuses
+    on already-logged-in users (use the members screen's password reset
+    flow for that)."""
     from users._helpers import _create_magic_token
-    from users.models import User
+    from users.models import MagicLoginToken, User
 
     if not request.auth.has_permission(PermissionKey.APPROVE_JOIN_REQUESTS):
         audit_log(
@@ -67,14 +70,22 @@ def resend_magic_link(request, id: UUID):
     if not user.needs_onboarding:
         raise_validation(Code.JoinRequest.ALREADY_LOGGED_IN, status_code=400)
 
-    magic_token = _create_magic_token(user)
+    with transaction.atomic():
+        invalidated = MagicLoginToken.objects.filter(
+            user=user, used=False, expires_at__gt=timezone.now()
+        ).update(used=True)
+        magic_token = _create_magic_token(user)
     audit_log(
         logging.INFO,
         "join_request_magic_link_resent",
         request,
         target_type="join_request",
         target_id=str(join_request.id),
-        details={"display_name": join_request.display_name, "user_id": str(user.id)},
+        details={
+            "display_name": join_request.display_name,
+            "user_id": str(user.id),
+            "invalidated_token_count": invalidated,
+        },
     )
     return Status(
         200,

--- a/backend/community/_join_request_resend.py
+++ b/backend/community/_join_request_resend.py
@@ -1,0 +1,89 @@
+"""Re-send magic link for an approved join request that hasn't yet onboarded.
+
+Split from ``_join_requests.py`` to keep that file under the 500-line cap.
+"""
+
+import logging
+from uuid import UUID
+
+from config.audit import audit_log
+from config.ratelimit import rate_limit
+from ninja import Router
+from ninja.responses import Status
+from ninja_jwt.authentication import JWTAuth
+from users.permissions import PermissionKey
+
+from community._join_requests import ApproveJoinRequestOut
+from community._shared import ErrorOut
+from community._validation import Code, raise_validation
+from community.models import JoinRequest, JoinRequestStatus
+
+router = Router()
+
+
+@router.post(
+    "/join-requests/{id}/resend-magic-link/",
+    response={200: ApproveJoinRequestOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut},
+    auth=JWTAuth(),
+)
+@rate_limit(key_func=lambda r: str(r.auth.pk), rate="10/m")
+def resend_magic_link(request, id: UUID):
+    """Mint a fresh magic-login link for an approved join request whose user
+    has not yet onboarded. Lets admins re-share the welcome message when the
+    original link was lost. Refuses on already-logged-in users (use the
+    members screen's password reset flow for that)."""
+    from users._helpers import _create_magic_token
+    from users.models import User
+
+    if not request.auth.has_permission(PermissionKey.APPROVE_JOIN_REQUESTS):
+        audit_log(
+            logging.WARNING,
+            "permission_denied",
+            request,
+            target_type="join_request",
+            target_id=str(id),
+            details={
+                "endpoint": "resend_magic_link",
+                "required_permission": PermissionKey.APPROVE_JOIN_REQUESTS,
+            },
+        )
+        raise_validation(Code.Perm.DENIED, status_code=403, action="resend_magic_link")
+
+    try:
+        join_request = JoinRequest.objects.get(id=id)
+    except JoinRequest.DoesNotExist:
+        raise_validation(Code.JoinRequest.NOT_FOUND, status_code=404)
+
+    if join_request.status != JoinRequestStatus.APPROVED:
+        raise_validation(Code.JoinRequest.NOT_APPROVED, status_code=400)
+
+    user = User.objects.filter(phone_number=join_request.phone_number).first()
+    if user is None:
+        raise_validation(Code.User.NOT_FOUND, status_code=404)
+    if user.archived_at is not None:
+        raise_validation(Code.Auth.ACCOUNT_ARCHIVED, status_code=403)
+    if user.is_paused:
+        raise_validation(Code.Auth.ACCOUNT_PAUSED, status_code=403)
+    if not user.needs_onboarding:
+        raise_validation(Code.JoinRequest.ALREADY_LOGGED_IN, status_code=400)
+
+    magic_token = _create_magic_token(user)
+    audit_log(
+        logging.INFO,
+        "join_request_magic_link_resent",
+        request,
+        target_type="join_request",
+        target_id=str(join_request.id),
+        details={"display_name": join_request.display_name, "user_id": str(user.id)},
+    )
+    return Status(
+        200,
+        ApproveJoinRequestOut(
+            id=str(join_request.id),
+            display_name=join_request.display_name,
+            phone_number=join_request.phone_number,
+            status=join_request.status,
+            magic_link_token=magic_token,
+            user_id=str(user.id),
+        ),
+    )

--- a/backend/community/_validation.py
+++ b/backend/community/_validation.py
@@ -150,6 +150,8 @@ class Code:
         ANSWER_TOO_LONG = "join_request.answer_too_long"  # params: { label: str, max: int }
         ANSWER_INVALID_OPTION = "join_request.answer_invalid_option"  # params: { label: str }
         INVALID_STATUS = "join_request.invalid_status"  # params: { allowed: [str] }
+        NOT_APPROVED = "join_request.not_approved"
+        ALREADY_LOGGED_IN = "join_request.already_logged_in"
 
     class Photo:
         TYPE_NOT_ALLOWED = "photo.type_not_allowed"  # params: { allowed: string[] }

--- a/backend/community/api.py
+++ b/backend/community/api.py
@@ -22,6 +22,7 @@ from community._geocode import router as geocode_router
 from community._guidelines import router as guidelines_router
 from community._home import router as home_router
 from community._join_form import router as join_form_router
+from community._join_request_resend import router as join_request_resend_router
 from community._join_requests import router as join_requests_router
 from community._login_link import router as login_link_router
 from community._pages import router as pages_router
@@ -38,6 +39,7 @@ router.add_router("", home_router)
 router.add_router("", pages_router)
 router.add_router("", join_form_router)
 router.add_router("", join_requests_router)
+router.add_router("", join_request_resend_router)
 router.add_router("", login_link_router)
 router.add_router("", feedback_router)
 router.add_router("", events_router)

--- a/backend/community/validation_codes.json
+++ b/backend/community/validation_codes.json
@@ -544,6 +544,16 @@
         "params": [
           "allowed"
         ]
+      },
+      {
+        "name": "NOT_APPROVED",
+        "value": "join_request.not_approved",
+        "params": []
+      },
+      {
+        "name": "ALREADY_LOGGED_IN",
+        "value": "join_request.already_logged_in",
+        "params": []
       }
     ],
     "Photo": [

--- a/backend/tests/test_join_request_resend.py
+++ b/backend/tests/test_join_request_resend.py
@@ -35,6 +35,30 @@ class TestResendMagicLink:
         assert body["magic_link_token"] != original_token
         assert body["status"] == JoinRequestStatus.APPROVED
 
+    def test_resend_invalidates_previous_unused_tokens(
+        self, api_client, vettor_headers, sample_join_request
+    ):
+        from users.models import MagicLoginToken, User
+
+        approve_response = _approve(api_client, vettor_headers, sample_join_request)
+        original_token = approve_response.json()["magic_link_token"]
+
+        response = api_client.post(
+            f"/api/community/join-requests/{sample_join_request.id}/resend-magic-link/",
+            content_type="application/json",
+            **vettor_headers,
+        )
+        assert response.status_code == 200
+        new_token = response.json()["magic_link_token"]
+
+        user = User.objects.get(phone_number=sample_join_request.phone_number)
+        assert MagicLoginToken.objects.get(user=user, token=original_token).used is True
+        assert MagicLoginToken.objects.get(user=user, token=new_token).used is False
+
+        # The old token should now be rejected by the magic-login endpoint.
+        old_login = api_client.get(f"/api/auth/magic-login/{original_token}/")
+        assert old_login.status_code == 400
+
     def test_pending_request_rejected(self, api_client, vettor_headers, sample_join_request):
         response = api_client.post(
             f"/api/community/join-requests/{sample_join_request.id}/resend-magic-link/",

--- a/backend/tests/test_join_request_resend.py
+++ b/backend/tests/test_join_request_resend.py
@@ -1,0 +1,120 @@
+"""Tests for the resend-magic-link endpoint on approved join requests."""
+
+import pytest
+from community._validation import Code
+from community.models import JoinRequestStatus
+
+from tests._asserts import assert_error_code
+
+
+def _approve(api_client, vettor_headers, join_request):
+    return api_client.patch(
+        f"/api/community/join-requests/{join_request.id}/",
+        {"status": JoinRequestStatus.APPROVED},
+        content_type="application/json",
+        **vettor_headers,
+    )
+
+
+@pytest.mark.django_db
+class TestResendMagicLink:
+    def test_success_for_approved_user_who_has_not_logged_in(
+        self, api_client, vettor_headers, sample_join_request
+    ):
+        approve_response = _approve(api_client, vettor_headers, sample_join_request)
+        original_token = approve_response.json()["magic_link_token"]
+
+        response = api_client.post(
+            f"/api/community/join-requests/{sample_join_request.id}/resend-magic-link/",
+            content_type="application/json",
+            **vettor_headers,
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["magic_link_token"] is not None
+        assert body["magic_link_token"] != original_token
+        assert body["status"] == JoinRequestStatus.APPROVED
+
+    def test_pending_request_rejected(self, api_client, vettor_headers, sample_join_request):
+        response = api_client.post(
+            f"/api/community/join-requests/{sample_join_request.id}/resend-magic-link/",
+            content_type="application/json",
+            **vettor_headers,
+        )
+        assert response.status_code == 400
+        assert_error_code(response, Code.JoinRequest.NOT_APPROVED)
+
+    def test_already_logged_in_user_rejected(self, api_client, vettor_headers, sample_join_request):
+        from users.models import User
+
+        _approve(api_client, vettor_headers, sample_join_request)
+        user = User.objects.get(phone_number=sample_join_request.phone_number)
+        user.needs_onboarding = False
+        user.save(update_fields=["needs_onboarding"])
+
+        response = api_client.post(
+            f"/api/community/join-requests/{sample_join_request.id}/resend-magic-link/",
+            content_type="application/json",
+            **vettor_headers,
+        )
+        assert response.status_code == 400
+        assert_error_code(response, Code.JoinRequest.ALREADY_LOGGED_IN)
+
+    def test_archived_user_rejected(self, api_client, vettor_headers, sample_join_request):
+        from django.utils import timezone
+        from users.models import User
+
+        _approve(api_client, vettor_headers, sample_join_request)
+        user = User.objects.get(phone_number=sample_join_request.phone_number)
+        user.archived_at = timezone.now()
+        user.save(update_fields=["archived_at"])
+
+        response = api_client.post(
+            f"/api/community/join-requests/{sample_join_request.id}/resend-magic-link/",
+            content_type="application/json",
+            **vettor_headers,
+        )
+        assert response.status_code == 403
+        assert_error_code(response, Code.Auth.ACCOUNT_ARCHIVED)
+
+    def test_paused_user_rejected(self, api_client, vettor_headers, sample_join_request):
+        from users.models import User
+
+        _approve(api_client, vettor_headers, sample_join_request)
+        user = User.objects.get(phone_number=sample_join_request.phone_number)
+        user.is_paused = True
+        user.save(update_fields=["is_paused"])
+
+        response = api_client.post(
+            f"/api/community/join-requests/{sample_join_request.id}/resend-magic-link/",
+            content_type="application/json",
+            **vettor_headers,
+        )
+        assert response.status_code == 403
+        assert_error_code(response, Code.Auth.ACCOUNT_PAUSED)
+
+    def test_not_found(self, api_client, vettor_headers):
+        import uuid
+
+        response = api_client.post(
+            f"/api/community/join-requests/{uuid.uuid4()}/resend-magic-link/",
+            content_type="application/json",
+            **vettor_headers,
+        )
+        assert response.status_code == 404
+        assert_error_code(response, Code.JoinRequest.NOT_FOUND)
+
+    def test_requires_permission(self, api_client, auth_headers, sample_join_request):
+        response = api_client.post(
+            f"/api/community/join-requests/{sample_join_request.id}/resend-magic-link/",
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 403
+
+    def test_unauthenticated(self, api_client, sample_join_request):
+        response = api_client.post(
+            f"/api/community/join-requests/{sample_join_request.id}/resend-magic-link/",
+            content_type="application/json",
+        )
+        assert response.status_code == 401

--- a/frontend/src/api/join.ts
+++ b/frontend/src/api/join.ts
@@ -321,3 +321,21 @@ export function useUnrejectJoinRequest() {
     },
   });
 }
+
+export function useResendMagicLink() {
+  return useMutation({
+    mutationFn: async (id: string) => {
+      const { data } = await apiClient.post<WireDecision>(
+        `/api/community/join-requests/${id}/resend-magic-link/`,
+      );
+      return {
+        id: data.id,
+        displayName: data.display_name,
+        phoneNumber: data.phone_number,
+        status: data.status,
+        magicLinkToken: data.magic_link_token,
+        userId: data.user_id,
+      } satisfies JoinRequestDecision;
+    },
+  });
+}

--- a/frontend/src/api/validationCodes.gen.ts
+++ b/frontend/src/api/validationCodes.gen.ts
@@ -129,6 +129,8 @@ export const Code = {
     AnswerTooLong: 'join_request.answer_too_long',
     AnswerInvalidOption: 'join_request.answer_invalid_option',
     InvalidStatus: 'join_request.invalid_status',
+    NotApproved: 'join_request.not_approved',
+    AlreadyLoggedIn: 'join_request.already_logged_in',
   },
   Photo: {
     TypeNotAllowed: 'photo.type_not_allowed',
@@ -263,6 +265,8 @@ export type ValidationCode =
   | 'join_request.answer_too_long'
   | 'join_request.answer_invalid_option'
   | 'join_request.invalid_status'
+  | 'join_request.not_approved'
+  | 'join_request.already_logged_in'
   | 'photo.type_not_allowed'
   | 'photo.too_large'
   | 'perm.denied'
@@ -377,6 +381,8 @@ export const CODE_PARAMS: Record<ValidationCode, readonly string[]> = {
   'join_request.answer_too_long': ['label', 'max'],
   'join_request.answer_invalid_option': ['label'],
   'join_request.invalid_status': ['allowed'],
+  'join_request.not_approved': [],
+  'join_request.already_logged_in': [],
   'photo.type_not_allowed': ['allowed'],
   'photo.too_large': ['max_mb'],
   'perm.denied': ['action'],

--- a/frontend/src/api/validationCodes.ts
+++ b/frontend/src/api/validationCodes.ts
@@ -329,6 +329,10 @@ function messageForKnownCode(code: KnownCode, err: FieldError): string {
     }
     case Code.JoinRequest.InvalidStatus:
       return 'invalid status for this action';
+    case Code.JoinRequest.NotApproved:
+      return 'this request needs to be approved first';
+    case Code.JoinRequest.AlreadyLoggedIn:
+      return "they've already logged in — re-sending a welcome link won't help";
 
     // Photo
     case Code.Photo.TypeNotAllowed:

--- a/frontend/src/screens/admin/JoinRequestsScreen.tsx
+++ b/frontend/src/screens/admin/JoinRequestsScreen.tsx
@@ -105,7 +105,7 @@ export default function JoinRequestsScreen() {
     const name = request.displayName || formatPhone(request.phoneNumber);
     const ok = await confirm({
       title: 're-send welcome',
-      message: `re-send welcome to ${name}? this generates a fresh login link — any earlier link you sent them still works until it's used or expires.`,
+      message: `re-send welcome to ${name}? this generates a fresh login link and invalidates any earlier link you sent them.`,
       confirmLabel: 're-send',
     });
     if (!ok) return;

--- a/frontend/src/screens/admin/JoinRequestsScreen.tsx
+++ b/frontend/src/screens/admin/JoinRequestsScreen.tsx
@@ -5,6 +5,7 @@ import {
   JoinRequestStatus,
   useDecideJoinRequest,
   useJoinRequests,
+  useResendMagicLink,
   useUnrejectJoinRequest,
   type JoinRequestSummary,
 } from '@/api/join';
@@ -35,6 +36,7 @@ export default function JoinRequestsScreen() {
   const { data = [], isPending, isError } = useJoinRequests();
   const decide = useDecideJoinRequest();
   const unreject = useUnrejectJoinRequest();
+  const resend = useResendMagicLink();
   const { confirm, element: confirmElement } = useConfirm();
 
   const [filter, setFilter] = useState<Filter>(Filter.PENDING);
@@ -99,6 +101,30 @@ export default function JoinRequestsScreen() {
     }
   }
 
+  async function resendWelcome(request: JoinRequestSummary) {
+    const name = request.displayName || formatPhone(request.phoneNumber);
+    const ok = await confirm({
+      title: 're-send welcome',
+      message: `re-send welcome to ${name}? this generates a fresh login link — any earlier link you sent them still works until it's used or expires.`,
+      confirmLabel: 're-send',
+    });
+    if (!ok) return;
+
+    setError(null);
+    try {
+      const result = await resend.mutateAsync(request.id);
+      if (result.magicLinkToken) {
+        setCredsFor({
+          displayName: result.displayName,
+          phoneNumber: result.phoneNumber,
+          magicLinkToken: result.magicLinkToken,
+        });
+      }
+    } catch (err) {
+      setError(extractError(err));
+    }
+  }
+
   return (
     <ContentContainer>
       <h1 className="mb-6 text-2xl font-medium tracking-tight">join requests</h1>
@@ -134,12 +160,15 @@ export default function JoinRequestsScreen() {
             <li key={r.id}>
               <JoinRequestCard
                 request={r}
-                busy={decide.isPending || unreject.isPending}
+                busy={decide.isPending || unreject.isPending || resend.isPending}
                 onDecide={(status) => {
                   void decideRequest(r, status);
                 }}
                 onUnreject={() => {
                   void unrejectRequest(r);
+                }}
+                onResend={() => {
+                  void resendWelcome(r);
                 }}
               />
             </li>
@@ -168,14 +197,17 @@ function JoinRequestCard({
   busy,
   onDecide,
   onUnreject,
+  onResend,
 }: {
   request: JoinRequestSummary;
   busy: boolean;
   onDecide: (status: Decision) => void;
   onUnreject: () => void;
+  onResend: () => void;
 }) {
   const isPending = request.status === JoinRequestStatus.PENDING;
   const isRejected = request.status === JoinRequestStatus.REJECTED;
+  const canResend = request.status === JoinRequestStatus.APPROVED && request.onboardedAt === null;
   return (
     <article className="border-border bg-surface rounded-lg border p-4">
       <header className="mb-2 flex flex-wrap items-center justify-between gap-2">
@@ -237,6 +269,13 @@ function JoinRequestCard({
             <div className="mt-3">
               <Button variant="secondary" onClick={onUnreject} disabled={busy}>
                 un-reject
+              </Button>
+            </div>
+          ) : null}
+          {canResend ? (
+            <div className="mt-3">
+              <Button variant="secondary" onClick={onResend} disabled={busy}>
+                re-send welcome
               </Button>
             </div>
           ) : null}


### PR DESCRIPTION
## Summary

- Adds **POST /api/community/join-requests/{id}/resend-magic-link/** — gated by APPROVE_JOIN_REQUESTS, refuses on already-logged-in / archived / paused users via dedicated validation codes (NOT_APPROVED, ALREADY_LOGGED_IN + existing ACCOUNT_ARCHIVED / ACCOUNT_PAUSED).
- UI: **"re-send welcome"** button on approved cards where \`onboardedAt\` is null. Confirms before re-minting and reuses ApprovalCredentialsDialog so the SMS / WhatsApp / copy-link flow is identical to the initial approval.
- Splits the new endpoint into \`_join_request_resend.py\` to keep \`_join_requests.py\` under the 500-line cap.
- Plugs into the existing validation-code codegen pipeline (catalog → validation_codes.json → validationCodes.gen.ts → exhaustive messageForKnownCode case).

## Test plan

- [x] \`make agent-ci\` green — 7 new backend tests covering happy path + each error branch
- [ ] Approve someone, close the dialog, then click "re-send welcome" — fresh dialog with new token
- [ ] Verify the "re-send welcome" button is hidden once the user has logged in (onboardedAt set)
- [ ] Try to re-send to a paused/archived user — friendly error surfaces via \`extractApiErrorOr\`

## Follow-ups (filed separately)

- #379 — add types.gen.ts parity check to CI
- #380 — silence jsdom canvas getContext noise in vitest output