### PR TITLE
fix(auth): prevent privilege escalation via admin-role grant and validate role permissions

### DIFF
--- a/backend/community/_join_requests.py
+++ b/backend/community/_join_requests.py
@@ -381,6 +381,7 @@ def update_join_request_status(request, id: UUID, payload: JoinRequestStatusIn):
                 join_request.display_name,
                 join_request.email,
                 None,
+                requesting_user=request.auth,
             )
             user_created = True
         elif existing_user.archived_at is not None:

--- a/backend/community/_validation.py
+++ b/backend/community/_validation.py
@@ -123,6 +123,8 @@ class Code:
         PROTECTED_CANNOT_DELETE = "role.protected_cannot_delete"
         CANNOT_REMOVE_OWN_ADMIN = "role.cannot_remove_own_admin"
         CANNOT_REMOVE_LAST_ADMIN = "role.cannot_remove_last_admin"
+        CANNOT_GRANT_ADMIN = "role.cannot_grant_admin"
+        INVALID_PERMISSION = "role.invalid_permission"  # params: { permission: str }
         MEMBER_ROLE_REQUIRED = "role.member_role_required"
 
     class Member:

--- a/backend/community/validation_codes.json
+++ b/backend/community/validation_codes.json
@@ -423,6 +423,18 @@
         "params": []
       },
       {
+        "name": "CANNOT_GRANT_ADMIN",
+        "value": "role.cannot_grant_admin",
+        "params": []
+      },
+      {
+        "name": "INVALID_PERMISSION",
+        "value": "role.invalid_permission",
+        "params": [
+          "permission"
+        ]
+      },
+      {
         "name": "MEMBER_ROLE_REQUIRED",
         "value": "role.member_role_required",
         "params": []

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -280,16 +280,29 @@ class TestUserManagementAPI:
 
 @pytest.mark.django_db
 class TestCreateUserWithRole:
+    def _requester(self):
+        from users.models import User
+
+        return User.objects.create_user(phone_number="+12025550000", password="p")
+
     def test_creates_user_with_default_member_role(self):
         Role.objects.get_or_create(name="member", defaults={"is_default": True})
-        user, magic_token = _create_user_with_role("+12025559999", "Test User", "t@e.com", None)
+        user, magic_token = _create_user_with_role(
+            "+12025559999", "Test User", "t@e.com", None, requesting_user=self._requester()
+        )
         assert user.phone_number == "+12025559999"
         assert len(magic_token) == 36  # UUID format
         assert user.roles.filter(name="member").exists()
 
     def test_creates_user_with_specific_role(self):
         role = Role.objects.create(name="custom_role")
-        user, _ = _create_user_with_role("+12025558888", "Custom User", "c@e.com", str(role.pk))
+        user, _ = _create_user_with_role(
+            "+12025558888",
+            "Custom User",
+            "c@e.com",
+            str(role.pk),
+            requesting_user=self._requester(),
+        )
         assert user.roles.filter(pk=role.pk).exists()
 
     def test_raises_on_duplicate_phone(self):
@@ -298,14 +311,18 @@ class TestCreateUserWithRole:
 
         User.objects.create_user(phone_number="+12025557777", password="pass123")
         with pytest.raises(ValidationException) as exc_info:
-            _create_user_with_role("+12025557777", "Dup", None, None)
+            _create_user_with_role(
+                "+12025557777", "Dup", None, None, requesting_user=self._requester()
+            )
         assert exc_info.value.code == Code.Phone.ALREADY_EXISTS
 
     def test_raises_on_invalid_phone(self):
         from community._validation import ValidationException
 
         with pytest.raises(ValidationException) as exc_info:
-            _create_user_with_role("not-a-phone", "Bad Phone", None, None)
+            _create_user_with_role(
+                "not-a-phone", "Bad Phone", None, None, requesting_user=self._requester()
+            )
         assert exc_info.value.code == Code.Phone.INVALID
 
     def test_raises_on_bad_role_and_deletes_user(self):
@@ -314,10 +331,41 @@ class TestCreateUserWithRole:
 
         with pytest.raises(ValidationException) as exc_info:
             _create_user_with_role(
-                "+12025556666", "Bad Role User", "b@e.com", "00000000-0000-0000-0000-000000000000"
+                "+12025556666",
+                "Bad Role User",
+                "b@e.com",
+                "00000000-0000-0000-0000-000000000000",
+                requesting_user=self._requester(),
             )
         assert exc_info.value.code == Code.Role.NOT_FOUND
         assert not User.objects.filter(phone_number="+12025556666").exists()
+
+    def test_raises_when_non_admin_grants_admin_role(self):
+        from community._validation import ValidationException
+        from users.models import User
+
+        admin_role = Role.objects.get_or_create(name="admin", defaults={"is_default": True})[0]
+        non_admin = self._requester()
+        with pytest.raises(ValidationException) as exc_info:
+            _create_user_with_role(
+                "+12025554444",
+                "Sneaky Admin",
+                None,
+                str(admin_role.pk),
+                requesting_user=non_admin,
+            )
+        assert exc_info.value.code == Code.Role.CANNOT_GRANT_ADMIN
+        assert exc_info.value.status_code == 403
+        assert not User.objects.filter(phone_number="+12025554444").exists()
+
+    def test_admin_can_grant_admin_role(self):
+        admin_role = Role.objects.get_or_create(name="admin", defaults={"is_default": True})[0]
+        requester = self._requester()
+        requester.roles.add(admin_role)
+        user, _ = _create_user_with_role(
+            "+12025553333", "New Admin", None, str(admin_role.pk), requesting_user=requester
+        )
+        assert user.roles.filter(pk=admin_role.pk).exists()
 
 
 # ---------------------------------------------------------------------------
@@ -327,12 +375,21 @@ class TestCreateUserWithRole:
 
 @pytest.mark.django_db
 class TestValidateAdminRoleChange:
+    def _admin_requester(self):
+        from users.models import User
+
+        admin_role = Role.objects.get_or_create(name="admin", defaults={"is_default": True})[0]
+        requester = User.objects.create_user(phone_number="+12025559000", password="p")
+        requester.roles.add(admin_role)
+        return requester
+
     def test_returns_none_when_no_admin_role_exists(self):
         from users.models import User
 
         user = User.objects.create_user(phone_number="+12025550101", password="p", email="a@e.com")
+        other = User.objects.create_user(phone_number="+12025550199", password="p")
         # No admin role exists — should be a no-op (not raise)
-        _validate_admin_role_change(user, "other-pk", [])
+        _validate_admin_role_change(user, other, [])
 
     def test_returns_error_when_removing_own_admin(self):
         from community._validation import ValidationException
@@ -343,7 +400,7 @@ class TestValidateAdminRoleChange:
         user = User.objects.create_user(phone_number="+12025550102", password="p", email="b@e.com")
         user.roles.add(admin_role)
         with pytest.raises(ValidationException) as exc_info:
-            _validate_admin_role_change(user, str(user.pk), [member_role])
+            _validate_admin_role_change(user, user, [member_role])
         assert exc_info.value.code == Code.Role.CANNOT_REMOVE_OWN_ADMIN
 
     def test_returns_none_when_keeping_own_admin(self):
@@ -353,7 +410,7 @@ class TestValidateAdminRoleChange:
         user = User.objects.create_user(phone_number="+12025550103", password="p", email="c@e.com")
         user.roles.add(admin_role)
         # Keeping admin — no-op
-        _validate_admin_role_change(user, str(user.pk), [admin_role])
+        _validate_admin_role_change(user, user, [admin_role])
 
     def test_returns_error_when_removing_last_admin(self):
         from community._validation import ValidationException
@@ -363,10 +420,32 @@ class TestValidateAdminRoleChange:
         member_role = Role.objects.get_or_create(name="member", defaults={"is_default": True})[0]
         user = User.objects.create_user(phone_number="+12025550104", password="p", email="d@e.com")
         user.roles.add(admin_role)
-        # Request from a different user (not self-removal)
+        # Request from a different user (not self-removal). The requester is not
+        # an admin, so ``user`` remains the sole/last admin.
+        requester = User.objects.create_user(phone_number="+12025550144", password="p")
         with pytest.raises(ValidationException) as exc_info:
-            _validate_admin_role_change(user, "someone-else", [member_role])
+            _validate_admin_role_change(user, requester, [member_role])
         assert exc_info.value.code == Code.Role.CANNOT_REMOVE_LAST_ADMIN
+
+    def test_returns_error_when_non_admin_grants_admin(self):
+        from community._validation import ValidationException
+        from users.models import User
+
+        admin_role = Role.objects.get_or_create(name="admin", defaults={"is_default": True})[0]
+        target = User.objects.create_user(phone_number="+12025550105", password="p")
+        non_admin = User.objects.create_user(phone_number="+12025550106", password="p")
+        with pytest.raises(ValidationException) as exc_info:
+            _validate_admin_role_change(target, non_admin, [admin_role])
+        assert exc_info.value.code == Code.Role.CANNOT_GRANT_ADMIN
+        assert exc_info.value.status_code == 403
+
+    def test_admin_may_grant_admin(self):
+        from users.models import User
+
+        admin_role = Role.objects.get_or_create(name="admin", defaults={"is_default": True})[0]
+        target = User.objects.create_user(phone_number="+12025550107", password="p")
+        # Admin requester granting admin to target — no-op (no raise)
+        _validate_admin_role_change(target, self._admin_requester(), [admin_role])
 
 
 # ---------------------------------------------------------------------------

--- a/backend/tests/test_role_management.py
+++ b/backend/tests/test_role_management.py
@@ -72,6 +72,30 @@ class TestRoleManagementAPI:
         )
         assert response.status_code == 400
 
