### PR TITLE
fix(admin): theme-aware tokens for roles + magic-link UI

### DIFF
--- a/frontend/src/screens/admin/BulkCreateDialog.tsx
+++ b/frontend/src/screens/admin/BulkCreateDialog.tsx
@@ -96,14 +96,14 @@ function ResultsView({
 
   return (
     <Dialog open={open} onClose={onClose} title="bulk results">
-      <p className="text-sm text-neutral-700">
+      <p className="text-foreground-secondary text-sm">
         created {response.created} of {response.created + response.failed} — share each magic link
         with its recipient; links won't be shown again.
       </p>
 
       {successes.length > 0 ? (
         <section className="mt-4">
-          <h3 className="mb-2 text-xs font-medium tracking-wide text-neutral-500">created</h3>
+          <h3 className="text-muted mb-2 text-xs font-medium tracking-wide">created</h3>
           <ul className="flex flex-col gap-2">
             {successes.map((r) => (
               <li key={r.row}>
@@ -116,10 +116,10 @@ function ResultsView({
 
       {failures.length > 0 ? (
         <section className="mt-4">
-          <h3 className="mb-2 text-xs font-medium tracking-wide text-neutral-500">failed</h3>
+          <h3 className="text-muted mb-2 text-xs font-medium tracking-wide">failed</h3>
           <ul className="flex flex-col gap-1">
             {failures.map((r) => (
-              <li key={r.row} className="text-sm text-red-700">
+              <li key={r.row} className="text-destructive text-sm">
                 {formatPhone(r.phoneNumber)} — {r.error ?? 'unknown error'}
               </li>
             ))}
@@ -149,9 +149,9 @@ function MagicLinkRow({ result }: { result: BulkCreateResult }) {
   }
 
   return (
-    <div className="flex flex-col gap-1 rounded-md border border-neutral-200 bg-white p-2">
+    <div className="border-border bg-surface flex flex-col gap-1 rounded-md border p-2">
       <div className="flex items-center justify-between gap-2">
-        <span className="truncate text-sm font-medium text-neutral-900">
+        <span className="text-foreground truncate text-sm font-medium">
           {formatPhone(result.phoneNumber)}
         </span>
         <div className="flex gap-2">
@@ -169,7 +169,7 @@ function MagicLinkRow({ result }: { result: BulkCreateResult }) {
         </div>
       </div>
       {url ? (
-        <code className="overflow-x-auto rounded bg-neutral-100 px-2 py-1 text-xs break-all">
+        <code className="bg-surface-dim text-foreground overflow-x-auto rounded px-2 py-1 text-xs break-all">
           {url}
         </code>
       ) : null}

--- a/frontend/src/screens/admin/MemberCreateDialog.tsx
+++ b/frontend/src/screens/admin/MemberCreateDialog.tsx
@@ -117,11 +117,11 @@ function CredentialsView({
 
   return (
     <Dialog open={open} onClose={onClose} title={`welcome ${greeting}`}>
-      <p className="text-sm text-neutral-700">
+      <p className="text-foreground-secondary text-sm">
         share this one-time login link with {formatPhone(result.phoneNumber)}. it won't be shown
         again.
       </p>
-      <div className="mt-3 overflow-x-auto rounded-md bg-neutral-100 px-3 py-2 font-mono text-xs break-all">
+      <div className="bg-surface-dim text-foreground mt-3 overflow-x-auto rounded-md px-3 py-2 font-mono text-xs break-all">
         {magicLinkUrl}
       </div>
       <div className="mt-3 flex flex-wrap gap-2">

--- a/frontend/src/screens/admin/MemberDetailScreen.tsx
+++ b/frontend/src/screens/admin/MemberDetailScreen.tsx
@@ -62,10 +62,7 @@ function MemberDetailView({ member }: { member: Member }) {
 
   return (
     <ContentContainer>
-      <Link
-        to="/admin/members"
-        className="mb-4 inline-block text-sm text-neutral-500 hover:underline"
-      >
+      <Link to="/admin/members" className="text-muted mb-4 inline-block text-sm hover:underline">
         ← back to members
       </Link>
 
@@ -75,10 +72,12 @@ function MemberDetailView({ member }: { member: Member }) {
           <h1 className="text-2xl font-medium tracking-tight">
             {member.displayName || formatPhone(member.phoneNumber)}
           </h1>
-          <p className="text-sm text-neutral-600">{formatPhone(member.phoneNumber)}</p>
-          {member.email ? <p className="text-sm text-neutral-600">{member.email}</p> : null}
+          <p className="text-foreground-secondary text-sm">{formatPhone(member.phoneNumber)}</p>
+          {member.email ? (
+            <p className="text-foreground-secondary text-sm">{member.email}</p>
+          ) : null}
           {member.isPaused ? (
-            <span className="mt-1 rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-800">
+            <span className="bg-warning-subtle text-warning mt-1 rounded-full px-2 py-0.5 text-xs">
               paused
             </span>
           ) : null}
@@ -96,9 +95,9 @@ function MemberDetailView({ member }: { member: Member }) {
       <MemberMagicLinkSection member={member} />
 
       {member.bio ? (
-        <section className="mb-6 rounded-lg border border-neutral-200 bg-white p-4">
-          <h2 className="mb-2 text-xs font-medium tracking-wide text-neutral-500">bio</h2>
-          <p className="text-sm whitespace-pre-wrap text-neutral-800">{member.bio}</p>
+        <section className="border-border bg-surface mb-6 rounded-lg border p-4">
+          <h2 className="text-muted mb-2 text-xs font-medium tracking-wide">bio</h2>
+          <p className="text-foreground text-sm whitespace-pre-wrap">{member.bio}</p>
         </section>
       ) : null}
 
@@ -151,13 +150,13 @@ function MemberRolesSection({ member }: { member: Member }) {
   }
 
   if (isPending) {
-    return <p className="mb-4 text-sm text-neutral-500">loading roles…</p>;
+    return <p className="text-muted mb-4 text-sm">loading roles…</p>;
   }
   if (isError) return null;
 
   return (
     <section className="mb-4">
-      <h2 className="mb-2 text-xs font-medium tracking-wide text-neutral-500">roles</h2>
+      <h2 className="text-muted mb-2 text-xs font-medium tracking-wide">roles</h2>
       <div className="flex flex-col gap-2">
         {allRoles.map((r) => (
           <label key={r.id} className="flex cursor-pointer items-center gap-2 text-sm">
@@ -219,10 +218,10 @@ function MemberMagicLinkSection({ member }: { member: Member }) {
 
   return (
     <section className="mb-6">
-      <h2 className="mb-2 text-xs font-medium tracking-wide text-neutral-500">access</h2>
+      <h2 className="text-muted mb-2 text-xs font-medium tracking-wide">access</h2>
       {url ? (
         <>
-          <div className="mb-2 overflow-x-auto rounded-md bg-neutral-100 px-3 py-2 font-mono text-xs break-all">
+          <div className="bg-surface-dim text-foreground mb-2 overflow-x-auto rounded-md px-3 py-2 font-mono text-xs break-all">
             {url}
           </div>
           <div className="flex flex-wrap gap-2">
@@ -247,7 +246,7 @@ function MemberMagicLinkSection({ member }: { member: Member }) {
           {magic.isPending ? 'working…' : 'generate magic login link'}
         </Button>
       )}
-      <p className="mt-1 text-xs text-neutral-500">
+      <p className="text-muted mt-1 text-xs">
         resets password flow for this member and generates a one-time login url for you to send
         them.
       </p>
@@ -265,7 +264,7 @@ function MemberAvatar({ member }: { member: Member }) {
   return (
     <span
       aria-hidden="true"
-      className="flex h-28 w-28 items-center justify-center rounded-full bg-neutral-200 text-3xl text-neutral-600"
+      className="bg-surface-dim text-foreground-secondary flex h-28 w-28 items-center justify-center rounded-full text-3xl"
     >
       {initials}
     </span>
@@ -350,7 +349,7 @@ function MemberEditForm({
         onChange={setIsPaused}
         disabled={targetIsAdmin}
       />
-      {targetIsAdmin ? <p className="text-xs text-neutral-500">admins can't be paused</p> : null}
+      {targetIsAdmin ? <p className="text-muted text-xs">admins can't be paused</p> : null}
 
       {error ? (
         <p role="alert" className="text-sm text-red-600">

--- a/frontend/src/screens/admin/RoleFormDialog.tsx
+++ b/frontend/src/screens/admin/RoleFormDialog.tsx
@@ -88,15 +88,13 @@ export function RoleFormDialog({ open, onClose, initialRole: role }: Props) {
             setName(e.target.value);
           }}
         />
-        {readOnly ? (
-          <p className="-mt-2 text-xs text-neutral-500">built-in role — view only</p>
-        ) : null}
+        {readOnly ? <p className="text-muted -mt-2 text-xs">built-in role — view only</p> : null}
 
         <fieldset className="flex flex-col gap-2" disabled={readOnly}>
           <legend className="mb-1 text-sm font-medium">permissions</legend>
           <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
             {Object.entries(PERMISSION_LABELS).map(([key, label]) => (
-              <label key={key} className="flex items-center gap-2 text-sm text-neutral-700">
+              <label key={key} className="text-foreground flex items-center gap-2 text-sm">
                 <input
                   type="checkbox"
                   checked={permissions.includes(key)}
@@ -112,7 +110,7 @@ export function RoleFormDialog({ open, onClose, initialRole: role }: Props) {
         </fieldset>
 
         {formError ? (
-          <p role="alert" className="text-sm break-words text-red-600">
+          <p role="alert" className="text-destructive text-sm break-words">
             {formError}
           </p>
         ) : null}

--- a/frontend/src/screens/admin/RolesTab.tsx
+++ b/frontend/src/screens/admin/RolesTab.tsx
@@ -56,17 +56,17 @@ export function RolesTab() {
       </div>
 
       {data.length === 0 ? (
-        <p className="text-sm text-neutral-500">no roles yet 🌿</p>
+        <p className="text-muted text-sm">no roles yet 🌿</p>
       ) : (
         <ul className="flex flex-col gap-2">
           {data.map((role) => (
             <li
               key={role.id}
-              className="flex items-center justify-between gap-3 rounded-lg border border-neutral-200 bg-white p-3"
+              className="border-border bg-surface flex items-center justify-between gap-3 rounded-lg border p-3"
             >
               <div className="min-w-0 flex-1">
-                <p className="truncate text-sm font-medium text-neutral-900">{role.name}</p>
-                <p className="truncate text-xs text-neutral-500">
+                <p className="text-foreground truncate text-sm font-medium">{role.name}</p>
+                <p className="text-muted truncate text-xs">
                   {role.permissions.length === 0
                     ? 'no permissions'
                     : `${String(role.permissions.length)} permission${role.permissions.length === 1 ? '' : 's'}`}


### PR DESCRIPTION
The roles tab cards and the magic-link URL display had hardcoded \`bg-white\` / \`bg-neutral-100\` / \`text-neutral-*\` classes that stayed light even in dark mode. Reported as: roles cards visibly white in dark mode + magic-link field on member detail same problem.

## Files

- **\`RolesTab.tsx\`** — role-list cards.
- **\`RoleFormDialog.tsx\`** — built-in-role hint + permission checkbox labels + form-error.
- **\`MemberDetailScreen.tsx\`** — magic-link URL display, bio card, roles section, avatar fallback, paused badge, back link, header text.
- **\`MemberCreateDialog.tsx\`** — magic-link URL display (same surface as member-detail, different surface).
- **\`BulkCreateDialog.tsx\`** — magic-link rows + per-row URL display + failure list.

## Token mapping

- \`bg-white\` → \`bg-surface\`
- \`bg-neutral-100\` (URL display) → \`bg-surface-dim\` (slight contrast against the page)
- \`bg-neutral-200\` (avatar fallback) → \`bg-surface-dim\`
- \`border-neutral-200\` → \`border-border\`
- \`text-neutral-500\` → \`text-muted\`
- \`text-neutral-600/700\` → \`text-foreground-secondary\`
- \`text-neutral-800/900\` → \`text-foreground\`
- \`text-red-600/700\` → \`text-destructive\`
- \`bg-amber-100 text-amber-800\` (paused badge) → \`bg-warning-subtle text-warning\`

## Test plan

- [x] \`make agent-frontend-ci\` clean — typecheck/lint/format/tests all pass (426 + 1 skipped).
- [ ] manual: toggle dark mode, visit /admin/roles → cards are theme-aware.
- [ ] manual: open a member → click 'generate magic login link' → URL field is theme-aware.
- [ ] manual: open 'create member' / 'bulk create' → magic-link URL display is theme-aware.

Followed the existing token patterns from \`JoinRequestsScreen\`, \`AdminHubScreen\`, and \`EventMemberSection\`. No behavior changes.