### PR TITLE
fix(events): center rsvp buttons, hide max-attendees number spinner

### DIFF
--- a/frontend/src/screens/events/RsvpSection.tsx
+++ b/frontend/src/screens/events/RsvpSection.tsx
@@ -85,7 +85,7 @@ export function RsvpSection({ event, canSeeInvited }: Props) {
         />
       ) : (
         <>
-          <div className="flex flex-wrap gap-2">
+          <div className="flex flex-wrap justify-center gap-2">
             {PILLS.map((p) => (
               <RsvpPill
                 key={p.status}
@@ -97,15 +97,17 @@ export function RsvpSection({ event, canSeeInvited }: Props) {
             ))}
           </div>
           {atCapacity && myRsvp !== RsvpServerStatus.Attending ? (
-            <p className="text-warning text-xs">
+            <p className="text-warning text-center text-xs">
               event is full — tapping "i'm going" adds you to the waitlist
             </p>
           ) : null}
           {event.allowPlusOnes &&
           (myRsvp === RsvpServerStatus.Attending || myRsvp === RsvpServerStatus.Maybe) ? (
-            <Button variant="secondary" onClick={() => void togglePlusOne()} disabled={busy}>
-              {hasPlusOne ? 'remove +1' : 'bring a +1'}
-            </Button>
+            <div className="flex justify-center">
+              <Button variant="secondary" onClick={() => void togglePlusOne()} disabled={busy}>
+                {hasPlusOne ? 'remove +1' : 'bring a +1'}
+              </Button>
+            </div>
           ) : null}
         </>
       )}

--- a/frontend/src/screens/events/form/EventFormRsvp.tsx
+++ b/frontend/src/screens/events/form/EventFormRsvp.tsx
@@ -60,7 +60,7 @@ export function EventFormRsvp({ values, onChange, errors }: Props) {
               onChange({ maxAttendees: v === '' ? null : Number(v) });
             }}
             error={errors.maxAttendees}
-            className="[&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [-moz-appearance:textfield]"
+            className="[-moz-appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
           />
         </>
       ) : null}

--- a/frontend/src/screens/events/form/EventFormRsvp.tsx
+++ b/frontend/src/screens/events/form/EventFormRsvp.tsx
@@ -51,6 +51,7 @@ export function EventFormRsvp({ values, onChange, errors }: Props) {
           <TextField
             label="max attendees (optional)"
             type="number"
+            inputMode="numeric"
             min={1}
             max={200}
             value={values.maxAttendees === null ? '' : String(values.maxAttendees)}
@@ -59,6 +60,7 @@ export function EventFormRsvp({ values, onChange, errors }: Props) {
               onChange({ maxAttendees: v === '' ? null : Number(v) });
             }}
             error={errors.maxAttendees}
+            className="[&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none [-moz-appearance:textfield]"
           />
         </>
       ) : null}


### PR DESCRIPTION
## Summary
- center the rsvp pill row, +1 button, and at-capacity warning on the event detail screen (#369)
- hide native browser up/down spinner arrows on the max-attendees field so it matches the rest of the form (#370)

closes #369
closes #370

## Test plan
- [ ] open an event detail page with rsvp enabled — pills, +1 button, and "event is full" warning all centered
- [ ] open an event edit page — max attendees field renders as a plain text-style input with no native arrows in chrome/safari/firefox
- [ ] still able to type a number, clear it, and see validation errors