### PR TITLE
fix: avatar crop circle locked into a band on any orientation (Issue 428)

### DIFF
--- a/docs/fix-428-avatar-crop.md
+++ b/docs/fix-428-avatar-crop.md
@@ -1,0 +1,61 @@
+# Fix 428 — profile picture crop forces image into fixed dimensions
+
+## Symptom (from the issue + reporter)
+
+> When I upload my current picture, it crops out the top of it, cutting off my head.
+>
+> it forces a photo into the dimensions and cuts off the rest so you cant select which
+> part of the photo you want, you can only move the crop circle on the visible portion
+
+- Route: `/profile` (avatar upload → `ImageCropDialog` in `round` mode)
+- Reproduced on **both iPhone Safari and desktop** → not EXIF/touch-specific; it is a
+  deterministic layout/geometry bug.
+
+## Root cause (confirmed)
+
+`ImageCropDialog.onImageLoad` builds the initial circular crop with:
+
+```ts
+centerCrop(makeAspectCrop({ unit: '%', width: 80 }, 1, width, height), width, height)
+```
+
+`makeAspectCrop` interprets `width: 80` as **80% of the image's width**, then sets the
+square's height equal to that same pixel value (aspect 1:1). For any image that is **not
+portrait** (landscape, square, panoramic), `0.8 × width` in pixels is **taller than the
+image height**, so react-image-crop clamps the crop to the image bounds and anchors it.
+With the aspect locked to 1:1, the user can no longer drag or resize the circle outside
+that clamped band — exactly "you can only move the crop circle on the visible portion."
+
+Verified two ways:
+
+1. **Library source** (`react-image-crop` `makeAspectCrop`): width-basis sizing followed
+   by a `t.y + t.height > n` clamp that shrinks + anchors the square.
+2. **Visual repro** (headless Chrome, real `ReactCrop.css`, same wrapper/img classes):
+   - portrait 3:4 → square fits (whole photo shown) ✓
+   - square → square ≈ image, edges clamped
+   - landscape 4:3 (4032×3024 → rendered 427×320) → 80%-width square = 342×342 **overflows
+     the 320px-tall image** → clamped
+   - wide pano (4032×1500 → 448×167) → square = 358×358, massively overflows → clamped
+
+The rendered image itself is fully visible (object-fit is correct); the bug is purely the
+**initial crop rectangle** being sized off the wrong axis.
+
+## Fix
+
+Size the initial 1:1 crop off the image's **shorter edge** so the square always fits
+inside the image regardless of orientation, then center it. Extract the geometry into a
+pure helper so it can be unit-tested (the current tests mock `makeAspectCrop`, so they
+never exercised this math).
+
+- New `initialCrop(width, height, shape)` helper returning a `PercentCrop`.
+- `round`: square side = `80% of min(width, height)`, expressed as a percentage of each
+  axis, centered.
+- `rect`: keep existing behaviour (free-form, capped at preview height).
+- Add unit tests for the helper across portrait / square / landscape / pano — assert the
+  crop never exceeds 100% on either axis and stays centered.
+
+## Out of scope (noted, not fixed here)
+
+- Zoom / pan of the underlying image (the reporter's "select which part" wish beyond
+  dragging the circle) would need a different cropper (e.g. react-easy-crop). This fix
+  restores full drag freedom within the visible image, which resolves the reported defect.

--- a/frontend/src/components/ImageCropDialog.tsx
+++ b/frontend/src/components/ImageCropDialog.tsx
@@ -6,22 +6,13 @@
 // blob via onCrop.
 
 import { useRef, useState } from 'react';
-import ReactCrop, {
-  centerCrop,
-  makeAspectCrop,
-  type Crop,
-  type PercentCrop,
-  type PixelCrop,
-} from 'react-image-crop';
+import ReactCrop, { type Crop, type PercentCrop, type PixelCrop } from 'react-image-crop';
 import 'react-image-crop/dist/ReactCrop.css';
 import { cropImage } from '@/utils/cropImage';
