### PR TITLE
fix(auth): harden password-reset flow (server-side enforcement, reuse, gate)

### DIFF
--- a/backend/community/_calendar.py
+++ b/backend/community/_calendar.py
@@ -3,12 +3,12 @@
 import secrets
 from datetime import timedelta
 
+from config.auth import gated_jwt
 from django.db.models import Q
 from django.http import HttpRequest, HttpResponse
 from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 from pydantic import BaseModel
 from users.models import CalendarFeedScope
 from users.models import User as UserModel
@@ -33,7 +33,7 @@ def _rotate_calendar_token(user: UserModel) -> None:
     user.save(update_fields=["calendar_token"])
 
 
-@router.get("/calendar/token/", response={200: CalendarTokenOut}, auth=JWTAuth())
+@router.get("/calendar/token/", response={200: CalendarTokenOut}, auth=gated_jwt)
 def get_calendar_token(request):
     user = request.auth
     if not user.calendar_token:
@@ -47,7 +47,7 @@ def get_calendar_token(request):
     )
 
 
-@router.post("/calendar/token/", response={200: CalendarTokenOut}, auth=JWTAuth())
+@router.post("/calendar/token/", response={200: CalendarTokenOut}, auth=gated_jwt)
 def generate_calendar_token(request):
     user = request.auth
     _rotate_calendar_token(user)

--- a/backend/community/_docs.py
+++ b/backend/community/_docs.py
@@ -9,9 +9,9 @@ import logging
 from datetime import datetime
 
 from config.audit import audit_log
+from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 from pydantic import BaseModel, Field
 from users.permissions import PermissionKey
 
