### PR TITLE
feat(events): autolink urls in event description (Issue 412)

### DIFF
--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -5,6 +5,7 @@ import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility } from '@/models/event';
 import { formatEventDateTime } from '@/utils/datetime';
+import { linkifyText } from '@/utils/linkifyText';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 import { CohostInviteBanner } from './CohostInviteBanner';
 import { EventActions } from './EventActions';
@@ -49,7 +50,7 @@ export default function EventDetailScreen() {
       {event.description ? (
         <section className="mt-6">
           <h2 className="text-muted mb-2 text-sm font-medium">about</h2>
-          <p className="text-foreground whitespace-pre-wrap">{event.description}</p>
+          <p className="text-foreground whitespace-pre-wrap">{linkifyText(event.description)}</p>
         </section>
       ) : null}
 

--- a/frontend/src/utils/linkifyText.test.tsx
+++ b/frontend/src/utils/linkifyText.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { linkifyText } from './linkifyText';
+
+function renderText(text: string) {
+  return render(<p>{linkifyText(text)}</p>);
+}
+
+describe('linkifyText', () => {
+  it('returns the original text when no urls are present', () => {
+    renderText('come hang out at the park');
+    expect(screen.getByText('come hang out at the park')).toBeInTheDocument();
+  });
+
+  it('renders an https url as a clickable link', () => {
+    renderText('rsvp at https://example.com soon');
+    const link = screen.getByRole('link', { name: 'https://example.com' });
+    expect(link).toHaveAttribute('href', 'https://example.com');
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+
+  it('prefixes www-only urls with https', () => {
+    renderText('see www.example.com for details');
+    const link = screen.getByRole('link', { name: 'www.example.com' });
+    expect(link).toHaveAttribute('href', 'https://www.example.com');
+  });
+
+  it('strips trailing sentence punctuation from the link', () => {
+    renderText('check https://example.com.');
+    const link = screen.getByRole('link', { name: 'https://example.com' });
+    expect(link).toHaveAttribute('href', 'https://example.com');
+    expect(link.parentElement?.textContent).toBe('check https://example.com.');
+  });
+
+  it('renders multiple links in one string', () => {
+    renderText('go to https://a.com or https://b.com');
+    expect(screen.getByRole('link', { name: 'https://a.com' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'https://b.com' })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/utils/linkifyText.tsx
+++ b/frontend/src/utils/linkifyText.tsx
@@ -1,0 +1,49 @@
+import { Fragment, type ReactNode } from 'react';
+
+const URL_PATTERN = /\b((?:https?:\/\/|www\.)[^\s<>()]+[^\s<>()!?.,;:'"])/gi;
+
+const TRAILING_PUNCT = /[.,;:!?)\]}'"]+$/;
+
+export function linkifyText(text: string): ReactNode[] {
+  const nodes: ReactNode[] = [];
+  let lastIndex = 0;
+  let key = 0;
+
+  for (const match of text.matchAll(URL_PATTERN)) {
+    const raw = match[0];
+    const start = match.index;
+
+    // Strip trailing punctuation that's likely sentence punctuation, not URL.
+    const trimmed = raw.replace(TRAILING_PUNCT, '');
+    const trailing = raw.slice(trimmed.length);
+
+    if (start > lastIndex) {
+      nodes.push(<Fragment key={key++}>{text.slice(lastIndex, start)}</Fragment>);
+    }
+
+    const href = trimmed.startsWith('www.') ? `https://${trimmed}` : trimmed;
+    nodes.push(
+      <a
+        key={key++}
+        href={href}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-brand-700 hover:text-brand-900 no-underline"
+      >
+        {trimmed}
+      </a>,
+    );
+
+    if (trailing) {
+      nodes.push(<Fragment key={key++}>{trailing}</Fragment>);
+    }
+
+    lastIndex = start + raw.length;
+  }
+
+  if (lastIndex < text.length) {
+    nodes.push(<Fragment key={key++}>{text.slice(lastIndex)}</Fragment>);
+  }
+
+  return nodes;
+}


### PR DESCRIPTION
## Summary
- urls inside an event's `description` now render as clickable links on the event detail screen — closes #412
- new `linkifyText` util splits text into text + `<a>` segments; strips trailing sentence punctuation; normalizes `www.` urls to `https://`
- links open in a new tab with `rel="noopener noreferrer"`, brand color, no underline (matches the location/maps anchor style)

## Notes
- only applied to `EventDetailScreen` (full description view). the calendar day-list preview is line-clamped and tap-to-open, so links there don't need to be clickable.
- description is still plain text on the backend (`TextField`); this is a render-time transformation only.

## Test plan
- [x] `make agent-frontend-ci` passes (lint, prettier, vitest, tsc, types parity)
- [x] new vitest covers: no-url, https url, www-only url, trailing punctuation, multiple urls
- [ ] manual: visit an event with `https://example.com` in the description → renders as clickable link
- [ ] manual: trailing period (`https://example.com.`) → period stays as text, link is just the url