+import { initialCrop } from './initialCrop';
 import { Button } from './ui/Button';
 
 export type CropShape = 'round' | 'rect';
-
-// Tailwind `max-h-80` → 20rem → 320px. Kept in sync with the wrapper + img
-// classes below so the initial crop math matches what the user sees.
-const MAX_PREVIEW_PX = 320;
 
 interface Props {
   file: File;
@@ -47,23 +38,7 @@ export function ImageCropDialog({
 
   function onImageLoad(e: React.SyntheticEvent<HTMLImageElement>) {
     const { width, height } = e.currentTarget;
-    if (lockedAspect !== undefined) {
-      setCrop(
-        centerCrop(
-          makeAspectCrop({ unit: '%', width: 80 }, lockedAspect, width, height),
-          width,
-          height,
-        ),
-      );
-      return;
-    }
-    // Rect (free-form) mode: the image is constrained to MAX_PREVIEW_PX in CSS,
-    // so a flat 80%-of-natural crop can overshoot the visible image when the
-    // photo is portrait or otherwise taller than the container. Cap the
-    // initial crop height at the rendered preview height instead.
-    const previewHeight = Math.min(height, MAX_PREVIEW_PX);
-    const heightPct = Math.min(80, (previewHeight / height) * 80);
-    setCrop(centerCrop({ unit: '%', x: 0, y: 0, width: 80, height: heightPct }, width, height));
+    setCrop(initialCrop(width, height, shape));
   }
 
   function handleCancel() {

--- a/frontend/src/components/ImageCropDialog.tsx
+++ b/frontend/src/components/ImageCropDialog.tsx
@@ -9,7 +9,7 @@ import { useRef, useState } from 'react';
 import ReactCrop, { type Crop, type PercentCrop, type PixelCrop } from 'react-image-crop';
 import 'react-image-crop/dist/ReactCrop.css';
 import { cropImage } from '@/utils/cropImage';
-import { initialCrop } from './initialCrop';
+import { initialCrop, MAX_PREVIEW_PX } from './initialCrop';
 import { Button } from './ui/Button';
 
 export type CropShape = 'round' | 'rect';
@@ -89,9 +89,15 @@ export function ImageCropDialog({
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
     >
       <div className="bg-surface flex w-full max-w-md flex-col gap-4 rounded-lg p-4 shadow-xl">
-        <div className="flex max-h-80 items-center justify-center overflow-hidden rounded-md bg-neutral-900">
-          <ReactCrop {...reactCropProps}>
-            <img ref={imgRef} src={src} alt="" onLoad={onImageLoad} className="max-h-80 w-auto" />
+        <div className="flex items-center justify-center rounded-md bg-neutral-900">
+          {/* Cap height on ReactCrop itself, not the wrapper. react-image-crop sets
+              `child-wrapper > img { max-height: inherit }`, so the constraint has to
+              live on the .ReactCrop element to actually *scale* a tall image down to
+              the preview height — a cap on the <img> or an `overflow-hidden` wrapper
+              would only clip it, leaving react-image-crop to render (and let the user
+              drag the crop into) the off-screen remainder. See issue 428. */}
+          <ReactCrop {...reactCropProps} style={{ maxHeight: MAX_PREVIEW_PX }}>
+            <img ref={imgRef} src={src} alt="" onLoad={onImageLoad} className="w-auto" />
           </ReactCrop>
         </div>
         <div className="flex justify-end gap-2">

--- a/frontend/src/components/ImageCropDialog.tsx
+++ b/frontend/src/components/ImageCropDialog.tsx
@@ -1,9 +1,5 @@
-// Crop dialog for avatar uploads (circular) and event covers (rectangular).
-// The user drags/resizes a crop box over a stationary image — the common
-// Instagram/Facebook/macOS-style UX. Built on react-image-crop. Round shape
-// is locked to a 1:1 square (circular mask); rect shape is free-form so the
-// box can be reshaped to any ratio by dragging its handles. Returns a PNG
-// blob via onCrop.
+// Crop dialog for avatar uploads (round, 1:1 circular mask) and event covers
+// (rect, free-form). Built on react-image-crop; returns a PNG blob via onCrop.
 
 import { useRef, useState } from 'react';
 import ReactCrop, { type Crop, type PercentCrop, type PixelCrop } from 'react-image-crop';
@@ -90,12 +86,10 @@ export function ImageCropDialog({
     >
       <div className="bg-surface flex w-full max-w-md flex-col gap-4 rounded-lg p-4 shadow-xl">
         <div className="flex items-center justify-center rounded-md bg-neutral-900">
-          {/* Cap height on ReactCrop itself, not the wrapper. react-image-crop sets
-              `child-wrapper > img { max-height: inherit }`, so the constraint has to
-              live on the .ReactCrop element to actually *scale* a tall image down to
-              the preview height — a cap on the <img> or an `overflow-hidden` wrapper
-              would only clip it, leaving react-image-crop to render (and let the user
-              drag the crop into) the off-screen remainder. See issue 428. */}
+          {/* Cap height on .ReactCrop itself, not a wrapper. react-image-crop sets
+              `child-wrapper > img { max-height: inherit }`, so only a cap here scales
+              a tall image down — a wrapper cap would just clip it and let the crop be
+              dragged into the off-screen remainder. See issue 428. */}
           <ReactCrop {...reactCropProps} style={{ maxHeight: MAX_PREVIEW_PX }}>
             <img ref={imgRef} src={src} alt="" onLoad={onImageLoad} className="w-auto" />
           </ReactCrop>

--- a/frontend/src/components/initialCrop.test.ts
+++ b/frontend/src/components/initialCrop.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { initialCrop } from './initialCrop';
+
+// Regression for issue 428: the round (1:1) crop was sized as 80% of the image
+// *width*, so for any non-portrait image the square was taller than the image and
+// react-image-crop clamped it into an unmovable band ("you can only move the crop
+// circle on the visible portion"). The crop must always fit inside the image.
+
+function fits(crop: { x: number; y: number; width: number; height: number }) {
+  expect(crop.x).toBeGreaterThanOrEqual(0);
+  expect(crop.y).toBeGreaterThanOrEqual(0);
+  expect(crop.x + crop.width).toBeLessThanOrEqual(100 + 1e-6);
+  expect(crop.y + crop.height).toBeLessThanOrEqual(100 + 1e-6);
+}
+
+function isCentered(crop: { x: number; y: number; width: number; height: number }) {
+  expect(crop.x).toBeCloseTo((100 - crop.width) / 2, 4);
+  expect(crop.y).toBeCloseTo((100 - crop.height) / 2, 4);
+}
+
+describe('initialCrop — round (1:1)', () => {
+  const cases: [string, number, number][] = [
+    ['portrait 3:4', 240, 320],
+    ['square', 320, 320],
+    ['landscape 4:3', 427, 320],
+    ['wide pano', 448, 167],
+    ['tall strip', 100, 600],
+  ];
+
+  it.each(cases)('fits inside the image and stays centered: %s', (_label, w, h) => {
+    const crop = initialCrop(w, h, 'round');
+    expect(crop.unit).toBe('%');
+    fits(crop);
+    isCentered(crop);
+  });
+
+  it('produces a true 1:1 square in pixel space', () => {
+    // landscape: 80% of the short edge (height) = 256px square.
+    const w = 427;
+    const h = 320;
+    const crop = initialCrop(w, h, 'round');
+    const pxW = (crop.width / 100) * w;
+    const pxH = (crop.height / 100) * h;
+    expect(pxW).toBeCloseTo(pxH, 2);
+    expect(pxH).toBeCloseTo(0.8 * Math.min(w, h), 2);
+  });
+
+  it('sizes off the shorter edge for portrait too', () => {
+    const w = 240;
+    const h = 320;
+    const crop = initialCrop(w, h, 'round');
+    const pxW = (crop.width / 100) * w;
+    expect(pxW).toBeCloseTo(0.8 * Math.min(w, h), 2);
+  });
+});
+
+describe('initialCrop — rect (free-form)', () => {
+  it('caps initial height at the visible preview, never overflowing', () => {
+    // very tall image: rendered preview is capped at 320px, natural is 3000px tall
+    const crop = initialCrop(2000, 3000, 'rect');
+    fits(crop);
+    expect(crop.width).toBe(80);
+  });
+
+  it('uses a plain 80% box when the image is not taller than the preview', () => {
+    const crop = initialCrop(800, 200, 'rect');
+    fits(crop);
+    expect(crop.width).toBe(80);
+    expect(crop.height).toBe(80);
+  });
+});

--- a/frontend/src/components/initialCrop.test.ts
+++ b/frontend/src/components/initialCrop.test.ts
@@ -1,14 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import { initialCrop } from './initialCrop';
 
-// Regression for issue 428: the round (1:1) crop was sized as 80% of the image
-// *width*, so for any non-portrait image the square was taller than the image and
-// react-image-crop clamped it into an unmovable band ("you can only move the crop
-// circle on the visible portion"). The crop must always fit inside the image.
-//
-// `width`/`height` here are the *rendered* preview dimensions. ImageCropDialog caps
-// the rendered height at MAX_PREVIEW_PX (320) by constraining the .ReactCrop element,
-// so the image is scaled — not clipped — and these inputs never exceed 320 tall.
+// Regression for issue 428: the round crop was sized off image *width*, so for any
+// non-portrait image the square was taller than the image and react-image-crop
+// clamped it into an unmovable band. The crop must always fit inside the image.
+// `width`/`height` are rendered preview dimensions, height-capped at 320 by the dialog.
 
 function fits(crop: { x: number; y: number; width: number; height: number }) {
   expect(crop.x).toBeGreaterThanOrEqual(0);
@@ -59,8 +55,7 @@ describe('initialCrop — round (1:1)', () => {
 });
 
 describe('initialCrop — rect (free-form)', () => {
-  // The rendered preview is height-capped by the dialog, so rect is always a plain
-  // centered 80% box that fits regardless of orientation.
+  // Rendered preview is height-capped, so rect is a plain centered 80% box in any orientation.
   const cases: [string, number, number][] = [
     ['landscape', 800, 200],
     ['square', 320, 320],

--- a/frontend/src/components/initialCrop.test.ts
+++ b/frontend/src/components/initialCrop.test.ts
@@ -5,6 +5,10 @@ import { initialCrop } from './initialCrop';
 // *width*, so for any non-portrait image the square was taller than the image and
 // react-image-crop clamped it into an unmovable band ("you can only move the crop
 // circle on the visible portion"). The crop must always fit inside the image.
+//
+// `width`/`height` here are the *rendered* preview dimensions. ImageCropDialog caps
+// the rendered height at MAX_PREVIEW_PX (320) by constraining the .ReactCrop element,
+// so the image is scaled — not clipped — and these inputs never exceed 320 tall.
 
 function fits(crop: { x: number; y: number; width: number; height: number }) {
   expect(crop.x).toBeGreaterThanOrEqual(0);
@@ -55,16 +59,18 @@ describe('initialCrop — round (1:1)', () => {
 });
 
 describe('initialCrop — rect (free-form)', () => {
-  it('caps initial height at the visible preview, never overflowing', () => {
-    // very tall image: rendered preview is capped at 320px, natural is 3000px tall
-    const crop = initialCrop(2000, 3000, 'rect');
-    fits(crop);
-    expect(crop.width).toBe(80);
-  });
+  // The rendered preview is height-capped by the dialog, so rect is always a plain
+  // centered 80% box that fits regardless of orientation.
+  const cases: [string, number, number][] = [
+    ['landscape', 800, 200],
+    ['square', 320, 320],
+    ['portrait (capped)', 213, 320],
+  ];
 
-  it('uses a plain 80% box when the image is not taller than the preview', () => {
-    const crop = initialCrop(800, 200, 'rect');
+  it.each(cases)('is a centered 80%% box that fits: %s', (_label, w, h) => {
+    const crop = initialCrop(w, h, 'rect');
     fits(crop);
+    isCentered(crop);
     expect(crop.width).toBe(80);
     expect(crop.height).toBe(80);
   });

--- a/frontend/src/components/initialCrop.ts
+++ b/frontend/src/components/initialCrop.ts
@@ -1,0 +1,43 @@
+// Initial crop geometry for ImageCropDialog. Kept separate from the component so
+// it can be unit-tested directly (the component test mocks react-image-crop, so
+// this math was previously unexercised — see issue 428).
+//
+// `width`/`height` are the *rendered* image dimensions in px (the CSS-constrained
+// preview, capped at MAX_PREVIEW_PX tall). The returned crop is in percent units
+// so it scales with the displayed image.
+
+import { centerCrop, type PercentCrop } from 'react-image-crop';
+import type { CropShape } from './ImageCropDialog';
+
+// Tailwind `max-h-80` → 20rem → 320px. The preview <img> is capped at this height,
+// so initial crop math must respect it to avoid overshooting the visible image.
+export const MAX_PREVIEW_PX = 320;
+
+// Fraction of the available space the initial crop covers.
+const INITIAL_FILL = 0.8;
+
+export function initialCrop(width: number, height: number, shape: CropShape): PercentCrop {
+  if (shape === 'round') {
+    // 1:1 square sized off the SHORTER edge so it always fits inside the image,
+    // regardless of orientation. Expressing the same pixel side as a percentage of
+    // each axis keeps it square in pixel space (issue 428: sizing off width alone
+    // made the square taller than landscape/pano images, so it got clamped into an
+    // unmovable band).
+    const side = INITIAL_FILL * Math.min(width, height);
+    const widthPct = (side / width) * 100;
+    const heightPct = (side / height) * 100;
+    return centerCrop({ unit: '%', x: 0, y: 0, width: widthPct, height: heightPct }, width, height);
+  }
+
+  // Rect (free-form): the image is constrained to MAX_PREVIEW_PX in CSS, so a flat
+  // 80%-of-natural crop can overshoot the visible image when the photo is portrait or
+  // otherwise taller than the container. Cap the initial crop height at the rendered
+  // preview height instead.
+  const previewHeight = Math.min(height, MAX_PREVIEW_PX);
+  const heightPct = Math.min(INITIAL_FILL * 100, (previewHeight / height) * INITIAL_FILL * 100);
+  return centerCrop(
+    { unit: '%', x: 0, y: 0, width: INITIAL_FILL * 100, height: heightPct },
+    width,
+    height,
+  );
+}

--- a/frontend/src/components/initialCrop.ts
+++ b/frontend/src/components/initialCrop.ts
@@ -1,20 +1,14 @@
-// Initial crop geometry for ImageCropDialog. Kept separate from the component so
-// it can be unit-tested directly (the component test mocks react-image-crop, so
-// this math was previously unexercised — see issue 428).
-//
-// `width`/`height` are the *rendered* image dimensions in px — i.e. what the user
-// actually sees. ImageCropDialog caps the rendered height at MAX_PREVIEW_PX by
-// constraining the .ReactCrop element (not the wrapper), so the image is scaled
-// down rather than clipped. That means the dimensions passed here always match the
-// visible preview, and the crop never extends past it in any orientation. The
-// returned crop is in percent units so it scales with the displayed image.
+// Initial crop geometry for ImageCropDialog, split out so it can be unit-tested
+// (the component test mocks react-image-crop). `width`/`height` are the *rendered*
+// image dimensions; ImageCropDialog caps rendered height at MAX_PREVIEW_PX, so the
+// inputs always match the visible preview. Returns percent units so the crop scales
+// with the displayed image. See issue 428.
 
 import { centerCrop, type PercentCrop } from 'react-image-crop';
 import type { CropShape } from './ImageCropDialog';
 
-// Max rendered preview height in px (20rem, matching the old Tailwind `max-h-80`).
-// ImageCropDialog applies this as the maxHeight on the .ReactCrop element, so it's
-// the single source of truth for how tall the preview can get.
+// Max rendered preview height (20rem). The single source of truth for the cap;
+// ImageCropDialog applies it as maxHeight on the .ReactCrop element.
 export const MAX_PREVIEW_PX = 320;
 
 // Fraction of the shorter edge the initial crop covers.
@@ -22,11 +16,10 @@ const INITIAL_FILL = 0.8;
 
 export function initialCrop(width: number, height: number, shape: CropShape): PercentCrop {
   if (shape === 'round') {
-    // 1:1 square sized off the SHORTER edge so it always fits inside the image,
-    // regardless of orientation. Expressing the same pixel side as a percentage of
-    // each axis keeps it square in pixel space (issue 428: sizing off width alone
-    // made the square taller than landscape/pano images, so it got clamped into an
-    // unmovable band).
+    // 1:1 square sized off the SHORTER edge so it fits in any orientation. The same
+    // pixel side as a percentage of each axis keeps it square in pixel space. (Issue
+    // 428: sizing off width alone made the square taller than landscape/pano images,
+    // clamping it into an unmovable band.)
     const side = INITIAL_FILL * Math.min(width, height);
     return centerCrop(
       { unit: '%', x: 0, y: 0, width: (side / width) * 100, height: (side / height) * 100 },
@@ -35,9 +28,8 @@ export function initialCrop(width: number, height: number, shape: CropShape): Pe
     );
   }
 
-  // Rect (free-form): a flat 80% box on both axes. The rendered height is already
-  // capped at MAX_PREVIEW_PX by the dialog, so 80% always lands inside the visible
-  // preview — no per-orientation height compensation needed.
+  // Rect (free-form): a flat 80% box. Rendered height is already capped by the
+  // dialog, so 80% always lands inside the visible preview.
   return centerCrop(
     { unit: '%', x: 0, y: 0, width: INITIAL_FILL * 100, height: INITIAL_FILL * 100 },
     width,

--- a/frontend/src/components/initialCrop.ts
+++ b/frontend/src/components/initialCrop.ts
@@ -2,18 +2,22 @@
 // it can be unit-tested directly (the component test mocks react-image-crop, so
 // this math was previously unexercised — see issue 428).
 //
-// `width`/`height` are the *rendered* image dimensions in px (the CSS-constrained
-// preview, capped at MAX_PREVIEW_PX tall). The returned crop is in percent units
-// so it scales with the displayed image.
+// `width`/`height` are the *rendered* image dimensions in px — i.e. what the user
+// actually sees. ImageCropDialog caps the rendered height at MAX_PREVIEW_PX by
+// constraining the .ReactCrop element (not the wrapper), so the image is scaled
+// down rather than clipped. That means the dimensions passed here always match the
+// visible preview, and the crop never extends past it in any orientation. The
+// returned crop is in percent units so it scales with the displayed image.
 
 import { centerCrop, type PercentCrop } from 'react-image-crop';
 import type { CropShape } from './ImageCropDialog';
 
-// Tailwind `max-h-80` → 20rem → 320px. The preview <img> is capped at this height,
-// so initial crop math must respect it to avoid overshooting the visible image.
+// Max rendered preview height in px (20rem, matching the old Tailwind `max-h-80`).
+// ImageCropDialog applies this as the maxHeight on the .ReactCrop element, so it's
+// the single source of truth for how tall the preview can get.
 export const MAX_PREVIEW_PX = 320;
 
-// Fraction of the available space the initial crop covers.
+// Fraction of the shorter edge the initial crop covers.
 const INITIAL_FILL = 0.8;
 
 export function initialCrop(width: number, height: number, shape: CropShape): PercentCrop {
@@ -24,19 +28,18 @@ export function initialCrop(width: number, height: number, shape: CropShape): Pe
     // made the square taller than landscape/pano images, so it got clamped into an
     // unmovable band).
     const side = INITIAL_FILL * Math.min(width, height);
-    const widthPct = (side / width) * 100;
-    const heightPct = (side / height) * 100;
-    return centerCrop({ unit: '%', x: 0, y: 0, width: widthPct, height: heightPct }, width, height);
+    return centerCrop(
+      { unit: '%', x: 0, y: 0, width: (side / width) * 100, height: (side / height) * 100 },
+      width,
+      height,
+    );
   }
 
-  // Rect (free-form): the image is constrained to MAX_PREVIEW_PX in CSS, so a flat
-  // 80%-of-natural crop can overshoot the visible image when the photo is portrait or
-  // otherwise taller than the container. Cap the initial crop height at the rendered
-  // preview height instead.
-  const previewHeight = Math.min(height, MAX_PREVIEW_PX);
-  const heightPct = Math.min(INITIAL_FILL * 100, (previewHeight / height) * INITIAL_FILL * 100);
+  // Rect (free-form): a flat 80% box on both axes. The rendered height is already
+  // capped at MAX_PREVIEW_PX by the dialog, so 80% always lands inside the visible
+  // preview — no per-orientation height compensation needed.
   return centerCrop(
-    { unit: '%', x: 0, y: 0, width: INITIAL_FILL * 100, height: heightPct },
+    { unit: '%', x: 0, y: 0, width: INITIAL_FILL * 100, height: INITIAL_FILL * 100 },
     width,
     height,
   );


### PR DESCRIPTION
## Summary

Closes #428

Fixes the avatar crop dialog (`ImageCropDialog` in `round` mode) so the crop circle can be freely positioned over a photo of **any** orientation, instead of being locked into an anchored band the user can't escape.

Two commits:
1. **Initial fix** — the round (1:1) crop was sized as 80% of image *width*, so landscape/square/pano photos got a square taller than the image and react-image-crop clamped it. Now sized off the shorter edge (`0.8 * min(w, h)`), extracted into a pure `initialCrop()` helper with unit tests across orientations.
2. **Portrait follow-up** — verification surfaced the same symptom in the opposite axis for **portrait** photos (the most common avatar case — phone selfies). Root cause: the preview height was capped via `max-h-80` + `overflow-hidden` on a *wrapper* div, but react-image-crop sets `child-wrapper > img { max-height: inherit }` and `.ReactCrop` had no max-height — so a tall image rendered at full natural height and was merely *clipped*. `onImageLoad` then read dimensions the user couldn't see, so the crop overshot the visible preview and dragged off-screen. Now the cap lives on the `.ReactCrop` element itself (`maxHeight: MAX_PREVIEW_PX`), so a tall image is *scaled down*, not clipped. Rendered dimensions match the visible preview in every orientation, so `initialCrop`'s math is correct and the rect branch no longer needs per-orientation height compensation. `MAX_PREVIEW_PX` becomes the single source of truth for the cap.

## Test plan

- [x] Unit tests: `initialCrop` covers round + rect across portrait, square, landscape, pano, and tall-strip — all fit inside the image and stay centered.
- [x] In-browser verification (real `ImageCropDialog` driven via Playwright) across portrait (400×1200), tall-strip (200×1600), landscape (1200×400), pano (2000×300), and square (600×600): the crop fits the visible preview initially **and** stays fully on-screen when dragged to any corner.
- [x] `tsc --noEmit`, ESLint + Prettier, and all component tests pass.
- [ ] Manual sanity check on `/profile`: upload a portrait selfie and a wide landscape photo, confirm the crop circle moves freely in both.

> Note: an unrelated, pre-existing time-dependent test failure in `EventAttendancePanel.test.tsx` is tracked separately in #516 — not touched by this PR.