### PR TITLE
fix(auth): route legacy users without email to /onboarding

### DIFF
--- a/frontend/src/auth/guards.test.tsx
+++ b/frontend/src/auth/guards.test.tsx
@@ -185,8 +185,12 @@ describe('OnboardingGate', () => {
     expect(screen.queryByText('calendar page')).not.toBeInTheDocument();
   });
 
-  it('redirects a password-reset user (needsOnboarding=true, has displayName) to /new-password', () => {
-    const user = makeUser({ needsOnboarding: true, displayName: 'Alice' });
+  it('redirects a password-reset user (needsOnboarding=true, has displayName + email) to /new-password', () => {
+    const user = makeUser({
+      needsOnboarding: true,
+      displayName: 'Alice',
+      email: 'alice@example.com',
+    });
     useAuthStore.setState({ status: 'authed', user, accessToken: 'tok-abc' });
 
     render(
@@ -203,6 +207,29 @@ describe('OnboardingGate', () => {
 
     expect(screen.getByText('new password page')).toBeInTheDocument();
     expect(screen.queryByText('calendar page')).not.toBeInTheDocument();
+  });
+
+  it('redirects a legacy user (needsOnboarding=true, has displayName but no email) to /onboarding', () => {
+    // Pre-email-requirement users were approved with a displayName but never
+    // supplied an email. On first login they must end up at /onboarding so
+    // they can add one — /new-password has no email field and would loop.
+    const user = makeUser({ needsOnboarding: true, displayName: 'Alice', email: '' });
+    useAuthStore.setState({ status: 'authed', user, accessToken: 'tok-abc' });
+
+    render(
+      <MemoryRouter initialEntries={['/calendar']}>
+        <Routes>
+          <Route element={<OnboardingGate />}>
+            <Route path="/calendar" element={<div>calendar page</div>} />
+            <Route path="/onboarding" element={<div>onboarding page</div>} />
+            <Route path="/new-password" element={<div>new password page</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('onboarding page')).toBeInTheDocument();
+    expect(screen.queryByText('new password page')).not.toBeInTheDocument();
   });
 
   it('redirects an onboarding-complete user on /onboarding to /guidelines', () => {

--- a/frontend/src/auth/guards.tsx
+++ b/frontend/src/auth/guards.tsx
@@ -66,9 +66,12 @@ export function OnboardingGate() {
 
   if (user?.needsOnboarding) {
     // Two shapes:
-    //   - first-time user (empty displayName)  → /onboarding (name + password)
-    //   - password reset (has displayName)     → /new-password (password only)
-    const target = user.displayName.length > 0 ? '/new-password' : '/onboarding';
+    //   - password reset (has displayName + email)  → /new-password (password only)
+    //   - everyone else                             → /onboarding (collects whatever's missing)
+    // Users approved before email was required can land here with a displayName
+    // but no email — they need /onboarding so they can supply one.
+    const hasNameAndEmail = user.displayName.length > 0 && !!user.email;
+    const target = hasNameAndEmail ? '/new-password' : '/onboarding';
     if (path !== target) {
       return <Navigate to={target} replace />;
     }

--- a/frontend/src/screens/auth/OnboardingScreen.tsx
+++ b/frontend/src/screens/auth/OnboardingScreen.tsx
@@ -22,6 +22,10 @@ type FormValues = z.infer<typeof schema>;
 
 export default function OnboardingScreen() {
   const completeOnboarding = useAuthStore((s) => s.completeOnboarding);
+  // Prefill displayName for legacy users who were approved before email was
+  // required — they already have a name on file and only need to add email
+  // + set a password.
+  const existingDisplayName = useAuthStore((s) => s.user?.displayName ?? '');
   const navigate = useNavigate();
   const [serverError, setServerError] = useState<string | null>(null);
 
@@ -32,7 +36,7 @@ export default function OnboardingScreen() {
     formState: { errors, isSubmitting },
   } = useForm<FormValues>({
     resolver: zodResolver(schema),
-    defaultValues: { displayName: '', email: '', newPassword: '' },
+    defaultValues: { displayName: existingDisplayName, email: '', newPassword: '' },
   });
   const passwordValue = useWatch({ control, name: 'newPassword' });
 


### PR DESCRIPTION
## Summary

- Legacy users approved before email was required (have `displayName`, no `email`) were stuck in a loop: `OnboardingGate` sent them to `/new-password`, that screen has no email field, and the backend rejected the password submit with 422 "email required."
- `OnboardingGate` now sends users to `/new-password` only when **both** `displayName` and `email` are present. Otherwise → `/onboarding`, which already collects all three fields and enforces required email (Zod + backend).
- `OnboardingScreen` prefills `displayName` from the auth store so legacy users don't retype their name.

## Test plan

- [x] `make agent-frontend-typecheck`
- [x] `make agent-frontend-lint`
- [x] `vitest run` on `guards.test.tsx` + `OnboardingScreen.test.tsx` (16/16 pass)
- [x] New guard test: legacy user (displayName set, email empty, needsOnboarding) → `/onboarding`
- [x] Updated existing test: password-reset user now requires both displayName and email to hit `/new-password`
- [ ] Manually verify with an affected user account (or seed one) once deployed to staging