@@ -141,7 +141,7 @@ def _has_manage_docs(user) -> bool:
 @router.get(
     "/docs/folders/",
     response={200: list[DocFolderOut], 403: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def list_folders(request):
     if not _has_manage_docs(request.auth):
@@ -164,7 +164,7 @@ def list_folders(request):
 @router.post(
     "/docs/folders/",
     response={201: DocFolderOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def create_folder(request, payload: FolderIn):
     if not _has_manage_docs(request.auth):
@@ -201,7 +201,7 @@ def create_folder(request, payload: FolderIn):
 @router.put(
     "/docs/folders/reorder/",
     response={200: dict, 403: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def reorder_folders(request, payload: ReorderIn):
     if not _has_manage_docs(request.auth):
@@ -225,7 +225,7 @@ def reorder_folders(request, payload: ReorderIn):
 @router.patch(
     "/docs/folders/{folder_id}/",
     response={200: DocFolderOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def update_folder(request, folder_id: str, payload: FolderPatchIn):
     if not _has_manage_docs(request.auth):
@@ -277,7 +277,7 @@ def update_folder(request, folder_id: str, payload: FolderPatchIn):
 @router.delete(
     "/docs/folders/{folder_id}/",
     response={200: dict, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def delete_folder(request, folder_id: str):
     if not _has_manage_docs(request.auth):

--- a/backend/community/_docs_documents.py
+++ b/backend/community/_docs_documents.py
@@ -8,9 +8,9 @@ from there — single source of truth.
 import logging
 
 from config.audit import audit_log
+from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 from users.permissions import PermissionKey
 
 from community._content_render import render_content_payload
@@ -35,7 +35,7 @@ router = Router()
 @router.post(
     "/docs/",
     response={201: DocumentOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def create_document(request, payload: DocumentIn):
     if not _has_manage_docs(request.auth):
@@ -78,7 +78,7 @@ def create_document(request, payload: DocumentIn):
 @router.put(
     "/docs/reorder/",
     response={200: dict, 403: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def reorder_documents(request, payload: ReorderIn):
     if not _has_manage_docs(request.auth):
@@ -102,7 +102,7 @@ def reorder_documents(request, payload: ReorderIn):
 @router.get(
     "/docs/{doc_id}/",
     response={200: DocumentOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def get_document(request, doc_id: str):
     if not _has_manage_docs(request.auth):
@@ -127,7 +127,7 @@ def get_document(request, doc_id: str):
 @router.patch(
     "/docs/{doc_id}/",
     response={200: DocumentOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def update_document(request, doc_id: str, payload: DocumentPatchIn):
     if not _has_manage_docs(request.auth):
@@ -185,7 +185,7 @@ def update_document(request, doc_id: str, payload: DocumentPatchIn):
 @router.delete(
     "/docs/{doc_id}/",
     response={200: dict, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def delete_document(request, doc_id: str):
     if not _has_manage_docs(request.auth):

--- a/backend/community/_event_actions.py
+++ b/backend/community/_event_actions.py
@@ -5,11 +5,11 @@ import time
 from uuid import UUID
 
 from config.audit import audit_log
+from config.auth import gated_jwt
 from config.ratelimit import rate_limit
 from ninja import File, Router
 from ninja.files import UploadedFile
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 from users.permissions import PermissionKey
 
 from community._event_helpers import _event_out
@@ -28,7 +28,7 @@ router = Router()
 @router.post(
     "/events/{event_id}/photo/",
     response={200: EventOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut, 429: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="20/h")
 def upload_event_photo(request, event_id: UUID, photo: UploadedFile = File(...)):  # ty: ignore[call-non-callable]
@@ -80,7 +80,7 @@ def upload_event_photo(request, event_id: UUID, photo: UploadedFile = File(...))
 @router.delete(
     "/events/{event_id}/photo/",
     response={200: EventOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def delete_event_photo(request, event_id: UUID):
     try:

--- a/backend/community/_event_cohost_invites.py
+++ b/backend/community/_event_cohost_invites.py
@@ -9,12 +9,12 @@ The DELETE endpoint covers both flows once an invite exists:
 
 from uuid import UUID
 
+from config.auth import gated_jwt
 from django.db import transaction
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 from notifications.service import (
     broadcast_cohost_change,
     create_cohost_invite_accepted_notification,
@@ -51,7 +51,7 @@ def _reload_event_for_response(event_id: UUID) -> Event:
 @router.post(
     "/events/{event_id}/cohost-invites/{invite_id}/accept/",
     response={200: EventOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def accept_cohost_invite(request, event_id: UUID, invite_id: UUID):
     invite = _get_invite_or_404(event_id, invite_id)
@@ -80,7 +80,7 @@ def accept_cohost_invite(request, event_id: UUID, invite_id: UUID):
 @router.post(
     "/events/{event_id}/cohost-invites/{invite_id}/decline/",
     response={200: EventOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def decline_cohost_invite(request, event_id: UUID, invite_id: UUID):
     invite = _get_invite_or_404(event_id, invite_id)
@@ -142,7 +142,7 @@ def _remove_accepted(invite: EventCoHostInvite, requester, is_host: bool, is_sel
 @router.delete(
     "/events/{event_id}/cohost-invites/{invite_id}/",
     response={200: EventOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def rescind_cohost_invite(request, event_id: UUID, invite_id: UUID):
     """Rescind a pending invite OR remove an accepted co-host.

--- a/backend/community/_event_comments.py
+++ b/backend/community/_event_comments.py
@@ -2,13 +2,13 @@
 
 from uuid import UUID
 
+from config.auth import gated_jwt
 from config.media_proxy import media_path
 from config.ratelimit import rate_limit
 from django.db import transaction
 from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 from users.permissions import PermissionKey
 
 from community._event_comment_schemas import (
@@ -197,7 +197,7 @@ def list_comments(request, event_id: UUID):
 @router.post(
     "/events/{event_id}/comments/",
     response={201: EventCommentOut, 403: ErrorOut, 404: ErrorOut, 422: ErrorOut, 429: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="10/m")
 def post_comment(request, event_id: UUID, payload: CommentBodyIn):
@@ -229,7 +229,7 @@ def post_comment(request, event_id: UUID, payload: CommentBodyIn):
         422: ErrorOut,
         429: ErrorOut,
     },
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="10/m")
 def post_reply(request, event_id: UUID, comment_id: UUID, payload: CommentBodyIn):
@@ -265,7 +265,7 @@ def post_reply(request, event_id: UUID, comment_id: UUID, payload: CommentBodyIn
 @router.delete(
     "/events/{event_id}/comments/{comment_id}/",
     response={204: None, 403: ErrorOut, 404: ErrorOut, 429: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="10/m")
 def delete_comment(request, event_id: UUID, comment_id: UUID):
@@ -304,7 +304,7 @@ _VALID_EMOJIS = {e.value for e in ReactionEmoji}
         422: ErrorOut,
         429: ErrorOut,
     },
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="10/m")
 def toggle_reaction(request, event_id: UUID, comment_id: UUID, payload: ReactionToggleIn):

--- a/backend/community/_event_flags.py
+++ b/backend/community/_event_flags.py
@@ -3,12 +3,12 @@
 from datetime import datetime
 from uuid import UUID
 
+from config.auth import gated_jwt
 from config.ratelimit import rate_limit
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 from pydantic import BaseModel, Field
 from users.permissions import PermissionKey
 
@@ -61,7 +61,7 @@ _VALID_REVIEW_STATUSES = {EventFlagStatus.DISMISSED, EventFlagStatus.ACTIONED}
 @router.post(
     "/events/{event_id}/flag/",
     response={201: EventFlagOut, 400: ErrorOut, 404: ErrorOut, 409: ErrorOut, 429: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="3/h")
 def flag_event(request, event_id: UUID, data: EventFlagIn):
@@ -87,7 +87,7 @@ def flag_event(request, event_id: UUID, data: EventFlagIn):
 @router.get(
     "/event-flags/",
     response={200: list[EventFlagOut], 403: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def list_event_flags(request, status: str | None = None):
     if not request.auth.has_permission(PermissionKey.MANAGE_EVENTS):
@@ -103,7 +103,7 @@ def list_event_flags(request, status: str | None = None):
 @router.patch(
     "/event-flags/{flag_id}/",
     response={200: EventFlagOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def review_event_flag(request, flag_id: UUID, data: EventFlagStatusIn):
     if not request.auth.has_permission(PermissionKey.MANAGE_EVENTS):

--- a/backend/community/_event_invitations.py
+++ b/backend/community/_event_invitations.py
@@ -13,10 +13,10 @@ import logging
 from uuid import UUID
 
 from config.audit import audit_log
+from config.auth import gated_jwt
 from django.shortcuts import get_object_or_404
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 from notifications.service import create_event_invite_notifications
 from pydantic import BaseModel, Field
 from users.models import User as UserModel
@@ -53,7 +53,7 @@ def _can_invite_to_event(user, event: Event) -> bool:
 @router.post(
     "/events/{event_id}/invitations/",
     response={200: EventOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def invite_to_event(request, event_id: UUID, payload: InviteIn):
     event = get_object_or_404(

--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -5,12 +5,12 @@ from datetime import timedelta
 from uuid import UUID
 
 from config.audit import audit_log
+from config.auth import gated_jwt
 from config.ratelimit import rate_limit
 from django.db import transaction
 from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 
 from community._event_helpers import (
     _attended_count,
@@ -134,7 +134,7 @@ def _apply_rsvp_in_transaction(event_id, user, status: str, has_plus_one: bool) 
 @router.post(
     "/events/{event_id}/rsvp/",
     response={200: EventOut, 400: ErrorOut, 404: ErrorOut, 429: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="30/m")
 def upsert_rsvp(request, event_id: UUID, payload: RSVPIn):
@@ -178,7 +178,7 @@ def _load_event_with_stats_prefetch(event_id: UUID) -> Event | None:
 @router.get(
     "/events/{event_id}/stats/",
     response={200: EventStatsOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def get_event_stats(request, event_id: UUID):
     event = _load_event_with_stats_prefetch(event_id)
@@ -205,7 +205,7 @@ def get_event_stats(request, event_id: UUID):
 @router.post(
     "/events/{event_id}/rsvps/{user_id}/attendance/",
     response={200: EventOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut, 429: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="60/m")
 def set_attendance(request, event_id: UUID, user_id: UUID, payload: AttendanceIn):
@@ -249,7 +249,7 @@ def set_attendance(request, event_id: UUID, user_id: UUID, payload: AttendanceIn
 @router.delete(
     "/events/{event_id}/rsvp/",
     response={204: None, 400: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def delete_rsvp(request, event_id: UUID):
     try:

--- a/backend/community/_events.py
+++ b/backend/community/_events.py
@@ -4,13 +4,13 @@ import logging
 from uuid import UUID
 
 from config.audit import audit_log
+from config.auth import gated_jwt
 from config.media_proxy import media_path
 from config.ratelimit import rate_limit
 from django.db.models import Count, Q
 from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 from users.permissions import PermissionKey
 
 from community._cohost_invite_helpers import has_pending_cohost_invite
@@ -278,7 +278,7 @@ def get_event(request, event_id: UUID):
 @router.post(
     "/events/",
     response={201: EventOut, 400: ErrorOut, 403: ErrorOut, 429: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="10/d")
 def create_event(request, payload: EventIn):
@@ -381,7 +381,7 @@ def _apply_field_updates(request, event: Event, event_id: UUID, updates: dict) -
 @router.patch(
     "/events/{event_id}/",
     response={200: EventOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def update_event(request, event_id: UUID, payload: EventPatchIn):
     try:

--- a/backend/community/_feedback.py
+++ b/backend/community/_feedback.py
@@ -5,11 +5,11 @@ import logging
 import time
 from urllib.request import Request, urlopen
 
+from config.auth import gated_jwt
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 from pydantic import BaseModel, Field
 
 from community._shared import ErrorOut, _optional_jwt
@@ -51,7 +51,7 @@ class FeedbackOut(BaseModel):
     html_url: str
 
 
-@router.post("/error-report/", response={201: ErrorReportOut}, auth=JWTAuth())
+@router.post("/error-report/", response={201: ErrorReportOut}, auth=gated_jwt)
 def report_error(request, payload: ErrorReportIn):
     extra = {
         k: v

--- a/backend/community/_geocode.py
+++ b/backend/community/_geocode.py
@@ -3,9 +3,9 @@
 import logging
 
 import httpx
+from config.auth import gated_jwt
 from django.http import HttpRequest
 from ninja import Router
-from ninja_jwt.authentication import JWTAuth
 
 from community._shared import ErrorOut
 
@@ -16,7 +16,7 @@ router = Router()
 _PHOTON_URL = "https://photon.komoot.io/api/"
 
 
-@router.get("/geocode/", auth=JWTAuth(), response={200: dict, 502: ErrorOut})
+@router.get("/geocode/", auth=gated_jwt, response={200: dict, 502: ErrorOut})
 def geocode(request: HttpRequest, q: str, limit: int = 5):
     """Proxy geocoding requests to Photon, biased toward NYC."""
     try:

--- a/backend/community/_guidelines.py
+++ b/backend/community/_guidelines.py
@@ -4,9 +4,9 @@ import logging
 from datetime import datetime
 
 from config.audit import audit_log
+from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 from pydantic import BaseModel, Field
 from users.permissions import PermissionKey
 
@@ -50,12 +50,12 @@ def _apply_update(obj: FAQ | CommunityGuidelines, payload: GuidelinesPatchIn) ->
     obj.save()
 
 
-@router.get("/guidelines/", response={200: GuidelinesOut}, auth=JWTAuth())
+@router.get("/guidelines/", response={200: GuidelinesOut}, auth=gated_jwt)
 def get_guidelines(request):
     return Status(200, _singleton_out(CommunityGuidelines.get()))
 
 
-@router.patch("/guidelines/", response={200: GuidelinesOut, 403: ErrorOut}, auth=JWTAuth())
+@router.patch("/guidelines/", response={200: GuidelinesOut, 403: ErrorOut}, auth=gated_jwt)
 def update_guidelines(request, payload: GuidelinesPatchIn):
     if not request.auth.has_permission(PermissionKey.EDIT_GUIDELINES):
         audit_log(
@@ -85,7 +85,7 @@ def get_faq(request):
     return Status(200, _singleton_out(FAQ.get()))
 
 
-@router.patch("/faq/", response={200: GuidelinesOut, 403: ErrorOut}, auth=JWTAuth())
+@router.patch("/faq/", response={200: GuidelinesOut, 403: ErrorOut}, auth=gated_jwt)
 def update_faq(request, payload: GuidelinesPatchIn):
     if not request.auth.has_permission(PermissionKey.EDIT_FAQ):
         audit_log(

--- a/backend/community/_home.py
+++ b/backend/community/_home.py
@@ -4,9 +4,9 @@ import logging
 from datetime import datetime
 
 from config.audit import audit_log
+from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 from pydantic import BaseModel, Field
 from users.permissions import PermissionKey
 
@@ -65,7 +65,7 @@ def _apply_content_update(
     return True
 
 
-@router.patch("/home/", response={200: HomePageOut, 403: ErrorOut}, auth=JWTAuth())
+@router.patch("/home/", response={200: HomePageOut, 403: ErrorOut}, auth=gated_jwt)
 def update_home(request, payload: HomePagePatchIn):
     if not request.auth.has_permission(PermissionKey.EDIT_HOMEPAGE):
         audit_log(

--- a/backend/community/_join_form.py
+++ b/backend/community/_join_form.py
@@ -4,9 +4,9 @@ import logging
 from uuid import UUID
 
 from config.audit import audit_log
+from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 from pydantic import BaseModel, Field
 from users.permissions import PermissionKey
 
@@ -58,7 +58,7 @@ def get_join_form(request):
 @router.post(
     "/join-form/questions/",
     response={201: JoinFormQuestionOut, 403: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def create_join_form_question(request, payload: JoinFormQuestionIn):
     if not request.auth.has_permission(PermissionKey.EDIT_JOIN_QUESTIONS):
@@ -94,7 +94,7 @@ def create_join_form_question(request, payload: JoinFormQuestionIn):
 @router.put(
     "/join-form/questions/order/",
     response={200: list[JoinFormQuestionOut], 403: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def reorder_join_form_questions(request, payload: JoinFormQuestionOrderIn):
     if not request.auth.has_permission(PermissionKey.EDIT_JOIN_QUESTIONS):
@@ -118,7 +118,7 @@ def reorder_join_form_questions(request, payload: JoinFormQuestionOrderIn):
 @router.patch(
     "/join-form/questions/{question_id}/",
     response={200: JoinFormQuestionOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def update_join_form_question(request, question_id: UUID, payload: JoinFormQuestionIn):
     if not request.auth.has_permission(PermissionKey.EDIT_JOIN_QUESTIONS):
@@ -157,7 +157,7 @@ def update_join_form_question(request, question_id: UUID, payload: JoinFormQuest
 @router.delete(
     "/join-form/questions/{question_id}/",
     response={204: None, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def delete_join_form_question(request, question_id: UUID):
     if not request.auth.has_permission(PermissionKey.EDIT_JOIN_QUESTIONS):

--- a/backend/community/_join_request_resend.py
+++ b/backend/community/_join_request_resend.py
@@ -7,12 +7,12 @@ import logging
 from uuid import UUID
 
 from config.audit import audit_log
+from config.auth import gated_jwt
 from config.ratelimit import rate_limit
 from django.db import transaction
 from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 from users.permissions import PermissionKey
 
 from community._join_requests import ApproveJoinRequestOut
@@ -26,7 +26,7 @@ router = Router()
 @router.post(
     "/join-requests/{id}/resend-magic-link/",
     response={200: ApproveJoinRequestOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="10/m")
 def resend_magic_link(request, id: UUID):

--- a/backend/community/_join_requests.py
+++ b/backend/community/_join_requests.py
@@ -5,13 +5,13 @@ from datetime import datetime, timedelta
 from uuid import UUID
 
 from config.audit import audit_log
+from config.auth import gated_jwt
 from config.ratelimit import client_ip, rate_limit
 from django.conf import settings
 from django.core.mail import send_mail
 from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 from notifications.service import create_join_request_notifications
 from pydantic import BaseModel, EmailStr, Field, field_validator
 from users.permissions import PermissionKey
@@ -279,7 +279,7 @@ def submit_join_request(request, payload: JoinRequestIn):
     return Status(201, _join_request_out(join_request))
 
 
-@router.get("/join-requests/", response={200: list[JoinRequestOut], 403: ErrorOut}, auth=JWTAuth())
+@router.get("/join-requests/", response={200: list[JoinRequestOut], 403: ErrorOut}, auth=gated_jwt)
 def list_join_requests(request):
     if not request.auth.has_permission(PermissionKey.APPROVE_JOIN_REQUESTS):
         audit_log(
@@ -332,7 +332,7 @@ def _stamp_decision(join_request: JoinRequest, status: str, actor) -> None:
         404: ErrorOut,
         409: ErrorOut,
     },
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def update_join_request_status(request, id: UUID, payload: JoinRequestStatusIn):
     from users.api import _create_user_with_role
@@ -424,7 +424,7 @@ def update_join_request_status(request, id: UUID, payload: JoinRequestStatusIn):
 @router.patch(
     "/join-requests/{id}/unreject/",
     response={200: JoinRequestOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def unreject_join_request(request, id: UUID):
     if not request.auth.has_permission(PermissionKey.APPROVE_JOIN_REQUESTS):

--- a/backend/community/_pages.py
+++ b/backend/community/_pages.py
@@ -4,10 +4,10 @@ import logging
 from datetime import datetime
 
 from config.audit import audit_log
+from config.auth import gated_jwt
 from django.contrib.auth.models import AnonymousUser
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 from pydantic import BaseModel, Field
 from users.permissions import PermissionKey
 
@@ -59,7 +59,7 @@ def get_page(request, slug: str):
     return Status(200, _page_out(page))
 
 
-@router.patch("/pages/{slug}/", response={200: EditablePageOut, 403: ErrorOut}, auth=JWTAuth())
+@router.patch("/pages/{slug}/", response={200: EditablePageOut, 403: ErrorOut}, auth=gated_jwt)
 def update_page(request, slug: str, payload: EditablePagePatchIn):
     if not request.auth.has_permission(PermissionKey.EDIT_GUIDELINES):
         audit_log(

--- a/backend/community/_polls.py
+++ b/backend/community/_polls.py
@@ -5,13 +5,13 @@ from datetime import datetime, timedelta
 from uuid import UUID
 
 from config.audit import audit_log
+from config.auth import gated_jwt
 from config.media_proxy import media_path
 from config.ratelimit import rate_limit
 from django.db import transaction
 from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 from users.permissions import PermissionKey
 
 from community._event_poll_schemas import (
@@ -125,7 +125,7 @@ def _poll_out(poll: EventPoll, requesting_user=None) -> EventPollOut:
 @router.post(
     "/events/{event_id}/poll/",
     response={201: EventPollOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut, 429: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="10/h")
 def create_event_poll(request, event_id: UUID, payload: EventPollIn):
@@ -192,7 +192,7 @@ def get_event_poll(request, event_id: UUID):
 @router.post(
     "/events/{event_id}/poll/vote/",
     response={200: EventPollOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut, 429: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="30/m")
 def vote_on_event_poll(request, event_id: UUID, payload: EventPollVoteIn):
@@ -251,7 +251,7 @@ def vote_on_event_poll(request, event_id: UUID, payload: EventPollVoteIn):
 @router.post(
     "/events/{event_id}/poll/finalize/",
     response={200: EventPollOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut, 429: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="10/h")
 def finalize_event_poll(request, event_id: UUID, payload: EventPollFinalizeIn):
@@ -312,7 +312,7 @@ def finalize_event_poll(request, event_id: UUID, payload: EventPollFinalizeIn):
 @router.delete(
     "/events/{event_id}/poll/",
     response={204: None, 403: ErrorOut, 404: ErrorOut, 429: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="10/h")
 def delete_event_poll(request, event_id: UUID):
@@ -392,7 +392,7 @@ def _get_poll_and_option(event, winning_option_id) -> tuple[EventPoll, PollOptio
 @router.post(
     "/events/{event_id}/poll/options/",
     response={201: EventPollOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut, 429: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="30/h")
 def add_poll_option(request, event_id: UUID, payload: PollOptionIn):
@@ -422,7 +422,7 @@ def add_poll_option(request, event_id: UUID, payload: PollOptionIn):
 @router.patch(
     "/events/{event_id}/poll/options/{option_id}/",
     response={200: EventPollOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut, 429: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="30/h")
 def update_poll_option(request, event_id: UUID, payload: PollOptionIn, option_id: UUID):
@@ -456,7 +456,7 @@ def update_poll_option(request, event_id: UUID, payload: PollOptionIn, option_id
 @router.delete(
     "/events/{event_id}/poll/options/{option_id}/",
     response={200: EventPollOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut, 429: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="30/h")
 def delete_poll_option(request, event_id: UUID, option_id: UUID):

--- a/backend/community/_surveys.py
+++ b/backend/community/_surveys.py
@@ -4,9 +4,9 @@ import logging
 from uuid import UUID
 
 from config.audit import audit_log
+from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 from users.permissions import PermissionKey
 
 from community._shared import ErrorOut
@@ -41,7 +41,7 @@ router = Router()
 @router.get(
     "/surveys/admin/",
     response={200: list[SurveyListOut], 403: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def list_surveys_admin(request):
     if not request.auth.has_permission(PermissionKey.MANAGE_SURVEYS):
@@ -77,7 +77,7 @@ def list_surveys_admin(request):
 @router.post(
     "/surveys/",
     response={201: SurveyOut, 403: ErrorOut, 400: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def create_survey(request, payload: SurveyIn):
     if not request.auth.has_permission(PermissionKey.MANAGE_SURVEYS):
@@ -123,7 +123,7 @@ def create_survey(request, payload: SurveyIn):
 @router.get(
     "/surveys/{survey_id}/admin/",
     response={200: SurveyOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def get_survey_admin(request, survey_id: UUID):
     if not request.auth.has_permission(PermissionKey.MANAGE_SURVEYS):
@@ -149,7 +149,7 @@ def get_survey_admin(request, survey_id: UUID):
 @router.patch(
     "/surveys/{survey_id}/",
     response={200: SurveyOut, 403: ErrorOut, 404: ErrorOut, 400: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def update_survey(request, survey_id: UUID, payload: SurveyPatchIn):
     if not request.auth.has_permission(PermissionKey.MANAGE_SURVEYS):
@@ -192,7 +192,7 @@ def update_survey(request, survey_id: UUID, payload: SurveyPatchIn):
 @router.delete(
     "/surveys/{survey_id}/",
     response={204: None, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def delete_survey(request, survey_id: UUID):
     if not request.auth.has_permission(PermissionKey.MANAGE_SURVEYS):
@@ -231,7 +231,7 @@ def delete_survey(request, survey_id: UUID):
 @router.post(
     "/surveys/{survey_id}/questions/",
     response={201: SurveyQuestionOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def create_survey_question(request, survey_id: UUID, payload: SurveyQuestionIn):
     if not request.auth.has_permission(PermissionKey.MANAGE_SURVEYS):
@@ -274,7 +274,7 @@ def create_survey_question(request, survey_id: UUID, payload: SurveyQuestionIn):
 @router.patch(
     "/surveys/{survey_id}/questions/{question_id}/",
     response={200: SurveyQuestionOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def update_survey_question(request, survey_id: UUID, question_id: UUID, payload: SurveyQuestionIn):
     if not request.auth.has_permission(PermissionKey.MANAGE_SURVEYS):
@@ -313,7 +313,7 @@ def update_survey_question(request, survey_id: UUID, question_id: UUID, payload:
 @router.delete(
     "/surveys/{survey_id}/questions/{question_id}/",
     response={204: None, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def delete_survey_question(request, survey_id: UUID, question_id: UUID):
     if not request.auth.has_permission(PermissionKey.MANAGE_SURVEYS):
@@ -348,7 +348,7 @@ def delete_survey_question(request, survey_id: UUID, question_id: UUID):
 @router.put(
     "/surveys/{survey_id}/questions/order/",
     response={200: list[SurveyQuestionOut], 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def reorder_survey_questions(request, survey_id: UUID, payload: SurveyQuestionOrderIn):
     if not request.auth.has_permission(PermissionKey.MANAGE_SURVEYS):
@@ -387,7 +387,7 @@ def reorder_survey_questions(request, survey_id: UUID, payload: SurveyQuestionOr
 @router.get(
     "/surveys/{survey_id}/responses/",
     response={200: list[SurveyResponseOut], 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def list_survey_responses(request, survey_id: UUID):
     if not request.auth.has_permission(PermissionKey.MANAGE_SURVEYS):

--- a/backend/community/_surveys_public.py
+++ b/backend/community/_surveys_public.py
@@ -4,9 +4,9 @@ import logging
 from uuid import UUID
 
 from config.audit import audit_log
+from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 
 from community._shared import ErrorOut, _authenticated_user, _optional_jwt
 from community._survey_helpers import (
@@ -97,7 +97,7 @@ def submit_survey_response(request, slug: str, payload: SurveyAnswersIn):
 @router.get(
     "/surveys/{survey_id}/tallies/",
     response={200: list[PollResultsOut], 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def get_survey_tallies(request, survey_id: UUID):
     try:
@@ -115,7 +115,7 @@ def get_survey_tallies(request, survey_id: UUID):
 @router.post(
     "/surveys/{survey_id}/finalize/",
     response={200: SurveyOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def finalize_poll(request, survey_id: UUID, payload: FinalizePollIn):
     try:

--- a/backend/community/_validation.py
+++ b/backend/community/_validation.py
@@ -108,9 +108,12 @@ class Code:
         REFRESH_TOKEN_INVALID = "auth.refresh_token_invalid"
         REFRESH_FAILED = "auth.refresh_failed"
         CURRENT_PASSWORD_INCORRECT = "auth.current_password_incorrect"
+        PASSWORD_RESET_REQUIRED = "auth.password_reset_required"
+        ONBOARDING_REQUIRED = "auth.onboarding_required"
 
     class Password:
         INVALID = "password.invalid"  # params: { reasons: string[] }
+        SAME_AS_OLD = "password.same_as_old"
 
     class Role:
         NOT_FOUND = "role.not_found"

--- a/backend/community/_welcome_template.py
+++ b/backend/community/_welcome_template.py
@@ -10,9 +10,9 @@ import logging
 from datetime import datetime
 
 from config.audit import audit_log
+from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 from pydantic import BaseModel, Field
 from users.permissions import PermissionKey
 
@@ -40,7 +40,7 @@ def _out(obj: WelcomeMessageTemplate) -> WelcomeTemplateOut:
     return WelcomeTemplateOut(body=obj.body, updated_at=obj.updated_at)
 
 
-@router.get("/welcome-template/", response={200: WelcomeTemplateOut}, auth=JWTAuth())
+@router.get("/welcome-template/", response={200: WelcomeTemplateOut}, auth=gated_jwt)
 def get_welcome_template(request):
     return Status(200, _out(WelcomeMessageTemplate.get()))
 
@@ -48,7 +48,7 @@ def get_welcome_template(request):
 @router.patch(
     "/welcome-template/",
     response={200: WelcomeTemplateOut, 403: ErrorOut, 422: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def update_welcome_template(request, payload: WelcomeTemplatePatchIn):
     if not request.auth.has_permission(PermissionKey.APPROVE_JOIN_REQUESTS):

--- a/backend/community/_whatsapp.py
+++ b/backend/community/_whatsapp.py
@@ -3,10 +3,10 @@
 import logging
 
 from config.audit import audit_log
+from config.auth import gated_jwt
 from django.conf import settings
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 from pydantic import BaseModel, Field
 from users.permissions import PermissionKey
 
@@ -37,7 +37,7 @@ class WhatsAppStatusOut(BaseModel):
 @router.get(
     "/whatsapp/config/",
     response={200: WhatsAppConfigOut, 403: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def get_whatsapp_config(request):
     if not request.auth.has_permission(PermissionKey.MANAGE_WHATSAPP):
@@ -65,7 +65,7 @@ def get_whatsapp_config(request):
 @router.patch(
     "/whatsapp/config/",
     response={200: WhatsAppConfigOut, 403: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def update_whatsapp_config(request, payload: WhatsAppConfigPatchIn):
     if not request.auth.has_permission(PermissionKey.MANAGE_WHATSAPP):
@@ -111,7 +111,7 @@ def update_whatsapp_config(request, payload: WhatsAppConfigPatchIn):
 @router.get(
     "/whatsapp/status/",
     response={200: WhatsAppStatusOut, 403: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def get_whatsapp_status(request):
     if not request.auth.has_permission(PermissionKey.MANAGE_WHATSAPP):

--- a/backend/community/validation_codes.json
+++ b/backend/community/validation_codes.json
@@ -360,6 +360,16 @@
         "name": "CURRENT_PASSWORD_INCORRECT",
         "value": "auth.current_password_incorrect",
         "params": []
+      },
+      {
+        "name": "PASSWORD_RESET_REQUIRED",
+        "value": "auth.password_reset_required",
+        "params": []
+      },
+      {
+        "name": "ONBOARDING_REQUIRED",
+        "value": "auth.onboarding_required",
+        "params": []
       }
     ],
     "Password": [
@@ -369,6 +379,11 @@
         "params": [
           "reasons"
         ]
+      },
+      {
+        "name": "SAME_AS_OLD",
+        "value": "password.same_as_old",
+        "params": []
       }
     ],
     "Role": [

--- a/backend/config/auth.py
+++ b/backend/config/auth.py
@@ -1,0 +1,74 @@
+"""Shared authentication for protected API endpoints.
+
+``GatedJWTAuth`` is the single chokepoint that enforces *per-request* account
+state on top of the JWT signature/expiry/``is_active`` checks the ninja-jwt
+library already does. It exists because a valid access token outlives the state
+changes that should revoke access:
+
+  - ``set_unusable_password()`` only blocks the ``/login/`` form (which runs
+    ``check_password``). It has no effect on a token that was already issued, so
+    a self-service magic-login user could otherwise call any endpoint without
+    ever setting a password.
+  - ``is_paused`` / ``archived_at`` were historically checked only at login and
+    on ``/me/``, so a user paused *after* getting a token kept access until it
+    expired. Enforcing here closes that hole too.
+
+A pending user (needs password reset / onboarding) must still reach the few
+endpoints required to *resolve* that state, so those paths are allowlisted.
+"""
+
+from community._validation import Code, ValidationException
+from django.http import HttpRequest
+from ninja_jwt.authentication import JWTAuth
+
+from users.models import User
+
+# Full request paths (under the ``/api`` mount) a pending user may still reach:
+#   - GET /me/                 — frontend reads needs_password_reset/onboarding here
+#   - POST /complete-onboarding/ — the only way to set a password / clear the flags
+#   - POST /change-password/   — alternate password-set path (also clears the flag)
+# /refresh/ and /logout/ are auth=None, so they bypass this gate already.
+_PENDING_ALLOWLIST = frozenset(
+    {
+        "/api/auth/me/",
+        "/api/auth/complete-onboarding/",
+        "/api/auth/change-password/",
+    }
+)
+
+
+class GatedJWTAuth(JWTAuth):
+    """JWTAuth that also rejects tokens whose account is in a blocked state.
+
+    Runs after the standard JWT validation. Raises ``ValidationException`` (the
+    project's structured-error type, reshaped by the global exception handler)
+    rather than returning None, so the client gets a specific code instead of a
+    bare 401.
+    """
+
+    def authenticate(self, request: HttpRequest, token: str):
+        user = super().authenticate(request, token)
+        if not isinstance(user, User):
+            return user
+
+        # Hard blocks — apply on every protected endpoint, no allowlist. These
+        # mirror the login-time checks so a token issued before the state change
+        # can't outlive it.
+        if user.archived_at is not None:
+            raise ValidationException(Code.Auth.ACCOUNT_ARCHIVED, status_code=403)
+        if user.is_paused:
+            raise ValidationException(Code.Auth.ACCOUNT_PAUSED, status_code=403)
+
+        # Pending password set — allow only the endpoints needed to resolve it.
+        if request.path not in _PENDING_ALLOWLIST:
+            if user.needs_password_reset:
+                raise ValidationException(Code.Auth.PASSWORD_RESET_REQUIRED, status_code=403)
+            if user.needs_onboarding:
+                raise ValidationException(Code.Auth.ONBOARDING_REQUIRED, status_code=403)
+
+        return user
+
+
+# Single shared instance — import and pass as ``auth=gated_jwt`` everywhere a
+# protected endpoint previously used ``auth=JWTAuth()``.
+gated_jwt = GatedJWTAuth()

--- a/backend/config/auth.py
+++ b/backend/config/auth.py
@@ -20,7 +20,6 @@ endpoints required to *resolve* that state, so those paths are allowlisted.
 from community._validation import Code, ValidationException
 from django.http import HttpRequest
 from ninja_jwt.authentication import JWTAuth
-
 from users.models import User
 
 # Full request paths (under the ``/api`` mount) a pending user may still reach:

--- a/backend/notifications/api.py
+++ b/backend/notifications/api.py
@@ -2,9 +2,9 @@ from uuid import UUID
 
 from community._shared import ErrorOut
 from community._validation import Code, raise_validation
+from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 
 from notifications.models import Notification
 from notifications.schemas import NotificationOut, UnreadCountOut
@@ -24,25 +24,25 @@ def _notification_out(n: Notification) -> NotificationOut:
     )
 
 
-@router.get("/", response={200: list[NotificationOut]}, auth=JWTAuth())
+@router.get("/", response={200: list[NotificationOut]}, auth=gated_jwt)
 def list_notifications(request):
     notifications = Notification.objects.filter(recipient=request.auth).order_by("-created_at")[:30]
     return Status(200, [_notification_out(n) for n in notifications])
 
 
-@router.get("/unread-count/", response={200: UnreadCountOut}, auth=JWTAuth())
+@router.get("/unread-count/", response={200: UnreadCountOut}, auth=gated_jwt)
 def unread_count(request):
     count = Notification.objects.filter(recipient=request.auth, is_read=False).count()
     return Status(200, UnreadCountOut(count=count))
 
 
-@router.post("/read-all/", response={200: dict}, auth=JWTAuth())
+@router.post("/read-all/", response={200: dict}, auth=gated_jwt)
 def mark_all_read(request):
     Notification.objects.filter(recipient=request.auth, is_read=False).update(is_read=True)
     return Status(200, {"detail": "ok"})
 
 
-@router.post("/{notification_id}/read/", response={200: dict, 404: ErrorOut}, auth=JWTAuth())
+@router.post("/{notification_id}/read/", response={200: dict, 404: ErrorOut}, auth=gated_jwt)
 def mark_read(request, notification_id: UUID):
     updated = Notification.objects.filter(id=notification_id, recipient=request.auth).update(
         is_read=True

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -4393,7 +4393,7 @@
       }
     },
     "securitySchemes": {
-      "JWTAuth": {
+      "GatedJWTAuth": {
         "scheme": "bearer",
         "type": "http"
       },
@@ -4448,7 +4448,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Bulk Create Users",
@@ -4495,7 +4495,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Change Password",
@@ -4548,11 +4548,21 @@
               }
             },
             "description": "Conflict"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Unprocessable Content"
           }
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Complete Onboarding",
@@ -4619,7 +4629,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Create User",
@@ -4793,7 +4803,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Me",
@@ -4848,7 +4858,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Update Me",
@@ -4875,7 +4885,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Delete Photo",
@@ -4931,7 +4941,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Upload Photo",
@@ -5004,7 +5014,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "List Roles",
@@ -5059,7 +5069,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Create Role",
@@ -5119,7 +5129,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Delete Role",
@@ -5194,7 +5204,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Update Role",
@@ -5235,7 +5245,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "List Users",
@@ -5267,7 +5277,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "List Member Directory",
@@ -5309,7 +5319,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Search Users",
@@ -5369,7 +5379,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Delete User",
@@ -5454,7 +5464,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Update User",
@@ -5511,7 +5521,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Generate Magic Link",
@@ -5558,7 +5568,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Get Member Profile",
@@ -5635,7 +5645,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Update User Roles",
@@ -5688,7 +5698,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Get Calendar Token",
@@ -5713,7 +5723,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Generate Calendar Token",
@@ -5802,7 +5812,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Create Document",
@@ -5843,7 +5853,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "List Folders",
@@ -5898,7 +5908,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Create Folder",
@@ -5947,7 +5957,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Reorder Folders",
@@ -6006,7 +6016,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Delete Folder",
@@ -6071,7 +6081,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Update Folder",
@@ -6120,7 +6130,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Reorder Documents",
@@ -6179,7 +6189,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Delete Document",
@@ -6234,7 +6244,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Get Document",
@@ -6299,7 +6309,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Update Document",
@@ -6336,7 +6346,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Report Error",
@@ -6394,7 +6404,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "List Event Flags",
@@ -6472,7 +6482,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Review Event Flag",
@@ -6589,7 +6599,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Create Event",
@@ -6723,7 +6733,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Update Event",
@@ -6802,7 +6812,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Rescind Cohost Invite",
@@ -6880,7 +6890,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Accept Cohost Invite",
@@ -6958,7 +6968,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Decline Cohost Invite",
@@ -7102,7 +7112,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Post Comment",
@@ -7173,7 +7183,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Delete Comment",
@@ -7271,7 +7281,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Toggle Reaction",
@@ -7369,7 +7379,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Post Reply",
@@ -7457,7 +7467,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Flag Event",
@@ -7560,7 +7570,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Invite To Event",
@@ -7618,7 +7628,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Delete Event Photo",
@@ -7715,7 +7725,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Upload Event Photo",
@@ -7776,7 +7786,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Delete Event Poll",
@@ -7908,7 +7918,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Create Event Poll",
@@ -7996,7 +8006,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Finalize Event Poll",
@@ -8084,7 +8094,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Add Poll Option",
@@ -8172,7 +8182,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Delete Poll Option",
@@ -8268,7 +8278,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Update Poll Option",
@@ -8356,7 +8366,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Vote On Event Poll",
@@ -8407,7 +8417,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Delete Rsvp",
@@ -8483,7 +8493,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Upsert Rsvp",
@@ -8581,7 +8591,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Set Attendance",
@@ -8639,7 +8649,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Get Event Stats",
@@ -8706,7 +8716,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Update Faq",
@@ -8813,7 +8823,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Geocode",
@@ -8840,7 +8850,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Get Guidelines",
@@ -8885,7 +8895,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Update Guidelines",
@@ -8952,7 +8962,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Update Home",
@@ -9025,7 +9035,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Create Join Form Question",
@@ -9076,7 +9086,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Reorder Join Form Questions",
@@ -9127,7 +9137,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Delete Join Form Question",
@@ -9193,7 +9203,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Update Join Form Question",
@@ -9306,7 +9316,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "List Join Requests",
@@ -9394,7 +9404,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Update Join Request Status",
@@ -9463,7 +9473,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Resend Magic Link",
@@ -9531,7 +9541,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Unreject Join Request",
@@ -9633,7 +9643,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Update Page",
@@ -9733,7 +9743,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Create Survey",
@@ -9774,7 +9784,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "List Surveys Admin",
@@ -9949,7 +9959,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Delete Survey",
@@ -10025,7 +10035,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Update Survey",
@@ -10083,7 +10093,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Get Survey Admin",
@@ -10161,7 +10171,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Finalize Poll",
@@ -10229,7 +10239,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Create Survey Question",
@@ -10301,7 +10311,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Reorder Survey Questions",
@@ -10362,7 +10372,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Delete Survey Question",
@@ -10438,7 +10448,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Update Survey Question",
@@ -10500,7 +10510,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "List Survey Responses",
@@ -10562,7 +10572,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Get Survey Tallies",
@@ -10611,7 +10621,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Get Welcome Template",
@@ -10666,7 +10676,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Update Welcome Template",
@@ -10703,7 +10713,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Get Whatsapp Config",
@@ -10748,7 +10758,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Update Whatsapp Config",
@@ -10785,7 +10795,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Get Whatsapp Status",
@@ -10816,7 +10826,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "List Notifications",
@@ -10845,7 +10855,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Mark All Read",
@@ -10872,7 +10882,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Unread Count",
@@ -10922,7 +10932,7 @@
         },
         "security": [
           {
-            "JWTAuth": []
+            "GatedJWTAuth": []
           }
         ],
         "summary": "Mark Read",

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -218,6 +218,45 @@ class TestChangePassword:
         assert response.status_code == 400
         assert_error_code(response, Code.Auth.CURRENT_PASSWORD_INCORRECT)
 
+    def test_change_password_rejects_reuse(self, api_client, db):
+        """New password must differ from the current one."""
+        from ninja_jwt.tokens import RefreshToken
+        from users.models import User
+
+        user = User.objects.create_user(
+            phone_number="+12025550401", password="ReusedPass123!", display_name="Reuse"
+        )
+        headers = {"HTTP_AUTHORIZATION": f"Bearer {RefreshToken.for_user(user).access_token}"}
+        response = api_client.post(
+            "/api/auth/change-password/",
+            {"current_password": "ReusedPass123!", "new_password": "ReusedPass123!"},
+            content_type="application/json",
+            **headers,
+        )
+        assert response.status_code == 400
+        assert_error_code(response, Code.Password.SAME_AS_OLD, "new_password")
+
+    def test_change_password_clears_needs_password_reset(self, api_client, db):
+        """Setting a password via change-password satisfies a pending forced reset."""
+        from ninja_jwt.tokens import RefreshToken
+        from users.models import User
+
+        user = User.objects.create_user(
+            phone_number="+12025550402", password="OldPass123!", display_name="Pending"
+        )
+        user.needs_password_reset = True
+        user.save(update_fields=["needs_password_reset"])
+        headers = {"HTTP_AUTHORIZATION": f"Bearer {RefreshToken.for_user(user).access_token}"}
+        response = api_client.post(
+            "/api/auth/change-password/",
+            {"current_password": "OldPass123!", "new_password": "BrandNew456!"},
+            content_type="application/json",
+            **headers,
+        )
+        assert response.status_code == 200
+        user.refresh_from_db()
+        assert user.needs_password_reset is False
+
     def test_change_password_too_short(self, api_client, auth_headers):
         response = api_client.post(
             "/api/auth/change-password/",

--- a/backend/tests/test_auth_gate.py
+++ b/backend/tests/test_auth_gate.py
@@ -1,0 +1,117 @@
+"""Tests for GatedJWTAuth — per-request enforcement of account state.
+
+A valid JWT outlives the state changes that should revoke access (unusable
+password, pause, archive). GatedJWTAuth re-checks on every protected request and
+403s, except for the allowlist a pending user needs to resolve their state.
+"""
+
+import pytest
+from ninja_jwt.tokens import RefreshToken
+
+
+def _headers(user):
+    return {"HTTP_AUTHORIZATION": f"Bearer {RefreshToken.for_user(user).access_token}"}  # type: ignore
+
+
+@pytest.mark.django_db
+class TestGatedJWTAuth:
+    def test_needs_password_reset_blocks_protected_endpoint(self, api_client):
+        from users.models import User
+
+        user = User.objects.create_user(
+            phone_number="+12025550301", password="pass", display_name="Reset Me"
+        )
+        user.needs_password_reset = True
+        user.save(update_fields=["needs_password_reset"])
+
+        # A normal protected endpoint (not on the allowlist) → 403.
+        resp = api_client.get("/api/notifications/", **_headers(user))
+        assert resp.status_code == 403
+        assert resp.json()["detail"][0]["code"] == "auth.password_reset_required"
+
+    def test_needs_password_reset_allows_me(self, api_client):
+        from users.models import User
+
+        user = User.objects.create_user(
+            phone_number="+12025550302", password="pass", display_name="Reset Me"
+        )
+        user.needs_password_reset = True
+        user.save(update_fields=["needs_password_reset"])
+
+        # /me/ is allowlisted so the frontend can read the flag and route.
+        resp = api_client.get("/api/auth/me/", **_headers(user))
+        assert resp.status_code == 200
+        assert resp.json()["needs_password_reset"] is True
+
+    def test_needs_password_reset_allows_complete_onboarding(self, api_client):
+        from users.models import User
+
+        user = User.objects.create_user(
+            phone_number="+12025550303",
+            password="pass",
+            display_name="Reset Me",
+            email="reset@example.com",
+        )
+        user.needs_password_reset = True
+        user.set_unusable_password()
+        user.save(update_fields=["needs_password_reset", "password"])
+
+        # The escape hatch must stay reachable.
+        resp = api_client.post(
+            "/api/auth/complete-onboarding/",
+            data={"new_password": "FreshPass123!"},
+            content_type="application/json",
+            **_headers(user),
+        )
+        assert resp.status_code == 200, resp.content
+        user.refresh_from_db()
+        assert user.needs_password_reset is False
+
+    def test_needs_onboarding_blocks_protected_endpoint(self, api_client):
+        from users.models import User
+
+        user = User.objects.create_user(
+            phone_number="+12025550304", password="pass", display_name="", needs_onboarding=True
+        )
+        resp = api_client.get("/api/notifications/", **_headers(user))
+        assert resp.status_code == 403
+        assert resp.json()["detail"][0]["code"] == "auth.onboarding_required"
+
+    def test_paused_user_blocked_on_protected_endpoint_after_token_issued(self, api_client):
+        """is_paused set AFTER a token was issued must still revoke access per-request."""
+        from users.models import User
+
+        user = User.objects.create_user(
+            phone_number="+12025550305", password="pass", display_name="Paused"
+        )
+        headers = _headers(user)  # token minted while active
+        user.is_paused = True
+        user.save(update_fields=["is_paused"])
+
+        resp = api_client.get("/api/notifications/", **headers)
+        assert resp.status_code == 403
+        assert resp.json()["detail"][0]["code"] == "auth.account_paused"
+
+    def test_archived_user_blocked_on_protected_endpoint_after_token_issued(self, api_client):
+        from django.utils import timezone
+        from users.models import User
+
+        user = User.objects.create_user(
+            phone_number="+12025550306", password="pass", display_name="Archived"
+        )
+        headers = _headers(user)
+        user.archived_at = timezone.now()
+        user.save(update_fields=["archived_at"])
+
+        resp = api_client.get("/api/notifications/", **headers)
+        assert resp.status_code == 403
+        assert resp.json()["detail"][0]["code"] == "auth.account_archived"
+
+    def test_normal_user_unaffected(self, api_client):
+        from users.models import User
+
+        user = User.objects.create_user(
+            phone_number="+12025550307", password="pass", display_name="Normal"
+        )
+        resp = api_client.get("/api/notifications/", **_headers(user))
+        assert resp.status_code == 200

--- a/backend/tests/test_onboarding.py
+++ b/backend/tests/test_onboarding.py
@@ -117,3 +117,50 @@ class TestOnboardingEmail:
         assert user.needs_password_reset is False
         assert user.has_usable_password() is True
         assert resp.json()["needs_password_reset"] is False
+
+    def test_complete_onboarding_rejects_reusing_usable_password(self, api_client, db):
+        """A user who still has a usable password can't 'reset' to the same one."""
+        from ninja_jwt.tokens import RefreshToken
+        from users.models import User
+
+        user = User.objects.create_user(
+            phone_number="+12025550113",
+            password="SamePass123!",
+            display_name="Reuser",
+            email="reuser@example.com",
+        )
+        user.needs_password_reset = True  # has a usable password AND a pending reset
+        user.save(update_fields=["needs_password_reset"])
+        headers = {"HTTP_AUTHORIZATION": f"Bearer {RefreshToken.for_user(user).access_token}"}
+        resp = api_client.post(
+            "/api/auth/complete-onboarding/",
+            data={"new_password": "SamePass123!"},
+            content_type="application/json",
+            **headers,
+        )
+        assert resp.status_code == 400
+        assert resp.json()["detail"][0]["code"] == "password.same_as_old"
+
+    def test_complete_onboarding_reset_user_can_set_any_password(self, api_client, db):
+        """A forced-reset user has an unusable password, so the reuse check must NOT
+        false-positive and block them from setting a password."""
+        from ninja_jwt.tokens import RefreshToken
+        from users.models import User
+
+        user = User.objects.create_user(
+            phone_number="+12025550114",
+            password="x",
+            display_name="Fresh Start",
+            email="fresh@example.com",
+        )
+        user.needs_password_reset = True
+        user.set_unusable_password()
+        user.save(update_fields=["needs_password_reset", "password"])
+        headers = {"HTTP_AUTHORIZATION": f"Bearer {RefreshToken.for_user(user).access_token}"}
+        resp = api_client.post(
+            "/api/auth/complete-onboarding/",
+            data={"new_password": "AnyNewPass123!"},
+            content_type="application/json",
+            **headers,
+        )
+        assert resp.status_code == 200, resp.content

--- a/backend/users/_auth.py
+++ b/backend/users/_auth.py
@@ -5,6 +5,7 @@ import logging
 from community._shared import validate_display_name
 from community._validation import Code, raise_validation
 from config.audit import audit_log
+from config.auth import gated_jwt
 from config.media_proxy import media_path
 from django.http import HttpResponse
 from django.utils import timezone
@@ -212,7 +213,7 @@ def logout(request, response: HttpResponse):
     return Status(200, LogoutOut(detail="logged out"))
 
 
-@router.get("/me/", response={200: UserOut, 401: ErrorOut, 403: ErrorOut}, auth=JWTAuth())
+@router.get("/me/", response={200: UserOut, 401: ErrorOut, 403: ErrorOut}, auth=gated_jwt)
 def me(request):
     user = User.objects.prefetch_related("roles").get(pk=request.auth.pk)
     if user.is_paused:
@@ -255,7 +256,7 @@ def _apply_me_patch(user, payload: MePatchIn) -> list[str]:
     return changed
 
 
-@router.patch("/me/", response={200: UserOut, 400: ErrorOut, 409: ErrorOut}, auth=JWTAuth())
+@router.patch("/me/", response={200: UserOut, 400: ErrorOut, 409: ErrorOut}, auth=gated_jwt)
 def update_me(request, payload: MePatchIn):
     user = User.objects.prefetch_related("roles").get(pk=request.auth.pk)
     changed = _apply_me_patch(user, payload)
@@ -272,7 +273,7 @@ def update_me(request, payload: MePatchIn):
     return Status(200, UserOut.from_user(user))
 
 
-@router.post("/me/photo/", response={200: UserOut, 400: ErrorOut}, auth=JWTAuth())
+@router.post("/me/photo/", response={200: UserOut, 400: ErrorOut}, auth=gated_jwt)
 def upload_photo(request, photo: UploadedFile = File(...)):  # ty: ignore[call-non-callable]
     if photo.content_type not in _ALLOWED_IMAGE_TYPES:
         raise_validation(
@@ -300,7 +301,7 @@ def upload_photo(request, photo: UploadedFile = File(...)):  # ty: ignore[call-n
     return Status(200, UserOut.from_user(user))
 
 
-@router.delete("/me/photo/", response={200: UserOut}, auth=JWTAuth())
+@router.delete("/me/photo/", response={200: UserOut}, auth=gated_jwt)
 def delete_photo(request):
     user = User.objects.prefetch_related("roles").get(pk=request.auth.pk)
     if user.profile_photo:
@@ -316,7 +317,7 @@ def delete_photo(request):
 @router.get(
     "/users/directory/",
     response={200: list[MemberDirectoryOut]},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def list_member_directory(request):
     """Authed-only member directory. Respects each user's show_phone/show_email flags."""
@@ -344,7 +345,7 @@ def list_member_directory(request):
 @router.get(
     "/users/{user_id}/profile/",
     response={200: MemberProfileOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def get_member_profile(request, user_id: str):
     try:
@@ -370,7 +371,9 @@ def get_member_profile(request, user_id: str):
 
 
 @router.post(
-    "/complete-onboarding/", response={200: UserOut, 400: ErrorOut, 409: ErrorOut}, auth=JWTAuth()
+    "/complete-onboarding/",
+    response={200: UserOut, 400: ErrorOut, 409: ErrorOut, 422: ErrorOut},
+    auth=gated_jwt,
 )
 def complete_onboarding(request, payload: OnboardingIn):
     pw_errors = validate_password(payload.new_password)
@@ -379,6 +382,11 @@ def complete_onboarding(request, payload: OnboardingIn):
             Code.Password.INVALID, field="new_password", status_code=400, reasons=pw_errors
         )
     user = User.objects.prefetch_related("roles").get(pk=request.auth.pk)
+    # Reject reusing the current password. Only meaningful when the user still
+    # has a usable one — a forced-reset user has an unusable password, so
+    # check_password always fails and this is correctly skipped.
+    if user.has_usable_password() and user.check_password(payload.new_password):
+        raise_validation(Code.Password.SAME_AS_OLD, field="new_password", status_code=400)
     if payload.display_name is not None:
         validate_display_name(payload.display_name)
         user.display_name = payload.display_name.strip()
@@ -398,7 +406,7 @@ def complete_onboarding(request, payload: OnboardingIn):
     return Status(200, UserOut.from_user(user))
 
 
-@router.post("/change-password/", response={200: ErrorOut, 400: ErrorOut}, auth=JWTAuth())
+@router.post("/change-password/", response={200: ErrorOut, 400: ErrorOut}, auth=gated_jwt)
 def change_password(request, payload: ChangePasswordIn):
     user = User.objects.get(pk=request.auth.pk)
     if not user.check_password(payload.current_password):
@@ -418,7 +426,13 @@ def change_password(request, payload: ChangePasswordIn):
         raise_validation(
             Code.Password.INVALID, field="new_password", status_code=400, reasons=pw_errors
         )
+    # current_password was just verified correct, so a matching new password is a
+    # no-op reuse — reject it.
+    if user.check_password(payload.new_password):
+        raise_validation(Code.Password.SAME_AS_OLD, field="new_password", status_code=400)
     user.set_password(payload.new_password)
+    # Setting a password also satisfies a pending forced reset.
+    user.needs_password_reset = False
     user.save()
     audit_log(logging.INFO, "password_changed", request, target_type="user", target_id=str(user.pk))
     return Status(200, ErrorOut(detail="Password updated successfully."))

--- a/backend/users/_magic_links.py
+++ b/backend/users/_magic_links.py
@@ -5,11 +5,11 @@ from datetime import timedelta
 
 from community._validation import Code, raise_validation
 from config.audit import audit_log
+from config.auth import gated_jwt
 from django.db import transaction
 from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 from notifications.models import Notification, NotificationType
 from notifications.service import _notify_users
 
@@ -24,7 +24,7 @@ router = Router()
 @router.post(
     "/users/{user_id}/magic-link/",
     response={200: ResetPasswordOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def generate_magic_link(request, user_id: str):
     if not request.auth.has_permission(PermissionKey.MANAGE_USERS):

--- a/backend/users/_management.py
+++ b/backend/users/_management.py
@@ -6,11 +6,11 @@ import re
 from community._shared import validate_display_name
 from community._validation import Code, ValidationException, raise_validation
 from config.audit import audit_log
+from config.auth import gated_jwt
 from django.db import models as dj_models
 from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 
 from users._helpers import (
     _check_and_set_email,
@@ -44,7 +44,7 @@ router = Router()
 @router.post(
     "/create-user/",
     response={201: UserCreateOut, 400: ErrorOut, 403: ErrorOut, 409: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def create_user(request, payload: UserCreateIn):
     if not request.auth.has_permission(PermissionKey.CREATE_USER):
@@ -88,7 +88,7 @@ def create_user(request, payload: UserCreateIn):
 @router.post(
     "/bulk-create-users/",
     response={200: BulkUserCreateOut, 403: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def bulk_create_users(request, payload: BulkUserCreateIn):
     if not request.auth.has_permission(PermissionKey.MANAGE_USERS):
@@ -165,7 +165,7 @@ def bulk_create_users(request, payload: BulkUserCreateIn):
     )
 
 
-@router.get("/users/search/", response={200: list[UserSearchOut]}, auth=JWTAuth())
+@router.get("/users/search/", response={200: list[UserSearchOut]}, auth=gated_jwt)
 def search_users(request, q: str = ""):
     qs = User.objects.filter(is_active=True, is_paused=False, archived_at__isnull=True).exclude(
         pk=request.auth.pk
@@ -194,7 +194,7 @@ def search_users(request, q: str = ""):
 @router.get(
     "/users/",
     response={200: list[UserOut], 403: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def list_users(request):
     if not request.auth.has_permission(PermissionKey.MANAGE_USERS):
@@ -216,7 +216,7 @@ def list_users(request):
 @router.patch(
     "/users/{user_id}/",
     response={200: UserOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut, 409: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def update_user(request, user_id: str, payload: UserPatchIn):
     if not request.auth.has_permission(PermissionKey.MANAGE_USERS):
@@ -293,7 +293,7 @@ def _apply_user_patch(user: User, user_id: str, payload: UserPatchIn, requester_
 @router.delete(
     "/users/{user_id}/",
     response={204: None, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def delete_user(request, user_id: str):
     if not request.auth.has_permission(PermissionKey.MANAGE_USERS):
@@ -333,7 +333,7 @@ def delete_user(request, user_id: str):
 @router.patch(
     "/users/{user_id}/roles/",
     response={200: UserOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def update_user_roles(request, user_id: str, payload: UserRolesIn):
     if not request.auth.has_permission(PermissionKey.MANAGE_USERS):

--- a/backend/users/_roles.py
+++ b/backend/users/_roles.py
@@ -4,10 +4,10 @@ import logging
 
 from community._validation import Code, raise_validation
 from config.audit import audit_log
+from config.auth import gated_jwt
 from django.db.models import Count, Q
 from ninja import Router
 from ninja.responses import Status
-from ninja_jwt.authentication import JWTAuth
 
 from users.permissions import PermissionKey
 from users.roles import PROTECTED_ROLE_NAMES, Role
@@ -16,7 +16,7 @@ from users.schemas import ErrorOut, RoleIn, RoleOut, RolePatchIn
 router = Router()
 
 
-@router.get("/roles/", response={200: list[RoleOut]}, auth=JWTAuth())
+@router.get("/roles/", response={200: list[RoleOut]}, auth=gated_jwt)
 def list_roles(request):
     roles = Role.objects.annotate(
         user_count=Count("users", filter=Q(users__archived_at__isnull=True)),
@@ -39,7 +39,7 @@ def list_roles(request):
 @router.post(
     "/roles/",
     response={201: RoleOut, 400: ErrorOut, 403: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def create_role(request, payload: RoleIn):
     if not request.auth.has_permission(PermissionKey.MANAGE_ROLES):
@@ -75,7 +75,7 @@ def create_role(request, payload: RoleIn):
 @router.patch(
     "/roles/{role_id}/",
     response={200: RoleOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def update_role(request, role_id: str, payload: RolePatchIn):
     if not request.auth.has_permission(PermissionKey.MANAGE_ROLES):
@@ -139,7 +139,7 @@ def update_role(request, role_id: str, payload: RolePatchIn):
 @router.delete(
     "/roles/{role_id}/",
     response={204: None, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut},
-    auth=JWTAuth(),
+    auth=gated_jwt,
 )
 def delete_role(request, role_id: str):
     if not request.auth.has_permission(PermissionKey.MANAGE_ROLES):

--- a/backend/users/schemas.py
+++ b/backend/users/schemas.py
@@ -195,7 +195,9 @@ class ErrorOut(BaseModel):
 class OnboardingIn(BaseModel):
     new_password: str = Field(max_length=FieldLimit.PASSWORD)
     display_name: str | None = Field(default=None, max_length=FieldLimit.DISPLAY_NAME)
-    email: EmailStr | None = None
+    # OptionalEmail (like the other schemas) so an empty-string email from the
+    # client coerces to None instead of failing EmailStr validation.
+    email: OptionalEmail = None
 
 
 class UserSearchOut(BaseModel):

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -3529,6 +3529,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorOut"];
                 };
             };
+            /** @description Unprocessable Content */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
         };
     };
     users__management_create_user: {

--- a/frontend/src/api/validationCodes.gen.ts
+++ b/frontend/src/api/validationCodes.gen.ts
@@ -91,9 +91,12 @@ export const Code = {
     RefreshTokenInvalid: 'auth.refresh_token_invalid',
     RefreshFailed: 'auth.refresh_failed',
     CurrentPasswordIncorrect: 'auth.current_password_incorrect',
+    PasswordResetRequired: 'auth.password_reset_required',
+    OnboardingRequired: 'auth.onboarding_required',
   },
   Password: {
     Invalid: 'password.invalid',
+    SameAsOld: 'password.same_as_old',
   },
   Role: {
     NotFound: 'role.not_found',
@@ -259,7 +262,10 @@ export type ValidationCode =
   | 'auth.refresh_token_invalid'
   | 'auth.refresh_failed'
   | 'auth.current_password_incorrect'
+  | 'auth.password_reset_required'
+  | 'auth.onboarding_required'
   | 'password.invalid'
+  | 'password.same_as_old'
   | 'role.not_found'
   | 'role.name_already_exists'
   | 'role.protected_cannot_edit'
@@ -393,7 +399,10 @@ export const CODE_PARAMS: Record<ValidationCode, readonly string[]> = {
   'auth.refresh_token_invalid': [],
   'auth.refresh_failed': [],
   'auth.current_password_incorrect': [],
+  'auth.password_reset_required': [],
+  'auth.onboarding_required': [],
   'password.invalid': ['reasons'],
+  'password.same_as_old': [],
   'role.not_found': [],
   'role.name_already_exists': [],
   'role.protected_cannot_edit': [],

--- a/frontend/src/api/validationCodes.ts
+++ b/frontend/src/api/validationCodes.ts
@@ -220,6 +220,10 @@ function messageForKnownCode(code: KnownCode, err: FieldError): string {
       return 'your session expired — please sign in again';
     case Code.Auth.CurrentPasswordIncorrect:
       return "current password doesn't match";
+    case Code.Auth.PasswordResetRequired:
+      return 'please set a new password to continue';
+    case Code.Auth.OnboardingRequired:
+      return 'finish setting up your account to continue';
 
     // Password
     case Code.Password.Invalid: {
@@ -227,6 +231,8 @@ function messageForKnownCode(code: KnownCode, err: FieldError): string {
       if (reasons.length > 0) return reasons.join(' · ');
       return 'password is not strong enough';
     }
+    case Code.Password.SameAsOld:
+      return 'new password must be different from your current one';
 
     // Role
     case Code.Role.NotFound:

--- a/frontend/src/auth/guards.tsx
+++ b/frontend/src/auth/guards.tsx
@@ -15,6 +15,7 @@ import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import { RequireEmail } from '@/components/RequireEmail';
 import { useAuthStore } from './store';
 import { hasPermission, type PermissionKey } from '@/models/permissions';
+import { passwordSetupRedirect } from '@/models/user';
 
 // ----------------------------------------------------------------------------
 // AuthBoot — kick off session restore exactly once on mount.
@@ -64,21 +65,13 @@ export function OnboardingGate() {
   const location = useLocation();
   const path = location.pathname.toLowerCase();
 
-  // Two signals force a password set, both gated the same way:
-  //   - needsOnboarding      — admin-created account, first-time setup
-  //   - needsPasswordReset   — consumed a self-service login link, must reset pw
-  const mustSetPassword = !!user && (user.needsOnboarding || user.needsPasswordReset);
+  // passwordSetupRedirect is the shared source of truth (also used by
+  // MagicLoginScreen) for where a setup-pending user must go.
+  const setupTarget = passwordSetupRedirect(user);
 
-  if (user && mustSetPassword) {
-    // Two shapes:
-    //   - password reset (has displayName + email)  → /new-password (password only)
-    //   - everyone else                             → /onboarding (collects whatever's missing)
-    // Users approved before email was required can land here with a displayName
-    // but no email — they need /onboarding so they can supply one.
-    const hasNameAndEmail = user.displayName.length > 0 && !!user.email;
-    const target = hasNameAndEmail ? '/new-password' : '/onboarding';
-    if (path !== target) {
-      return <Navigate to={target} replace />;
+  if (setupTarget) {
+    if (path !== setupTarget) {
+      return <Navigate to={setupTarget} replace />;
     }
   } else if (user) {
     // Authed user with nothing pending shouldn't sit on onboarding screens.

--- a/frontend/src/models/user.ts
+++ b/frontend/src/models/user.ts
@@ -35,3 +35,22 @@ export interface User {
   photoUpdatedAt: string | null;
   roles: Role[];
 }
+
+/**
+ * Where a user must go to finish setting up their account before using the app,
+ * or null if nothing is pending. SINGLE source of truth for this decision —
+ * both OnboardingGate and MagicLoginScreen call this so they can't drift.
+ *
+ *   - needsOnboarding (admin-created, first-time) or needsPasswordReset
+ *     (consumed a self-service login link) → must set a password.
+ *   - /new-password only works when name AND email are already on file (it
+ *     collects neither). Anyone missing either goes to /onboarding, which
+ *     collects whatever's missing (legacy accounts approved before email was
+ *     required land here).
+ */
+export function passwordSetupRedirect(user: User | null): '/new-password' | '/onboarding' | null {
+  if (!user) return null;
+  if (!user.needsOnboarding && !user.needsPasswordReset) return null;
+  const hasNameAndEmail = user.displayName.length > 0 && !!user.email;
+  return hasNameAndEmail ? '/new-password' : '/onboarding';
+}

--- a/frontend/src/screens/auth/MagicLoginScreen.test.tsx
+++ b/frontend/src/screens/auth/MagicLoginScreen.test.tsx
@@ -67,6 +67,14 @@ describe('MagicLoginScreen', () => {
     expect(await screen.findByText('new password page')).toBeInTheDocument();
   });
 
+  it('routes a needsPasswordReset user with NO email to /onboarding (matches the gate)', async () => {
+    // Regression: MagicLoginScreen used to send any named user to /new-password,
+    // which the gate then bounced to /onboarding. Both must now agree.
+    currentUser = makeUser({ needsPasswordReset: true, displayName: 'Alice', email: '' });
+    renderAt('tok-noemail');
+    expect(await screen.findByText('onboarding page')).toBeInTheDocument();
+  });
+
   it('routes a plain login (no flags) to /calendar', async () => {
     currentUser = makeUser({ needsPasswordReset: false, needsOnboarding: false });
     renderAt('tok-2');

--- a/frontend/src/screens/auth/MagicLoginScreen.tsx
+++ b/frontend/src/screens/auth/MagicLoginScreen.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { AxiosError } from 'axios';
 import { Navigate, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useAuthStore } from '@/auth/store';
+import { passwordSetupRedirect } from '@/models/user';
 import { AuthLayout } from './AuthLayout';
 import { Button } from '@/components/ui/Button';
 import { RequestLoginLinkDialog } from './RequestLoginLinkDialog';
@@ -30,11 +31,11 @@ export default function MagicLoginScreen() {
         // of leaning on OnboardingGate) avoids a race where /calendar renders
         // before the gate re-evaluates with the new auth state.
         const user = useAuthStore.getState().user;
-        // needsOnboarding (first-time setup) and needsPasswordReset (consumed a
-        // self-service login link) both force a password set; mirror OnboardingGate.
-        if (user && (user.needsOnboarding || user.needsPasswordReset)) {
-          const target = user.displayName.length > 0 ? '/new-password' : '/onboarding';
-          void navigate(target, { replace: true });
+        // Same shared decision as OnboardingGate, so the two can't disagree (a
+        // no-email user must reach /onboarding, not /new-password).
+        const setupTarget = passwordSetupRedirect(user);
+        if (setupTarget) {
+          void navigate(setupTarget, { replace: true });
           return;
         }
         const redirect = params.get('redirect');

--- a/frontend/src/screens/auth/NewPasswordScreen.test.tsx
+++ b/frontend/src/screens/auth/NewPasswordScreen.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import NewPasswordScreen from './NewPasswordScreen';
+import { useAuthStore } from '@/auth/store';
+
+vi.mock('@/auth/store', () => ({
+  useAuthStore: vi.fn(),
+}));
+
+vi.mock('@/api/client', () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+  authClient: { post: vi.fn() },
+  setAuthBridge: vi.fn(),
+}));
+
+const VALID = 'abcd1234ABCD!';
+
+describe('NewPasswordScreen', () => {
+  const completeOnboarding = vi.fn();
+
+  beforeEach(() => {
+    completeOnboarding.mockReset();
+    vi.mocked(useAuthStore).mockImplementation((selector) =>
+      selector({ completeOnboarding } as never),
+    );
+  });
+
+  it('blocks submit when confirmation does not match', async () => {
+    render(
+      <MemoryRouter>
+        <NewPasswordScreen />
+      </MemoryRouter>,
+    );
+    await userEvent.type(screen.getByLabelText(/^new password$/i), VALID);
+    await userEvent.type(screen.getByLabelText(/confirm new password/i), `${VALID}x`);
+    await userEvent.click(screen.getByRole('button', { name: /save password/i }));
+
+    expect(await screen.findByText(/passwords do not match/i)).toBeInTheDocument();
+    expect(completeOnboarding).not.toHaveBeenCalled();
+  });
+
+  it('submits the new password when confirmation matches', async () => {
+    completeOnboarding.mockResolvedValue(undefined);
+    render(
+      <MemoryRouter>
+        <NewPasswordScreen />
+      </MemoryRouter>,
+    );
+    await userEvent.type(screen.getByLabelText(/^new password$/i), VALID);
+    await userEvent.type(screen.getByLabelText(/confirm new password/i), VALID);
+    await userEvent.click(screen.getByRole('button', { name: /save password/i }));
+
+    await vi.waitFor(() => {
+      expect(completeOnboarding).toHaveBeenCalledWith({ newPassword: VALID });
+    });
+  });
+});

--- a/frontend/src/screens/auth/NewPasswordScreen.tsx
+++ b/frontend/src/screens/auth/NewPasswordScreen.tsx
@@ -11,9 +11,15 @@ import { extractApiError } from '@/utils/errors';
 import { passwordRule } from './passwordRule';
 import { PasswordChecklist } from './PasswordChecklist';
 
-const schema = z.object({
-  newPassword: passwordRule,
-});
+const schema = z
+  .object({
+    newPassword: passwordRule,
+    confirmPassword: z.string(),
+  })
+  .refine((v) => v.newPassword === v.confirmPassword, {
+    message: 'passwords do not match',
+    path: ['confirmPassword'],
+  });
 
 type FormValues = z.infer<typeof schema>;
 
@@ -31,7 +37,7 @@ export default function NewPasswordScreen() {
     formState: { errors, isSubmitting },
   } = useForm<FormValues>({
     resolver: zodResolver(schema),
-    defaultValues: { newPassword: '' },
+    defaultValues: { newPassword: '', confirmPassword: '' },
   });
   const passwordValue = useWatch({ control, name: 'newPassword' });
 
@@ -54,6 +60,12 @@ export default function NewPasswordScreen() {
           autoComplete="new-password"
           {...register('newPassword')}
           error={errors.newPassword?.message}
+        />
+        <PasswordField
+          label="confirm new password"
+          autoComplete="new-password"
+          {...register('confirmPassword')}
+          error={errors.confirmPassword?.message}
         />
         {serverError ? (
           <p role="alert" className="text-destructive text-sm">


### PR DESCRIPTION
## Summary

Hardens the password-reset / onboarding flow. Follow-up to #434 (magic-login email), prompted by a bug sweep after noticing the reset flow let you set a new password equal to the old one. Several related gaps surfaced.

## What's fixed

### Server-side enforcement (the big one)
The forced password reset (set when a self-service magic login link is consumed) was enforced **only** by the React `OnboardingGate`. The JWT issued at magic-login is fully valid, and `set_unusable_password()` blocks only the `/login/` form — not API calls carrying the already-issued token. So a reset-pending user could call any authenticated endpoint without ever setting a password. The same gap meant `is_paused` / `archived_at` users kept access until their token expired (those were only checked at login).

- **`GatedJWTAuth`** (`backend/config/auth.py`) — single chokepoint that re-checks account state on **every** protected request: 403s `needs_password_reset` / `needs_onboarding` users (allowlisting `/me/`, `/complete-onboarding/`, `/change-password/` so they can resolve it) and re-checks `is_paused` / `archived_at` per-request. Adopted across all ~28 router modules in place of bare `JWTAuth()`.

### Password reuse
- `complete_onboarding` and `change_password` now reject `new == current` (`password.same_as_old`). The onboarding check is guarded by `has_usable_password()` so a forced-reset user (unusable password) isn't falsely blocked.
- `change_password` now also clears `needs_password_reset` (it's an alternate password-set path).

### Gate divergence
`OnboardingGate` and `MagicLoginScreen` computed the redirect independently and had drifted (`displayName && email` vs `displayName` alone), so a reset user with a name but no email was sent to `/new-password` then bounced to `/onboarding`. Extracted **`passwordSetupRedirect(user)`** as the single source of truth used by both.

### Smaller correctness gaps
- `NewPasswordScreen` now has a confirm-password field (zod refine match) — a typo can't silently lock the user to a mistyped password.
- `OnboardingIn.email` uses `OptionalEmail` (empty-string coercion, consistent with other schemas); declared the `422` email-required response on `complete_onboarding`.
- New validation codes + UI copy: `auth.password_reset_required`, `auth.onboarding_required`, `password.same_as_old`.

## Tests
- New `backend/tests/test_auth_gate.py` (7) — reset/onboarding/paused/archived blocking, allowlist reachable, normal users unaffected.
- Password-reuse + flag-clear tests (auth + onboarding), no-false-positive for unusable-password reset users.
- `NewPasswordScreen.test.tsx` (confirm match) + MagicLoginScreen no-email regression test.
- **860 backend + 488 frontend tests green; lint, typecheck, complexity, prettier all clean.**

## Test plan
- [ ] Consume a self-service login link → routed to `/new-password`; confirm old password no longer works and the new one differs (reuse rejected).
- [ ] With the magic-login access token, hit a protected API (e.g. `GET /api/notifications/`) before setting a password → expect `403 auth.password_reset_required`; `GET /me/` and `complete-onboarding` still work.
- [ ] Legacy no-email user consumes a link → lands on `/onboarding` (not a `/new-password` bounce), must add an email.
- [ ] Pause a user who already holds a token → next protected call 403s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
