### PR TITLE
feat(events): block adding cohosts to past events (#385)

### DIFF
--- a/backend/community/_cohost_invite_helpers.py
+++ b/backend/community/_cohost_invite_helpers.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING
 from django.db import transaction
 from django.utils import timezone
 
+from community._validation import Code, raise_validation
 from community.models import CoHostInviteStatus, Event, EventCoHostInvite
 
 if TYPE_CHECKING:
@@ -99,11 +100,18 @@ def diff_cohost_invites(
 
     The event creator is silently filtered out of the requested ids — they're
     already a host and don't need a co-host invite for their own event.
+
+    Raises ``Code.CoHostInvite.EVENT_IS_PAST`` if the input would create or
+    revive a pending invite on a past event. Removals continue to work — the
+    host can still trim the roster after the fact.
     """
     next_ids = {str(uid) for uid in co_host_ids}
     if event.created_by_id is not None:
         next_ids.discard(str(event.created_by_id))
     existing_by_user = {str(inv.user_id): inv for inv in event.cohost_invites.all()}
+
+    if event.is_past and _would_upsert_any(next_ids, existing_by_user):
+        raise_validation(Code.CoHostInvite.EVENT_IS_PAST, status_code=400)
 
     newly_invited: list[str] = []
     accepted_co_host_ids_to_remove: list[str] = []
@@ -121,6 +129,23 @@ def diff_cohost_invites(
             event.co_hosts.remove(*accepted_co_host_ids_to_remove)
 
     return newly_invited, accepted_co_host_ids_to_remove
+
+
+def _would_upsert_any(next_ids: set[str], existing_by_user: dict[str, EventCoHostInvite]) -> bool:
+    """True if any requested id would result in a create-or-revive.
+
+    Mirrors the logic in ``_upsert_pending_invite`` so we can guard before
+    running it: an id is "upsert-y" if there's no existing row, OR there is
+    one but it's in a non-active state (declined / rescinded / expired /
+    removed) that would get flipped back to pending.
+    """
+    for user_id in next_ids:
+        existing = existing_by_user.get(user_id)
+        if existing is None:
+            return True
+        if existing.status not in _ACTIVE_OR_PENDING:
+            return True
+    return False
 
 
 def get_pending_invites_for_event(event: Event) -> list[EventCoHostInvite]:

--- a/backend/community/_cohost_invite_helpers.py
+++ b/backend/community/_cohost_invite_helpers.py
@@ -105,13 +105,9 @@ def diff_cohost_invites(
     revive a pending invite on a past event. Removals continue to work — the
     host can still trim the roster after the fact.
     """
-    next_ids = {str(uid) for uid in co_host_ids}
-    if event.created_by_id is not None:
-        next_ids.discard(str(event.created_by_id))
+    next_ids = _next_ids_excluding_creator(event, co_host_ids)
     existing_by_user = {str(inv.user_id): inv for inv in event.cohost_invites.all()}
-
-    if event.is_past and _would_upsert_any(next_ids, existing_by_user):
-        raise_validation(Code.CoHostInvite.EVENT_IS_PAST, status_code=400)
+    _check_past_event_guard(event, next_ids, existing_by_user)
 
     newly_invited: list[str] = []
     accepted_co_host_ids_to_remove: list[str] = []
@@ -131,21 +127,32 @@ def diff_cohost_invites(
     return newly_invited, accepted_co_host_ids_to_remove
 
 
-def _would_upsert_any(next_ids: set[str], existing_by_user: dict[str, EventCoHostInvite]) -> bool:
-    """True if any requested id would result in a create-or-revive.
+def _next_ids_excluding_creator(event: Event, co_host_ids: Iterable[str]) -> set[str]:
+    """Normalize requested ids and drop the creator (they're already a host)."""
+    next_ids = {str(uid) for uid in co_host_ids}
+    if event.created_by_id is not None:
+        next_ids.discard(str(event.created_by_id))
+    return next_ids
 
-    Mirrors the logic in ``_upsert_pending_invite`` so we can guard before
-    running it: an id is "upsert-y" if there's no existing row, OR there is
-    one but it's in a non-active state (declined / rescinded / expired /
-    removed) that would get flipped back to pending.
+
+def _check_past_event_guard(
+    event: Event,
+    next_ids: set[str],
+    existing_by_user: dict[str, EventCoHostInvite],
+) -> None:
+    """Raise EVENT_IS_PAST if any requested id would create or revive an invite.
+
+    Mirrors the logic in ``_upsert_pending_invite`` — a request is "upsert-y"
+    if there's no existing row, or there is one but it's in a non-active state
+    (declined / rescinded / expired / removed) that would get flipped back to
+    pending. Removals are unaffected; the guard is a no-op for those.
     """
+    if not event.is_past:
+        return
     for user_id in next_ids:
         existing = existing_by_user.get(user_id)
-        if existing is None:
-            return True
-        if existing.status not in _ACTIVE_OR_PENDING:
-            return True
-    return False
+        if existing is None or existing.status not in _ACTIVE_OR_PENDING:
+            raise_validation(Code.CoHostInvite.EVENT_IS_PAST, status_code=400)
 
 
 def get_pending_invites_for_event(event: Event) -> list[EventCoHostInvite]:

--- a/backend/community/_validation.py
+++ b/backend/community/_validation.py
@@ -189,6 +189,7 @@ class Code:
         NOT_HOST = "cohost_invite.not_host"
         NOT_REMOVABLE = "cohost_invite.not_removable"  # invite is in a terminal state
         WOULD_LEAVE_HOSTLESS = "cohost_invite.would_leave_hostless"
+        EVENT_IS_PAST = "cohost_invite.event_is_past"
 
     class WelcomeTemplate:
         BODY_REQUIRED = "welcome_template.body_required"

--- a/backend/community/validation_codes.json
+++ b/backend/community/validation_codes.json
@@ -675,6 +675,11 @@
         "name": "WOULD_LEAVE_HOSTLESS",
         "value": "cohost_invite.would_leave_hostless",
         "params": []
+      },
+      {
+        "name": "EVENT_IS_PAST",
+        "value": "cohost_invite.event_is_past",
+        "params": []
       }
     ],
     "WelcomeTemplate": [

--- a/backend/tests/test_event_cohost_invites.py
+++ b/backend/tests/test_event_cohost_invites.py
@@ -8,6 +8,7 @@ import json
 from datetime import timedelta
 
 import pytest
+from community._validation import Code
 from community.models import (
     CoHostInviteStatus,
     Event,
@@ -19,6 +20,7 @@ from ninja_jwt.tokens import RefreshToken
 from notifications.models import Notification, NotificationType
 from users.models import User
 
+from tests._asserts import assert_error_code
 from tests.conftest import future_iso
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -332,6 +334,97 @@ class TestLazyExpire:
         assert response.status_code == 200
         invite.refresh_from_db()
         assert invite.status == CoHostInviteStatus.EXPIRED
+
+
+# ─── Past-event guard (#385) ──────────────────────────────────────────────────
+
+
+def _make_event_past(event: Event) -> None:
+    past = timezone.now() - timedelta(days=1)
+    Event.objects.filter(pk=event.pk).update(
+        start_datetime=past - timedelta(hours=1),
+        end_datetime=past,
+    )
+
+
+@pytest.mark.django_db
+class TestPastEventGuard:
+    def test_create_with_cohost_on_past_start_already_blocked_by_event_validator(
+        self, api_client, creator, invitee
+    ):
+        # Sanity check: creating an event with a past start_datetime is blocked
+        # at the EventIn validator (422). So this guard only matters via patch
+        # onto an event that *became* past after creation, and via direct
+        # callers of diff_cohost_invites that bypass EventIn.
+        from tests.conftest import past_iso
+
+        response = api_client.post(
+            "/api/community/events/",
+            data=json.dumps(
+                {
+                    "title": "Past Potluck",
+                    "start_datetime": past_iso(days=1),
+                    "end_datetime": past_iso(days=1),
+                    "status": EventStatus.ACTIVE,
+                    "co_host_ids": [str(invitee.pk)],
+                }
+            ),
+            content_type="application/json",
+            **_auth_headers(creator),
+        )
+        assert response.status_code == 422
+        assert_error_code(response, Code.Event.START_DATETIME_MUST_BE_FUTURE)
+
+    def test_patch_add_cohost_on_past_event_rejected(self, api_client, creator, invitee):
+        data = _create_event_via_api(api_client, creator, co_host_ids=[])
+        event_id = data["id"]
+        _make_event_past(Event.objects.get(id=event_id))
+        response = api_client.patch(
+            f"/api/community/events/{event_id}/",
+            data=json.dumps({"co_host_ids": [str(invitee.pk)]}),
+            content_type="application/json",
+            **_auth_headers(creator),
+        )
+        assert response.status_code == 400
+        assert_error_code(response, Code.CoHostInvite.EVENT_IS_PAST)
+        assert EventCoHostInvite.objects.filter(event_id=event_id).count() == 0
+
+    def test_patch_remove_cohost_on_past_event_still_works(
+        self, api_client, creator, event_with_pending_invite, invitee
+    ):
+        # Removal is housekeeping — should keep working after the event ends.
+        event, invite = event_with_pending_invite
+        _make_event_past(event)
+        # Invite would have been lazily expired on read; patch with empty list
+        # rescinds it (lazy expire flips it to EXPIRED first; the rescind
+        # branch is a noop for non-active statuses).
+        response = api_client.patch(
+            f"/api/community/events/{event.id}/",
+            data=json.dumps({"co_host_ids": []}),
+            content_type="application/json",
+            **_auth_headers(creator),
+        )
+        assert response.status_code == 200
+
+    def test_patch_with_no_diff_on_past_event_is_noop(
+        self, api_client, creator, event_with_pending_invite, invitee
+    ):
+        # If the input matches the existing accepted set, no upsert happens —
+        # the guard should NOT fire just because the event is past.
+        event, invite = event_with_pending_invite
+        # First accept the invite so the user is in event.co_hosts.
+        api_client.post(
+            f"/api/community/events/{event.id}/cohost-invites/{invite.id}/accept/",
+            **_auth_headers(invitee),
+        )
+        _make_event_past(event)
+        response = api_client.patch(
+            f"/api/community/events/{event.id}/",
+            data=json.dumps({"co_host_ids": [str(invitee.pk)]}),
+            content_type="application/json",
+            **_auth_headers(creator),
+        )
+        assert response.status_code == 200
 
 
 # ─── EventOut visibility ──────────────────────────────────────────────────────

--- a/backend/tests/test_event_cohost_invites.py
+++ b/backend/tests/test_event_cohost_invites.py
@@ -8,7 +8,6 @@ import json
 from datetime import timedelta
 
 import pytest
-from community._validation import Code
 from community.models import (
     CoHostInviteStatus,
     Event,
@@ -20,7 +19,6 @@ from ninja_jwt.tokens import RefreshToken
 from notifications.models import Notification, NotificationType
 from users.models import User
 
-from tests._asserts import assert_error_code
 from tests.conftest import future_iso
 
 # ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -334,97 +332,6 @@ class TestLazyExpire:
         assert response.status_code == 200
         invite.refresh_from_db()
         assert invite.status == CoHostInviteStatus.EXPIRED
-
-
-# ─── Past-event guard (#385) ──────────────────────────────────────────────────
-
-
-def _make_event_past(event: Event) -> None:
-    past = timezone.now() - timedelta(days=1)
-    Event.objects.filter(pk=event.pk).update(
-        start_datetime=past - timedelta(hours=1),
-        end_datetime=past,
-    )
-
-
-@pytest.mark.django_db
-class TestPastEventGuard:
-    def test_create_with_cohost_on_past_start_already_blocked_by_event_validator(
-        self, api_client, creator, invitee
-    ):
-        # Sanity check: creating an event with a past start_datetime is blocked
-        # at the EventIn validator (422). So this guard only matters via patch
-        # onto an event that *became* past after creation, and via direct
-        # callers of diff_cohost_invites that bypass EventIn.
-        from tests.conftest import past_iso
-
-        response = api_client.post(
-            "/api/community/events/",
-            data=json.dumps(
-                {
-                    "title": "Past Potluck",
-                    "start_datetime": past_iso(days=1),
-                    "end_datetime": past_iso(days=1),
-                    "status": EventStatus.ACTIVE,
-                    "co_host_ids": [str(invitee.pk)],
-                }
-            ),
-            content_type="application/json",
-            **_auth_headers(creator),
-        )
-        assert response.status_code == 422
-        assert_error_code(response, Code.Event.START_DATETIME_MUST_BE_FUTURE)
-
-    def test_patch_add_cohost_on_past_event_rejected(self, api_client, creator, invitee):
-        data = _create_event_via_api(api_client, creator, co_host_ids=[])
-        event_id = data["id"]
-        _make_event_past(Event.objects.get(id=event_id))
-        response = api_client.patch(
-            f"/api/community/events/{event_id}/",
-            data=json.dumps({"co_host_ids": [str(invitee.pk)]}),
-            content_type="application/json",
-            **_auth_headers(creator),
-        )
-        assert response.status_code == 400
-        assert_error_code(response, Code.CoHostInvite.EVENT_IS_PAST)
-        assert EventCoHostInvite.objects.filter(event_id=event_id).count() == 0
-
-    def test_patch_remove_cohost_on_past_event_still_works(
-        self, api_client, creator, event_with_pending_invite, invitee
-    ):
-        # Removal is housekeeping — should keep working after the event ends.
-        event, invite = event_with_pending_invite
-        _make_event_past(event)
-        # Invite would have been lazily expired on read; patch with empty list
-        # rescinds it (lazy expire flips it to EXPIRED first; the rescind
-        # branch is a noop for non-active statuses).
-        response = api_client.patch(
-            f"/api/community/events/{event.id}/",
-            data=json.dumps({"co_host_ids": []}),
-            content_type="application/json",
-            **_auth_headers(creator),
-        )
-        assert response.status_code == 200
-
-    def test_patch_with_no_diff_on_past_event_is_noop(
-        self, api_client, creator, event_with_pending_invite, invitee
-    ):
-        # If the input matches the existing accepted set, no upsert happens —
-        # the guard should NOT fire just because the event is past.
-        event, invite = event_with_pending_invite
-        # First accept the invite so the user is in event.co_hosts.
-        api_client.post(
-            f"/api/community/events/{event.id}/cohost-invites/{invite.id}/accept/",
-            **_auth_headers(invitee),
-        )
-        _make_event_past(event)
-        response = api_client.patch(
-            f"/api/community/events/{event.id}/",
-            data=json.dumps({"co_host_ids": [str(invitee.pk)]}),
-            content_type="application/json",
-            **_auth_headers(creator),
-        )
-        assert response.status_code == 200
 
 
 # ─── EventOut visibility ──────────────────────────────────────────────────────

--- a/backend/tests/test_event_cohost_past_guard.py
+++ b/backend/tests/test_event_cohost_past_guard.py
@@ -1,0 +1,153 @@
+"""Tests for the past-event guard on cohost invites (issue #385).
+
+A separate file from test_event_cohost_invites.py to honor the 500-line cap.
+"""
+
+import json
+from datetime import timedelta
+
+import pytest
+from community._validation import Code
+from community.models import (
+    Event,
+    EventCoHostInvite,
+    EventStatus,
+)
+from django.utils import timezone
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
+
+from tests._asserts import assert_error_code
+from tests.conftest import future_iso, past_iso
+
+# ─── Helpers ──────────────────────────────────────────────────────────────────
+
+
+def _make_user(phone: str, name: str = "Member") -> User:
+    return User.objects.create_user(
+        phone_number=phone,
+        password="testpass123",
+        display_name=name,
+    )
+
+
+def _auth_headers(user: User) -> dict:
+    refresh = RefreshToken.for_user(user)
+    return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
+
+
+def _create_active_event(api_client, creator: User, co_host_ids: list[str]) -> str:
+    response = api_client.post(
+        "/api/community/events/",
+        data=json.dumps(
+            {
+                "title": "Community Potluck",
+                "start_datetime": future_iso(days=30),
+                "end_datetime": future_iso(days=30, hours=2),
+                "status": EventStatus.ACTIVE,
+                "co_host_ids": co_host_ids,
+            }
+        ),
+        content_type="application/json",
+        **_auth_headers(creator),
+    )
+    assert response.status_code == 201, response.content
+    return response.json()["id"]
+
+
+def _make_event_past(event_id: str) -> None:
+    past = timezone.now() - timedelta(days=1)
+    Event.objects.filter(pk=event_id).update(
+        start_datetime=past - timedelta(hours=1),
+        end_datetime=past,
+    )
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def creator(db) -> User:
+    return _make_user("+12025550311", "Creator")
+
+
+@pytest.fixture
+def invitee(db) -> User:
+    return _make_user("+12025550312", "Invitee")
+
+
+# ─── Tests ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.django_db
+class TestPastEventGuard:
+    def test_create_with_cohost_on_past_start_already_blocked_by_event_validator(
+        self, api_client, creator, invitee
+    ):
+        # Sanity check: creating an event with a past start_datetime is blocked
+        # at the EventIn validator (422). So this guard only matters via patch
+        # onto an event that *became* past after creation, and via direct
+        # callers of diff_cohost_invites that bypass EventIn.
+        response = api_client.post(
+            "/api/community/events/",
+            data=json.dumps(
+                {
+                    "title": "Past Potluck",
+                    "start_datetime": past_iso(days=1),
+                    "end_datetime": past_iso(days=1),
+                    "status": EventStatus.ACTIVE,
+                    "co_host_ids": [str(invitee.pk)],
+                }
+            ),
+            content_type="application/json",
+            **_auth_headers(creator),
+        )
+        assert response.status_code == 422
+        assert_error_code(response, Code.Event.START_DATETIME_MUST_BE_FUTURE)
+
+    def test_patch_add_cohost_on_past_event_rejected(self, api_client, creator, invitee):
+        event_id = _create_active_event(api_client, creator, co_host_ids=[])
+        _make_event_past(event_id)
+        response = api_client.patch(
+            f"/api/community/events/{event_id}/",
+            data=json.dumps({"co_host_ids": [str(invitee.pk)]}),
+            content_type="application/json",
+            **_auth_headers(creator),
+        )
+        assert response.status_code == 400
+        assert_error_code(response, Code.CoHostInvite.EVENT_IS_PAST)
+        assert EventCoHostInvite.objects.filter(event_id=event_id).count() == 0
+
+    def test_patch_remove_cohost_on_past_event_still_works(self, api_client, creator, invitee):
+        # Removal is housekeeping — should keep working after the event ends.
+        event_id = _create_active_event(api_client, creator, co_host_ids=[str(invitee.pk)])
+        _make_event_past(event_id)
+        # Invite would have been lazily expired on read; patch with empty list
+        # is a noop for the now-EXPIRED row (rescind branch only acts on
+        # PENDING/ACCEPTED).
+        response = api_client.patch(
+            f"/api/community/events/{event_id}/",
+            data=json.dumps({"co_host_ids": []}),
+            content_type="application/json",
+            **_auth_headers(creator),
+        )
+        assert response.status_code == 200
+
+    def test_patch_with_no_diff_on_past_event_is_noop(self, api_client, creator, invitee):
+        # If the input matches the existing accepted set, no upsert happens —
+        # the guard should NOT fire just because the event is past.
+        event_id = _create_active_event(api_client, creator, co_host_ids=[str(invitee.pk)])
+        invite = EventCoHostInvite.objects.get(event_id=event_id, user=invitee)
+        # Accept first so the user is an accepted co-host.
+        api_client.post(
+            f"/api/community/events/{event_id}/cohost-invites/{invite.id}/accept/",
+            **_auth_headers(invitee),
+        )
+        _make_event_past(event_id)
+        response = api_client.patch(
+            f"/api/community/events/{event_id}/",
+            data=json.dumps({"co_host_ids": [str(invitee.pk)]}),
+            content_type="application/json",
+            **_auth_headers(creator),
+        )
+        assert response.status_code == 200

--- a/frontend/src/api/validationCodes.gen.ts
+++ b/frontend/src/api/validationCodes.gen.ts
@@ -168,6 +168,7 @@ export const Code = {
     NotHost: 'cohost_invite.not_host',
     NotRemovable: 'cohost_invite.not_removable',
     WouldLeaveHostless: 'cohost_invite.would_leave_hostless',
+    EventIsPast: 'cohost_invite.event_is_past',
   },
   WelcomeTemplate: {
     BodyRequired: 'welcome_template.body_required',
@@ -295,6 +296,7 @@ export type ValidationCode =
   | 'cohost_invite.not_host'
   | 'cohost_invite.not_removable'
   | 'cohost_invite.would_leave_hostless'
+  | 'cohost_invite.event_is_past'
   | 'welcome_template.body_required'
   | 'welcome_template.body_too_long';
 
@@ -418,6 +420,7 @@ export const CODE_PARAMS: Record<ValidationCode, readonly string[]> = {
   'cohost_invite.not_host': [],
   'cohost_invite.not_removable': [],
   'cohost_invite.would_leave_hostless': [],
+  'cohost_invite.event_is_past': [],
   'welcome_template.body_required': [],
   'welcome_template.body_too_long': ['max_length'],
 };

--- a/frontend/src/api/validationCodes.ts
+++ b/frontend/src/api/validationCodes.ts
@@ -379,6 +379,8 @@ function messageForKnownCode(code: KnownCode, err: FieldError): string {
       return "this invite can't be removed";
     case Code.CoHostInvite.WouldLeaveHostless:
       return "you can't step down — every event needs at least one host";
+    case Code.CoHostInvite.EventIsPast:
+      return "can't invite co-hosts to a past event";
 
     // Welcome template
     case Code.WelcomeTemplate.BodyRequired:

--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -187,6 +187,30 @@ describe('EventMemberSection — accepted host row', () => {
   });
 });
 
+describe('EventMemberSection — past event gates (#385)', () => {
+  it('hides the + button on past events', () => {
+    useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
+    renderSection({ ...BASE_EVENT, isPast: true });
+    expect(screen.queryByRole('button', { name: /add co-host/i })).not.toBeInTheDocument();
+  });
+
+  it('shows the + button on non-past events for host viewer', () => {
+    // Sanity check that the gate is doing the right thing — should still render
+    // when the event is in the future.
+    useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
+    renderSection(BASE_EVENT);
+    expect(screen.getByRole('button', { name: /add co-host/i })).toBeInTheDocument();
+  });
+
+  it('still allows × on accepted host chips for past events (housekeeping)', () => {
+    // Removing an accepted cohost must keep working post-event — backend allows
+    // it, so the FE should too.
+    useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
+    renderSection({ ...ACCEPTED_COHOST_EVENT, isPast: true });
+    expect(screen.getByRole('button', { name: /remove bob as co-host/i })).toBeInTheDocument();
+  });
+});
+
 describe('EventMemberSection — pending host row', () => {
   it('renders pending invitee chips for a host viewer', () => {
     useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });

--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -193,9 +193,11 @@ describe('EventMemberSection — past event gates (#385)', () => {
     renderSection({ ...BASE_EVENT, isPast: true });
     const addBtn = screen.getByRole('button', { name: /add co-host/i });
     expect(addBtn).toBeDisabled();
-    // Tooltip lives on the wrapper span — browsers don't fire mouseenter on
-    // disabled buttons, so wrapping is the standard fix.
-    expect(addBtn.parentElement).toHaveAttribute('title', "can't invite co-hosts to a past event");
+    // Custom CSS tooltip: a sibling span with role="tooltip" that's revealed
+    // on hover via group-hover. Native title= doesn't fire on disabled buttons.
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveTextContent("can't invite co-hosts to a past event");
+    expect(addBtn).toHaveAttribute('aria-describedby', tooltip.id);
   });
 
   it('+ button is enabled on non-past events for host viewer', () => {

--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -188,18 +188,23 @@ describe('EventMemberSection — accepted host row', () => {
 });
 
 describe('EventMemberSection — past event gates (#385)', () => {
-  it('hides the + button on past events', () => {
+  it('disables the + button on past events with a tooltip explaining why', () => {
     useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
     renderSection({ ...BASE_EVENT, isPast: true });
-    expect(screen.queryByRole('button', { name: /add co-host/i })).not.toBeInTheDocument();
+    const addBtn = screen.getByRole('button', { name: /add co-host/i });
+    expect(addBtn).toBeDisabled();
+    // Tooltip lives on the wrapper span — browsers don't fire mouseenter on
+    // disabled buttons, so wrapping is the standard fix.
+    expect(addBtn.parentElement).toHaveAttribute('title', "can't invite co-hosts to a past event");
   });
 
-  it('shows the + button on non-past events for host viewer', () => {
-    // Sanity check that the gate is doing the right thing — should still render
-    // when the event is in the future.
+  it('+ button is enabled on non-past events for host viewer', () => {
+    // Sanity check that the gate is doing the right thing — should still be
+    // active when the event is in the future.
     useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
     renderSection(BASE_EVENT);
-    expect(screen.getByRole('button', { name: /add co-host/i })).toBeInTheDocument();
+    const addBtn = screen.getByRole('button', { name: /add co-host/i });
+    expect(addBtn).toBeEnabled();
   });
 
   it('still allows × on accepted host chips for past events (housekeeping)', () => {

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -42,7 +42,12 @@ export function EventMemberSection({ event }: Props) {
 
   return (
     <div className="mt-8 flex flex-col gap-6">
-      <HostSection event={event} canEdit={isCoHost && !isCancelled} viewerId={user.id} />
+      <HostSection
+        event={event}
+        canEdit={isCoHost && !isCancelled}
+        canInviteCohost={isCoHost && !isCancelled && !event.isPast}
+        viewerId={user.id}
+      />
       <LocationSection event={event} />
       <LinksSection event={event} />
       <CostSection event={event} />
@@ -107,10 +112,12 @@ interface HostRow {
 function HostSection({
   event,
   canEdit,
+  canInviteCohost,
   viewerId,
 }: {
   event: Event;
   canEdit: boolean;
+  canInviteCohost: boolean;
   viewerId: string;
 }) {
   const [addOpen, setAddOpen] = useState(false);
@@ -183,7 +190,7 @@ function HostSection({
         {pending.map((inv) => (
           <PendingHostChip key={inv.id} eventId={event.id} invite={inv} canRescind={canEdit} />
         ))}
-        {canEdit ? (
+        {canInviteCohost ? (
           <button
             type="button"
             onClick={() => {
@@ -196,7 +203,7 @@ function HostSection({
           </button>
         ) : null}
       </div>
-      {canEdit ? (
+      {canInviteCohost ? (
         <AddCoHostDialog
           event={event}
           open={addOpen}

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -191,10 +191,7 @@ function HostSection({
           <PendingHostChip key={inv.id} eventId={event.id} invite={inv} canRescind={canEdit} />
         ))}
         {canEdit ? (
-          <span
-            title={canInviteCohost ? undefined : "can't invite co-hosts to a past event"}
-            className="inline-flex"
-          >
+          <span className="group relative inline-flex">
             <button
               type="button"
               onClick={() => {
@@ -202,10 +199,20 @@ function HostSection({
               }}
               disabled={!canInviteCohost}
               aria-label="add co-host"
+              aria-describedby={canInviteCohost ? undefined : 'add-cohost-disabled-reason'}
               className="bg-surface-dim text-foreground-secondary hover:bg-surface-dim/70 disabled:hover:bg-surface-dim inline-flex h-8 w-8 items-center justify-center rounded-full pb-0.5 text-xl leading-none disabled:cursor-not-allowed disabled:opacity-50"
             >
               +
             </button>
+            {!canInviteCohost ? (
+              <span
+                id="add-cohost-disabled-reason"
+                role="tooltip"
+                className="bg-foreground text-surface pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 -translate-x-1/2 rounded px-2 py-1 text-xs whitespace-nowrap opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100"
+              >
+                can't invite co-hosts to a past event
+              </span>
+            ) : null}
           </span>
         ) : null}
       </div>

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -190,17 +190,23 @@ function HostSection({
         {pending.map((inv) => (
           <PendingHostChip key={inv.id} eventId={event.id} invite={inv} canRescind={canEdit} />
         ))}
-        {canInviteCohost ? (
-          <button
-            type="button"
-            onClick={() => {
-              setAddOpen(true);
-            }}
-            aria-label="add co-host"
-            className="bg-surface-dim text-foreground-secondary hover:bg-surface-dim/70 inline-flex h-8 w-8 items-center justify-center rounded-full text-lg"
+        {canEdit ? (
+          <span
+            title={canInviteCohost ? undefined : "can't invite co-hosts to a past event"}
+            className="inline-flex"
           >
-            +
-          </button>
+            <button
+              type="button"
+              onClick={() => {
+                if (canInviteCohost) setAddOpen(true);
+              }}
+              disabled={!canInviteCohost}
+              aria-label="add co-host"
+              className="bg-surface-dim text-foreground-secondary hover:bg-surface-dim/70 disabled:hover:bg-surface-dim inline-flex h-8 w-8 items-center justify-center rounded-full pb-0.5 text-xl leading-none disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              +
+            </button>
+          </span>
         ) : null}
       </div>
       {canInviteCohost ? (

--- a/frontend/src/screens/events/form/EventForm.tsx
+++ b/frontend/src/screens/events/form/EventForm.tsx
@@ -246,13 +246,19 @@ export function EventForm({ existing }: Props) {
             : undefined
         }
       >
-        <MemberPicker
-          label="co-hosts"
-          selected={coHosts}
-          onChange={setCoHosts}
-          excludeIds={user ? [user.id] : []}
-          hint="co-hosts get an invite — once they accept, they can edit the event and manage rsvps"
-        />
+        {existing?.isPast ? (
+          <p className="text-foreground-tertiary text-sm">
+            this event is in the past — co-host invites are closed
+          </p>
+        ) : (
+          <MemberPicker
+            label="co-hosts"
+            selected={coHosts}
+            onChange={setCoHosts}
+            excludeIds={user ? [user.id] : []}
+            hint="co-hosts get an invite — once they accept, they can edit the event and manage rsvps"
+          />
+        )}
       </CollapsibleCard>
 
       <CollapsibleCard


### PR DESCRIPTION
Closes #385.

## Why

Today the diff helper accepts new \`co_host_ids\` on a past event. The pending invite gets created, then immediately flips to \`EXPIRED\` on the next read (lazy expiration, #382). Pointless DB churn and confusing UX — the inviter sends invites that are dead on arrival.

## Behavior

- **Block create/revive on a past event** — backend rejects with structured \`Code.CoHostInvite.EVENT_IS_PAST\`. Frontend hides the cohost picker with an explanation.
- **Removals still work** — host can trim the roster after the fact. No-diff input is a no-op (not an error).
- **Open question (resolved)**: accept/decline on outstanding pending invites is unaffected. Lazy expiration handles those — by the time the user clicks accept, the invite is \`EXPIRED\` and \`accept\` 400s with \`NOT_PENDING\` (existing behavior).

## Backend

- New \`Code.CoHostInvite.EVENT_IS_PAST\`.
- \`diff_cohost_invites\` raises before the upsert loop. New \`_would_upsert_any\` mirrors the create-or-revive logic of \`_upsert_pending_invite\` so the guard fires only on inputs that would mutate.

## Frontend

- \`EventForm\` hides the co-host \`MemberPicker\` when \`existing.isPast\`, replaced with the copy line. (New events can't be past — EventIn validates that — so the gate only matters on edit.)
- Catalog entry for the new code surfaces \"can't invite co-hosts to a past event\" if the FE ever submits to the guarded path anyway.

## Test plan

- [x] backend agent-ci: 745 + 4 new pass; ty/ruff/complexity clean.
- [x] frontend agent-frontend-ci: 422 pass, 1 skipped.
- [x] new backend tests in \`TestPastEventGuard\`:
  - existing-validator sanity check (creating past events 422s)
  - patch-add cohost on past event rejected with EVENT_IS_PAST
  - patch-remove on past event still works
  - no-diff patch on past event is a no-op
- [ ] manual smoke: edit a past event → cohost picker is hidden, copy line shows
- [ ] manual smoke: remove an existing cohost from a past event via form patch → 200