### PR TITLE
fix(auth): make consent gate skippable and let users read the guidelines

### DIFF
--- a/frontend/src/auth/guards.test.tsx
+++ b/frontend/src/auth/guards.test.tsx
@@ -320,6 +320,25 @@ describe('OnboardingGate', () => {
     expect(screen.queryByText('calendar page')).not.toBeInTheDocument();
   });
 
+  it('lets a needsGuidelinesConsent user read /guidelines (so consent is possible)', () => {
+    const user = makeUser({ needsGuidelinesConsent: true });
+    useAuthStore.setState({ status: 'authed', user, accessToken: 'tok-abc' });
+
+    render(
+      <MemoryRouter initialEntries={['/guidelines']}>
+        <Routes>
+          <Route element={<OnboardingGate />}>
+            <Route path="/guidelines" element={<div>guidelines page</div>} />
+            <Route path="/consent" element={<div>consent page</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('guidelines page')).toBeInTheDocument();
+    expect(screen.queryByText('consent page')).not.toBeInTheDocument();
+  });
+
   it('sends a password setup to /onboarding before asking for consent', () => {
     // A brand-new user who owes both password setup and consent resolves the
     // password gate first — consent is only asked once setup is done.

--- a/frontend/src/auth/guards.tsx
+++ b/frontend/src/auth/guards.tsx
@@ -77,9 +77,13 @@ export function OnboardingGate() {
       return <Navigate to={setupTarget} replace />;
     }
   } else if (consentTarget) {
-    // Hard guidelines-consent gate — no skip, no dismiss. Pin the user to
-    // /consent until they accept (clears needsGuidelinesConsent on /me/).
-    if (path !== consentTarget) {
+    // Guidelines-consent gate. The consent screen blocks login completion, but
+    // the user can either accept (clears needsGuidelinesConsent on /me/) or pick
+    // "not now" on the screen itself to log out. We pin them to /consent EXCEPT
+    // for /guidelines — they must be able to read what they're agreeing to (the
+    // consent screen links there), so trapping that page would make honest
+    // consent impossible.
+    if (path !== consentTarget && path !== '/guidelines') {
       return <Navigate to={consentTarget} replace />;
     }
   } else if (user) {

--- a/frontend/src/screens/auth/ConsentScreen.test.tsx
+++ b/frontend/src/screens/auth/ConsentScreen.test.tsx
@@ -1,9 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
+import type * as RouterDom from 'react-router-dom';
 import ConsentScreen from './ConsentScreen';
 import { useAuthStore } from '@/auth/store';
+
+const navigate = vi.fn();
+vi.mock('react-router-dom', async (importActual) => {
+  const actual = await importActual<typeof RouterDom>();
+  return { ...actual, useNavigate: () => navigate };
+});
 
 vi.mock('@/auth/store', () => ({
   useAuthStore: vi.fn(),
@@ -17,11 +24,14 @@ vi.mock('@/api/client', () => ({
 
 describe('ConsentScreen', () => {
   const acceptGuidelines = vi.fn();
+  const logout = vi.fn();
 
   beforeEach(() => {
     acceptGuidelines.mockReset();
+    logout.mockReset();
+    navigate.mockReset();
     vi.mocked(useAuthStore).mockImplementation((selector) =>
-      selector({ acceptGuidelines } as never),
+      selector({ acceptGuidelines, logout } as never),
     );
   });
 
@@ -46,7 +56,7 @@ describe('ConsentScreen', () => {
     );
   });
 
-  it('accepts the guidelines once checked', async () => {
+  it('accepts the guidelines once checked and goes to calendar', async () => {
     acceptGuidelines.mockResolvedValue(undefined);
     render(
       <MemoryRouter>
@@ -56,6 +66,7 @@ describe('ConsentScreen', () => {
     await userEvent.click(screen.getByRole('checkbox'));
     await userEvent.click(screen.getByRole('button', { name: /continue/i }));
     expect(acceptGuidelines).toHaveBeenCalledOnce();
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/calendar', { replace: true }));
   });
 
   it('shows a server error on failure', async () => {
@@ -68,5 +79,28 @@ describe('ConsentScreen', () => {
     await userEvent.click(screen.getByRole('checkbox'));
     await userEvent.click(screen.getByRole('button', { name: /continue/i }));
     expect(await screen.findByRole('alert')).toBeInTheDocument();
+  });
+
+  it('logs out and returns to the landing page on "not now"', async () => {
+    logout.mockResolvedValue(undefined);
+    render(
+      <MemoryRouter>
+        <ConsentScreen />
+      </MemoryRouter>,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /not now/i }));
+    expect(logout).toHaveBeenCalledOnce();
+    await waitFor(() => expect(navigate).toHaveBeenCalledWith('/', { replace: true }));
+    // "not now" is available without ticking the checkbox — it's a decline.
+    expect(acceptGuidelines).not.toHaveBeenCalled();
+  });
+
+  it('allows "not now" even before the checkbox is ticked', () => {
+    render(
+      <MemoryRouter>
+        <ConsentScreen />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole('button', { name: /not now/i })).toBeEnabled();
   });
 });

--- a/frontend/src/screens/auth/ConsentScreen.tsx
+++ b/frontend/src/screens/auth/ConsentScreen.tsx
@@ -5,12 +5,15 @@ import { Button } from '@/components/ui/Button';
 import { useAuthStore } from '@/auth/store';
 import { extractApiError } from '@/utils/errors';
 
-// Hard guidelines-consent gate. Modeled on OnboardingScreen — same AuthLayout
-// shell, single blocking action, no skip or dismiss. Reached only via
-// OnboardingGate redirecting consent-pending users to /consent; the gate pins
-// them here until acceptGuidelines() clears needsGuidelinesConsent.
+// Guidelines-consent gate. Modeled on OnboardingScreen — same AuthLayout shell.
+// Blocks login completion: the only ways forward are to accept (clears
+// needsGuidelinesConsent) or "not now", which logs out and returns to the
+// landing page. Reached via OnboardingGate redirecting consent-pending users
+// here; that gate pins them to /consent (except /guidelines, so they can read
+// what they're agreeing to) until one of those two happens.
 export default function ConsentScreen() {
   const acceptGuidelines = useAuthStore((s) => s.acceptGuidelines);
+  const logout = useAuthStore((s) => s.logout);
   const navigate = useNavigate();
   const [consented, setConsented] = useState(false);
   const [serverError, setServerError] = useState<string | null>(null);
@@ -27,6 +30,14 @@ export default function ConsentScreen() {
       setServerError(extractApiError(err, "couldn't save your consent — try again"));
       setSubmitting(false);
     }
+  }
+
+  async function onSkip() {
+    // Decline for now: drop the session and return to the landing page logged
+    // out. No half-authed state — the only way into the app is to accept.
+    setSubmitting(true);
+    await logout();
+    void navigate('/', { replace: true });
   }
 
   return (
@@ -65,6 +76,14 @@ export default function ConsentScreen() {
         >
           {submitting ? 'saving…' : 'continue'}
         </Button>
+        <button
+          type="button"
+          disabled={submitting}
+          onClick={() => void onSkip()}
+          className="text-foreground-tertiary text-center text-sm underline disabled:opacity-50"
+        >
+          not now
+        </button>
       </div>
     </AuthLayout>
   );


### PR DESCRIPTION
## overview

Follow-up to #480. On staging the hard consent gate **trapped** consent-pending users:
- navigating away from `/consent` showed a blank/broken page, and
- the "community guidelines" link bounced straight back to `/consent`, so you couldn't read what you were agreeing to.

This reframes the gate as a **login decision point** rather than a trap, and fixes the unreadable-guidelines bug.

## changes

- **"not now" link on the consent screen** — drops the session (`logout`) and returns to the landing page (`/`), logged out. Consent still blocks *login completion* (the only way *into* the app is to accept), but declining is now a graceful exit with no half-authed browsing state.
- **`/guidelines` reachable while consent-pending** — `OnboardingGate`'s consent branch now allow-lists `/guidelines`, so a pending user can actually read the guidelines (the consent screen links there) before accepting. Trapping that page made honest consent impossible.

The server-side `GatedJWTAuth` gate is **unchanged** — a token without consent still `403`s on protected endpoints (defense in depth). This is a frontend-only behavior fix.

## verification

- `make agent-frontend-test` — ✅ 500 passed (1 skipped)
- `make agent-frontend-lint` / `agent-frontend-format-check` / `agent-frontend-typecheck` — ✅ all clean

New tests cover: "not now" logs out + navigates to `/`; "not now" works without ticking the checkbox; a consent-pending user can load `/guidelines`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)