### PR TITLE
chore: drop unused SITE_URL setting and event_url helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,10 +8,6 @@ SECRET_KEY=
 # Vetting
 VETTING_EMAIL=
 
-# Public origin (e.g. https://app.pda.community) used in outbound payloads —
-# leave empty in dev; the frontend resolves relative paths against its origin.
-SITE_URL=
-
 # Email (optional — leave empty for console backend in dev)
 EMAIL_HOST=
 EMAIL_HOST_USER=

--- a/backend/community/_calendar.py
+++ b/backend/community/_calendar.py
@@ -14,7 +14,6 @@ from users.models import CalendarFeedScope
 from users.models import User as UserModel
 
 from community._event_helpers import _can_see_invite_only
-from community._shared import ErrorOut, event_url  # noqa: F401
 from community.models import Event, EventStatus, PageVisibility, RSVPStatus
 
 router = Router()
@@ -131,7 +130,7 @@ def single_event_ics(request, event_id: str):
     return response
 
 
-def _build_vevent(event, request: HttpRequest | None = None):
+def _build_vevent(event, request: HttpRequest):
     import icalendar
 
     vevent = icalendar.Event()
@@ -144,11 +143,7 @@ def _build_vevent(event, request: HttpRequest | None = None):
             event.end_datetime or event.start_datetime + timedelta(hours=2),
         )
     vevent.add("summary", event.title)
-    target_url = (
-        request.build_absolute_uri(f"/events/{event.id}")
-        if request is not None
-        else event_url(event)
-    )
+    target_url = request.build_absolute_uri(f"/events/{event.id}")
     desc = _event_ics_description(event, target_url)
     if desc:
         vevent.add("description", desc)

--- a/backend/community/_shared.py
+++ b/backend/community/_shared.py
@@ -85,17 +85,3 @@ def _authenticated_user(requesting_user) -> "UserModel | None":
 def _members_only(value, default, is_authed: bool):
     """Return value if user is authenticated, default otherwise."""
     return value if is_authed else default
-
-
-def event_url(event) -> str:
-    """Build the PDA event detail URL.
-
-    Uses ``SITE_URL`` when configured (prod/staging); falls back to a relative
-    path in dev so callers (or the frontend) can resolve it against the
-    appropriate origin. Centralized here because outbound surfaces (calendar
-    descriptions, future SMS / push / email reminders) all need the same link.
-    """
-    from django.conf import settings
-
-    site_url = getattr(settings, "SITE_URL", "")
-    return f"{site_url}/events/{event.id}" if site_url else f"/events/{event.id}"

--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -21,11 +21,6 @@ DEBUG = os.environ.get("DEBUG", "False") == "True"
 
 ALLOWED_HOSTS = os.environ.get("ALLOWED_HOSTS", "").split(",")
 
-# Public origin used to build links in outbound payloads (calendar descriptions,
-# emails). Empty in dev — consumers fall back to the request host or to relative
-# paths the frontend can resolve against window.location.origin.
-SITE_URL = os.environ.get("SITE_URL", "").rstrip("/")
-
 INSTALLED_APPS = [
     "django.contrib.auth",
     "django.contrib.contenttypes",


### PR DESCRIPTION
## Summary

`SITE_URL` was added prospectively in #395 alongside the calendar-feed "view on pda" link, intended as a fallback for outbound surfaces generating links outside an HTTP request context. It was never actually needed: every caller of `_build_vevent` passes the `request`, so the `event_url()` fallback branch (which read `SITE_URL`) is unreachable. The setting's value never affects any current execution path.

Future SMS/push/email link surfaces will use their own URL-building helpers tailored to those channels (Twilio templates, push payload formats, etc.), so there's no caller waiting in the wings either. Drop the dead scaffolding now; reintroduce when something real needs it.

### What changed

- Remove `event_url()` from `community/_shared.py`.
- Inline `request.build_absolute_uri(...)` in `_build_vevent` and tighten the type signature (`request` was always passed by both call sites — make it required).
- Drop `SITE_URL` from `config/settings.py` and `.env.example`.

### What did NOT change

- Calendar feed and single-event `.ics` URLs are still built from the request host (`request.build_absolute_uri`) — same behavior as before.
- No env-var configuration needed in Railway staging/production. (None was actually being read today — confirmed by tracing the call graph.)

## Test plan

- [x] `make agent-ci` — backend (736 tests) + frontend (426 tests) all green
- [x] All four codegen parity checks pass (validation codes JSON + TS, openapi schema JSON, types.gen.ts)
- [ ] After merge: subscribe to the calendar feed in staging and confirm the "View on PDA" line in event descriptions still has the correct URL (sanity-check that nothing was relying on `SITE_URL` invisibly)