+    def test_create_role_rejects_unknown_permission(self, api_client, manage_users_headers):
+        response = api_client.post(
+            "/api/auth/roles/",
+            {"name": "bogus", "permissions": ["not_a_real_permission"]},
+            content_type="application/json",
+            **manage_users_headers,
+        )
+        assert response.status_code == 422
+        assert_error_code(response, Code.Role.INVALID_PERMISSION)
+        assert not Role.objects.filter(name="bogus").exists()
+
+    def test_update_role_rejects_unknown_permission(self, api_client, manage_users_headers):
+        role = Role.objects.create(name="custom_perm", permissions=[])
+        response = api_client.patch(
+            f"/api/auth/roles/{role.id}/",
+            {"permissions": [PermissionKey.MANAGE_EVENTS, "bogus_permission"]},
+            content_type="application/json",
+            **manage_users_headers,
+        )
+        assert response.status_code == 422
+        assert_error_code(response, Code.Role.INVALID_PERMISSION)
+        role.refresh_from_db()
+        assert role.permissions == []
+
     def test_patch_role_permissions(self, api_client, manage_users_headers):
         role = Role.objects.create(name="custom", permissions=[])
         response = api_client.patch(

--- a/backend/tests/users/test_users_admin_extended.py
+++ b/backend/tests/users/test_users_admin_extended.py
@@ -290,3 +290,42 @@ class TestGenerateMagicLink:
         assert notif.is_read is True
         other_user.refresh_from_db()
         assert other_user.login_link_requested is False
+
+
+@pytest.mark.django_db
+class TestUpdateUserRoles:
+    def test_non_admin_cannot_grant_admin_role(self, api_client, manage_users_headers, other_user):
+        from users.roles import Role
+
+        admin_role = Role.objects.get(name="admin")
+        member_role = Role.objects.get(name="member")
+        response = api_client.patch(
+            f"/api/auth/users/{other_user.pk}/roles/",
+            {"role_ids": [str(member_role.id), str(admin_role.id)]},
+            content_type="application/json",
+            **manage_users_headers,
+        )
+        assert response.status_code == 403
+        assert_error_code(response, Code.Role.CANNOT_GRANT_ADMIN)
+        assert not other_user.roles.filter(name="admin").exists()
+
+    def test_admin_can_grant_admin_role(self, api_client, other_user):
+        from ninja_jwt.tokens import RefreshToken
+        from users.models import User
+        from users.roles import Role
+
+        admin_role = Role.objects.get(name="admin")
+        member_role = Role.objects.get(name="member")
+        admin_user = User.objects.create_user(phone_number="+12025550401", password="adminpass123")
+        admin_user.roles.add(admin_role)
+        refresh = RefreshToken.for_user(admin_user)
+        headers = {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
+
+        response = api_client.patch(
+            f"/api/auth/users/{other_user.pk}/roles/",
+            {"role_ids": [str(member_role.id), str(admin_role.id)]},
+            content_type="application/json",
+            **headers,
+        )
+        assert response.status_code == 200
+        assert other_user.roles.filter(name="admin").exists()

--- a/backend/tests/users/test_users_crud.py
+++ b/backend/tests/users/test_users_crud.py
@@ -28,6 +28,20 @@ class TestCreateUser:
         )
         assert response.status_code == 201
 
+    def test_create_user_non_admin_cannot_assign_admin_role(self, api_client, manage_users_headers):
+        from users.models import User
+
+        admin_role = Role.objects.get(name="admin")
+        response = api_client.post(
+            "/api/auth/create-user/",
+            {"phone_number": "+12025550950", "role_id": str(admin_role.id)},
+            content_type="application/json",
+            **manage_users_headers,
+        )
+        assert response.status_code == 403
+        assert_error_code(response, Code.Role.CANNOT_GRANT_ADMIN, "role_id")
+        assert not User.objects.filter(phone_number="+12025550950").exists()
+
     def test_create_user_invalid_role_id(self, api_client, manage_users_headers):
         response = api_client.post(
             "/api/auth/create-user/",

--- a/backend/users/_helpers.py
+++ b/backend/users/_helpers.py
@@ -92,17 +92,32 @@ def _validate_phone(raw: str, field: str = "phone_number") -> str:
     return phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164)
 
 
+def _guard_admin_role_grant(role_id: str | None, requesting_user: User) -> None:
+    """Block assigning the built-in admin role unless the requester is an admin.
+
+    Prevents privilege escalation when a user holds CREATE_USER but is not
+    themselves an admin. No-op for any non-admin role (or no role).
+    """
+    if not role_id:
+        return
+    admin_role = Role.objects.filter(name="admin", is_default=True).first()
+    if admin_role and str(role_id) == str(admin_role.pk) and not _is_admin(requesting_user):
+        raise_validation(Code.Role.CANNOT_GRANT_ADMIN, field="role_id", status_code=403)
+
+
 def _create_user_with_role(
     phone: str,
     display_name: str,
     email: str | None,
     role_id: str | None,
     *,
-    needs_onboarding: bool = True,
+    requesting_user: User,
 ) -> tuple[User, str]:
     """Validate phone, create user, assign role. Returns (user, magic_link_token).
 
     Raises ValidationException on validation failure (bad phone, duplicate, bad role).
+    Assigning the built-in admin role is only permitted when ``requesting_user``
+    is themselves an admin (prevents escalation under CREATE_USER alone).
     """
     validated_phone = _validate_phone(phone)
     if User.objects.filter(phone_number=validated_phone).exists():
@@ -110,11 +125,12 @@ def _create_user_with_role(
     normalized_email = _normalize_email(email)
     if normalized_email and User.objects.filter(email=normalized_email).exists():
         raise_validation(Code.Email.ALREADY_EXISTS, field="email", status_code=409)
+    _guard_admin_role_grant(role_id, requesting_user)
     user = User.objects.create_user(
         phone_number=validated_phone,
         display_name=display_name,
         email=normalized_email,
-        needs_onboarding=needs_onboarding,
+        needs_onboarding=True,
     )
     user.set_unusable_password()
     user.save(update_fields=["password"])
@@ -133,15 +149,25 @@ def _create_user_with_role(
     return user, magic_token
 
 
-def _validate_admin_role_change(user: User, requesting_user_pk, new_roles: list[Role]) -> None:
-    """Raise ValidationException if an admin role change is invalid."""
+def _validate_admin_role_change(user: User, requesting_user: User, new_roles: list[Role]) -> None:
+    """Raise ValidationException if an admin role change is invalid.
+
+    Guards both directions:
+    - Removing admin from oneself or the last admin is blocked.
+    - Granting the built-in admin role is blocked unless the requester is
+      themselves an admin (prevents privilege escalation via MANAGE_USERS).
+    """
     admin_role = Role.objects.filter(name="admin", is_default=True).first()
     if not admin_role:
         return
 
-    is_self = str(user.pk) == str(requesting_user_pk)
+    is_self = str(user.pk) == str(requesting_user.pk)
     is_current_admin = user.roles.filter(pk=admin_role.pk).exists()
     removing_admin = admin_role not in new_roles
+    adding_admin = admin_role in new_roles and not is_current_admin
+
+    if adding_admin and not _is_admin(requesting_user):
+        raise_validation(Code.Role.CANNOT_GRANT_ADMIN, status_code=403)
 
     if is_self and is_current_admin and removing_admin:
         raise_validation(Code.Role.CANNOT_REMOVE_OWN_ADMIN, status_code=400)

--- a/backend/users/_management.py
+++ b/backend/users/_management.py
@@ -60,7 +60,11 @@ def create_user(request, payload: UserCreateIn):
         validate_display_name(payload.display_name)
 
     user, magic_token = _create_user_with_role(
-        payload.phone_number, payload.display_name, payload.email, payload.role_id
+        payload.phone_number,
+        payload.display_name,
+        payload.email,
+        payload.role_id,
+        requesting_user=request.auth,
     )
 
     audit_log(
@@ -358,7 +362,7 @@ def update_user_roles(request, user_id: str, payload: UserRolesIn):
     if len(roles) != len(payload.role_ids):
         raise_validation(Code.User.ROLE_IDS_NOT_FOUND, field="role_ids", status_code=400)
 
-    _validate_admin_role_change(user, request.auth.pk, roles)
+    _validate_admin_role_change(user, request.auth, roles)
     _validate_member_role_required(roles)
 
     old_role_ids = [str(r.id) for r in user.roles.all()]

--- a/backend/users/schemas.py
+++ b/backend/users/schemas.py
@@ -1,10 +1,29 @@
 from typing import Annotated, Literal
 
 from community._field_limits import FieldLimit
+from community._validation import Code, raise_validation
 from config.media_proxy import media_path
-from pydantic import BaseModel, BeforeValidator, EmailStr, Field
+from pydantic import BaseModel, BeforeValidator, EmailStr, Field, field_validator
 
 from users.models import User
+from users.permissions import PermissionKey
+
+
+def _validate_permission_keys(permissions: list[str]) -> list[str]:
+    """Reject any permission key not defined in PermissionKey.
+
+    Roles persist permissions to a JSONField with no DB-level enforcement,
+    so unknown/typo'd keys would silently become dead grants. Validate here.
+    """
+    valid = set(PermissionKey.values)
+    for perm in permissions:
+        if perm not in valid:
+            raise_validation(
+                Code.Role.INVALID_PERMISSION,
+                field="permissions",
+                permission=perm,
+            )
+    return permissions
 
 
 def _empty_str_to_none(v: str | None) -> str | None:
@@ -182,10 +201,22 @@ class RoleIn(BaseModel):
     name: str = Field(max_length=FieldLimit.ROLE_NAME)
     permissions: list[str] = []
 
+    @field_validator("permissions")
+    @classmethod
+    def validate_permissions(cls, v: list[str]) -> list[str]:
+        return _validate_permission_keys(v)
+
 
 class RolePatchIn(BaseModel):
     name: str | None = Field(default=None, max_length=FieldLimit.ROLE_NAME)
     permissions: list[str] | None = None
+
+    @field_validator("permissions")
+    @classmethod
+    def validate_permissions(cls, v: list[str] | None) -> list[str] | None:
+        if v is None:
+            return v
+        return _validate_permission_keys(v)
 
 
 class ErrorOut(BaseModel):

--- a/frontend/src/api/validationCodes.gen.ts
+++ b/frontend/src/api/validationCodes.gen.ts
@@ -106,6 +106,8 @@ export const Code = {
     ProtectedCannotDelete: 'role.protected_cannot_delete',
     CannotRemoveOwnAdmin: 'role.cannot_remove_own_admin',
     CannotRemoveLastAdmin: 'role.cannot_remove_last_admin',
+    CannotGrantAdmin: 'role.cannot_grant_admin',
+    InvalidPermission: 'role.invalid_permission',
     MemberRoleRequired: 'role.member_role_required',
   },
   Member: {
@@ -273,6 +275,8 @@ export type ValidationCode =
   | 'role.protected_cannot_delete'
   | 'role.cannot_remove_own_admin'
   | 'role.cannot_remove_last_admin'
+  | 'role.cannot_grant_admin'
+  | 'role.invalid_permission'
   | 'role.member_role_required'
   | 'member.not_found'
   | 'user.not_found'
@@ -410,6 +414,8 @@ export const CODE_PARAMS: Record<ValidationCode, readonly string[]> = {
   'role.protected_cannot_delete': [],
   'role.cannot_remove_own_admin': [],
   'role.cannot_remove_last_admin': [],
+  'role.cannot_grant_admin': [],
+  'role.invalid_permission': ['permission'],
   'role.member_role_required': [],
   'member.not_found': [],
   'user.not_found': [],

--- a/frontend/src/api/validationCodes.ts
+++ b/frontend/src/api/validationCodes.ts
@@ -261,6 +261,12 @@ function messageForKnownCode(code: KnownCode, err: FieldError): string {
       return "you can't remove your own admin role";
     case Code.Role.CannotRemoveLastAdmin:
       return "can't remove admin from the last admin — promote someone else first";
+    case Code.Role.CannotGrantAdmin:
+      return 'only an admin can grant the admin role';
+    case Code.Role.InvalidPermission: {
+      const perm = typeof err.params?.permission === 'string' ? err.params.permission : null;
+      return perm ? `unknown permission: ${perm}` : 'one or more permissions are invalid';
+    }
     case Code.Role.MemberRoleRequired:
       return 'every user must keep the member role';
 


### PR DESCRIPTION
## Description
Closes two privilege-escalation paths found in the codebase audit.

**Issue 443 — admin-role grant escalation:** `_validate_admin_role_change` only blocked *removing* admin, never *adding* it. A non-admin holding only `MANAGE_USERS` could grant the built-in admin role (which implies all permissions) to anyone, including themselves; `create_user` could likewise assign admin under only `CREATE_USER`. Now adding the admin role requires the requester to be an admin, in both `update_user_roles` and `create_user`.

**Issue 444 — unvalidated role permissions:** `create_role`/`update_role` wrote `payload.permissions` straight to the JSONField. Permissions are now validated against `PermissionKey` before persisting, rejecting unknown keys.

## Tasks
- [x] Guard admin-role addition behind admin-only in `update_user_roles` and `create_user` (`backend/users/_helpers.py`, `_management.py`)
- [x] Validate role permissions against `PermissionKey` (`backend/users/schemas.py`)
- [x] New validation codes wired through backend + generated frontend codes
- [x] Regression tests (admin-grant blocked for `MANAGE_USERS`/`CREATE_USER`; invalid permission key rejected)

## Verification
`make agent-ci` passes: 869 backend tests, ty typecheck, complexity, file-size, validation-code + OpenAPI parity, and all frontend checks (eslint, prettier, vitest, tsc, types parity).

Closes #443
Closes #444