### PR TITLE
refactor(fe): centralize axios error inspection in apiErrors helpers (Issue 388)

### DIFF
--- a/frontend/src/api/apiErrors.test.ts
+++ b/frontend/src/api/apiErrors.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { extractApiError, extractApiErrorOr } from './apiErrors';
+import { extractApiError, extractApiErrorOr, getApiStatus, hasErrorCode } from './apiErrors';
 import { Code } from './validationCodes';
 
 function axiosError(status: number, data: unknown) {
@@ -72,5 +72,55 @@ describe('extractApiErrorOr', () => {
   it('returns the fallback when no message is recoverable', () => {
     expect(extractApiErrorOr(new Error('not an axios error'), 'fallback')).toBe('fallback');
     expect(extractApiErrorOr(axiosError(500, undefined), 'fallback')).toBe('fallback');
+  });
+});
+
+describe('getApiStatus', () => {
+  it('returns the status when the error is an axios error with a response', () => {
+    expect(getApiStatus(axiosError(403, { detail: 'nope' }))).toBe(403);
+    expect(getApiStatus(axiosError(429, undefined))).toBe(429);
+  });
+
+  it('returns null for non-axios errors', () => {
+    expect(getApiStatus(new Error('boom'))).toBeNull();
+    expect(getApiStatus('string')).toBeNull();
+    expect(getApiStatus(undefined)).toBeNull();
+  });
+
+  it('returns null for axios errors with no response (e.g. network)', () => {
+    const networkErr = Object.assign(new Error('network'), { isAxiosError: true });
+    expect(getApiStatus(networkErr)).toBeNull();
+  });
+});
+
+describe('hasErrorCode', () => {
+  it('returns true when the structured detail contains the code', () => {
+    const err = axiosError(409, {
+      detail: [{ code: Code.Event.FlagAlreadyFlagged, field: null }],
+    });
+    expect(hasErrorCode(err, Code.Event.FlagAlreadyFlagged)).toBe(true);
+  });
+
+  it('returns true when the code is one of several entries', () => {
+    const err = axiosError(422, {
+      detail: [
+        { code: 'field_required', field: 'title' },
+        { code: Code.CoHostInvite.NotPending, field: null },
+      ],
+    });
+    expect(hasErrorCode(err, Code.CoHostInvite.NotPending)).toBe(true);
+  });
+
+  it('returns false when the code is not present', () => {
+    const err = axiosError(409, { detail: [{ code: 'something.else', field: null }] });
+    expect(hasErrorCode(err, Code.Event.FlagAlreadyFlagged)).toBe(false);
+  });
+
+  it('returns false for legacy string-detail responses', () => {
+    expect(hasErrorCode(axiosError(400, { detail: 'free text' }), 'anything')).toBe(false);
+  });
+
+  it('returns false for non-axios errors', () => {
+    expect(hasErrorCode(new Error('boom'), 'anything')).toBe(false);
   });
 });

--- a/frontend/src/api/apiErrors.ts
+++ b/frontend/src/api/apiErrors.ts
@@ -43,3 +43,27 @@ export function extractApiError(err: unknown): string | null {
 export function extractApiErrorOr(err: unknown, fallback: string): string {
   return extractApiError(err) ?? fallback;
 }
+
+/**
+ * HTTP status from any API error, or null if the error isn't an axios error
+ * with a response. Use this instead of importing `isAxiosError` directly so
+ * call sites don't reach into `error.response?.status` on their own.
+ */
+export function getApiStatus(err: unknown): number | null {
+  if (!isAxiosError(err)) return null;
+  return err.response?.status ?? null;
+}
+
+/**
+ * True if the error carries a structured-detail entry with the given code.
+ * Prefer this over status-based branching when the code is more specific than
+ * the status (e.g. distinguishing flag_already_flagged from any 409).
+ */
+export function hasErrorCode(err: unknown, code: string): boolean {
+  if (!isAxiosError(err)) return false;
+  const data = err.response?.data as Record<string, unknown> | undefined;
+  if (!data || !Array.isArray(data.detail)) return false;
+  return data.detail.some(
+    (e) => typeof e === 'object' && e !== null && (e as { code?: unknown }).code === code,
+  );
+}

--- a/frontend/src/api/eventFlags.ts
+++ b/frontend/src/api/eventFlags.ts
@@ -6,8 +6,9 @@
 // Transitions: pending → dismissed | actioned. Cannot go back to pending.
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { isAxiosError } from 'axios';
 import { apiClient } from './client';
+import { getApiStatus, hasErrorCode } from './apiErrors';
+import { Code } from './validationCodes';
 
 export type FlagStatus = 'pending' | 'dismissed' | 'actioned';
 
@@ -84,16 +85,14 @@ export function useFlagEvent(eventId: string) {
         });
         return mapFlag(data);
       } catch (err) {
-        if (isAxiosError(err)) {
-          if (err.response?.status === 409) {
-            throw new FlagEventError('already-flagged', "you've already flagged this event");
-          }
-          if (err.response?.status === 429) {
-            throw new FlagEventError(
-              'rate-limited',
-              "you've flagged too many events — try again later",
-            );
-          }
+        if (hasErrorCode(err, Code.Event.FlagAlreadyFlagged)) {
+          throw new FlagEventError('already-flagged', "you've already flagged this event");
+        }
+        if (getApiStatus(err) === 429) {
+          throw new FlagEventError(
+            'rate-limited',
+            "you've flagged too many events — try again later",
+          );
         }
         throw new FlagEventError('unknown', "couldn't submit — try again");
       }

--- a/frontend/src/api/eventPolls.ts
+++ b/frontend/src/api/eventPolls.ts
@@ -2,9 +2,9 @@
 // Mirrors backend/community/_polls.py. GET is optional-auth, so unauthed
 // viewers see counts but not their own votes.
 
-import { isAxiosError } from 'axios';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { apiClient } from './client';
+import { extractApiErrorOr, getApiStatus } from './apiErrors';
 import { eventKeys } from './events';
 import { mapEventPoll, type WireEventPoll } from './eventPollMapper';
 import { useAuthStore } from '@/auth/store';
@@ -25,7 +25,7 @@ async function fetchEventPoll(eventId: string): Promise<EventPoll | null> {
     const { data } = await apiClient.get<WireEventPoll>(pollUrl(eventId));
     return mapEventPoll(data);
   } catch (err) {
-    if (isAxiosError(err) && err.response?.status === 404) return null;
+    if (getApiStatus(err) === 404) return null;
     throw err;
   }
 }
