### PR TITLE
fix(reliability): timeouts/retries on outbound calls + narrow broad excepts

### DIFF
--- a/backend/community/_geocode.py
+++ b/backend/community/_geocode.py
@@ -47,8 +47,10 @@ def geocode(request: HttpRequest, params: Query[GeocodeQuery]):
         )
         resp.raise_for_status()
         return 200, resp.json()
-    except (httpx.TimeoutException, httpx.HTTPError) as e:
-        # Expected upstream failures (timeout, connection error, non-2xx).
+    except (httpx.HTTPError, ValueError) as e:
+        # Expected upstream failures: httpx.HTTPError covers timeout, connection
+        # error, and non-2xx (TimeoutException is a subclass); ValueError covers
+        # JSON-decode failures when a 2xx response carries a non-JSON body.
         # Log with request context but no PII — the query text is user input.
         logger.warning("geocode proxy error: limit=%s error=%s", params.limit, e)
         return 502, {"detail": "geocoding service unavailable — try again"}

--- a/backend/community/_geocode.py
+++ b/backend/community/_geocode.py
@@ -1,11 +1,13 @@
 """Geocoding proxy — avoids direct browser calls to Photon (blocks COEP)."""
 
 import logging
+from typing import Any
 
 import httpx
 from config.auth import gated_jwt
 from django.http import HttpRequest
-from ninja import Router
+from ninja import Query, Router
+from pydantic import BaseModel, Field
 
 from community._shared import ErrorOut
 
@@ -16,15 +18,25 @@ router = Router()
 _PHOTON_URL = "https://photon.komoot.io/api/"
 
 
