### PR TITLE
feat(events): move attendance to dedicated page behind kebab menu (Issue 410)

### DIFF
--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -1,3 +1,6 @@
+import { hasPermission, Permission } from './permissions';
+import type { User } from './user';
+
 export const EventType = {
   Community: 'community',
   Official: 'official',
@@ -142,6 +145,13 @@ export interface PendingCohostInvite {
   userName: string;
   userPhotoUrl: string;
   invitedAt: Date;
+}
+
+export function canManageEvent(event: Event, user: User | null): boolean {
+  if (!user) return false;
+  if (user.id === event.createdById) return true;
+  if (event.coHostIds.includes(user.id)) return true;
+  return hasPermission(user, Permission.ManageEvents);
 }
 
 export function eventClass(e: Event): string {

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -32,6 +32,7 @@ const Calendar = lazyWithRetry(() => import('@/screens/calendar/CalendarScreen')
 const EventDetail = lazyWithRetry(() => import('@/screens/events/EventDetailScreen'));
 const EventCreate = lazyWithRetry(() => import('@/screens/events/EventCreateScreen'));
 const EventEdit = lazyWithRetry(() => import('@/screens/events/EventEditScreen'));
+const EventAttendance = lazyWithRetry(() => import('@/screens/events/EventAttendanceScreen'));
 const MyEvents = lazyWithRetry(() => import('@/screens/events/MyEventsScreen'));
 const Notifications = lazyWithRetry(() => import('@/screens/notifications/NotificationsScreen'));
 const Profile = lazyWithRetry(() => import('@/screens/profile/ProfileScreen'));
@@ -104,6 +105,7 @@ export const router = createBrowserRouter([
                   { path: '/events/mine', element: el(<MyEvents />) },
                   { path: '/events/add', element: el(<EventCreate />) },
                   { path: '/events/:id/edit', element: el(<EventEdit />) },
+                  { path: '/events/:id/attendance', element: el(<EventAttendance />) },
                   { path: '/members', element: el(<MembersDirectory />) },
                   { path: '/members/:userId', element: el(<MemberProfile />) },
                 ],

--- a/frontend/src/screens/events/EventAttendancePanel.test.tsx
+++ b/frontend/src/screens/events/EventAttendancePanel.test.tsx
@@ -146,9 +146,6 @@ describe('EventAttendancePanel', () => {
     mockStats(BASE_STATS);
     renderPanel(BASE_EVENT);
 
-    // Card is collapsed by default; expand it.
-    fireEvent.click(screen.getByRole('button', { name: /attendance/i }));
-
     expect(screen.getByText(/going/)).toBeInTheDocument();
     expect(screen.getByText(/can't go/)).toBeInTheDocument();
     expect(screen.getByText(/no response/)).toBeInTheDocument();
@@ -157,8 +154,6 @@ describe('EventAttendancePanel', () => {
   it('hides check-in buttons until an hour before the event', () => {
     mockStats(BASE_STATS);
     renderPanel(BASE_EVENT);
-    fireEvent.click(screen.getByRole('button', { name: /attendance/i }));
-
     expect(screen.queryByRole('button', { name: /^attended$/i })).not.toBeInTheDocument();
     expect(screen.getByText(/check-in opens an hour before the event/i)).toBeInTheDocument();
   });
@@ -171,8 +166,6 @@ describe('EventAttendancePanel', () => {
       startDatetime: new Date(Date.now() + 30 * 60 * 1000),
     };
     renderPanel(soonEvent);
-    fireEvent.click(screen.getByRole('button', { name: /attendance/i }));
-
     const attendedBtn = screen.getByRole('button', { name: /^attended$/i });
     fireEvent.click(attendedBtn);
 
@@ -186,16 +179,12 @@ describe('EventAttendancePanel', () => {
     mockStats(BASE_STATS);
     const pastEvent: Event = { ...BASE_EVENT, isPast: true };
     renderPanel(pastEvent);
-    fireEvent.click(screen.getByRole('button', { name: /attendance/i }));
-
     expect(screen.getByRole('button', { name: /^attended$/i })).toBeInTheDocument();
   });
 
   it('renders cancellations list before the event opens for check-in', () => {
     mockStats(BASE_STATS);
     renderPanel(BASE_EVENT);
-    fireEvent.click(screen.getByRole('button', { name: /attendance/i }));
-
     expect(screen.getByText(/cancelled 3 days before/i)).toBeInTheDocument();
   });
 
@@ -219,8 +208,6 @@ describe('EventAttendancePanel', () => {
     };
     mockStats(stats);
     renderPanel(BASE_EVENT);
-    fireEvent.click(screen.getByRole('button', { name: /attendance/i }));
-
     expect(screen.getByText('early bird')).toBeInTheDocument();
     expect(screen.getByText('late one')).toBeInTheDocument();
 
@@ -244,8 +231,6 @@ describe('EventAttendancePanel', () => {
   it('shows error state when stats fail to load', () => {
     mockStats(null, 'error');
     renderPanel(BASE_EVENT);
-    fireEvent.click(screen.getByRole('button', { name: /attendance/i }));
-
     expect(screen.getByText(/couldn't load stats/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/events/EventAttendancePanel.tsx
+++ b/frontend/src/screens/events/EventAttendancePanel.tsx
@@ -1,16 +1,6 @@
-// Host-only attendance panel. Gated upstream in EventMemberSection — component
-// itself expects to only render when the viewer is creator/co-host/admin.
-//
-// Sections:
-//   - stats row + cancellations list: always visible.
-//   - check-in controls: open 1h before start, never close.
-// Cancellation lead time is inferred from `CANT_GO` rows' updated_at — lossy
-// for users who flipped statuses (see docs/event-attendance-stats-plan.md).
-
 import { useState } from 'react';
 
 import { useEventStats, useSetAttendance } from '@/api/eventStats';
-import { CollapsibleCard } from '@/components/ui/CollapsibleCard';
 import type {
   AttendanceStatusValue,
   Event,
@@ -40,30 +30,28 @@ export function EventAttendancePanel({ event }: Props) {
   const goingGuests = event.guests.filter((g) => g.status === RsvpServerStatus.Attending);
   const checkInOpen = isCheckInOpen(event);
 
+  if (stats.isLoading) {
+    return <p className="text-muted text-sm">loading stats…</p>;
+  }
+  if (stats.isError || !stats.data) {
+    return <p className="text-sm text-red-600">couldn't load stats — try refreshing</p>;
+  }
   return (
-    <CollapsibleCard title="attendance">
-      {stats.isLoading ? (
-        <p className="text-muted text-sm">loading stats…</p>
-      ) : stats.isError || !stats.data ? (
-        <p className="text-sm text-red-600">couldn't load stats — try refreshing</p>
+    <div className="flex flex-col gap-4">
+      <StatsRow stats={stats.data} />
+      {checkInOpen ? (
+        <CheckInList
+          guests={goingGuests}
+          onMark={(userId, attendance) => {
+            setAttendance.mutate({ userId, attendance });
+          }}
+          isPending={setAttendance.isPending}
+        />
       ) : (
-        <div className="flex flex-col gap-4">
-          <StatsRow stats={stats.data} />
-          {checkInOpen ? (
-            <CheckInList
-              guests={goingGuests}
-              onMark={(userId, attendance) => {
-                setAttendance.mutate({ userId, attendance });
-              }}
-              isPending={setAttendance.isPending}
-            />
-          ) : (
-            <p className="text-muted text-xs">check-in opens an hour before the event</p>
-          )}
-          <CancellationsList cancellations={stats.data.cancellations} />
-        </div>
+        <p className="text-muted text-xs">check-in opens an hour before the event</p>
       )}
-    </CollapsibleCard>
+      <CancellationsList cancellations={stats.data.cancellations} />
+    </div>
   );
 }
 

--- a/frontend/src/screens/events/EventAttendanceScreen.test.tsx
+++ b/frontend/src/screens/events/EventAttendanceScreen.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { useAuthStore } from '@/auth/store';
+import type { Event } from '@/models/event';
+import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
+import type { User } from '@/models/user';
+
+vi.mock('@/api/events', () => ({
+  useEvent: vi.fn(),
+  eventKeys: { all: ['events'], list: vi.fn(), detail: vi.fn() },
+}));
+
+vi.mock('@/api/eventStats', () => ({
+  useEventStats: vi.fn().mockReturnValue({ data: undefined, isLoading: true, isError: false }),
+  useSetAttendance: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+import { useEvent } from '@/api/events';
+import EventAttendanceScreen from './EventAttendanceScreen';
+
+const BASE_EVENT: Event = {
+  id: 'ev1',
+  title: 'Spring Potluck',
+  description: '',
+  startDatetime: new Date('2099-06-01T18:00:00Z'),
+  endDatetime: null,
+  location: '',
+  latitude: null,
+  longitude: null,
+  whatsappLink: '',
+  partifulLink: '',
+  otherLink: '',
+  venmoLink: '',
+  cashappLink: '',
+  zelleInfo: '',
+  price: '',
+  rsvpEnabled: true,
+  allowPlusOnes: false,
+  maxAttendees: null,
+  attendingCount: 0,
+  waitlistedCount: 0,
+  invitedCount: 0,
+  datetimeTbd: false,
+  hasPoll: false,
+  datetimePollSlug: null,
+  createdById: 'user-creator',
+  createdByName: 'Alice',
+  createdByPhotoUrl: '',
+  coHostIds: [],
+  coHostNames: [],
+  coHostPhotoUrls: [],
+  coHostInviteIds: [],
+  guests: [],
+  myRsvp: null,
+  surveySlugs: [],
+  invitedUserIds: [],
+  invitedUserNames: [],
+  invitedUserPhotoUrls: [],
+  invitePermission: InvitePermission.AllMembers,
+  pendingCohostInvites: [],
+  myPendingCohostInviteId: null,
+  eventType: EventType.Community,
+  visibility: EventVisibility.Public,
+  photoUrl: '',
+  isPast: false,
+  status: EventStatus.Active,
+};
+
+const CREATOR: User = {
+  id: 'user-creator',
+  phoneNumber: '+12125550001',
+  displayName: 'Alice',
+  email: '',
+  bio: '',
+  isSuperuser: false,
+  isStaff: false,
+  needsOnboarding: false,
+  showPhone: false,
+  showEmail: false,
+  weekStart: 'sunday',
+  calendarFeedScope: 'all',
+  profilePhotoUrl: '',
+  photoUpdatedAt: null,
+  roles: [],
+};
+
+const STRANGER: User = { ...CREATOR, id: 'user-stranger', displayName: 'Stranger' };
+
+function renderScreen() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/events/ev1/attendance']}>
+        <Routes>
+          <Route path="/events/:id/attendance" element={<EventAttendanceScreen />} />
+          <Route path="/events/:id" element={<div>event detail</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(useEvent).mockReturnValue({
+    data: BASE_EVENT,
+    isPending: false,
+    isError: false,
+  } as ReturnType<typeof useEvent>);
+});
+
+describe('EventAttendanceScreen', () => {
+  it('renders the panel for the event creator', () => {
+    useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
+    renderScreen();
+
+    expect(screen.getByRole('heading', { name: /attendance/i })).toBeInTheDocument();
+    expect(screen.getByText(BASE_EVENT.title)).toBeInTheDocument();
+  });
+
+  it('blocks non-host members with a forbidden notice', () => {
+    useAuthStore.setState({ status: 'authed', user: STRANGER, accessToken: 'tok' });
+    renderScreen();
+
+    expect(screen.getByText(/only the host or a co-host/i)).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /^attendance$/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/events/EventAttendanceScreen.test.tsx
+++ b/frontend/src/screens/events/EventAttendanceScreen.test.tsx
@@ -77,7 +77,7 @@ describe('EventAttendanceScreen', () => {
     useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
     renderScreen();
 
-    expect(screen.getByText(/only the host or a co-host/i)).toBeInTheDocument();
+    expect(screen.getByText(/rsvps are off for this event/i)).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: /^attendance$/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/events/EventAttendanceScreen.test.tsx
+++ b/frontend/src/screens/events/EventAttendanceScreen.test.tsx
@@ -1,11 +1,10 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { useAuthStore } from '@/auth/store';
-import type { Event } from '@/models/event';
-import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
-import type { User } from '@/models/user';
+import { makeEvent, makeUser } from '@/test/fixtures';
 
 vi.mock('@/api/events', () => ({
   useEvent: vi.fn(),
@@ -18,75 +17,17 @@ vi.mock('@/api/eventStats', () => ({
 }));
 
 import { useEvent } from '@/api/events';
+
 import EventAttendanceScreen from './EventAttendanceScreen';
 
-const BASE_EVENT: Event = {
-  id: 'ev1',
+const BASE_EVENT = makeEvent({
   title: 'Spring Potluck',
-  description: '',
-  startDatetime: new Date('2099-06-01T18:00:00Z'),
-  endDatetime: null,
-  location: '',
-  latitude: null,
-  longitude: null,
-  whatsappLink: '',
-  partifulLink: '',
-  otherLink: '',
-  venmoLink: '',
-  cashappLink: '',
-  zelleInfo: '',
-  price: '',
-  rsvpEnabled: true,
-  allowPlusOnes: false,
-  maxAttendees: null,
-  attendingCount: 0,
-  waitlistedCount: 0,
-  invitedCount: 0,
-  datetimeTbd: false,
-  hasPoll: false,
-  datetimePollSlug: null,
   createdById: 'user-creator',
-  createdByName: 'Alice',
-  createdByPhotoUrl: '',
-  coHostIds: [],
-  coHostNames: [],
-  coHostPhotoUrls: [],
-  coHostInviteIds: [],
   guests: [],
-  myRsvp: null,
-  surveySlugs: [],
-  invitedUserIds: [],
-  invitedUserNames: [],
-  invitedUserPhotoUrls: [],
-  invitePermission: InvitePermission.AllMembers,
-  pendingCohostInvites: [],
-  myPendingCohostInviteId: null,
-  eventType: EventType.Community,
-  visibility: EventVisibility.Public,
-  photoUrl: '',
-  isPast: false,
-  status: EventStatus.Active,
-};
+});
 
-const CREATOR: User = {
-  id: 'user-creator',
-  phoneNumber: '+12125550001',
-  displayName: 'Alice',
-  email: '',
-  bio: '',
-  isSuperuser: false,
-  isStaff: false,
-  needsOnboarding: false,
-  showPhone: false,
-  showEmail: false,
-  weekStart: 'sunday',
-  calendarFeedScope: 'all',
-  profilePhotoUrl: '',
-  photoUpdatedAt: null,
-  roles: [],
-};
-
-const STRANGER: User = { ...CREATOR, id: 'user-stranger', displayName: 'Stranger' };
+const CREATOR = makeUser({ id: 'user-creator', displayName: 'Alice' });
+const nonMember = makeUser({ id: 'user-nonmember', displayName: 'Casey' });
 
 function renderScreen() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -120,7 +61,7 @@ describe('EventAttendanceScreen', () => {
   });
 
   it('blocks non-host members with a forbidden notice', () => {
-    useAuthStore.setState({ status: 'authed', user: STRANGER, accessToken: 'tok' });
+    useAuthStore.setState({ status: 'authed', user: nonMember, accessToken: 'tok' });
     renderScreen();
 
     expect(screen.getByText(/only the host or a co-host/i)).toBeInTheDocument();

--- a/frontend/src/screens/events/EventAttendanceScreen.test.tsx
+++ b/frontend/src/screens/events/EventAttendanceScreen.test.tsx
@@ -67,4 +67,17 @@ describe('EventAttendanceScreen', () => {
     expect(screen.getByText(/only the host or a co-host/i)).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: /^attendance$/i })).not.toBeInTheDocument();
   });
+
+  it('blocks even the creator when rsvp is disabled', () => {
+    vi.mocked(useEvent).mockReturnValue({
+      data: makeEvent({ createdById: 'user-creator', guests: [], rsvpEnabled: false }),
+      isPending: false,
+      isError: false,
+    } as ReturnType<typeof useEvent>);
+    useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
+    renderScreen();
+
+    expect(screen.getByText(/only the host or a co-host/i)).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /^attendance$/i })).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/screens/events/EventAttendanceScreen.tsx
+++ b/frontend/src/screens/events/EventAttendanceScreen.tsx
@@ -1,0 +1,76 @@
+// Dedicated host-only page for event attendance — accessed via the kebab menu
+// on the event detail screen. Gates the panel behind creator/co-host/manage_events.
+
+import { Link, useParams } from 'react-router-dom';
+import { extractApiError, getApiStatus } from '@/api/apiErrors';
+import { useEvent } from '@/api/events';
+import { useAuthStore } from '@/auth/store';
+import type { Event } from '@/models/event';
+import { Permission, hasPermission } from '@/models/permissions';
+import type { User } from '@/models/user';
+import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
+import { EventAttendancePanel } from './EventAttendancePanel';
+
+export default function EventAttendanceScreen() {
+  const { id } = useParams<{ id: string }>();
+  const user = useAuthStore((s) => s.user);
+  const { data: event, isPending, isError, error } = useEvent(id);
+
+  if (isPending) return <ContentLoading />;
+  if (isError) {
+    if (getApiStatus(error) === 403) {
+      const message = extractApiError(error) ?? "you don't have permission to see this event";
+      return <ForbiddenNotice eventId={id} message={message} />;
+    }
+    return <ContentError message="couldn't load this event — try refreshing" />;
+  }
+
+  if (!canSeeAttendance(event, user)) {
+    return (
+      <ForbiddenNotice eventId={event.id} message="only the host or a co-host can see attendance" />
+    );
+  }
+
+  return (
+    <ContentContainer>
+      <BackLink eventId={event.id} />
+      <h1 className="mb-1 text-2xl font-medium tracking-tight">attendance</h1>
+      <p className="text-foreground-secondary mb-6 text-sm">{event.title}</p>
+      <EventAttendancePanel event={event} />
+    </ContentContainer>
+  );
+}
+
+function canSeeAttendance(event: Event, user: User | null): boolean {
+  if (!user) return false;
+  if (user.id === event.createdById) return true;
+  if (event.coHostIds.includes(user.id)) return true;
+  return hasPermission(user, Permission.ManageEvents);
+}
+
+function BackLink({ eventId }: { eventId: string }) {
+  return (
+    <Link
+      to={`/events/${eventId}`}
+      className="text-foreground-secondary hover:text-foreground mb-4 inline-flex items-center gap-1 text-sm"
+    >
+      ← back to event
+    </Link>
+  );
+}
+
+function ForbiddenNotice({ eventId, message }: { eventId: string | undefined; message: string }) {
+  return (
+    <ContentContainer>
+      <section className="border-border bg-surface mt-8 rounded-lg border p-6">
+        <h2 className="mb-2 text-base font-medium">{message}</h2>
+        <Link
+          to={eventId ? `/events/${eventId}` : '/calendar'}
+          className="border-border-strong text-foreground-secondary hover:bg-background mt-4 inline-flex h-10 items-center rounded-md border px-4 text-sm font-medium"
+        >
+          back to event
+        </Link>
+      </section>
+    </ContentContainer>
+  );
+}

--- a/frontend/src/screens/events/EventAttendanceScreen.tsx
+++ b/frontend/src/screens/events/EventAttendanceScreen.tsx
@@ -22,7 +22,7 @@ export default function EventAttendanceScreen() {
     return <ContentError message="couldn't load this event — try refreshing" />;
   }
 
-  if (!canManageEvent(event, user)) {
+  if (!event.rsvpEnabled || !canManageEvent(event, user)) {
     return (
       <ForbiddenNotice eventId={event.id} message="only the host or a co-host can see attendance" />
     );

--- a/frontend/src/screens/events/EventAttendanceScreen.tsx
+++ b/frontend/src/screens/events/EventAttendanceScreen.tsx
@@ -22,9 +22,17 @@ export default function EventAttendanceScreen() {
     return <ContentError message="couldn't load this event — try refreshing" />;
   }
 
-  if (!event.rsvpEnabled || !canManageEvent(event, user)) {
+  if (!canManageEvent(event, user)) {
     return (
       <ForbiddenNotice eventId={event.id} message="only the host or a co-host can see attendance" />
+    );
+  }
+  if (!event.rsvpEnabled) {
+    return (
+      <ForbiddenNotice
+        eventId={event.id}
+        message="attendance isn't available — rsvps are off for this event"
+      />
     );
   }
 

--- a/frontend/src/screens/events/EventAttendanceScreen.tsx
+++ b/frontend/src/screens/events/EventAttendanceScreen.tsx
@@ -1,14 +1,11 @@
-// Dedicated host-only page for event attendance — accessed via the kebab menu
-// on the event detail screen. Gates the panel behind creator/co-host/manage_events.
-
 import { Link, useParams } from 'react-router-dom';
+
 import { extractApiError, getApiStatus } from '@/api/apiErrors';
 import { useEvent } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
-import type { Event } from '@/models/event';
-import { Permission, hasPermission } from '@/models/permissions';
-import type { User } from '@/models/user';
+import { canManageEvent } from '@/models/event';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
+
 import { EventAttendancePanel } from './EventAttendancePanel';
 
 export default function EventAttendanceScreen() {
@@ -25,7 +22,7 @@ export default function EventAttendanceScreen() {
     return <ContentError message="couldn't load this event — try refreshing" />;
   }
 
-  if (!canSeeAttendance(event, user)) {
+  if (!canManageEvent(event, user)) {
     return (
       <ForbiddenNotice eventId={event.id} message="only the host or a co-host can see attendance" />
     );
@@ -39,13 +36,6 @@ export default function EventAttendanceScreen() {
       <EventAttendancePanel event={event} />
     </ContentContainer>
   );
-}
-
-function canSeeAttendance(event: Event, user: User | null): boolean {
-  if (!user) return false;
-  if (user.id === event.createdById) return true;
-  if (event.coHostIds.includes(user.id)) return true;
-  return hasPermission(user, Permission.ManageEvents);
 }
 
 function BackLink({ eventId }: { eventId: string }) {

--- a/frontend/src/screens/events/EventDetailKebabMenu.tsx
+++ b/frontend/src/screens/events/EventDetailKebabMenu.tsx
@@ -1,0 +1,77 @@
+// Host-only kebab menu rendered next to the event title. Items navigate to
+// dedicated pages rather than opening modals — keeps the detail page tidy and
+// gives each setting room to breathe.
+
+import { useEffect, useRef, useState } from 'react';
+import { Link } from 'react-router-dom';
+
+interface Props {
+  eventId: string;
+}
+
+export function EventDetailKebabMenu({ eventId }: Props) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDocClick(e: MouseEvent) {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('mousedown', onDocClick);
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('mousedown', onDocClick);
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  return (
+    <div ref={rootRef} className="relative">
+      <button
+        type="button"
+        aria-label="event settings"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => {
+          setOpen((v) => !v);
+        }}
+        className="bg-surface-dim text-foreground-secondary hover:bg-surface-dim/70 hover:text-foreground inline-flex h-9 w-9 items-center justify-center rounded-md transition-colors"
+      >
+        <KebabIcon />
+      </button>
+      {open ? (
+        <div
+          role="menu"
+          className="border-border bg-surface absolute right-0 z-10 mt-1 w-44 overflow-hidden rounded-md border text-sm shadow-lg"
+        >
+          <Link
+            to={`/events/${eventId}/attendance`}
+            role="menuitem"
+            className="text-foreground hover:bg-surface-dim block px-3 py-2"
+            onClick={() => {
+              setOpen(false);
+            }}
+          >
+            attendance
+          </Link>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function KebabIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+      <circle cx="12" cy="5" r="1.6" />
+      <circle cx="12" cy="12" r="1.6" />
+      <circle cx="12" cy="19" r="1.6" />
+    </svg>
+  );
+}

--- a/frontend/src/screens/events/EventDetailKebabMenu.tsx
+++ b/frontend/src/screens/events/EventDetailKebabMenu.tsx
@@ -1,7 +1,3 @@
-// Host-only kebab menu rendered next to the event title. Items navigate to
-// dedicated pages rather than opening modals — keeps the detail page tidy and
-// gives each setting room to breathe.
-
 import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 

--- a/frontend/src/screens/events/EventDetailScreen.test.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.test.tsx
@@ -203,4 +203,26 @@ describe('EventDetailScreen', () => {
     expect(screen.getByRole('link', { name: /sign in/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /request to join/i })).toBeInTheDocument();
   });
+
+  it('shows event-settings kebab for the creator', () => {
+    const creator: User = { ...AUTHED_USER, id: 'user1' };
+    useAuthStore.setState({ status: 'authed', user: creator, accessToken: 'tok' });
+    renderScreen();
+
+    expect(screen.getByRole('button', { name: /event settings/i })).toBeInTheDocument();
+  });
+
+  it('hides event-settings kebab from non-host members', () => {
+    useAuthStore.setState({ status: 'authed', user: AUTHED_USER, accessToken: 'tok' });
+    renderScreen();
+
+    expect(screen.queryByRole('button', { name: /event settings/i })).not.toBeInTheDocument();
+  });
+
+  it('hides event-settings kebab from unauthenticated guests', () => {
+    useAuthStore.setState({ status: 'unauthed', user: null, accessToken: null });
+    renderScreen();
+
+    expect(screen.queryByRole('button', { name: /event settings/i })).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -37,7 +37,7 @@ export default function EventDetailScreen() {
     return <ContentError message="couldn't load this event — try refreshing" />;
   }
 
-  const showKebab = isAuthed && canManageEvent(event, user);
+  const showKebab = isAuthed && event.rsvpEnabled && canManageEvent(event, user);
 
   return (
     <ContentContainer>

--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -6,12 +6,15 @@ import { useEvent } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility } from '@/models/event';
+import { Permission, hasPermission } from '@/models/permissions';
+import type { User } from '@/models/user';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 import { formatEventDateTime } from '@/utils/datetime';
 import { linkifyText } from '@/utils/linkifyText';
 
 import { CohostInviteBanner } from './CohostInviteBanner';
 import { EventActions } from './EventActions';
+import { EventDetailKebabMenu } from './EventDetailKebabMenu';
 import { EventMemberSection } from './EventMemberSection';
 import { EventTagChips } from './EventTagChips';
 import { EventPollCard } from './poll/EventPollCard';
@@ -24,6 +27,7 @@ function photoSrc(url: string, updatedAt: string | null): string {
 export default function EventDetailScreen() {
   const { id } = useParams<{ id: string }>();
   const isAuthed = useAuthStore((s) => s.status === 'authed');
+  const user = useAuthStore((s) => s.user);
   const { data: event, isPending, isError, error } = useEvent(id);
 
   if (isPending) return <ContentLoading />;
@@ -34,6 +38,8 @@ export default function EventDetailScreen() {
     }
     return <ContentError message="couldn't load this event — try refreshing" />;
   }
+
+  const showKebab = isAuthed && canManageEventSettings(event, user);
 
   return (
     <ContentContainer>
@@ -51,6 +57,11 @@ export default function EventDetailScreen() {
           {event.title}
         </h1>
         <VisibilityBadge event={event} />
+        {showKebab ? (
+          <div className="ml-auto">
+            <EventDetailKebabMenu eventId={event.id} />
+          </div>
+        ) : null}
       </div>
 
       <WhenLine event={event} />
@@ -117,6 +128,13 @@ function Badge({
     lavender: 'bg-highlight-subtle text-highlight',
   };
   return <span className={`rounded-full px-2 py-0.5 text-xs ${tones[tone]}`}>{children}</span>;
+}
+
+function canManageEventSettings(event: Event, user: User | null): boolean {
+  if (!user) return false;
+  if (user.id === event.createdById) return true;
+  if (event.coHostIds.includes(user.id)) return true;
+  return hasPermission(user, Permission.ManageEvents);
 }
 
 function ForbiddenNotice({ message }: { message: string }) {

--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -5,9 +5,7 @@ import { extractApiError, getApiStatus } from '@/api/apiErrors';
 import { useEvent } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
-import { EventStatus, EventType, EventVisibility } from '@/models/event';
-import { Permission, hasPermission } from '@/models/permissions';
-import type { User } from '@/models/user';
+import { canManageEvent, EventStatus, EventType, EventVisibility } from '@/models/event';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 import { formatEventDateTime } from '@/utils/datetime';
 import { linkifyText } from '@/utils/linkifyText';
@@ -39,7 +37,7 @@ export default function EventDetailScreen() {
     return <ContentError message="couldn't load this event — try refreshing" />;
   }
 
-  const showKebab = isAuthed && canManageEventSettings(event, user);
+  const showKebab = isAuthed && canManageEvent(event, user);
 
   return (
     <ContentContainer>
@@ -128,13 +126,6 @@ function Badge({
     lavender: 'bg-highlight-subtle text-highlight',
   };
   return <span className={`rounded-full px-2 py-0.5 text-xs ${tones[tone]}`}>{children}</span>;
-}
-
-function canManageEventSettings(event: Event, user: User | null): boolean {
-  if (!user) return false;
-  if (user.id === event.createdById) return true;
-  if (event.coHostIds.includes(user.id)) return true;
-  return hasPermission(user, Permission.ManageEvents);
 }
 
 function ForbiddenNotice({ message }: { message: string }) {

--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -20,7 +20,6 @@ vi.mock('@/api/cohostInvites', () => ({
 vi.mock('./RsvpSection', () => ({ RsvpSection: () => <div data-testid="rsvp-section" /> }));
 vi.mock('./RsvpGuestList', () => ({ InvitedList: () => null }));
 vi.mock('./EventAdminActions', () => ({ EventAdminActions: () => null }));
-vi.mock('./EventAttendancePanel', () => ({ EventAttendancePanel: () => null }));
 vi.mock('./EventFlagDialog', () => ({ EventFlagDialog: () => null }));
 vi.mock('./InviteDialog', () => ({ InviteDialog: () => null }));
 vi.mock('./AddCoHostDialog', () => ({ AddCoHostDialog: () => null }));

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -18,7 +18,6 @@ import { AddCoHostDialog } from './AddCoHostDialog';
 import { EventCommentsCard } from './comments/EventCommentsCard';
 import { EmailBlastButton } from './EmailBlastButton';
 import { EventAdminActions } from './EventAdminActions';
-import { EventAttendancePanel } from './EventAttendancePanel';
 import { EventFlagDialog } from './EventFlagDialog';
 import { GroupTextButton } from './GroupTextButton';
 import { InviteDialog } from './InviteDialog';
@@ -73,7 +72,6 @@ export function EventMemberSection({ event }: Props) {
       ) : null}
       {canInvite ? <InviteSection event={event} /> : null}
       <EventCommentsCard eventId={event.id} />
-      {canSeeInvited && event.rsvpEnabled ? <EventAttendancePanel event={event} /> : null}
       <EventAdminActions event={event} />
       <ReportEventButton eventId={event.id} />
     </div>

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -10,6 +10,7 @@ import {
   InvitePermission,
   RsvpServerStatus,
 } from '@/models/event';
+import type { User } from '@/models/user';
 
 export function makeEvent(overrides: Partial<Event> = {}): Event {
   return {
@@ -79,6 +80,30 @@ export function makeEvent(overrides: Partial<Event> = {}): Event {
     tags: [],
     isPast: false,
     status: EventStatus.Active,
+    ...overrides,
+  };
+}
+
+export function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 'user1',
+    phoneNumber: '+12125550001',
+    displayName: 'Test User',
+    email: '',
+    bio: '',
+    isSuperuser: false,
+    isStaff: false,
+    needsOnboarding: false,
+    needsPasswordReset: false,
+    needsGuidelinesConsent: false,
+    needsSmsConsent: false,
+    showPhone: false,
+    showEmail: false,
+    weekStart: 'sunday',
+    calendarFeedScope: 'all',
+    profilePhotoUrl: '',
+    photoUpdatedAt: null,
+    roles: [],
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary
- Adds a 3-dot menu next to the event title (visible only to host / co-host / `manage_events`) that links to a new `/events/:id/attendance` page.
- Moves the inline attendance panel off the event detail page so the detail page stays focused on member-facing info.
- New screen wraps the existing `EventAttendancePanel` content (collapsible wrapper dropped — it's its own page now), with creator/co-host/admin gating and a back link.

Closes #410

## Test plan
- [ ] As event creator: open the event detail page → see kebab next to title → click → see "attendance" → navigates to the page → stats / check-in / cancellations all render.
- [ ] As a non-host member: kebab is not visible on the event detail page; visiting `/events/:id/attendance` directly shows a forbidden notice.
- [ ] As a logged-out viewer: kebab is not visible.
- [ ] Back link from attendance page returns to the event detail.