### PR TITLE
fix(frontend): safer refresh-retry, block open redirect, handle mutation errors, tighten event-write types

### DIFF
--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -85,6 +85,57 @@ describe('apiClient refresh interceptor', () => {
     authMock.restore();
   });
 
+  it('does NOT replay a mutating request after refresh — surfaces the 401 instead', async () => {
+    const apiMock = new MockAdapter(apiClient);
+    const authMock = new MockAdapter(authClient);
+    authMock.onPost('/api/auth/refresh/').reply(200, { access: 'access-v2' });
+
+    let postAttempts = 0;
+    apiMock.onPost('/api/community/events/').reply(() => {
+      postAttempts += 1;
+      return [401, { detail: 'expired' }];
+    });
+
+    await expect(apiClient.post('/api/community/events/', { title: 'x' })).rejects.toThrow();
+    // The mutation must be sent exactly once — never blind-replayed.
+    expect(postAttempts).toBe(1);
+    // Session is still valid (refresh succeeded), so we must NOT force logout.
+    expect(onSessionExpired).not.toHaveBeenCalled();
+    // But the refresh did land, so the next request would use the new token.
+    expect(accessToken).toBe('access-v2');
+
+    apiMock.restore();
+    authMock.restore();
+  });
+
+  it('does not force logout when refresh fails transiently (5xx)', async () => {
+    const apiMock = new MockAdapter(apiClient);
+    const authMock = new MockAdapter(authClient);
+    apiMock.onGet('/api/events').reply(401, { detail: 'expired' });
+    // Refresh endpoint is briefly down — NOT a real 401.
+    authMock.onPost('/api/auth/refresh/').reply(503, { detail: 'unavailable' });
+
+    await expect(apiClient.get('/api/events')).rejects.toThrow();
+    // Transient failure: session is NOT nuked.
+    expect(onSessionExpired).not.toHaveBeenCalled();
+
+    apiMock.restore();
+    authMock.restore();
+  });
+
+  it('does not force logout when refresh fails with a network error', async () => {
+    const apiMock = new MockAdapter(apiClient);
+    const authMock = new MockAdapter(authClient);
+    apiMock.onGet('/api/events').reply(401, { detail: 'expired' });
+    authMock.onPost('/api/auth/refresh/').networkError();
+
+    await expect(apiClient.get('/api/events')).rejects.toThrow();
+    expect(onSessionExpired).not.toHaveBeenCalled();
+
+    apiMock.restore();
+    authMock.restore();
+  });
+
   it('does not retry a second time after a successful refresh still fails', async () => {
     const apiMock = new MockAdapter(apiClient);
     const authMock = new MockAdapter(authClient);

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -85,7 +85,38 @@ describe('apiClient refresh interceptor', () => {
     authMock.restore();
   });
 
-  it('does NOT replay a mutating request after refresh — surfaces the 401 instead', async () => {
+  it('replays a mutating request once after a clean 401 + successful refresh', async () => {
+    // A clean 401 means the server rejected the request before processing it
+    // (expired access token), so it never mutated state — replaying it with the
+    // refreshed token is safe and recovers the action instead of failing it.
+    const apiMock = new MockAdapter(apiClient);
+    const authMock = new MockAdapter(authClient);
+    authMock.onPost('/api/auth/refresh/').reply(200, { access: 'access-v2' });
+
+    let postAttempts = 0;
+    apiMock.onPost('/api/community/events/').reply((config) => {
+      postAttempts += 1;
+      const auth = (config.headers as Record<string, string> | undefined)?.Authorization;
+      if (auth === 'Bearer access-v1') {
+        return [401, { detail: 'expired' }];
+      }
+      return [201, { id: 'evt-1' }];
+    });
+
+    const res = await apiClient.post('/api/community/events/', { title: 'x' });
+    // Succeeded on the replay with the refreshed token.
+    expect(res.status).toBe(201);
+    // Sent exactly twice: original (401) + one replay. Never more.
+    expect(postAttempts).toBe(2);
+    // Session was always valid, so we must NOT force logout.
+    expect(onSessionExpired).not.toHaveBeenCalled();
+    expect(accessToken).toBe('access-v2');
+
+    apiMock.restore();
+    authMock.restore();
+  });
+
+  it('does not replay a mutation more than once if it still 401s after refresh', async () => {
     const apiMock = new MockAdapter(apiClient);
     const authMock = new MockAdapter(authClient);
     authMock.onPost('/api/auth/refresh/').reply(200, { access: 'access-v2' });
@@ -93,16 +124,13 @@ describe('apiClient refresh interceptor', () => {
     let postAttempts = 0;
     apiMock.onPost('/api/community/events/').reply(() => {
       postAttempts += 1;
-      return [401, { detail: 'expired' }];
+      return [401, { detail: 'still expired' }];
     });
 
     await expect(apiClient.post('/api/community/events/', { title: 'x' })).rejects.toThrow();
-    // The mutation must be sent exactly once — never blind-replayed.
-    expect(postAttempts).toBe(1);
-    // Session is still valid (refresh succeeded), so we must NOT force logout.
+    // Exactly two sends: original + one replay. No infinite loop, no triple-submit.
+    expect(postAttempts).toBe(2);
     expect(onSessionExpired).not.toHaveBeenCalled();
-    // But the refresh did land, so the next request would use the new token.
-    expect(accessToken).toBe('access-v2');
 
     apiMock.restore();
     authMock.restore();

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -111,12 +111,13 @@ export async function refreshAccessToken(): Promise<string | null> {
   return result.ok ? result.token : null;
 }
 
-// Idempotent methods are safe to blind-replay after a refresh. Mutating
-// requests (POST/PATCH/PUT/DELETE) are NOT — replaying them can double-submit.
-// For those we still refresh (so the session recovers for the next request)
-// but surface the original 401 instead of retrying the mutation.
-const REPLAYABLE_METHODS = new Set(['get', 'head', 'options']);
-
+// A clean 401 means the server rejected the request *before* processing it
+// (the expired access token failed auth), so the request demonstrably never
+// mutated state server-side. Replaying it after a successful refresh is
+// therefore idempotent in effect — even for POST/PATCH/PUT/DELETE — and avoids
+// turning every post-expiry first action (create event, RSVP, mark-read,
+// cancel) into a user-visible failure. The `_retried` guard below caps replay
+// at one attempt, so there's no risk of an infinite loop or double-submit.
 apiClient.interceptors.response.use(
   (response) => response,
   async (error: AxiosError) => {
@@ -132,13 +133,8 @@ apiClient.interceptors.response.use(
     // runRefresh already fired onSessionExpired.
     if (!result.ok) throw error;
 
-    const method = (config.method ?? 'get').toLowerCase();
-    if (!REPLAYABLE_METHODS.has(method)) {
-      // Token is refreshed for subsequent requests, but we must not replay a
-      // mutation — surface the 401 and let the caller decide.
-      throw error;
-    }
-
+    // Refresh succeeded and the original 401 proves the request had no side
+    // effect, so replay it once with the new token — regardless of method.
     config.headers.Authorization = `Bearer ${result.token}`;
     const retried = await apiClient.request(config);
     return retried;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -10,7 +10,12 @@
 // Both instances send cookies (`withCredentials`) so the httpOnly refresh cookie
 // reaches the server on cross-origin dev (React :3000 → Django :8000).
 
-import axios, { type AxiosError, type AxiosInstance, type InternalAxiosRequestConfig } from 'axios';
+import axios, {
+  isAxiosError,
+  type AxiosError,
+  type AxiosInstance,
+  type InternalAxiosRequestConfig,
+} from 'axios';
 import { API_BASE_URL } from '@/config/env';
 
 interface RetryableConfig extends InternalAxiosRequestConfig {
@@ -59,32 +64,58 @@ apiClient.interceptors.request.use((config) => {
 
 // Response: refresh on 401, retry once.
 // `refreshPromise` is the lock: all concurrent 401s wait on the same refresh.
-let refreshPromise: Promise<string | null> | null = null;
+//
+// `refreshPromise` resolves to one of three outcomes so callers can tell a
+// truly-dead session apart from a transient blip:
+//   - { ok: true, token }     — refreshed; retry with the new token
+//   - { ok: false, expired }  — refresh endpoint returned 401: session is
+//                               genuinely gone → force logout
+//   - { ok: false, !expired } — network/5xx/CORS: DON'T nuke the session, let
+//                               the original error surface as retryable
+type RefreshResult = { ok: true; token: string } | { ok: false; sessionExpired: boolean };
 
-async function doRefresh(): Promise<string | null> {
+let refreshPromise: Promise<RefreshResult> | null = null;
+
+async function doRefresh(): Promise<RefreshResult> {
   try {
     const res = await authClient.post<{ access: string }>('/api/auth/refresh/', {});
     const { access } = res.data;
     bridge?.setAccessToken(access);
-    return access;
-  } catch {
-    return null;
+    return { ok: true, token: access };
+  } catch (err) {
+    // Only a real 401 from the refresh endpoint means the session is gone.
+    // Network errors, 5xx, CORS, timeouts etc. are transient — surface them
+    // as retryable rather than logging the user out.
+    const sessionExpired = isAxiosError(err) && err.response?.status === 401;
+    return { ok: false, sessionExpired };
   }
+}
+
+async function runRefresh(): Promise<RefreshResult> {
+  refreshPromise ??= doRefresh().finally(() => {
+    refreshPromise = null;
+  });
+  const result = await refreshPromise;
+  if (!result.ok && result.sessionExpired) bridge?.onSessionExpired();
+  return result;
 }
 
 // Shared entry point for non-axios callers (e.g. the SSE hook, which can't
 // go through the response interceptor). Uses the same in-flight lock so
-// concurrent callers don't each kick off a refresh. On failure, flips the
-// store to 'unauthed' so downstream effects (e.g. SSE hooks) tear down on
-// the next render.
+// concurrent callers don't each kick off a refresh. On a genuinely-expired
+// session it flips the store to 'unauthed' (via runRefresh) so downstream
+// effects tear down on the next render; on transient failures it returns null
+// without nuking the session so the caller can retry later.
 export async function refreshAccessToken(): Promise<string | null> {
-  refreshPromise ??= doRefresh().finally(() => {
-    refreshPromise = null;
-  });
-  const token = await refreshPromise;
-  if (!token) bridge?.onSessionExpired();
-  return token;
+  const result = await runRefresh();
+  return result.ok ? result.token : null;
 }
+
+// Idempotent methods are safe to blind-replay after a refresh. Mutating
+// requests (POST/PATCH/PUT/DELETE) are NOT — replaying them can double-submit.
+// For those we still refresh (so the session recovers for the next request)
+// but surface the original 401 instead of retrying the mutation.
+const REPLAYABLE_METHODS = new Set(['get', 'head', 'options']);
 
 apiClient.interceptors.response.use(
   (response) => response,
@@ -95,9 +126,20 @@ apiClient.interceptors.response.use(
     }
     config._retried = true;
 
-    const token = await refreshAccessToken();
-    if (!token) throw error; // refreshAccessToken already flipped to unauthed
-    config.headers.Authorization = `Bearer ${token}`;
+    const result = await runRefresh();
+    // Transient refresh failure (network/5xx) or genuinely-expired session:
+    // either way, don't retry — surface the original error. On a real expiry
+    // runRefresh already fired onSessionExpired.
+    if (!result.ok) throw error;
+
+    const method = (config.method ?? 'get').toLowerCase();
+    if (!REPLAYABLE_METHODS.has(method)) {
+      // Token is refreshed for subsequent requests, but we must not replay a
+      // mutation — surface the 401 and let the caller decide.
+      throw error;
+    }
+
+    config.headers.Authorization = `Bearer ${result.token}`;
     const retried = await apiClient.request(config);
     return retried;
   },

--- a/frontend/src/api/eventWrites.test.ts
+++ b/frontend/src/api/eventWrites.test.ts
@@ -1,0 +1,136 @@
+// Pure-helper tests for the event write layer: enum-coercion on the inbound
+// side (eventToFormValues) and per-field PATCH body building (toPartialWireBody).
+import { describe, it, expect } from 'vitest';
+import { eventToFormValues, toPartialWireBody } from './eventWrites';
+import {
+  EventStatus,
+  EventType,
+  EventVisibility,
+  InvitePermission,
+  type Event,
+} from '@/models/event';
+
+function makeEvent(overrides: Partial<Event> = {}): Event {
+  return {
+    id: 'e1',
+    title: 'potluck',
+    description: 'bring food',
+    startDatetime: new Date('2026-06-01T18:00:00Z'),
+    endDatetime: new Date('2026-06-01T20:00:00Z'),
+    location: 'the park',
+    latitude: null,
+    longitude: null,
+    whatsappLink: '',
+    partifulLink: '',
+    otherLink: '',
+    venmoLink: '',
+    cashappLink: '',
+    zelleInfo: '',
+    price: '',
+    rsvpEnabled: true,
+    allowPlusOnes: true,
+    maxAttendees: null,
+    attendingCount: 0,
+    waitlistedCount: 0,
+    invitedCount: 0,
+    datetimeTbd: false,
+    hasPoll: false,
+    datetimePollSlug: null,
+    createdById: null,
+    createdByName: null,
+    createdByPhotoUrl: '',
+    coHostIds: [],
+    coHostNames: [],
+    coHostPhotoUrls: [],
+    coHostInviteIds: [],
+    guests: [],
+    myRsvp: null,
+    surveySlugs: [],
+    invitedUserIds: [],
+    invitedUserNames: [],
+    invitedUserPhotoUrls: [],
+    invitePermission: InvitePermission.AllMembers,
+    pendingCohostInvites: [],
+    myPendingCohostInviteId: null,
+    eventType: EventType.Community,
+    visibility: EventVisibility.Public,
+    photoUrl: '',
+    isPast: false,
+    status: EventStatus.Active,
+    ...overrides,
+  };
+}
+
+describe('eventToFormValues enum validation', () => {
+  it('passes through known enum values', () => {
+    const form = eventToFormValues(
+      makeEvent({
+        eventType: EventType.Official,
+        visibility: EventVisibility.MembersOnly,
+        invitePermission: InvitePermission.CoHostsOnly,
+        status: EventStatus.Cancelled,
+      }),
+    );
+    expect(form.eventType).toBe('official');
+    expect(form.visibility).toBe('members_only');
+    expect(form.invitePermission).toBe('co_hosts_only');
+    expect(form.status).toBe('cancelled');
+  });
+
+  it('falls back to safe defaults on unknown enum values', () => {
+    const form = eventToFormValues(
+      makeEvent({
+        eventType: 'galaxy_brain',
+        visibility: 'top_secret',
+        invitePermission: 'nobody',
+        status: 'quantum',
+      }),
+    );
+    expect(form.eventType).toBe(EventType.Community);
+    expect(form.visibility).toBe(EventVisibility.Public);
+    expect(form.invitePermission).toBe(InvitePermission.AllMembers);
+    expect(form.status).toBe(EventStatus.Active);
+  });
+
+  it('derives visibilityChoice from the coerced (not raw) values', () => {
+    const form = eventToFormValues(makeEvent({ eventType: 'bogus', visibility: 'bogus' }));
+    // community + public → 'public'
+    expect(form.visibilityChoice).toBe('public');
+  });
+});
+
+describe('toPartialWireBody', () => {
+  it('only includes keys present in the partial', () => {
+    const body = toPartialWireBody({ title: 'new title' });
+    expect(body).toEqual({ title: 'new title' });
+  });
+
+  it('keeps meaningful falsy values (false, "", null)', () => {
+    const body = toPartialWireBody({ rsvpEnabled: false, price: '', maxAttendees: null });
+    expect(body).toEqual({ rsvp_enabled: false, price: '', max_attendees: null });
+  });
+
+  it('drops explicitly-undefined keys', () => {
+    const body = toPartialWireBody({ title: 'x', description: undefined });
+    expect(body).toEqual({ title: 'x' });
+  });
+
+  it('expands visibilityChoice into visibility + event_type', () => {
+    expect(toPartialWireBody({ visibilityChoice: 'official' })).toEqual({
+      visibility: 'public',
+      event_type: 'official',
+    });
+    expect(toPartialWireBody({ visibilityChoice: 'invite_only' })).toEqual({
+      visibility: 'invite_only',
+      event_type: 'community',
+    });
+  });
+
+  it('maps camelCase keys to their snake_case wire keys with transforms', () => {
+    const body = toPartialWireBody({ startDatetime: '2026-06-01T00:00:00Z', venmoLink: 'leah' });
+    expect(body.start_datetime).toBe('2026-06-01T00:00:00Z');
+    // venmoLink is run through toVenmoUrl — the bare handle becomes a full url.
+    expect(typeof body.venmo_link).toBe('string');
+    expect(body.venmo_link).toContain('leah');
+  });
+});

--- a/frontend/src/api/eventWrites.ts
+++ b/frontend/src/api/eventWrites.ts
@@ -72,46 +72,68 @@ export interface EventFormValues {
 type WireBody = Record<string, unknown>;
 
 // Per-field mapping from a form value to its wire key + serialized value.
+// Each encoder receives *only its own field's value*, so the same map drives
+// both the full-body and partial-body builders without ever casting a
+// `Partial<EventFormValues>` to the full type.
 // `visibilityChoice` is virtual on the wire — it expands into `visibility` +
 // `event_type` — so it's handled separately rather than living in this map.
-type WireField = readonly [wireKey: string, encode: (values: EventFormValues) => unknown];
+type WireField<K extends keyof EventFormValues> = readonly [
+  wireKey: string,
+  encode: (value: EventFormValues[K]) => unknown,
+];
 
-const FIELD_TO_WIRE: Partial<Record<keyof EventFormValues, WireField>> = {
-  title: ['title', (v) => v.title],
-  description: ['description', (v) => v.description],
-  location: ['location', (v) => v.location],
-  latitude: ['latitude', (v) => v.latitude],
-  longitude: ['longitude', (v) => v.longitude],
-  startDatetime: ['start_datetime', (v) => v.startDatetime],
-  endDatetime: ['end_datetime', (v) => v.endDatetime],
-  datetimeTbd: ['datetime_tbd', (v) => v.datetimeTbd],
-  invitePermission: ['invite_permission', (v) => v.invitePermission],
-  rsvpEnabled: ['rsvp_enabled', (v) => v.rsvpEnabled],
-  allowPlusOnes: ['allow_plus_ones', (v) => v.allowPlusOnes],
-  maxAttendees: ['max_attendees', (v) => v.maxAttendees],
-  whatsappLink: ['whatsapp_link', (v) => v.whatsappLink],
-  partifulLink: ['partiful_link', (v) => v.partifulLink],
-  otherLink: ['other_link', (v) => v.otherLink],
-  price: ['price', (v) => v.price],
-  venmoLink: ['venmo_link', (v) => toVenmoUrl(v.venmoLink)],
-  cashappLink: ['cashapp_link', (v) => toCashAppUrl(v.cashappLink)],
-  zelleInfo: ['zelle_info', (v) => v.zelleInfo],
-  coHostIds: ['co_host_ids', (v) => v.coHostIds],
-  status: ['status', (v) => v.status],
+type WireFieldMap = { [K in keyof EventFormValues]?: WireField<K> };
+
+const FIELD_TO_WIRE: WireFieldMap = {
+  title: ['title', (v) => v],
+  description: ['description', (v) => v],
+  location: ['location', (v) => v],
+  latitude: ['latitude', (v) => v],
+  longitude: ['longitude', (v) => v],
+  startDatetime: ['start_datetime', (v) => v],
+  endDatetime: ['end_datetime', (v) => v],
+  datetimeTbd: ['datetime_tbd', (v) => v],
+  invitePermission: ['invite_permission', (v) => v],
+  rsvpEnabled: ['rsvp_enabled', (v) => v],
+  allowPlusOnes: ['allow_plus_ones', (v) => v],
+  maxAttendees: ['max_attendees', (v) => v],
+  whatsappLink: ['whatsapp_link', (v) => v],
+  partifulLink: ['partiful_link', (v) => v],
+  otherLink: ['other_link', (v) => v],
+  price: ['price', (v) => v],
+  venmoLink: ['venmo_link', (v) => toVenmoUrl(v)],
+  cashappLink: ['cashapp_link', (v) => toCashAppUrl(v)],
+  zelleInfo: ['zelle_info', (v) => v],
+  coHostIds: ['co_host_ids', (v) => v],
+  status: ['status', (v) => v],
 };
+
+// Encode a single field by key, looking up its wire entry. The generic `K`
+// keeps the field value and its encoder bound to the same key, so TS verifies
+// each encoder only ever receives its own field's value — no cast required.
+function encodeField<K extends keyof EventFormValues>(
+  key: K,
+  value: EventFormValues[K],
+): readonly [string, unknown] | undefined {
+  const field = FIELD_TO_WIRE[key];
+  if (!field) return undefined;
+  const [wireKey, encode] = field;
+  return [wireKey, encode(value)];
+}
 
 function toWireBody(values: EventFormValues): WireBody {
   const { visibility, eventType } = visibilityChoiceToFields(values.visibilityChoice);
   const body: WireBody = { visibility, event_type: eventType };
-  for (const field of Object.values(FIELD_TO_WIRE)) {
-    const [wireKey, encode] = field;
-    body[wireKey] = encode(values);
+  for (const key of Object.keys(FIELD_TO_WIRE) as (keyof EventFormValues)[]) {
+    const encoded = encodeField(key, values[key]);
+    if (!encoded) continue;
+    body[encoded[0]] = encoded[1];
   }
   return body;
 }
 
-// Build a PATCH body from only the keys present in the Partial. Avoids the
-// unsafe Partial→full cast: we never read a field that wasn't provided.
+// Build a PATCH body from only the keys present in the Partial. Each encoder
+// reads only its own field's value, so no `Partial → full` cast is needed.
 // `visibilityChoice` (if present) expands into `visibility` + `event_type`.
 export function toPartialWireBody(values: Partial<EventFormValues>): WireBody {
   const body: WireBody = {};
@@ -125,10 +147,9 @@ export function toPartialWireBody(values: Partial<EventFormValues>): WireBody {
       body.event_type = eventType;
       continue;
     }
-    const field = FIELD_TO_WIRE[key];
-    if (!field) continue;
-    const [wireKey, encode] = field;
-    body[wireKey] = encode(values as EventFormValues);
+    const encoded = encodeField(key, values[key]);
+    if (!encoded) continue;
+    body[encoded[0]] = encoded[1];
   }
   return body;
 }

--- a/frontend/src/api/eventWrites.ts
+++ b/frontend/src/api/eventWrites.ts
@@ -10,10 +10,19 @@ import { extractApiErrorOr, getApiStatus } from './apiErrors';
 import { useAuthStore } from '@/auth/store';
 import { eventKeys } from './events';
 import { mapEvent, type WireEvent } from './eventMapper';
-import type { Event } from '@/models/event';
+import {
+  EventStatus as EventStatusEnum,
+  EventType as EventTypeEnum,
+  EventVisibility,
+  InvitePermission,
+  type Event,
+} from '@/models/event';
+import { reportError } from '@/utils/errorReporter';
 import { fromCashAppUrl, fromVenmoUrl, toCashAppUrl, toVenmoUrl } from '@/utils/paymentHandle';
 
-export type EventStatus = 'active' | 'draft' | 'cancelled' | 'deleted';
+const ROUTE = '/events';
+
+export type EventStatus = (typeof EventStatusEnum)[keyof typeof EventStatusEnum];
 
 export type VisibilityChoice = 'official' | 'public' | 'members_only' | 'invite_only';
 
@@ -62,33 +71,66 @@ export interface EventFormValues {
 
 type WireBody = Record<string, unknown>;
 
+// Per-field mapping from a form value to its wire key + serialized value.
+// `visibilityChoice` is virtual on the wire — it expands into `visibility` +
+// `event_type` — so it's handled separately rather than living in this map.
+type WireField = readonly [wireKey: string, encode: (values: EventFormValues) => unknown];
+
+const FIELD_TO_WIRE: Partial<Record<keyof EventFormValues, WireField>> = {
+  title: ['title', (v) => v.title],
+  description: ['description', (v) => v.description],
+  location: ['location', (v) => v.location],
+  latitude: ['latitude', (v) => v.latitude],
+  longitude: ['longitude', (v) => v.longitude],
+  startDatetime: ['start_datetime', (v) => v.startDatetime],
+  endDatetime: ['end_datetime', (v) => v.endDatetime],
+  datetimeTbd: ['datetime_tbd', (v) => v.datetimeTbd],
+  invitePermission: ['invite_permission', (v) => v.invitePermission],
+  rsvpEnabled: ['rsvp_enabled', (v) => v.rsvpEnabled],
+  allowPlusOnes: ['allow_plus_ones', (v) => v.allowPlusOnes],
+  maxAttendees: ['max_attendees', (v) => v.maxAttendees],
+  whatsappLink: ['whatsapp_link', (v) => v.whatsappLink],
+  partifulLink: ['partiful_link', (v) => v.partifulLink],
+  otherLink: ['other_link', (v) => v.otherLink],
+  price: ['price', (v) => v.price],
+  venmoLink: ['venmo_link', (v) => toVenmoUrl(v.venmoLink)],
+  cashappLink: ['cashapp_link', (v) => toCashAppUrl(v.cashappLink)],
+  zelleInfo: ['zelle_info', (v) => v.zelleInfo],
+  coHostIds: ['co_host_ids', (v) => v.coHostIds],
+  status: ['status', (v) => v.status],
+};
+
 function toWireBody(values: EventFormValues): WireBody {
   const { visibility, eventType } = visibilityChoiceToFields(values.visibilityChoice);
-  return {
-    title: values.title,
-    description: values.description,
-    location: values.location,
-    latitude: values.latitude,
-    longitude: values.longitude,
-    start_datetime: values.startDatetime,
-    end_datetime: values.endDatetime,
-    datetime_tbd: values.datetimeTbd,
-    event_type: eventType,
-    visibility,
-    invite_permission: values.invitePermission,
-    rsvp_enabled: values.rsvpEnabled,
-    allow_plus_ones: values.allowPlusOnes,
-    max_attendees: values.maxAttendees,
-    whatsapp_link: values.whatsappLink,
-    partiful_link: values.partifulLink,
-    other_link: values.otherLink,
-    price: values.price,
-    venmo_link: toVenmoUrl(values.venmoLink),
-    cashapp_link: toCashAppUrl(values.cashappLink),
-    zelle_info: values.zelleInfo,
-    co_host_ids: values.coHostIds,
-    status: values.status,
-  };
+  const body: WireBody = { visibility, event_type: eventType };
+  for (const field of Object.values(FIELD_TO_WIRE)) {
+    const [wireKey, encode] = field;
+    body[wireKey] = encode(values);
+  }
+  return body;
+}
+
+// Build a PATCH body from only the keys present in the Partial. Avoids the
+// unsafe Partial→full cast: we never read a field that wasn't provided.
+// `visibilityChoice` (if present) expands into `visibility` + `event_type`.
+export function toPartialWireBody(values: Partial<EventFormValues>): WireBody {
+  const body: WireBody = {};
+  for (const key of Object.keys(values) as (keyof EventFormValues)[]) {
+    if (values[key] === undefined) continue;
+    if (key === 'visibilityChoice') {
+      const choice = values.visibilityChoice;
+      if (choice === undefined) continue;
+      const { visibility, eventType } = visibilityChoiceToFields(choice);
+      body.visibility = visibility;
+      body.event_type = eventType;
+      continue;
+    }
+    const field = FIELD_TO_WIRE[key];
+    if (!field) continue;
+    const [wireKey, encode] = field;
+    body[wireKey] = encode(values as EventFormValues);
+  }
+  return body;
 }
 
 export function useCreateEvent() {
@@ -105,6 +147,9 @@ export function useCreateEvent() {
     onSuccess: (event) => {
       qc.setQueryData(eventKeys.detail(event.id, isAuthed), event);
       void qc.invalidateQueries({ queryKey: eventKeys.list(isAuthed) });
+    },
+    onError: (err) => {
+      void reportError(err, ROUTE, { action: 'create-event' });
     },
   });
 }
@@ -128,6 +173,9 @@ export function useInviteToEvent(eventId: string) {
       qc.setQueryData(eventKeys.detail(event.id, isAuthed), event);
       void qc.invalidateQueries({ queryKey: eventKeys.list(isAuthed) });
     },
+    onError: (err) => {
+      void reportError(err, ROUTE, { action: 'invite-to-event', eventId });
+    },
   });
 }
 
@@ -136,15 +184,9 @@ export function useUpdateEvent(eventId: string) {
   const isAuthed = useAuthStore((s) => s.status === 'authed');
   return useMutation({
     mutationFn: async (values: Partial<EventFormValues>) => {
-      // Strip undefined: PATCH is partial. Falsy values other than undefined
-      // should still be sent — false/""/null carry meaning.
-      const full = values as EventFormValues;
-      const wire = toWireBody(full);
-      const body = Object.fromEntries(
-        Object.entries(wire).filter(
-          ([k]) => (values as Record<string, unknown>)[kebabToCamel(k)] !== undefined,
-        ),
-      );
+      // PATCH is partial: build the wire body from only the provided keys.
+      // Falsy values other than undefined still carry meaning (false/""/null).
+      const body = toPartialWireBody(values);
       const { data } = await apiClient.patch<WireEvent>(`/api/community/events/${eventId}/`, body);
       return mapEvent(data);
     },
@@ -152,11 +194,10 @@ export function useUpdateEvent(eventId: string) {
       qc.setQueryData(eventKeys.detail(event.id, isAuthed), event);
       void qc.invalidateQueries({ queryKey: eventKeys.list(isAuthed) });
     },
+    onError: (err) => {
+      void reportError(err, ROUTE, { action: 'update-event', eventId });
+    },
   });
-}
-
-function kebabToCamel(s: string): string {
-  return s.replace(/_([a-z])/g, (_, c: string) => c.toUpperCase());
 }
 
 // Cancel an event (active → cancelled). Notifies attendees; the backend
@@ -167,7 +208,7 @@ export function useCancelEvent(eventId: string) {
   return useMutation({
     mutationFn: async () => {
       const body: WireBody = {
-        status: 'cancelled' satisfies EventStatus,
+        status: EventStatusEnum.Cancelled,
         notify_attendees: true,
       };
       const { data } = await apiClient.patch<WireEvent>(`/api/community/events/${eventId}/`, body);
@@ -176,6 +217,9 @@ export function useCancelEvent(eventId: string) {
     onSuccess: (event) => {
       qc.setQueryData(eventKeys.detail(event.id, isAuthed), event);
       void qc.invalidateQueries({ queryKey: eventKeys.list(isAuthed) });
+    },
+    onError: (err) => {
+      void reportError(err, ROUTE, { action: 'cancel-event', eventId });
     },
   });
 }
@@ -187,13 +231,16 @@ export function useDeleteEvent(eventId: string) {
   const isAuthed = useAuthStore((s) => s.status === 'authed');
   return useMutation({
     mutationFn: async () => {
-      const body: WireBody = { status: 'deleted' satisfies EventStatus };
+      const body: WireBody = { status: EventStatusEnum.Deleted };
       const { data } = await apiClient.patch<WireEvent>(`/api/community/events/${eventId}/`, body);
       return mapEvent(data);
     },
     onSuccess: (event) => {
       qc.setQueryData(eventKeys.detail(event.id, isAuthed), event);
       void qc.invalidateQueries({ queryKey: eventKeys.list(isAuthed) });
+    },
+    onError: (err) => {
+      void reportError(err, ROUTE, { action: 'delete-event', eventId });
     },
   });
 }
@@ -216,6 +263,9 @@ export function useUploadEventPhoto(eventId: string) {
       qc.setQueryData(eventKeys.detail(event.id, isAuthed), event);
       void qc.invalidateQueries({ queryKey: eventKeys.list(isAuthed) });
     },
+    onError: (err) => {
+      void reportError(err, ROUTE, { action: 'upload-event-photo', eventId });
+    },
   });
 }
 
@@ -230,6 +280,9 @@ export function useDeleteEventPhoto(eventId: string) {
     onSuccess: (event) => {
       qc.setQueryData(eventKeys.detail(event.id, isAuthed), event);
       void qc.invalidateQueries({ queryKey: eventKeys.list(isAuthed) });
+    },
+    onError: (err) => {
+      void reportError(err, ROUTE, { action: 'delete-event-photo', eventId });
     },
   });
 }
@@ -271,7 +324,33 @@ export function emptyEventFormValues(): EventFormValues {
   };
 }
 
+// Coerce an arbitrary wire string to a known union value, falling back to a
+// safe default on anything unexpected. The server *should* only ever send
+// known values, but a stale client / schema drift shouldn't blow up the form.
+function coerceEnum<T extends string>(value: string, allowed: readonly T[], fallback: T): T {
+  return (allowed as readonly string[]).includes(value) ? (value as T) : fallback;
+}
+
+const FORM_EVENT_TYPES = [EventTypeEnum.Community, EventTypeEnum.Official] as const;
+const FORM_VISIBILITIES = [
+  EventVisibility.Public,
+  EventVisibility.MembersOnly,
+  EventVisibility.InviteOnly,
+] as const;
+const FORM_INVITE_PERMISSIONS = [
+  InvitePermission.AllMembers,
+  InvitePermission.CoHostsOnly,
+] as const;
+const FORM_STATUSES = [
+  EventStatusEnum.Active,
+  EventStatusEnum.Draft,
+  EventStatusEnum.Cancelled,
+  EventStatusEnum.Deleted,
+] as const;
+
 export function eventToFormValues(e: Event): EventFormValues {
+  const eventType = coerceEnum(e.eventType, FORM_EVENT_TYPES, EventTypeEnum.Community);
+  const visibility = coerceEnum(e.visibility, FORM_VISIBILITIES, EventVisibility.Public);
   return {
     title: e.title,
     description: e.description,
@@ -281,13 +360,14 @@ export function eventToFormValues(e: Event): EventFormValues {
     startDatetime: e.startDatetime ? e.startDatetime.toISOString() : null,
     endDatetime: e.endDatetime ? e.endDatetime.toISOString() : null,
     datetimeTbd: e.datetimeTbd,
-    eventType: e.eventType as 'community' | 'official',
-    visibility: e.visibility as 'public' | 'members_only' | 'invite_only',
-    visibilityChoice: fieldsToVisibilityChoice(
-      e.visibility as 'public' | 'members_only' | 'invite_only',
-      e.eventType as 'community' | 'official',
+    eventType,
+    visibility,
+    visibilityChoice: fieldsToVisibilityChoice(visibility, eventType),
+    invitePermission: coerceEnum(
+      e.invitePermission,
+      FORM_INVITE_PERMISSIONS,
+      InvitePermission.AllMembers,
     ),
-    invitePermission: e.invitePermission as 'all_members' | 'co_hosts_only',
     rsvpEnabled: e.rsvpEnabled,
     allowPlusOnes: e.allowPlusOnes,
     maxAttendees: e.maxAttendees,
@@ -299,6 +379,6 @@ export function eventToFormValues(e: Event): EventFormValues {
     cashappLink: fromCashAppUrl(e.cashappLink),
     zelleInfo: e.zelleInfo,
     coHostIds: e.coHostIds,
-    status: e.status as EventStatus,
+    status: coerceEnum(e.status, FORM_STATUSES, EventStatusEnum.Active),
   };
 }

--- a/frontend/src/layout/NotificationBell.test.tsx
+++ b/frontend/src/layout/NotificationBell.test.tsx
@@ -25,6 +25,12 @@ vi.mock('@/hooks/useEventSource', () => ({
   useEventSource: vi.fn(),
 }));
 
+// errorReporter posts to the backend — stub it so onError handlers don't try
+// to hit the network in tests.
+vi.mock('@/utils/errorReporter', () => ({
+  reportError: vi.fn().mockResolvedValue(undefined),
+}));
+
 import {
   useUnreadCount,
   useNotifications,
@@ -39,7 +45,7 @@ const mockUseMarkNotificationRead = vi.mocked(useMarkNotificationRead);
 const mockUseMarkAllNotificationsRead = vi.mocked(useMarkAllNotificationsRead);
 
 function makeMutation(overrides = {}) {
-  return { mutateAsync: vi.fn(), isPending: false, ...overrides };
+  return { mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false, ...overrides };
 }
 
 function makeQc() {
@@ -177,29 +183,34 @@ describe('NotificationBell auto-clear on open', () => {
   });
 
   it('fires mark-all-read after the delay when opened with unread items', () => {
-    const mutateAsync = vi.fn().mockResolvedValue(undefined);
+    const mutate = vi.fn();
     mockUseUnreadCount.mockReturnValue({ data: 2 } as unknown as ReturnType<typeof useUnreadCount>);
     mockUseMarkAllNotificationsRead.mockReturnValue(
-      makeMutation({ mutateAsync }) as unknown as ReturnType<typeof useMarkAllNotificationsRead>,
+      makeMutation({ mutate }) as unknown as ReturnType<typeof useMarkAllNotificationsRead>,
     );
 
     renderBell();
 
     fireEvent.click(screen.getByRole('button', { name: /notifications \(2 unread\)/i }));
-    expect(mutateAsync).not.toHaveBeenCalled();
+    expect(mutate).not.toHaveBeenCalled();
 
     act(() => {
       vi.advanceTimersByTime(AUTO_READ_DELAY_MS);
     });
 
-    expect(mutateAsync).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledTimes(1);
+    // Called with an onError handler so a rejection can't become unhandled.
+    expect(mutate).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ onError: expect.any(Function) }),
+    );
   });
 
   it('does not fire when the dropdown is opened with zero unread', () => {
-    const mutateAsync = vi.fn().mockResolvedValue(undefined);
+    const mutate = vi.fn();
     mockUseUnreadCount.mockReturnValue({ data: 0 } as unknown as ReturnType<typeof useUnreadCount>);
     mockUseMarkAllNotificationsRead.mockReturnValue(
-      makeMutation({ mutateAsync }) as unknown as ReturnType<typeof useMarkAllNotificationsRead>,
+      makeMutation({ mutate }) as unknown as ReturnType<typeof useMarkAllNotificationsRead>,
     );
 
     renderBell();
@@ -210,14 +221,14 @@ describe('NotificationBell auto-clear on open', () => {
       vi.advanceTimersByTime(AUTO_READ_DELAY_MS * 2);
     });
 
-    expect(mutateAsync).not.toHaveBeenCalled();
+    expect(mutate).not.toHaveBeenCalled();
   });
 
   it('cancels the pending mark-all call if the dropdown closes within the delay', () => {
-    const mutateAsync = vi.fn().mockResolvedValue(undefined);
+    const mutate = vi.fn();
     mockUseUnreadCount.mockReturnValue({ data: 3 } as unknown as ReturnType<typeof useUnreadCount>);
     mockUseMarkAllNotificationsRead.mockReturnValue(
-      makeMutation({ mutateAsync }) as unknown as ReturnType<typeof useMarkAllNotificationsRead>,
+      makeMutation({ mutate }) as unknown as ReturnType<typeof useMarkAllNotificationsRead>,
     );
 
     renderBell();
@@ -233,14 +244,14 @@ describe('NotificationBell auto-clear on open', () => {
       vi.advanceTimersByTime(AUTO_READ_DELAY_MS * 2);
     });
 
-    expect(mutateAsync).not.toHaveBeenCalled();
+    expect(mutate).not.toHaveBeenCalled();
   });
 
   it('resets the timer when the dropdown is reopened', () => {
-    const mutateAsync = vi.fn().mockResolvedValue(undefined);
+    const mutate = vi.fn();
     mockUseUnreadCount.mockReturnValue({ data: 1 } as unknown as ReturnType<typeof useUnreadCount>);
     mockUseMarkAllNotificationsRead.mockReturnValue(
-      makeMutation({ mutateAsync }) as unknown as ReturnType<typeof useMarkAllNotificationsRead>,
+      makeMutation({ mutate }) as unknown as ReturnType<typeof useMarkAllNotificationsRead>,
     );
 
     renderBell();
@@ -257,12 +268,72 @@ describe('NotificationBell auto-clear on open', () => {
     act(() => {
       vi.advanceTimersByTime(AUTO_READ_DELAY_MS - 500);
     });
-    expect(mutateAsync).not.toHaveBeenCalled();
+    expect(mutate).not.toHaveBeenCalled();
 
     // Now advance the rest of the new full delay — fires exactly once
     act(() => {
       vi.advanceTimersByTime(500);
     });
-    expect(mutateAsync).toHaveBeenCalledTimes(1);
+    expect(mutate).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-fire in a tight loop after a failure while the panel stays open', () => {
+    // mutate reports failure synchronously via its onError callback.
+    const mutate = vi.fn((_vars, opts?: { onError?: (e: unknown) => void }) => {
+      opts?.onError?.(new Error('boom'));
+    });
+    mockUseUnreadCount.mockReturnValue({ data: 4 } as unknown as ReturnType<typeof useUnreadCount>);
+    mockUseMarkAllNotificationsRead.mockReturnValue(
+      makeMutation({ mutate }) as unknown as ReturnType<typeof useMarkAllNotificationsRead>,
+    );
+
+    renderBell();
+
+    fireEvent.click(screen.getByRole('button', { name: /notifications \(4 unread\)/i }));
+    act(() => {
+      vi.advanceTimersByTime(AUTO_READ_DELAY_MS);
+    });
+    expect(mutate).toHaveBeenCalledTimes(1);
+
+    // Even though count stays non-zero and the panel stays open, the failure
+    // latch prevents another attempt — no tight retry loop.
+    act(() => {
+      vi.advanceTimersByTime(AUTO_READ_DELAY_MS * 5);
+    });
+    expect(mutate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('NotificationBell mark-read error handling', () => {
+  it('uses mutate with an onError handler when a row is tapped (no unhandled rejection)', async () => {
+    const user = userEvent.setup();
+    const mutate = vi.fn();
+    mockUseUnreadCount.mockReturnValue({ data: 1 } as unknown as ReturnType<typeof useUnreadCount>);
+    mockUseNotifications.mockReturnValue({
+      isPending: false,
+      data: [
+        {
+          id: 'n9',
+          notificationType: NotificationType.EventComment,
+          eventId: 'evt1',
+          relatedUserId: null,
+          message: 'someone commented',
+          isRead: false,
+          createdAt: '2024-01-01T00:00:00Z',
+        },
+      ],
+    } as unknown as ReturnType<typeof useNotifications>);
+    mockUseMarkNotificationRead.mockReturnValue(
+      makeMutation({ mutate }) as unknown as ReturnType<typeof useMarkNotificationRead>,
+    );
+
+    renderBell();
+    await user.click(screen.getByRole('button', { name: /notifications \(1 unread\)/i }));
+    await user.click(await screen.findByRole('button', { name: /someone commented/i }));
+
+    expect(mutate).toHaveBeenCalledWith(
+      'n9',
+      expect.objectContaining({ onError: expect.any(Function) }),
+    );
   });
 });

--- a/frontend/src/layout/NotificationBell.tsx
+++ b/frontend/src/layout/NotificationBell.tsx
@@ -3,7 +3,7 @@
 // count refetch. Polling is a fallback (30s when SSE is disconnected, 5 min
 // when connected).
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { useAuthStore } from '@/auth/store';
@@ -17,6 +17,9 @@ import {
 import { useEventSource } from '@/hooks/useEventSource';
 import { NotificationType, type AppNotification } from '@/models/notification';
 import { cn } from '@/utils/cn';
+import { reportError } from '@/utils/errorReporter';
+
+const ROUTE = '/notifications';
 
 const AUTO_READ_DELAY_MS = 1500;
 
@@ -59,12 +62,28 @@ export function NotificationBell() {
   // the user time to actually see what's new before we clear the badge.
   // Closing (or unmounting) within the window cancels the pending call; a new
   // SSE-pushed notification bumps `count`, which resets the timer.
-  const markAllMutate = markAll.mutateAsync;
+  //
+  // We use `mutate` (not `mutateAsync`) with an inline `onError` so a rejected
+  // mark-all never becomes an unhandled promise rejection. After a failure we
+  // latch `autoMarkFailedRef` so the effect won't re-fire in a tight loop while
+  // `count` stays non-zero; the latch clears whenever the dropdown closes, so
+  // the next open retries once.
+  const markAllMutate = markAll.mutate;
   const markAllPending = markAll.isPending;
+  const autoMarkFailedRef = useRef(false);
   useEffect(() => {
-    if (!open || count === 0 || markAllPending) return;
+    if (!open) {
+      autoMarkFailedRef.current = false;
+      return;
+    }
+    if (count === 0 || markAllPending || autoMarkFailedRef.current) return;
     const timer = setTimeout(() => {
-      void markAllMutate();
+      markAllMutate(undefined, {
+        onError: (err) => {
+          autoMarkFailedRef.current = true;
+          void reportError(err, ROUTE, { action: 'mark-all-read' });
+        },
+      });
     }, AUTO_READ_DELAY_MS);
     return () => {
       clearTimeout(timer);
@@ -120,7 +139,16 @@ export function NotificationBell() {
                       <NotificationRow
                         n={n}
                         onMarkRead={() => {
-                          if (!n.isRead) void markRead.mutateAsync(n.id);
+                          if (!n.isRead) {
+                            markRead.mutate(n.id, {
+                              onError: (err) => {
+                                void reportError(err, ROUTE, {
+                                  action: 'mark-read',
+                                  notificationId: n.id,
+                                });
+                              },
+                            });
+                          }
                         }}
                         onClose={() => {
                           setOpen(false);

--- a/frontend/src/screens/auth/LoginScreen.tsx
+++ b/frontend/src/screens/auth/LoginScreen.tsx
@@ -13,6 +13,7 @@ import { useAuthStore } from '@/auth/store';
 import { checkPhone } from '@/api/join';
 import { extractApiError } from '@/utils/errors';
 import { RequestLoginLinkDialog } from './RequestLoginLinkDialog';
+import { safeRedirect } from './redirect';
 
 type Step = 'phone' | 'password' | 'pending';
 
@@ -88,8 +89,7 @@ export default function LoginScreen() {
           setStep('phone');
         }}
         onSuccess={() => {
-          const redirect = params.get('redirect');
-          void navigate(redirect ? decodeURIComponent(redirect) : '/calendar', { replace: true });
+          void navigate(safeRedirect(params.get('redirect')), { replace: true });
         }}
         loginFn={login}
       />

--- a/frontend/src/screens/auth/redirect.test.ts
+++ b/frontend/src/screens/auth/redirect.test.ts
@@ -1,0 +1,48 @@
+// Open-redirect guard for the post-login `redirect` query param.
+import { describe, it, expect } from 'vitest';
+import { safeRedirect } from './redirect';
+
+const DEFAULT = '/calendar';
+
+describe('safeRedirect', () => {
+  it('falls back to the default route when no redirect is given', () => {
+    expect(safeRedirect(null)).toBe(DEFAULT);
+    expect(safeRedirect('')).toBe(DEFAULT);
+  });
+
+  it('allows a plain relative in-app path', () => {
+    expect(safeRedirect('/events/abc123')).toBe('/events/abc123');
+    expect(safeRedirect('/admin/members')).toBe('/admin/members');
+  });
+
+  it('decodes percent-encoded relative paths', () => {
+    expect(safeRedirect(encodeURIComponent('/events/abc?tab=guests'))).toBe(
+      '/events/abc?tab=guests',
+    );
+  });
+
+  it('rejects scheme-relative urls (//evil.com)', () => {
+    expect(safeRedirect('//evil.com')).toBe(DEFAULT);
+    expect(safeRedirect(encodeURIComponent('//evil.com'))).toBe(DEFAULT);
+  });
+
+  it('rejects absolute urls with a scheme', () => {
+    expect(safeRedirect('https://evil.com')).toBe(DEFAULT);
+    expect(safeRedirect('http://evil.com/path')).toBe(DEFAULT);
+    expect(safeRedirect('javascript://alert(1)')).toBe(DEFAULT);
+  });
+
+  it('rejects paths that do not start with a single slash', () => {
+    expect(safeRedirect('evil.com')).toBe(DEFAULT);
+    expect(safeRedirect('calendar')).toBe(DEFAULT);
+  });
+
+  it('rejects backslash tricks (/\\evil.com)', () => {
+    expect(safeRedirect('/\\evil.com')).toBe(DEFAULT);
+  });
+
+  it('falls back when decoding throws on a malformed escape', () => {
+    expect(safeRedirect('%')).toBe(DEFAULT);
+    expect(safeRedirect('%E0%A4%A')).toBe(DEFAULT);
+  });
+});

--- a/frontend/src/screens/auth/redirect.ts
+++ b/frontend/src/screens/auth/redirect.ts
@@ -1,0 +1,24 @@
+// Open-redirect guard for the post-login `redirect` query param. Lives in its
+// own module (not LoginScreen.tsx) so react-refresh stays happy — component
+// files may only export components.
+
+export const DEFAULT_POST_LOGIN_ROUTE = '/calendar';
+
+// Only allow relative in-app paths. Reject anything that could leave the app —
+// absolute URLs (`http://evil.com`), scheme-relative URLs (`//evil.com`),
+// backslash tricks (`/\evil.com`), or paths that don't start with a single
+// `/`. Falls back to the default route on anything unsafe or malformed.
+export function safeRedirect(raw: string | null): string {
+  if (!raw) return DEFAULT_POST_LOGIN_ROUTE;
+  let decoded: string;
+  try {
+    decoded = decodeURIComponent(raw);
+  } catch {
+    return DEFAULT_POST_LOGIN_ROUTE;
+  }
+  const isRelativePath =
+    decoded.startsWith('/') && !decoded.startsWith('//') && !decoded.includes('://');
+  // Normalize backslashes — some browsers treat `/\` like `//`.
+  if (!isRelativePath || decoded.startsWith('/\\')) return DEFAULT_POST_LOGIN_ROUTE;
+  return decoded;
+}


### PR DESCRIPTION
## summary

frontend correctness / error-handling fixes for the api client, login redirect, notification bell, and event-write hooks.

### Issue 458 — refresh-retry + open redirect (`api/client.ts`, `screens/auth/LoginScreen.tsx`)
- **safe one-shot replay after refresh.** the 401 response interceptor refreshes the token and replays the original request once — for *any* method, including POST/PATCH/DELETE. this is safe because a clean 401 means the server rejected the request at auth *before* processing it, so it demonstrably never mutated state; replaying with the refreshed token is idempotent in effect. the `_retried` guard caps replay at a single attempt, so there's no infinite loop or double-submit. previously the interceptor also replayed any request, but without distinguishing a dead session from a transient refresh failure (see next bullet).
- **distinguish a dead session from a transient blip.** `doRefresh` used to catch *every* error and return null, forcing a logout on any network/5xx/CORS failure. it now returns a discriminated `RefreshResult`: only a real **401 from the refresh endpoint** triggers `onSessionExpired`; transient failures leave the session intact and surface as retryable (the interceptor rethrows the original error without retrying).
- **block open redirect.** the post-login `redirect` param was `decodeURIComponent`'d and passed straight to `navigate()`. new `safeRedirect` helper (in `screens/auth/redirect.ts`, separate module so react-refresh stays happy) only allows relative in-app paths — rejects `://`, leading `//`, backslash tricks, non-`/` paths, and malformed escapes — falling back to `/calendar`.

### Issue 459 — unhandled rejections + event-write type safety (`layout/NotificationBell.tsx`, `api/eventWrites.ts`)
- **no more unhandled promise rejections in the bell.** `void markRead.mutateAsync(...)` and the auto-mark-all effect now use `mutate` with an inline `onError` that routes through `reportError`. the auto-mark effect latches on failure so it can't tight-loop while `count` stays non-zero (latch clears when the panel closes → one retry on next open).
- **safe partial PATCH bodies.** `useUpdateEvent` no longer casts `Partial<EventFormValues>` to the full type then filters back via a misnamed `kebabToCamel`. new `toPartialWireBody` builds the wire body from *only* the provided keys via a per-field map; `visibilityChoice` expands into `visibility` + `event_type`. the misnamed helper is gone.
- **validated enum coercion.** `eventToFormValues` validated nothing — it `as`-cast `eventType`/`visibility`/`invitePermission`/`status`. it now coerces against the model unions (`EventType`/`EventVisibility`/`InvitePermission`/`EventStatus`) and falls back to safe defaults on unexpected values.
- **onError logging on all write mutations** (create/invite/update/cancel/delete/photo) via `reportError`. cancel/delete now use the `EventStatus` enum instead of raw strings.

## tests
- `api/client.test.ts`: a mutating request is replayed exactly once after a clean 401 + successful refresh (sent twice total, no logout); replay never happens more than once even if the retry still 401s (no infinite loop / triple-submit); transient refresh failure (5xx) doesn't force logout; network-error refresh doesn't force logout; a failed refresh that 401s fires `onSessionExpired`.
- `screens/auth/redirect.test.ts`: open-redirect cases (`//evil.com`, `https://evil.com`, `javascript:`, backslash, malformed escape) all fall back to `/calendar`; valid relative paths pass through.
- `layout/NotificationBell.test.tsx`: mark-all + mark-read use `mutate` with an `onError` handler; failure latch prevents tight retry loop; existing timer/cancel/reset tests migrated to `mutate`.
- `api/eventWrites.test.ts`: `eventToFormValues` falls back on unknown enum values (and derives `visibilityChoice` from the coerced values); `toPartialWireBody` includes only provided keys, keeps meaningful falsy values, drops undefined, and expands `visibilityChoice`.

## decisions
- **refresh-retry replay:** chose to replay the original request once after a successful refresh, regardless of method, rather than withholding replay for mutations. a clean 401 proves the request was rejected at auth before any side-effect, so the replay is idempotent in effect, and the `_retried` guard caps it at one attempt. this matches the existing interceptor shape and needs no backend contract change. the safety guarantee depends on the backend always rejecting expired tokens at auth before applying a mutation — true for the django-ninja auth dependency used across the api.
- **enum validation:** derived from the existing `@/models/event` const-enums (the generated `types.gen.ts` types these as bare `string`), keeping a single source of truth.
- **safeRedirect lives in its own module** because exporting a non-component from `LoginScreen.tsx` trips `react-refresh/only-export-components`.

`make agent-ci` passed (exit 0); frontend suite 509 passed / 1 skipped across 76 files.

Closes #458
Closes #459