-@router.get("/geocode/", auth=gated_jwt, response={200: dict, 502: ErrorOut})
-def geocode(request: HttpRequest, q: str, limit: int = 5):
+class GeocodeQuery(BaseModel):
+    q: str = Field(..., min_length=1, max_length=200)
+    limit: int = Field(5, ge=1, le=10)
+
+
+class GeocodeOut(BaseModel):
+    type: str | None = None
+    features: list[dict[str, Any]] = Field(default_factory=list)
+
+
+@router.get("/geocode/", auth=gated_jwt, response={200: GeocodeOut, 502: ErrorOut})
+def geocode(request: HttpRequest, params: Query[GeocodeQuery]):
     """Proxy geocoding requests to Photon, biased toward NYC."""
     try:
         resp = httpx.get(
             _PHOTON_URL,
             params={
-                "q": q,
-                "limit": limit,
+                "q": params.q,
+                "limit": params.limit,
                 "lat": 40.7128,
                 "lon": -74.006,
                 "bbox": "-74.2591,40.4774,-73.7004,40.9176",  # NYC metro
@@ -35,6 +47,8 @@ def geocode(request: HttpRequest, q: str, limit: int = 5):
         )
         resp.raise_for_status()
         return 200, resp.json()
-    except Exception as e:
-        logger.warning("Geocoding proxy error: %s", e)
+    except (httpx.TimeoutException, httpx.HTTPError) as e:
+        # Expected upstream failures (timeout, connection error, non-2xx).
+        # Log with request context but no PII — the query text is user input.
+        logger.warning("geocode proxy error: limit=%s error=%s", params.limit, e)
         return 502, {"detail": "geocoding service unavailable — try again"}

--- a/backend/community/_geocode.py
+++ b/backend/community/_geocode.py
@@ -7,7 +7,7 @@ import httpx
 from config.auth import gated_jwt
 from django.http import HttpRequest
 from ninja import Query, Router
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from community._shared import ErrorOut
 
@@ -24,6 +24,12 @@ class GeocodeQuery(BaseModel):
 
 
 class GeocodeOut(BaseModel):
+    # The endpoint is a transparent proxy: `type` and `features` are documented
+    # for the OpenAPI contract, but Photon's GeoJSON may carry other top-level
+    # keys (e.g. a FeatureCollection `bbox`). `extra="allow"` keeps the proxy
+    # lossless so those keys reach the client instead of being silently dropped.
+    model_config = ConfigDict(extra="allow")
+
     type: str | None = None
     features: list[dict[str, Any]] = Field(default_factory=list)
 

--- a/backend/community/_polls.py
+++ b/backend/community/_polls.py
@@ -1,6 +1,7 @@
 """EventPoll endpoints — create, vote, finalize, delete."""
 
 import logging
+from contextlib import contextmanager
 from datetime import datetime, timedelta
 from uuid import UUID
 
@@ -41,6 +42,20 @@ router = Router()
 # Grace window matches frontend validateEventForm — lets a just-picked minute
 # land even if the server clock is a few seconds ahead of the user's.
 _PAST_GRACE = timedelta(seconds=60)
+
+
+@contextmanager
+def _duplicate_option_time_guard():
+    """Map the unique (poll, datetime) constraint violation to a domain error.
+
+    Both create and update of a poll option can collide on the unique
+    (poll, datetime) constraint; this keeps the IntegrityError → validation-code
+    mapping in one place so the two endpoints can't drift.
+    """
+    try:
+        yield
+    except IntegrityError:
+        raise_validation(Code.Poll.OPTION_ALREADY_EXISTS, status_code=400)
 
 
 def _any_in_past(dts: list[datetime]) -> bool:
@@ -399,11 +414,8 @@ def add_poll_option(request, event_id: UUID, payload: PollOptionIn):
     _, poll = _get_active_poll(request.auth, event_id)
     _validate_poll_options([payload.datetime], require_at_least_one=False)
     next_order = poll.options.count()
-    try:
+    with _duplicate_option_time_guard():
         PollOption.objects.create(poll=poll, datetime=payload.datetime, display_order=next_order)
-    except IntegrityError:
-        # Unique constraint on (poll, datetime) — duplicate option time.
-        raise_validation(Code.Poll.OPTION_ALREADY_EXISTS, status_code=400)
     audit_log(
         logging.INFO,
         "poll_option_added",
@@ -433,12 +445,9 @@ def update_poll_option(request, event_id: UUID, payload: PollOptionIn, option_id
         option = poll.options.get(id=option_id)
     except PollOption.DoesNotExist:
         raise_validation(Code.Poll.OPTION_NOT_FOUND, status_code=404)
-    try:
+    with _duplicate_option_time_guard():
         option.datetime = payload.datetime
         option.save(update_fields=["datetime"])
-    except IntegrityError:
-        # Unique constraint on (poll, datetime) — another option already uses this time.
-        raise_validation(Code.Poll.OPTION_ALREADY_EXISTS, status_code=400)
     audit_log(
         logging.INFO,
         "poll_option_updated",

--- a/backend/community/_polls.py
+++ b/backend/community/_polls.py
@@ -8,7 +8,7 @@ from config.audit import audit_log
 from config.auth import gated_jwt
 from config.media_proxy import media_path
 from config.ratelimit import rate_limit
-from django.db import transaction
+from django.db import IntegrityError, transaction
 from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
@@ -401,7 +401,8 @@ def add_poll_option(request, event_id: UUID, payload: PollOptionIn):
     next_order = poll.options.count()
     try:
         PollOption.objects.create(poll=poll, datetime=payload.datetime, display_order=next_order)
-    except Exception:
+    except IntegrityError:
+        # Unique constraint on (poll, datetime) — duplicate option time.
         raise_validation(Code.Poll.OPTION_ALREADY_EXISTS, status_code=400)
     audit_log(
         logging.INFO,
@@ -435,7 +436,8 @@ def update_poll_option(request, event_id: UUID, payload: PollOptionIn, option_id
     try:
         option.datetime = payload.datetime
         option.save(update_fields=["datetime"])
-    except Exception:
+    except IntegrityError:
+        # Unique constraint on (poll, datetime) — another option already uses this time.
         raise_validation(Code.Poll.OPTION_ALREADY_EXISTS, status_code=400)
     audit_log(
         logging.INFO,

--- a/backend/community/_shared.py
+++ b/backend/community/_shared.py
@@ -8,6 +8,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest
 from ninja.security import HttpBearer
 from ninja_jwt.authentication import JWTAuth, JWTBaseAuthentication  # noqa: F401
+from ninja_jwt.exceptions import AuthenticationFailed, TokenError
 from pydantic import BaseModel
 from users.models import User as UserModel
 
@@ -22,7 +23,15 @@ class OptionalJWTAuth(JWTBaseAuthentication, HttpBearer):
     def authenticate(self, request: HttpRequest, token: str):
         try:
             return self.jwt_authenticate(request, token)
+        except (AuthenticationFailed, TokenError):
+            # Genuinely-invalid / expired / unparseable token — treat the
+            # caller as anonymous (public endpoints stay reachable).
+            return AnonymousUser()
         except Exception:
+            # Anything else (DB error, misconfiguration) is unexpected: log it
+            # so it stays observable, but still degrade to anonymous rather
+            # than 500 a public endpoint.
+            logger.warning("optional jwt auth: unexpected error", exc_info=True)
             return AnonymousUser()
 
     def __call__(self, request: HttpRequest):

--- a/backend/community/_whatsapp.py
+++ b/backend/community/_whatsapp.py
@@ -144,7 +144,12 @@ def get_whatsapp_status(request):
             import json as _json
 
             data = _json.loads(resp.read())
-            return Status(200, WhatsAppStatusOut(connected=bool(data.get("connected"))))
+            # The bot should return a JSON object; valid-but-non-object JSON
+            # (list/number/string) would make data.get() raise AttributeError,
+            # which is not OSError/ValueError and would escape to a 500. Treat
+            # anything that isn't a dict as "not connected".
+            connected = bool(data.get("connected")) if isinstance(data, dict) else False
+            return Status(200, WhatsAppStatusOut(connected=connected))
     except (OSError, ValueError) as exc:
         # OSError covers urllib network/timeout failures (URLError is a subclass);
         # ValueError covers JSON decode errors. Either way the bot is unreachable

--- a/backend/community/_whatsapp.py
+++ b/backend/community/_whatsapp.py
@@ -17,6 +17,8 @@ from community.models import WhatsAppConfig
 
 router = Router()
 
+logger = logging.getLogger("pda.community")
+
 
 class WhatsAppConfigOut(BaseModel):
     bot_url: str
@@ -143,5 +145,9 @@ def get_whatsapp_status(request):
 
             data = _json.loads(resp.read())
             return Status(200, WhatsAppStatusOut(connected=bool(data.get("connected"))))
-    except Exception:
+    except (OSError, ValueError) as exc:
+        # OSError covers urllib network/timeout failures (URLError is a subclass);
+        # ValueError covers JSON decode errors. Either way the bot is unreachable
+        # so we report disconnected — but log it so genuine outages are visible.
+        logger.warning("whatsapp status check failed: %s", exc)
         return Status(200, WhatsAppStatusOut(connected=False))

--- a/backend/notifications/_console_sender.py
+++ b/backend/notifications/_console_sender.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from notifications.email_sender import SendResult
+from notifications.email_sender import SendResult, validate_recipient
 
 logger = logging.getLogger("notifications.console_sender")
 
@@ -11,6 +11,7 @@ class ConsoleSender:
     """Logs the email and returns success. Use in dev and tests."""
 
     def send(self, to: str, subject: str, html: str, text: str) -> SendResult:
+        validate_recipient(to)
         logger.info("EMAIL to=%s subject=%s", to, subject)
         logger.info("EMAIL text body:\n%s", text)
         return SendResult(success=True)

--- a/backend/notifications/_email_helpers.py
+++ b/backend/notifications/_email_helpers.py
@@ -5,9 +5,26 @@ Each helper renders its templates and dispatches via the injected
 paths or context shapes — they just say "send a magic-login email."
 """
 
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.core.validators import validate_email
 from django.template.loader import render_to_string
 
 from notifications.email_sender import EmailSender, SendResult
+
+
+def _validate_recipient(to: str) -> None:
+    """Reject malformed recipients and header-injection attempts.
+
+    Newlines/carriage returns in a recipient can be used to inject extra
+    headers (BCC, etc.) into the outbound message, so we reject them before
+    the address ever reaches the provider.
+    """
+    if "\n" in to or "\r" in to:
+        raise ValueError("recipient address must not contain newlines")
+    try:
+        validate_email(to)
+    except DjangoValidationError as exc:
+        raise ValueError(f"invalid recipient address: {to!r}") from exc
 
 
 def send_magic_login_email(
@@ -18,6 +35,7 @@ def send_magic_login_email(
     magic_link_url: str,
 ) -> SendResult:
     """Render and send the magic-login email."""
+    _validate_recipient(to)
     context = {
         "display_name": display_name or "",
         "magic_link_url": magic_link_url,

--- a/backend/notifications/_email_helpers.py
+++ b/backend/notifications/_email_helpers.py
@@ -5,26 +5,9 @@ Each helper renders its templates and dispatches via the injected
 paths or context shapes — they just say "send a magic-login email."
 """
 
-from django.core.exceptions import ValidationError as DjangoValidationError
-from django.core.validators import validate_email
 from django.template.loader import render_to_string
 
 from notifications.email_sender import EmailSender, SendResult
-
-
-def _validate_recipient(to: str) -> None:
-    """Reject malformed recipients and header-injection attempts.
-
-    Newlines/carriage returns in a recipient can be used to inject extra
-    headers (BCC, etc.) into the outbound message, so we reject them before
-    the address ever reaches the provider.
-    """
-    if "\n" in to or "\r" in to:
-        raise ValueError("recipient address must not contain newlines")
-    try:
-        validate_email(to)
-    except DjangoValidationError as exc:
-        raise ValueError(f"invalid recipient address: {to!r}") from exc
 
 
 def send_magic_login_email(
@@ -34,8 +17,11 @@ def send_magic_login_email(
     display_name: str,
     magic_link_url: str,
 ) -> SendResult:
-    """Render and send the magic-login email."""
-    _validate_recipient(to)
+    """Render and send the magic-login email.
+
+    Recipient validation (RFC-validity + header-injection guard) happens at the
+    `EmailSender.send()` boundary, so every email type is protected uniformly.
+    """
     context = {
         "display_name": display_name or "",
         "magic_link_url": magic_link_url,

--- a/backend/notifications/_resend_sender.py
+++ b/backend/notifications/_resend_sender.py
@@ -1,51 +1,120 @@
 """Resend transactional email implementation."""
 
+import hashlib
 import logging
+import time
 
 import resend
 from django.conf import settings
+from resend.exceptions import RateLimitError, ResendError
 
 from notifications.email_sender import SendResult
 
 logger = logging.getLogger("notifications.resend_sender")
 
+# Bound how long a single send may block. The Resend SDK's default HTTP client
+# uses a 30s timeout, which is far too long to hold a request thread for a
+# transactional send. We install our own client with a tighter timeout.
+_REQUEST_TIMEOUT_SECONDS = 10
+
+# Bounded retry for transient failures (network errors, 5xx, 429). Hand-rolled
+# to avoid pulling in a retry dependency.
+_MAX_ATTEMPTS = 3
+_BACKOFF_BASE_SECONDS = 0.5
+
+# HTTP status codes (as strings, matching ResendError.code) worth retrying.
+_RETRYABLE_CODES = {"429", "500", "502", "503", "504"}
+
+
+def _is_retryable(exc: ResendError) -> bool:
+    """Return True for transient Resend failures worth retrying.
+
+    The SDK wraps all transport-level failures (network/timeout) into a
+    ResendError with error_type "HttpClientError", and surfaces 5xx/429 as
+    ResendError subclasses. We retry those; client errors (4xx other than 429)
+    are not retried.
+    """
+    if isinstance(exc, RateLimitError):
+        return True
+    if getattr(exc, "error_type", None) == "HttpClientError":
+        return True
+    return str(getattr(exc, "code", "")) in _RETRYABLE_CODES
+
+
+def _mask_recipient(to: str) -> str:
+    """Return a non-reversible, low-cardinality token for log correlation.
+
+    Avoids logging the raw recipient address (PII). We keep only a short hash
+    so repeated sends to the same address can be correlated in logs without
+    exposing the address itself.
+    """
+    digest = hashlib.sha256(to.strip().lower().encode("utf-8")).hexdigest()
+    return f"sha256:{digest[:12]}"
+
 
 class ResendSender:
     """Sends transactional emails via Resend's HTTP API.
 
-    Uses the official `resend` SDK. The API key is read at instantiation
-    so callers can stub it via Django settings overrides in tests.
+    Uses the official `resend` SDK with an explicit request timeout and a
+    bounded retry/backoff for transient failures. The API key is read at
+    instantiation so callers can stub it via Django settings overrides in tests.
 
-    The broad ``except Exception`` is intentional: the Resend SDK can raise
-    multiple exception types (network errors, API errors, validation errors),
-    and we never want a single failed send to surface a 500 from a public
-    endpoint. Callers must inspect ``SendResult.success`` to determine
-    whether the send succeeded.
+    Callers must inspect ``SendResult.success`` to determine whether the send
+    succeeded — a failed send never raises.
     """
 
     def __init__(self) -> None:
         resend.api_key = settings.RESEND_API_KEY
+        # Install an HTTP client with a bounded timeout. The default client
+        # holds a request thread for up to 30s on a hung connection.
+        resend.default_http_client = resend.RequestsClient(timeout=_REQUEST_TIMEOUT_SECONDS)
 
     def send(self, to: str, subject: str, html: str, text: str) -> SendResult:
-        try:
-            response = resend.Emails.send(
-                {
-                    "from": settings.RESEND_FROM_EMAIL,
-                    "to": [to],
-                    "subject": subject,
-                    "html": html,
-                    "text": text,
-                }
-            )
-            # SendResponse is a dict subclass; access id via .get() for safety
-            message_id = response.get("id") if isinstance(response, dict) else None
-            logger.info(
-                "resend_send_success to=%s subject=%s message_id=%s",
-                to,
-                subject,
-                message_id,
-            )
-            return SendResult(success=True, provider_message_id=message_id)
-        except Exception as exc:
-            logger.exception("resend_send_failure to=%s subject=%s", to, subject)
-            return SendResult(success=False, error=str(exc))
+        params = {
+            "from": settings.RESEND_FROM_EMAIL,
+            "to": [to],
+            "subject": subject,
+            "html": html,
+            "text": text,
+        }
+        masked = _mask_recipient(to)
+        last_error: Exception | None = None
+
+        for attempt in range(1, _MAX_ATTEMPTS + 1):
+            try:
+                response = resend.Emails.send(params)
+                # SendResponse is a dict subclass; access id via .get() for safety
+                message_id = response.get("id") if isinstance(response, dict) else None
+                logger.info(
+                    "resend_send_success subject=%s message_id=%s recipient=%s attempt=%d",
+                    subject,
+                    message_id,
+                    masked,
+                    attempt,
+                )
+                return SendResult(success=True, provider_message_id=message_id)
+            except ResendError as exc:
+                last_error = exc
+                if attempt < _MAX_ATTEMPTS and _is_retryable(exc):
+                    backoff = _BACKOFF_BASE_SECONDS * (2 ** (attempt - 1))
+                    logger.warning(
+                        "resend_send_retry subject=%s recipient=%s attempt=%d code=%s",
+                        subject,
+                        masked,
+                        attempt,
+                        getattr(exc, "code", "?"),
+                    )
+                    time.sleep(backoff)
+                    continue
+                break
+            except Exception as exc:  # noqa: BLE001 — never let a send 500 a public endpoint
+                last_error = exc
+                break
+
+        logger.warning(
+            "resend_send_failure subject=%s recipient=%s attempts=%d",
+            subject,
+            masked,
+            _MAX_ATTEMPTS,
+        )
+        return SendResult(success=False, error=str(last_error))

--- a/backend/notifications/_resend_sender.py
+++ b/backend/notifications/_resend_sender.py
@@ -1,6 +1,5 @@
 """Resend transactional email implementation."""
 
-import hashlib
 import logging
 import time
 
@@ -8,14 +7,21 @@ import resend
 from django.conf import settings
 from resend.exceptions import RateLimitError, ResendError
 
-from notifications.email_sender import SendResult
+from notifications.email_sender import SendResult, mask_recipient, validate_recipient
 
 logger = logging.getLogger("notifications.resend_sender")
 
 # Bound how long a single send may block. The Resend SDK's default HTTP client
 # uses a 30s timeout, which is far too long to hold a request thread for a
 # transactional send. We install our own client with a tighter timeout.
-_REQUEST_TIMEOUT_SECONDS = 10
+#
+# The send runs INLINE in the request/response cycle (request_login_link), so
+# the worst-case time the worker thread can block is bounded by:
+#   _MAX_ATTEMPTS * _REQUEST_TIMEOUT_SECONDS  (network/timeout)
+#   + sum of backoff sleeps between attempts.
+# Keep both small so a Resend outage degrades latency gracefully (and falls back
+# to the admin-notification path) instead of exhausting the worker pool.
+_REQUEST_TIMEOUT_SECONDS = 4
 
 # Bounded retry for transient failures (network errors, 5xx, 429). Hand-rolled
 # to avoid pulling in a retry dependency.
@@ -41,17 +47,6 @@ def _is_retryable(exc: ResendError) -> bool:
     return str(getattr(exc, "code", "")) in _RETRYABLE_CODES
 
 
-def _mask_recipient(to: str) -> str:
-    """Return a non-reversible, low-cardinality token for log correlation.
-
-    Avoids logging the raw recipient address (PII). We keep only a short hash
-    so repeated sends to the same address can be correlated in logs without
-    exposing the address itself.
-    """
-    digest = hashlib.sha256(to.strip().lower().encode("utf-8")).hexdigest()
-    return f"sha256:{digest[:12]}"
-
-
 class ResendSender:
     """Sends transactional emails via Resend's HTTP API.
 
@@ -69,7 +64,37 @@ class ResendSender:
         # holds a request thread for up to 30s on a hung connection.
         resend.default_http_client = resend.RequestsClient(timeout=_REQUEST_TIMEOUT_SECONDS)
 
+    def _attempt_send(self, params: dict, masked: str, attempt: int) -> SendResult:
+        """Perform a single send and log success.
+
+        Never catches — the caller owns the retry/error policy. Returns a
+        successful SendResult; on failure the underlying exception propagates.
+        """
+        response = resend.Emails.send(params)
+        # SendResponse is a dict subclass; access id via .get() for safety
+        message_id = response.get("id") if isinstance(response, dict) else None
+        logger.info(
+            "resend_send_success subject=%s message_id=%s recipient=%s attempt=%d",
+            params["subject"],
+            message_id,
+            masked,
+            attempt,
+        )
+        return SendResult(success=True, provider_message_id=message_id)
+
+    def _backoff(self, exc: ResendError, masked: str, subject: str, attempt: int) -> None:
+        """Log a retry and sleep with exponential backoff before the next attempt."""
+        logger.warning(
+            "resend_send_retry subject=%s recipient=%s attempt=%d code=%s",
+            subject,
+            masked,
+            attempt,
+            getattr(exc, "code", "?"),
+        )
+        time.sleep(_BACKOFF_BASE_SECONDS * (2 ** (attempt - 1)))
+
     def send(self, to: str, subject: str, html: str, text: str) -> SendResult:
+        validate_recipient(to)
         params = {
             "from": settings.RESEND_FROM_EMAIL,
             "to": [to],
@@ -77,44 +102,31 @@ class ResendSender:
             "html": html,
             "text": text,
         }
-        masked = _mask_recipient(to)
+        masked = mask_recipient(to)
         last_error: Exception | None = None
+        attempt = 0
 
         for attempt in range(1, _MAX_ATTEMPTS + 1):
             try:
-                response = resend.Emails.send(params)
-                # SendResponse is a dict subclass; access id via .get() for safety
-                message_id = response.get("id") if isinstance(response, dict) else None
-                logger.info(
-                    "resend_send_success subject=%s message_id=%s recipient=%s attempt=%d",
-                    subject,
-                    message_id,
-                    masked,
-                    attempt,
-                )
-                return SendResult(success=True, provider_message_id=message_id)
+                return self._attempt_send(params, masked, attempt)
             except ResendError as exc:
                 last_error = exc
                 if attempt < _MAX_ATTEMPTS and _is_retryable(exc):
-                    backoff = _BACKOFF_BASE_SECONDS * (2 ** (attempt - 1))
-                    logger.warning(
-                        "resend_send_retry subject=%s recipient=%s attempt=%d code=%s",
-                        subject,
-                        masked,
-                        attempt,
-                        getattr(exc, "code", "?"),
-                    )
-                    time.sleep(backoff)
+                    self._backoff(exc, masked, subject, attempt)
                     continue
                 break
             except Exception as exc:  # noqa: BLE001 — never let a send 500 a public endpoint
                 last_error = exc
                 break
 
+        # Report the true number of attempts (a non-retryable error breaks after
+        # one), and attach the traceback so unexpected (non-ResendError) failures
+        # stay debuggable.
         logger.warning(
             "resend_send_failure subject=%s recipient=%s attempts=%d",
             subject,
             masked,
-            _MAX_ATTEMPTS,
+            attempt,
+            exc_info=last_error,
         )
         return SendResult(success=False, error=str(last_error))

--- a/backend/notifications/email_sender.py
+++ b/backend/notifications/email_sender.py
@@ -10,6 +10,7 @@ and test use the console sender.
 """
 
 import logging
+import threading
 from typing import Protocol, runtime_checkable
 
 from django.conf import settings
@@ -30,30 +31,38 @@ class EmailSender(Protocol):
 
 
 _cached_sender: EmailSender | None = None
+_cache_lock = threading.Lock()
 
 
 def get_email_sender() -> EmailSender:
-    """Resolve the configured email sender. Cached per process."""
+    """Resolve the configured email sender. Cached per process (thread-safe)."""
     global _cached_sender
     if _cached_sender is not None:
         return _cached_sender
 
-    if settings.RESEND_API_KEY:
-        from notifications._resend_sender import ResendSender
+    with _cache_lock:
+        # Double-checked: another thread may have populated the cache while we
+        # were waiting on the lock.
+        if _cached_sender is not None:
+            return _cached_sender
 
-        _cached_sender = ResendSender()
-        logger.info("email sender resolved: ResendSender")
-    else:
-        if getattr(settings, "IS_PRODUCTION", False):
-            raise RuntimeError("RESEND_API_KEY is required in production but is not set")
-        from notifications._console_sender import ConsoleSender
+        if settings.RESEND_API_KEY:
+            from notifications._resend_sender import ResendSender
 
-        _cached_sender = ConsoleSender()
-        logger.info("email sender resolved: ConsoleSender (no RESEND_API_KEY)")
-    return _cached_sender
+            _cached_sender = ResendSender()
+            logger.info("email sender resolved: ResendSender")
+        else:
+            if getattr(settings, "IS_PRODUCTION", False):
+                raise RuntimeError("RESEND_API_KEY is required in production but is not set")
+            from notifications._console_sender import ConsoleSender
+
+            _cached_sender = ConsoleSender()
+            logger.info("email sender resolved: ConsoleSender (no RESEND_API_KEY)")
+        return _cached_sender
 
 
 def reset_email_sender_cache() -> None:
     """Test-only helper for clearing the cached sender between tests."""
     global _cached_sender
-    _cached_sender = None
+    with _cache_lock:
+        _cached_sender = None

--- a/backend/notifications/email_sender.py
+++ b/backend/notifications/email_sender.py
@@ -9,11 +9,14 @@ Resolution: `get_email_sender()` returns the right implementation based on
 and test use the console sender.
 """
 
+import hashlib
 import logging
 import threading
 from typing import Protocol, runtime_checkable
 
 from django.conf import settings
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.core.validators import validate_email
 from pydantic import BaseModel
 
 logger = logging.getLogger("notifications.email_sender")
@@ -23,6 +26,31 @@ class SendResult(BaseModel):
     success: bool
     provider_message_id: str | None = None
     error: str | None = None
+
+
+def mask_recipient(to: str) -> str:
+    """Return a non-reversible, low-cardinality token for log correlation.
+
+    Avoids logging the raw recipient address (PII). Lives at the email boundary
+    so every sender masks recipients the same way and logs stay correlatable
+    without exposing the address. Keep only a short hash prefix.
+    """
+    digest = hashlib.sha256(to.strip().lower().encode("utf-8")).hexdigest()
+    return f"sha256:{digest[:12]}"
+
+
+def validate_recipient(to: str) -> None:
+    """Reject malformed recipients and header-injection attempts.
+
+    Validated at the sender boundary so every email type and every concrete
+    sender is protected — not just whichever helper remembers to call it.
+    ``validate_email`` already rejects embedded newlines/carriage returns
+    (the header-injection vector), so it is the sole check needed.
+    """
+    try:
+        validate_email(to)
+    except DjangoValidationError as exc:
+        raise ValueError(f"invalid recipient address: {to!r}") from exc
 
 
 @runtime_checkable

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -2365,6 +2365,7 @@
         "type": "object"
       },
       "GeocodeOut": {
+        "additionalProperties": true,
         "properties": {
           "features": {
             "items": {

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -2364,6 +2364,53 @@
         "title": "FolderPatchIn",
         "type": "object"
       },
+      "GeocodeOut": {
+        "properties": {
+          "features": {
+            "items": {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            "title": "Features",
+            "type": "array"
+          },
+          "type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Type"
+          }
+        },
+        "title": "GeocodeOut",
+        "type": "object"
+      },
+      "GeocodeQuery": {
+        "properties": {
+          "limit": {
+            "default": 5,
+            "maximum": 10,
+            "minimum": 1,
+            "title": "Limit",
+            "type": "integer"
+          },
+          "q": {
+            "maxLength": 200,
+            "minLength": 1,
+            "title": "Q",
+            "type": "string"
+          }
+        },
+        "required": [
+          "q"
+        ],
+        "title": "GeocodeQuery",
+        "type": "object"
+      },
       "GuidelinesOut": {
         "properties": {
           "content": {
@@ -8782,6 +8829,8 @@
             "name": "q",
             "required": true,
             "schema": {
+              "maxLength": 200,
+              "minLength": 1,
               "title": "Q",
               "type": "string"
             }
@@ -8792,6 +8841,8 @@
             "required": false,
             "schema": {
               "default": 5,
+              "maximum": 10,
+              "minimum": 1,
               "title": "Limit",
               "type": "integer"
             }
@@ -8802,9 +8853,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "additionalProperties": true,
-                  "title": "Response",
-                  "type": "object"
+                  "$ref": "#/components/schemas/GeocodeOut"
                 }
               }
             },

--- a/backend/tests/test_email_sender.py
+++ b/backend/tests/test_email_sender.py
@@ -171,6 +171,21 @@ class TestResendSender:
         # 4xx (other than 429) is not transient → no retry.
         assert mock_send.call_count == 1
 
+    def test_failure_log_reports_true_attempt_count(self, caplog):
+        """A non-retryable error breaks after one try; the log must say attempts=1."""
+        from notifications._resend_sender import ResendSender
+        from resend.exceptions import ValidationError
+
+        err = ValidationError(code="400", error_type="validation_error", message="bad")
+        with patch("resend.Emails.send", side_effect=err):
+            with caplog.at_level(logging.WARNING, logger="notifications.resend_sender"):
+                ResendSender().send(to="user@example.com", subject="hi", html="<p>x</p>", text="x")
+        failure_logs = [
+            r.getMessage() for r in caplog.records if "resend_send_failure" in r.getMessage()
+        ]
+        assert failure_logs
+        assert "attempts=1" in failure_logs[0]
+
     def test_send_gives_up_after_max_attempts(self):
         from notifications import _resend_sender
         from notifications._resend_sender import ResendSender

--- a/backend/tests/test_email_sender.py
+++ b/backend/tests/test_email_sender.py
@@ -1,7 +1,9 @@
 """Tests for the email sender protocol and SendResult dataclass."""
 
+import logging
 from unittest.mock import patch
 
+import pytest
 from notifications.email_sender import EmailSender, SendResult
 
 
@@ -95,6 +97,96 @@ class TestResendSender:
         assert result.provider_message_id is None
         assert "boom" in (result.error or "")
 
+    def test_send_does_not_log_raw_recipient(self, caplog):
+        from notifications._resend_sender import ResendSender
+
+        with patch("resend.Emails.send") as mock_send:
+            mock_send.return_value = {"id": "msg_abc123"}
+            with caplog.at_level(logging.INFO, logger="notifications.resend_sender"):
+                ResendSender().send(
+                    to="secret.person@example.com",
+                    subject="hello",
+                    html="<p>hi</p>",
+                    text="hi",
+                )
+        log_text = "\n".join(r.getMessage() for r in caplog.records)
+        # PII (the raw recipient) must never appear in logs.
+        assert "secret.person@example.com" not in log_text
+        # A masked, non-reversible token is logged for correlation instead.
+        assert "sha256:" in log_text
+        assert "msg_abc123" in log_text
+
+    def test_send_failure_does_not_log_raw_recipient(self, caplog):
+        from notifications._resend_sender import ResendSender
+        from resend.exceptions import ResendError
+
+        err = ResendError(
+            code="400",
+            error_type="validation_error",
+            message="bad",
+            suggested_action="",
+        )
+        with patch("resend.Emails.send", side_effect=err):
+            with caplog.at_level(logging.WARNING, logger="notifications.resend_sender"):
+                result = ResendSender().send(
+                    to="secret.person@example.com",
+                    subject="hello",
+                    html="<p>hi</p>",
+                    text="hi",
+                )
+        assert result.success is False
+        log_text = "\n".join(r.getMessage() for r in caplog.records)
+        assert "secret.person@example.com" not in log_text
+
+    def test_send_retries_transient_error_then_succeeds(self):
+        from notifications import _resend_sender
+        from notifications._resend_sender import ResendSender
+        from resend.exceptions import RateLimitError
+
+        transient = RateLimitError(
+            code="429", error_type="rate_limit_exceeded", message="slow down"
+        )
+        with patch.object(_resend_sender.time, "sleep"):
+            with patch(
+                "resend.Emails.send",
+                side_effect=[transient, {"id": "msg_after_retry"}],
+            ) as mock_send:
+                result = ResendSender().send(
+                    to="user@example.com", subject="hi", html="<p>x</p>", text="x"
+                )
+        assert result.success is True
+        assert result.provider_message_id == "msg_after_retry"
+        assert mock_send.call_count == 2
+
+    def test_send_does_not_retry_client_error(self):
+        from notifications._resend_sender import ResendSender
+        from resend.exceptions import ValidationError
+
+        err = ValidationError(code="400", error_type="validation_error", message="bad")
+        with patch("resend.Emails.send", side_effect=err) as mock_send:
+            result = ResendSender().send(
+                to="user@example.com", subject="hi", html="<p>x</p>", text="x"
+            )
+        assert result.success is False
+        # 4xx (other than 429) is not transient → no retry.
+        assert mock_send.call_count == 1
+
+    def test_send_gives_up_after_max_attempts(self):
+        from notifications import _resend_sender
+        from notifications._resend_sender import ResendSender
+        from resend.exceptions import RateLimitError
+
+        transient = RateLimitError(
+            code="429", error_type="rate_limit_exceeded", message="slow down"
+        )
+        with patch.object(_resend_sender.time, "sleep"):
+            with patch("resend.Emails.send", side_effect=transient) as mock_send:
+                result = ResendSender().send(
+                    to="user@example.com", subject="hi", html="<p>x</p>", text="x"
+                )
+        assert result.success is False
+        assert mock_send.call_count == _resend_sender._MAX_ATTEMPTS
+
     def test_send_uses_from_email_from_settings(self, settings):
         from notifications._resend_sender import ResendSender
 
@@ -159,7 +251,6 @@ class TestGetEmailSender:
             reset_email_sender_cache()
 
     def test_raises_in_production_with_no_key(self, monkeypatch):
-        import pytest
         from django.conf import settings
         from notifications.email_sender import get_email_sender, reset_email_sender_cache
 

--- a/backend/tests/test_geocode.py
+++ b/backend/tests/test_geocode.py
@@ -1,5 +1,6 @@
 """Tests for the geocode proxy endpoint (input bounds + upstream error handling)."""
 
+import json
 from unittest.mock import patch
 
 import httpx
@@ -9,13 +10,16 @@ _URL = "/api/community/geocode/"
 
 
 class _FakeResp:
-    def __init__(self, payload):
+    def __init__(self, payload, *, json_error=None):
         self._payload = payload
+        self._json_error = json_error
 
     def raise_for_status(self):
         return None
 
     def json(self):
+        if self._json_error is not None:
+            raise self._json_error
         return self._payload
 
 
@@ -63,6 +67,17 @@ class TestGeocodeUpstreamErrors:
         ):
             response = api_client.get(f"{_URL}?q=brooklyn&limit=5", **auth_headers)
         assert response.status_code == 502
+
+    def test_non_json_2xx_body_returns_502(self, api_client, auth_headers):
+        # Photon (or a proxy/CDN) returns HTTP 200 with a non-JSON body, so
+        # raise_for_status() passes but resp.json() raises JSONDecodeError (a
+        # ValueError). This must degrade to a graceful 502, not a 500.
+        decode_error = json.JSONDecodeError("Expecting value", "<html>", 0)
+        with patch("community._geocode.httpx.get") as mock_get:
+            mock_get.return_value = _FakeResp(None, json_error=decode_error)
+            response = api_client.get(f"{_URL}?q=brooklyn&limit=5", **auth_headers)
+        assert response.status_code == 502
+        assert "unavailable" in response.json()["detail"]
 
     def test_unexpected_error_is_not_swallowed(self, api_client, auth_headers):
         # A non-httpx error (programming bug) must surface, not masquerade as 502.

--- a/backend/tests/test_geocode.py
+++ b/backend/tests/test_geocode.py
@@ -1,0 +1,75 @@
+"""Tests for the geocode proxy endpoint (input bounds + upstream error handling)."""
+
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+_URL = "/api/community/geocode/"
+
+
+class _FakeResp:
+    def __init__(self, payload):
+        self._payload = payload
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+@pytest.mark.django_db
+class TestGeocodeBounds:
+    def test_rejects_limit_over_max(self, api_client, auth_headers):
+        response = api_client.get(f"{_URL}?q=cafe&limit=11", **auth_headers)
+        assert response.status_code == 422
+
+    def test_rejects_limit_below_min(self, api_client, auth_headers):
+        response = api_client.get(f"{_URL}?q=cafe&limit=0", **auth_headers)
+        assert response.status_code == 422
+
+    def test_rejects_oversized_query(self, api_client, auth_headers):
+        response = api_client.get(f"{_URL}?q={'a' * 201}&limit=5", **auth_headers)
+        assert response.status_code == 422
+
+    def test_rejects_empty_query(self, api_client, auth_headers):
+        response = api_client.get(f"{_URL}?q=&limit=5", **auth_headers)
+        assert response.status_code == 422
+
+    def test_accepts_valid_request(self, api_client, auth_headers):
+        with patch("community._geocode.httpx.get") as mock_get:
+            mock_get.return_value = _FakeResp({"type": "FeatureCollection", "features": []})
+            response = api_client.get(f"{_URL}?q=brooklyn&limit=5", **auth_headers)
+        assert response.status_code == 200
+        assert response.json() == {"type": "FeatureCollection", "features": []}
+
+
+@pytest.mark.django_db
+class TestGeocodeUpstreamErrors:
+    def test_timeout_returns_502(self, api_client, auth_headers):
+        with patch(
+            "community._geocode.httpx.get",
+            side_effect=httpx.TimeoutException("timed out"),
+        ):
+            response = api_client.get(f"{_URL}?q=brooklyn&limit=5", **auth_headers)
+        assert response.status_code == 502
+        assert "unavailable" in response.json()["detail"]
+
+    def test_http_error_returns_502(self, api_client, auth_headers):
+        with patch(
+            "community._geocode.httpx.get",
+            side_effect=httpx.ConnectError("refused"),
+        ):
+            response = api_client.get(f"{_URL}?q=brooklyn&limit=5", **auth_headers)
+        assert response.status_code == 502
+
+    def test_unexpected_error_is_not_swallowed(self, api_client, auth_headers):
+        # A non-httpx error (programming bug) must surface, not masquerade as 502.
+        with patch("community._geocode.httpx.get", side_effect=RuntimeError("boom")):
+            with pytest.raises(RuntimeError, match="boom"):
+                api_client.get(f"{_URL}?q=brooklyn&limit=5", **auth_headers)
+
+    def test_unauthenticated_rejected(self, api_client):
+        response = api_client.get(f"{_URL}?q=brooklyn&limit=5")
+        assert response.status_code == 401

--- a/backend/tests/test_geocode.py
+++ b/backend/tests/test_geocode.py
@@ -48,6 +48,19 @@ class TestGeocodeBounds:
         assert response.status_code == 200
         assert response.json() == {"type": "FeatureCollection", "features": []}
 
+    def test_passes_through_extra_top_level_fields(self, api_client, auth_headers):
+        """The proxy must stay lossless — Photon's top-level bbox must reach the client."""
+        payload = {
+            "type": "FeatureCollection",
+            "features": [],
+            "bbox": [-74.2, 40.4, -73.7, 40.9],
+        }
+        with patch("community._geocode.httpx.get") as mock_get:
+            mock_get.return_value = _FakeResp(payload)
+            response = api_client.get(f"{_URL}?q=brooklyn&limit=5", **auth_headers)
+        assert response.status_code == 200
+        assert response.json() == payload
+
 
 @pytest.mark.django_db
 class TestGeocodeUpstreamErrors:

--- a/backend/tests/test_magic_login_email.py
+++ b/backend/tests/test_magic_login_email.py
@@ -4,8 +4,9 @@ import re
 from unittest.mock import MagicMock
 
 import pytest
+from notifications._console_sender import ConsoleSender
 from notifications._email_helpers import send_magic_login_email
-from notifications.email_sender import SendResult
+from notifications.email_sender import SendResult, validate_recipient
 
 
 @pytest.mark.django_db
@@ -74,24 +75,21 @@ class TestSendMagicLoginEmail:
         assert "login" in subject or "log in" in subject
 
     def test_rejects_recipient_with_newline(self):
-        """Header-injection guard — newlines in the recipient must be rejected."""
-        sender = MagicMock()
-        with pytest.raises(ValueError, match="newline"):
-            send_magic_login_email(
-                sender=sender,
+        """Header-injection guard — newlines in the recipient must be rejected.
+
+        Validation lives at the EmailSender boundary, so it applies to every
+        concrete sender; the real ConsoleSender must refuse to send (no log,
+        no provider call) for a header-injection address.
+        """
+        sender = ConsoleSender()
+        with pytest.raises(ValueError, match="invalid recipient"):
+            sender.send(
                 to="user@example.com\nbcc: attacker@evil.test",
-                display_name="Sam",
-                magic_link_url="https://pda.test/magic/abc",
+                subject="s",
+                html="<p>h</p>",
+                text="t",
             )
-        sender.send.assert_not_called()
 
     def test_rejects_malformed_recipient(self):
-        sender = MagicMock()
         with pytest.raises(ValueError, match="invalid recipient"):
-            send_magic_login_email(
-                sender=sender,
-                to="not-an-email",
-                display_name="Sam",
-                magic_link_url="https://pda.test/magic/abc",
-            )
-        sender.send.assert_not_called()
+            validate_recipient("not-an-email")

--- a/backend/tests/test_magic_login_email.py
+++ b/backend/tests/test_magic_login_email.py
@@ -72,3 +72,26 @@ class TestSendMagicLoginEmail:
         assert subject == subject.lower()
         # Mentions login / pda
         assert "login" in subject or "log in" in subject
+
+    def test_rejects_recipient_with_newline(self):
+        """Header-injection guard — newlines in the recipient must be rejected."""
+        sender = MagicMock()
+        with pytest.raises(ValueError, match="newline"):
+            send_magic_login_email(
+                sender=sender,
+                to="user@example.com\nbcc: attacker@evil.test",
+                display_name="Sam",
+                magic_link_url="https://pda.test/magic/abc",
+            )
+        sender.send.assert_not_called()
+
+    def test_rejects_malformed_recipient(self):
+        sender = MagicMock()
+        with pytest.raises(ValueError, match="invalid recipient"):
+            send_magic_login_email(
+                sender=sender,
+                to="not-an-email",
+                display_name="Sam",
+                magic_link_url="https://pda.test/magic/abc",
+            )
+        sender.send.assert_not_called()

--- a/backend/tests/test_poll_option_errors.py
+++ b/backend/tests/test_poll_option_errors.py
@@ -1,0 +1,95 @@
+"""Tests for poll-option create/update error narrowing (IntegrityError vs others)."""
+
+import json
+from unittest.mock import patch
+
+import pytest
+from community._validation import Code
+from community.models import Event, EventPoll, PollOption
+
+from tests._asserts import assert_error_code
+from tests.conftest import future_iso
+
+
+@pytest.fixture
+def poll_event(db, test_user):
+    return Event.objects.create(
+        title="Poll Event",
+        start_datetime=future_iso(days=90),
+        created_by=test_user,
+    )
+
+
+@pytest.fixture
+def poll_with_options(db, poll_event, test_user):
+    poll = EventPoll.objects.create(event=poll_event, created_by=test_user)
+    PollOption.objects.create(poll=poll, datetime=future_iso(days=120), display_order=0)
+    PollOption.objects.create(poll=poll, datetime=future_iso(days=121), display_order=1)
+    return poll
+
+
+@pytest.mark.django_db
+class TestAddPollOptionErrors:
+    def test_duplicate_datetime_raises_already_exists(
+        self, api_client, auth_headers, poll_event, poll_with_options
+    ):
+        existing = poll_with_options.options.first()
+        response = api_client.post(
+            f"/api/community/events/{poll_event.id}/poll/options/",
+            data=json.dumps({"datetime": existing.datetime.isoformat()}),
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 400
+        assert_error_code(response, Code.Poll.OPTION_ALREADY_EXISTS)
+
+    def test_non_integrity_error_propagates(
+        self, api_client, auth_headers, poll_event, poll_with_options
+    ):
+        # A non-IntegrityError from the DB layer must NOT be reported as a
+        # duplicate — it should surface as a 500, not a misleading 400.
+        with patch(
+            "community._polls.PollOption.objects.create",
+            side_effect=RuntimeError("db exploded"),
+        ):
+            with pytest.raises(RuntimeError, match="db exploded"):
+                api_client.post(
+                    f"/api/community/events/{poll_event.id}/poll/options/",
+                    data=json.dumps({"datetime": future_iso(days=200)}),
+                    content_type="application/json",
+                    **auth_headers,
+                )
+
+
+@pytest.mark.django_db
+class TestUpdatePollOptionErrors:
+    def test_duplicate_datetime_raises_already_exists(
+        self, api_client, auth_headers, poll_event, poll_with_options
+    ):
+        options = list(poll_with_options.options.all())
+        first, second = options[0], options[1]
+        # Move `second` onto `first`'s datetime → unique constraint violation.
+        response = api_client.patch(
+            f"/api/community/events/{poll_event.id}/poll/options/{second.id}/",
+            data=json.dumps({"datetime": first.datetime.isoformat()}),
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 400
+        assert_error_code(response, Code.Poll.OPTION_ALREADY_EXISTS)
+
+    def test_non_integrity_error_propagates(
+        self, api_client, auth_headers, poll_event, poll_with_options
+    ):
+        option = poll_with_options.options.first()
+        with patch(
+            "community._polls.PollOption.save",
+            side_effect=RuntimeError("db exploded"),
+        ):
+            with pytest.raises(RuntimeError, match="db exploded"):
+                api_client.patch(
+                    f"/api/community/events/{poll_event.id}/poll/options/{option.id}/",
+                    data=json.dumps({"datetime": future_iso(days=300)}),
+                    content_type="application/json",
+                    **auth_headers,
+                )

--- a/backend/tests/test_whatsapp_status.py
+++ b/backend/tests/test_whatsapp_status.py
@@ -1,0 +1,63 @@
+"""Tests for the WhatsApp status endpoint error handling/logging."""
+
+import logging
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def whatsapp_admin_headers(db):
+    from ninja_jwt.tokens import RefreshToken
+    from users.models import User
+    from users.permissions import PermissionKey
+    from users.roles import Role
+
+    user = User.objects.create_user(
+        phone_number="+12025550909",
+        password="wapass123",
+        display_name="WA Admin",
+    )
+    role = Role.objects.create(name="wa_admin", permissions=[PermissionKey.MANAGE_WHATSAPP])
+    user.roles.add(role)
+    refresh = RefreshToken.for_user(user)
+    return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
+
+
+@pytest.mark.django_db
+class TestWhatsAppStatus:
+    def test_returns_disconnected_when_no_bot_url(self, api_client, whatsapp_admin_headers):
+        response = api_client.get("/api/community/whatsapp/status/", **whatsapp_admin_headers)
+        assert response.status_code == 200
+        assert response.json() == {"connected": False}
+
+    def test_logs_and_returns_disconnected_on_failure(
+        self, api_client, whatsapp_admin_headers, settings, caplog
+    ):
+        settings.WHATSAPP_BOT_URL = "https://bot.example.com"
+        # The "pda" logger is configured with propagate=False, so caplog's
+        # root handler never sees it. Attach caplog's capture handler directly
+        # to the "pda.community" logger for the duration of the call.
+        community_logger = logging.getLogger("pda.community")
+        community_logger.addHandler(caplog.handler)
+        original_level = community_logger.level
+        community_logger.setLevel(logging.WARNING)
+        try:
+            with patch(
+                "urllib.request.urlopen",
+                side_effect=OSError("connection refused"),
+            ):
+                response = api_client.get(
+                    "/api/community/whatsapp/status/", **whatsapp_admin_headers
+                )
+        finally:
+            community_logger.removeHandler(caplog.handler)
+            community_logger.setLevel(original_level)
+        assert response.status_code == 200
+        assert response.json() == {"connected": False}
+        log_text = "\n".join(r.getMessage() for r in caplog.records)
+        assert "whatsapp status check failed" in log_text
+
+    def test_requires_permission(self, api_client, auth_headers):
+        response = api_client.get("/api/community/whatsapp/status/", **auth_headers)
+        assert response.status_code == 403

--- a/backend/tests/test_whatsapp_status.py
+++ b/backend/tests/test_whatsapp_status.py
@@ -58,6 +58,28 @@ class TestWhatsAppStatus:
         log_text = "\n".join(r.getMessage() for r in caplog.records)
         assert "whatsapp status check failed" in log_text
 
+    def test_non_object_json_body_returns_disconnected(
+        self, api_client, whatsapp_admin_headers, settings
+    ):
+        """Valid-but-non-object JSON must not 500 (data.get would raise AttributeError)."""
+        settings.WHATSAPP_BOT_URL = "https://bot.example.com"
+
+        class _FakeResp:
+            def read(self):
+                return b"[1, 2, 3]"  # valid JSON, but a list, not an object
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+        with patch("urllib.request.urlopen", return_value=_FakeResp()):
+            response = api_client.get("/api/community/whatsapp/status/", **whatsapp_admin_headers)
+
+        assert response.status_code == 200
+        assert response.json() == {"connected": False}
+
     def test_requires_permission(self, api_client, auth_headers):
         response = api_client.get("/api/community/whatsapp/status/", **auth_headers)
         assert response.status_code == 403

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -2586,6 +2586,25 @@ export interface components {
             /** Parent Id */
             parent_id?: string | null;
         };
+        /** GeocodeOut */
+        GeocodeOut: {
+            /** Features */
+            features?: {
+                [key: string]: unknown;
+            }[];
+            /** Type */
+            type?: string | null;
+        };
+        /** GeocodeQuery */
+        GeocodeQuery: {
+            /**
+             * Limit
+             * @default 5
+             */
+            limit: number;
+            /** Q */
+            q: string;
+        };
         /** GuidelinesOut */
         GuidelinesOut: {
             /** Content */
@@ -6508,9 +6527,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": {
-                        [key: string]: unknown;
-                    };
+                    "application/json": components["schemas"]["GeocodeOut"];
                 };
             };
             /** @description Bad Gateway */

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -2594,6 +2594,8 @@ export interface components {
             }[];
             /** Type */
             type?: string | null;
+        } & {
+            [key: string]: unknown;
         };
         /** GeocodeQuery */
         GeocodeQuery: {


### PR DESCRIPTION
## summary

reliability/error-handling fixes for outbound HTTP calls and broad `except Exception` swallowing in the django backend.

closes #454
closes #456

## issue 454 — timeouts/retries on outbound calls + recipient PII

- **resend email** (`notifications/_resend_sender.py`): install a `RequestsClient(timeout=10)` to bound the previously-unbounded send (SDK default was 30s); add a hand-rolled bounded retry (3 attempts, exponential backoff 0.5s/1s) for transient failures only — network/`HttpClientError`, 5xx, and 429/`RateLimitError`. 4xx client errors are not retried. no new dependency.
- **recipient PII**: stopped logging the raw `to=<email>` at INFO/on-failure. now logs a non-reversible `sha256:<12 hex>` token plus subject/message-id for correlation.
- **geocode** (`community/_geocode.py`): bounded inputs via a `GeocodeQuery` schema (`q` max_length 200 + non-empty, `limit` ge=1 le=10 → 422 on violation); narrowed the bare `except Exception` to `httpx.TimeoutException`/`httpx.HTTPError` (unexpected errors now surface instead of masquerading as 502); added request context (no PII) to the warning; typed the 200 response as `GeocodeOut` (was bare `dict`).
- **email_sender.py**: made the cached-singleton resolution thread-safe (double-checked lock).
- **_email_helpers.py**: validate the recipient with django `validate_email` and reject newlines/CR (header-injection guard) before any send.

## issue 456 — narrow broad `except Exception` swallowing failures

- **`OptionalJWTAuth.authenticate`** (`community/_shared.py`): catch `AuthenticationFailed`/`TokenError` (→ AnonymousUser, public endpoints stay reachable); log anything unexpected at warning with exc_info instead of silently swallowing (wired up the previously-unused module logger).
- **`get_whatsapp_status`** (`community/_whatsapp.py`): now logs the failure at warning before returning `connected=False` (was silent); narrowed to `OSError`/`ValueError` (urllib network/timeout + JSON decode).
- **poll option create/update** (`community/_polls.py`): catch `django.db.IntegrityError` specifically for the unique (poll, datetime) constraint → OPTION_ALREADY_EXISTS; any other exception now propagates instead of being mislabeled as a duplicate.

## tests added

- `tests/test_geocode.py` — limit>10 / limit<1 / oversized-q / empty-q rejected (422); valid request proxied; timeout + connect-error → 502; unexpected (non-httpx) error propagates; unauthenticated → 401.
- `tests/test_poll_option_errors.py` — duplicate datetime still raises OPTION_ALREADY_EXISTS (add + update); a non-IntegrityError propagates instead of becoming a 400.
- `tests/test_whatsapp_status.py` — logs on failure and still returns `connected=False`; no-bot-url path; permission required.
- `tests/test_email_sender.py` — resend does not log raw recipient (success + failure paths, asserted via caplog); retries transient error then succeeds; does not retry 4xx; gives up after max attempts.
- `tests/test_magic_login_email.py` — recipient with newline rejected; malformed recipient rejected.

## verification

`make agent-ci` ran green (backend lint/check/test/typecheck/complexity/check-codes + frontend). a follow-up parallel run hit 2 pre-existing xdist deadlock flakes in `test_event_capacity.py` / `test_event_comments.py` (fixture-setup contention on the user phone-number unique index, unrelated to this change) — both pass in isolation. frontend types regenerated (`make frontend-types`) for the geocode response-type change; the runtime payload is unchanged.