@@ -40,12 +40,8 @@ export function useEventPoll(eventId: string, hasPoll: boolean) {
 }
 
 function extractPollError(err: unknown): string {
-  if (isAxiosError(err)) {
-    if (err.response?.status === 429) return 'slow down — try again in a moment';
-    const data = err.response?.data as { detail?: unknown } | undefined;
-    if (typeof data?.detail === 'string') return data.detail;
-  }
-  return "couldn't update the poll — try again";
+  if (getApiStatus(err) === 429) return 'slow down — try again in a moment';
+  return extractApiErrorOr(err, "couldn't update the poll — try again");
 }
 
 function invalidateEventAndPoll(

--- a/frontend/src/api/eventWrites.ts
+++ b/frontend/src/api/eventWrites.ts
@@ -5,9 +5,8 @@
 // dedicated error so the UI can show a sane message.
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { isAxiosError } from 'axios';
 import { apiClient } from './client';
-import { extractApiErrorOr } from './apiErrors';
+import { extractApiErrorOr, getApiStatus } from './apiErrors';
 import { useAuthStore } from '@/auth/store';
 import { eventKeys } from './events';
 import { mapEvent, type WireEvent } from './eventMapper';
@@ -217,7 +216,7 @@ export function useDeleteEventPhoto(eventId: string) {
 
 export function extractEventError(err: unknown): string {
   // Event-create has a hard daily rate limit; surface that specifically.
-  if (isAxiosError(err) && err.response?.status === 429) {
+  if (getApiStatus(err) === 429) {
     return "you've hit the daily event-creation limit — try again tomorrow";
   }
   return extractApiErrorOr(err, "couldn't save the event — try again");

--- a/frontend/src/screens/events/CohostInviteBanner.tsx
+++ b/frontend/src/screens/events/CohostInviteBanner.tsx
@@ -3,9 +3,10 @@
 // banner relies on `myPendingCohostInviteId` from EventOut, which the backend
 // clears via lazy expiration once the event ends.
 
-import { isAxiosError } from 'axios';
 import { toast } from 'sonner';
+import { hasErrorCode } from '@/api/apiErrors';
 import { useAcceptCohostInvite, useDeclineCohostInvite } from '@/api/cohostInvites';
+import { Code } from '@/api/validationCodes';
 import { Button } from '@/components/ui/Button';
 import type { Event } from '@/models/event';
 
@@ -53,9 +54,9 @@ export function CohostInviteBanner({ event }: Props) {
               { eventId: event.id, inviteId },
               {
                 onError: (err) => {
-                  // 400 with "not_pending" means someone (e.g. inviter rescinding) raced us.
+                  // not_pending means someone (e.g. inviter rescinding) raced us.
                   // Treat as success — the banner will disappear on the next refetch.
-                  if (isAxiosError(err) && err.response?.status === 400) return;
+                  if (hasErrorCode(err, Code.CoHostInvite.NotPending)) return;
                   toast.error("couldn't decline — try again");
                 },
               },

--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -1,6 +1,5 @@
-import { isAxiosError } from 'axios';
 import { Link, useParams } from 'react-router-dom';
-import { extractApiError } from '@/api/apiErrors';
+import { extractApiError, getApiStatus } from '@/api/apiErrors';
 import { useEvent } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
@@ -19,7 +18,7 @@ export default function EventDetailScreen() {
 
   if (isPending) return <ContentLoading />;
   if (isError) {
-    if (isAxiosError(error) && error.response?.status === 403) {
+    if (getApiStatus(error) === 403) {
       const message = extractApiError(error) ?? "you don't have permission to see this event";
       return <ForbiddenNotice message={message} />;
     }

--- a/frontend/src/screens/public/DonateScreen.tsx
+++ b/frontend/src/screens/public/DonateScreen.tsx
@@ -1,4 +1,4 @@
-import { isAxiosError } from 'axios';
+import { getApiStatus } from '@/api/apiErrors';
 import { useEditablePage, useUpdateEditablePage } from '@/api/content';
 import { useAuthStore } from '@/auth/store';
 import { EditableHtmlBlock } from '@/components/EditableHtmlBlock';
@@ -15,7 +15,7 @@ export default function DonateScreen() {
 
   if (isPending) return <ContentLoading />;
   if (error) {
-    if (isAxiosError(error) && error.response?.status === 403) {
+    if (getApiStatus(error) === 403) {
       return <ContentError message="this page is for members only" />;
     }
     return <ContentError message="couldn't load the donate page — try refreshing" />;

--- a/frontend/src/screens/public/VolunteerScreen.tsx
+++ b/frontend/src/screens/public/VolunteerScreen.tsx
@@ -1,4 +1,4 @@
-import { isAxiosError } from 'axios';
+import { getApiStatus } from '@/api/apiErrors';
 import { useEditablePage, useUpdateEditablePage } from '@/api/content';
 import { useAuthStore } from '@/auth/store';
 import { EditableHtmlBlock } from '@/components/EditableHtmlBlock';
@@ -13,7 +13,7 @@ export default function VolunteerScreen() {
 
   if (isPending) return <ContentLoading />;
   if (error) {
-    if (isAxiosError(error) && error.response?.status === 403) {
+    if (getApiStatus(error) === 403) {
       return <ContentError message="this page is for members only" />;
     }
     return <ContentError message="couldn't load the volunteer page — try refreshing" />;


### PR DESCRIPTION
## Summary

- Add `getApiStatus(err): number | null` and `hasErrorCode(err, code): boolean` to `frontend/src/api/apiErrors.ts`. These join the existing `extractApiError` / `extractApiErrorOr` so all wire-shape knowledge lives in one file.
- Sweep the 7 call sites listed in Issue 388, replacing every `isAxiosError(err) && err.response?.status === N` with `getApiStatus(err) === N`. Where a structured code is more specific than the status, switch to `hasErrorCode`:
  - `CohostInviteBanner` decline race → `hasErrorCode(err, Code.CoHostInvite.NotPending)`
  - `eventFlags.useFlagEvent` 409 → `hasErrorCode(err, Code.Event.FlagAlreadyFlagged)`
- `eventPolls.extractPollError` now delegates to `extractApiErrorOr` instead of hand-rolling the legacy `data.detail` shape — it picks up structured codes for free.
- After this, only `apiErrors.ts` itself imports `isAxiosError` from `axios` in the non-test, non-generated frontend tree (acceptance criterion).

Closes Issue 388.

## Test plan

- [x] New unit tests for `getApiStatus` (axios w/ response, axios w/o response, non-axios) and `hasErrorCode` (single code, multi-detail, missing, legacy string, non-axios) — 17 total in `apiErrors.test.ts`
- [x] `make agent-frontend-test` — 415 passed / 1 skipped, no regressions
- [x] `make agent-frontend-typecheck` — clean
- [x] `make agent-frontend-lint` — clean
- [x] Behavior preserved: status-only call sites still branch on the same status; `CohostInviteBanner` decline race is now keyed on the actual code rather than "any 400"