### PR TITLE
refactor(perms): drop edit_welcome_message; gate template editor on approve_join_requests

### DIFF
--- a/backend/community/_welcome_template.py
+++ b/backend/community/_welcome_template.py
@@ -2,7 +2,8 @@
 
 Plain-text template stored as a singleton (pk=1). Read by any authed user
 (vetters need it to render the message); edited by users with
-EDIT_WELCOME_MESSAGE.
+APPROVE_JOIN_REQUESTS — the welcome template is part of the approval
+workflow, so anyone who can approve requests can also tune the copy.
 """
 
 import logging
@@ -50,14 +51,14 @@ def get_welcome_template(request):
     auth=JWTAuth(),
 )
 def update_welcome_template(request, payload: WelcomeTemplatePatchIn):
-    if not request.auth.has_permission(PermissionKey.EDIT_WELCOME_MESSAGE):
+    if not request.auth.has_permission(PermissionKey.APPROVE_JOIN_REQUESTS):
         audit_log(
             logging.WARNING,
             "permission_denied",
             request,
             details={
                 "endpoint": "update_welcome_template",
-                "required_permission": PermissionKey.EDIT_WELCOME_MESSAGE,
+                "required_permission": PermissionKey.APPROVE_JOIN_REQUESTS,
             },
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="edit_welcome_message")

--- a/backend/tests/test_welcome_template.py
+++ b/backend/tests/test_welcome_template.py
@@ -16,7 +16,7 @@ def edit_welcome_user(db):
         display_name="Welcome Editor",
     )
     role = Role.objects.create(
-        name="welcome_editor", permissions=[PermissionKey.EDIT_WELCOME_MESSAGE]
+        name="welcome_editor", permissions=[PermissionKey.APPROVE_JOIN_REQUESTS]
     )
     user.roles.add(role)
     return user

--- a/backend/users/migrations/0021_drop_edit_welcome_message_perm.py
+++ b/backend/users/migrations/0021_drop_edit_welcome_message_perm.py
@@ -1,0 +1,38 @@
+"""Drop the retired edit_welcome_message permission key from Role.permissions.
+
+The welcome-template editor is now gated on approve_join_requests instead, so
+edit_welcome_message is dead. Role.permissions is a JSONField holding raw
+strings, so old values would survive even without this — they'd just be
+ignored at runtime. Scrub them anyway for tidiness and to keep the role
+editor's permission grid aligned with the truth.
+"""
+
+from django.db import migrations
+
+DOOMED_KEY = "edit_welcome_message"
+
+
+def drop_key(apps, schema_editor):
+    Role = apps.get_model("users", "Role")
+    for role in Role.objects.all():
+        perms = role.permissions or []
+        if DOOMED_KEY in perms:
+            role.permissions = [p for p in perms if p != DOOMED_KEY]
+            role.save(update_fields=["permissions"])
+
+
+def restore_key(apps, schema_editor):
+    # No-op: we don't know which roles previously held the key, so we can't
+    # faithfully restore it. The forward migration is destructive but harmless
+    # given the key's runtime no-op status.
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0020_user_onboarded_at"),
+    ]
+
+    operations = [
+        migrations.RunPython(drop_key, reverse_code=restore_key),
+    ]

--- a/backend/users/permissions.py
+++ b/backend/users/permissions.py
@@ -8,7 +8,6 @@ class PermissionKey(models.TextChoices):
     APPROVE_JOIN_REQUESTS = "approve_join_requests", "Approve join requests"
     MANAGE_EVENTS = "manage_events", "Manage events"
     EDIT_GUIDELINES = "edit_guidelines", "Edit community guidelines"
-    EDIT_WELCOME_MESSAGE = "edit_welcome_message", "Edit welcome message template"
     MANAGE_WHATSAPP = "manage_whatsapp", "Manage WhatsApp configuration"
     EDIT_FAQ = "edit_faq", "Edit FAQ"
     EDIT_HOMEPAGE = "edit_homepage", "Edit homepage"

--- a/frontend/src/models/permissions.ts
+++ b/frontend/src/models/permissions.ts
@@ -7,7 +7,6 @@ export const Permission = {
   ApproveJoinRequests: 'approve_join_requests',
   ManageEvents: 'manage_events',
   EditGuidelines: 'edit_guidelines',
-  EditWelcomeMessage: 'edit_welcome_message',
   ManageWhatsapp: 'manage_whatsapp',
   EditFaq: 'edit_faq',
   EditHomepage: 'edit_homepage',

--- a/frontend/src/screens/admin/ApprovalCredentialsDialog.test.tsx
+++ b/frontend/src/screens/admin/ApprovalCredentialsDialog.test.tsx
@@ -89,7 +89,7 @@ describe('ApprovalCredentialsDialog', () => {
           id: 'r1',
           name: 'vetter',
           isDefault: false,
-          permissions: ['edit_welcome_message'],
+          permissions: ['approve_join_requests'],
         },
       ],
     });

--- a/frontend/src/screens/admin/ApprovalCredentialsDialog.tsx
+++ b/frontend/src/screens/admin/ApprovalCredentialsDialog.tsx
@@ -54,7 +54,7 @@ export function ApprovalCredentialsDialog({
   const smsHref = buildSmsHref(phoneNumber, welcomeMessage);
   const whatsappHref = buildWhatsAppHref(phoneNumber, welcomeMessage);
   const sendButtonsDisabled = templateQ.isPending;
-  const canEditTemplate = hasPermission(currentUser, Permission.EditWelcomeMessage);
+  const canEditTemplate = hasPermission(currentUser, Permission.ApproveJoinRequests);
 
   async function copyLink() {
     await navigator.clipboard.writeText(magicLinkUrl);

--- a/frontend/src/screens/admin/WelcomeTemplateEditorDialog.tsx
+++ b/frontend/src/screens/admin/WelcomeTemplateEditorDialog.tsx
@@ -1,5 +1,5 @@
 // Sub-modal opened from ApprovalCredentialsDialog. Lets users with
-// EDIT_WELCOME_MESSAGE edit the shared template. Plain-text only —
+// APPROVE_JOIN_REQUESTS edit the shared template. Plain-text only —
 // placeholders ${NAME}, ${SENDER_NAME}, ${MAGIC_LINK} are substituted at
 // render time by renderWelcomeMessage().
 


### PR DESCRIPTION
## Summary

`Permission.EditWelcomeMessage` (BE: `EDIT_WELCOME_MESSAGE`) was added in #376 alongside the editable welcome template, but was never wired into `RoleFormDialog`'s `PERMISSION_LABELS` — the hand-maintained allowlist that powers the role editor's checkbox grid. As a result no admin could grant it via the UI, no non-admin role held it, and the "edit shared welcome template" button was effectively unreachable except for default admins (whose wildcard bypasses the gate anyway).

The welcome template is functionally part of the join-approval workflow (it's only ever rendered while approving a request), so the cleanest fix is to fold edit-template into `APPROVE_JOIN_REQUESTS` rather than maintain a separate permission that nothing can grant.

### What changed

- **Backend**: drop `EDIT_WELCOME_MESSAGE` from `PermissionKey`, switch the PATCH `/welcome-template/` gate to `APPROVE_JOIN_REQUESTS`, update the test fixture role accordingly.
- **Migration 0021**: defensive scrub of any stale `"edit_welcome_message"` strings in `Role.permissions` JSON values. (There shouldn't be any — no UI path could set them — but cheap insurance.)
- **Frontend**: drop `Permission.EditWelcomeMessage`, switch the `canEditTemplate` gate in `ApprovalCredentialsDialog` to `ApproveJoinRequests`, fix the test fixture and the `WelcomeTemplateEditorDialog` comment.

### Wider fix (separate PR)

The underlying gap — new permissions silently not appearing in the role editor — is a structural problem worth its own ticket. Long-term fix is to drive `PERMISSION_LABELS` from a generated source of truth (mirroring the validation-codes codegen pattern) so this can't drift again. This PR just removes the stranded permission; happy to file a follow-up if useful.

## Test plan

- [x] `make agent-ci` — backend (736 tests) + frontend (426 tests) all green
- [x] Codegen parity checks pass (validation codes, openapi schema, types.gen.ts)
- [x] Migration 0021 dry-applied via test suite (no errors); reverse migration is a no-op (documented)
- [ ] After merge: confirm in staging that a vetter (non-admin role with `approve_join_requests`) sees the "edit shared welcome template" button