### PR TITLE
test: silence jsdom HTMLCanvasElement.getContext noise in vitest (#380)

### DIFF
--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -34,3 +34,8 @@ Object.defineProperty(window, 'matchMedia', {
     dispatchEvent: () => false,
   }),
 });
+
+// jsdom doesn't implement HTMLCanvasElement.getContext — return null so
+// jsdom stops emitting "Not implemented" warnings during component rendering.
+// No test currently inspects canvas output.
+HTMLCanvasElement.prototype.getContext = (() => null) as never;


### PR DESCRIPTION
## Summary

- Stub `HTMLCanvasElement.prototype.getContext` to return `null` in `frontend/src/test/setup.ts`, matching the existing `ResizeObserver` / `matchMedia` jsdom-gap stubs.
- Eliminates the `Not implemented: HTMLCanvasElement's getContext() method` warning that was appearing multiple times per `make agent-frontend-test` run and cluttering CI logs.
- No test currently inspects canvas output, so a no-op stub is safe.

Closes #380.

## Test plan

- [x] `make agent-frontend-test` — 407 passed / 1 skipped, **0** `HTMLCanvasElement` warnings in output (previously multiple per run)
- [x] `make agent-frontend-typecheck` — clean
- [x] `make agent-frontend-lint` — clean