### PR TITLE
feat: show member count and emails on admin members cards

### DIFF
--- a/frontend/src/screens/admin/MembersTab.tsx
+++ b/frontend/src/screens/admin/MembersTab.tsx
@@ -92,6 +92,12 @@ export function MembersTab() {
         ) : null}
       </div>
 
+      {data.length > 0 ? (
+        <p className="text-foreground-tertiary mb-3 text-sm">
+          {data.length === 1 ? '1 member' : `${String(data.length)} members`}
+        </p>
+      ) : null}
+
       <MembersList
         members={visible}
         selectedRoles={selectedRoles}
@@ -340,6 +346,11 @@ function MemberRow({ member }: { member: Member }) {
         <p className="text-foreground-tertiary truncate text-xs">
           {formatPhone(member.phoneNumber)}
         </p>
+        {member.email ? (
+          <p className="text-foreground-tertiary truncate text-xs">{member.email.toLowerCase()}</p>
+        ) : (
+          <p className="text-foreground-tertiary/60 truncate text-xs italic">no email</p>
+        )}
       </div>
       <div className="flex shrink-0 flex-wrap justify-end gap-1">
         {member.roles.map((role) => (


### PR DESCRIPTION
## Overview

Two improvements to the admin members page: a total member count is shown
above the list so admins can see community size at a glance, and each member
card now displays the member's email below their phone number (with a muted
"no email" fallback for members without one). Frontend-only — email and the
members array were already available client-side.

Closes #441

## Test plan

- [ ] member count appears above the list and reflects the total membership
- [ ] each member card shows the member's email
- [ ] members without an email show muted "no email"
- [ ] `make agent-frontend-ci` passes
