### PR TITLE
chore: add commit and open-pr skills

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: commit
+description: Stage and commit changes using conventional commits. Run `make agent-ci` first, then create a properly formatted commit. Use when the user asks to commit, save, or check in changes.
+---
+
+# commit
+
+Stage and create a commit using **conventional commits** format.
+
+## Steps
+
+1. **Run CI first**: `make agent-ci`. If it fails, surface the errors and stop — do not commit.
+2. **Inspect state** in parallel:
+   - `git status` (no `-uall`)
+   - `git diff` (staged + unstaged)
+   - `git log -5 --oneline` to match local style
+3. **Draft the message** in conventional commits format:
+   ```
+   <type>(<scope>): <short summary>
+   ```
+   - **Types**: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`, `ci`, `perf`, `style`
+   - **Scope**: the affected area (e.g. `events`, `sms`, `vetting`, `fe`, `admin`, `perms`). Omit if cross-cutting.
+   - **Summary**: lowercase, imperative ("add", "fix", "drop"), no trailing period.
+   - **Issue ref**: if the work relates to a GitHub issue, append ` (Issue <number>)` to the summary. Use `(Issue 380)` style — never `#380` for issue refs in commits.
+   - Keep the subject under ~72 chars. Add a body only if the *why* isn't obvious.
+4. **Stage explicitly** — name files; never `git add -A` or `git add .`. Skip anything that looks like secrets (`.env`, credentials).
+5. **Commit** via HEREDOC so formatting is preserved.
+6. **Verify** with `git status` after.
+
+## Hard rules
+
+- **Never** add a `Co-Authored-By` trailer (see `.claude/rules/no-co-authored-by.md`).
+- **Never** use `--no-verify`, `--amend` (unless the user explicitly asks), or skip hooks.
+- **Never** push as part of this skill — committing only.
+- If pre-commit hooks fail, fix the underlying issue and create a **new** commit (do not amend).
+- Only commit when the user has explicitly asked to commit.
+
+## Examples
+
+```
+feat(events): autolink urls in event description (Issue 412)
+fix(rsvp): match my guest record by user id, not status (Issue 368)
+chore: drop unused SITE_URL setting and event_url helper
+refactor(fe): centralize axios error inspection in apiErrors helpers (Issue 388)
+ci: enforce types.gen.ts + openapi schema parity in check-codes (Issue 379)
+```

--- a/.claude/skills/open-pr/SKILL.md
+++ b/.claude/skills/open-pr/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: open-pr
+description: Create a GitHub pull request for the current branch with a conventional-commit title. Handles branch creation/renaming if needed and pushes before opening. Use when the user asks to open a PR, create a PR, or "ship" a branch.
+---
+
+# open-pr
+
+Open a GitHub pull request from the current branch to `main`.
+
+## Branch naming
+
+Branches must be named:
+
+- **With a GitHub issue**: `<issue-number>-<short-kebab-description>` — e.g. `412-linkify-event-description`, `380-stub-canvas-getcontext`.
+- **Without an issue**: `<short-kebab-description>` only — e.g. `tidy-axios-helpers`. Do **not** prefix with the user's name (no `leah/...`).
+
+If the current branch doesn't fit this pattern and isn't already pushed, rename it before pushing:
+```
+git branch -m <new-name>
+```
+If it's already pushed under a non-conforming name, leave it alone and proceed.
+
+Never work directly on `main`. If the user asks for a PR while on `main`, create a new branch off `origin/main` first (after `git fetch origin main`).
+
+## Steps
+
+1. **Inspect** in parallel:
+   - `git status`
+   - `git log main..HEAD --oneline` (all commits going into the PR — review **all** of them, not just HEAD)
+   - `git diff main...HEAD` (full diverged diff)
+   - `git rev-parse --abbrev-ref HEAD` and tracking info
+2. **Verify branch name** matches the convention above; rename if needed and unpushed.
+3. **Push** with `-u` if the branch isn't tracking a remote: `git push -u origin <branch>`.
+4. **Draft the PR**:
+   - **Title**: conventional commits format, same rules as the commit skill.
+     - `<type>(<scope>): <short summary>`
+     - Lowercase, imperative, no trailing period, under ~70 chars.
+     - If linked to an issue, append ` (Issue <number>)` — e.g. `feat(events): autolink urls in event description (Issue 412)`.
+   - **Body** (HEREDOC):
+     ```
+     ## Summary
+     - <1-3 bullets on what changed and why>
+
+     ## Test plan
+     - [ ] <how to verify>
+     ```
+     If the PR closes an issue, add `Closes #<number>` on its own line under Summary.
+5. **Create** the PR:
+   ```
+   gh pr create --title "..." --body "$(cat <<'EOF'
+   ...
+   EOF
+   )"
+   ```
+6. **Return the PR URL.**
+
+## Hard rules
+
+- **Never merge** the PR (`.claude/rules/no-merge-prs.md`). Creating only.
+- **Never push to `main`** directly.
+- **Never force-push** without explicit user approval.
+- **Never** add `Co-Authored-By` to commits or PR body (`.claude/rules/no-co-authored-by.md`).
+- Use `(Issue 380)` style for issue refs in titles/bodies; PR refs themselves stay as `#<num>`.
+- If `make agent-ci` hasn't been run for the latest changes, run it before pushing.
+
+## Examples
+
+Title:
+```
+feat(events): cohost invite approval flow (Issue 363)
+fix(sms): use & separator on ios for sms: hrefs
+refactor(perms): drop edit_welcome_message; gate template editor on approve_join_requests
+```
+
+Branch:
+```
+412-linkify-event-description
+363-cohost-invite-approval
+tidy-axios-helpers          # no issue
+```


### PR DESCRIPTION
## Summary
- adds `/commit` skill: runs `make agent-ci`, then stages and commits with conventional-commit format (`type(scope): summary`), appends `(Issue N)` when relevant, no `Co-Authored-By`, no amend/no-verify.
- adds `/open-pr` skill: enforces branch naming (`<issue>-<desc>`, or just `<desc>` when no issue — no name prefix), pushes with `-u`, opens a PR with a conventional-commit title and Summary/Test plan body. Never merges, never pushes to `main`.
- both reference existing repo rules (`no-co-authored-by`, `no-merge-prs`, `never-discard-changes`).

## Test plan
- [ ] restart Claude Code session and confirm `/commit` and `/open-pr` show up in the available-skills list
- [ ] run `/commit` on a small change and confirm conventional-commit formatting + CI gate
- [ ] run `/open-pr` on a branch and confirm it enforces the naming convention and opens a PR with the expected title/body shape