### PR TITLE
fix(auth): route consent-pending users at login, not via the gate

### DIFF
--- a/frontend/src/models/user.test.ts
+++ b/frontend/src/models/user.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from 'vitest';
+import {
+  guidelinesConsentRedirect,
+  passwordSetupRedirect,
+  postAuthRedirect,
+  type User,
+} from './user';
+
+function makeUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 'u1',
+    phoneNumber: '+12125550001',
+    displayName: 'Alice',
+    email: 'alice@example.com',
+    bio: '',
+    isSuperuser: false,
+    isStaff: false,
+    needsOnboarding: false,
+    needsPasswordReset: false,
+    needsGuidelinesConsent: false,
+    showPhone: false,
+    showEmail: false,
+    weekStart: 'sunday',
+    calendarFeedScope: 'all',
+    profilePhotoUrl: '',
+    photoUpdatedAt: null,
+    roles: [],
+    ...overrides,
+  };
+}
+
+describe('passwordSetupRedirect', () => {
+  it('returns null when nothing is pending', () => {
+    expect(passwordSetupRedirect(makeUser())).toBeNull();
+  });
+
+  it('returns /new-password for a reset user with name + email', () => {
+    expect(passwordSetupRedirect(makeUser({ needsPasswordReset: true }))).toBe('/new-password');
+  });
+
+  it('returns /onboarding when name or email is missing', () => {
+    expect(passwordSetupRedirect(makeUser({ needsOnboarding: true, email: '' }))).toBe(
+      '/onboarding',
+    );
+  });
+});
+
+describe('guidelinesConsentRedirect', () => {
+  it('returns null when consented', () => {
+    expect(guidelinesConsentRedirect(makeUser())).toBeNull();
+  });
+
+  it('returns /consent when consent is pending', () => {
+    expect(guidelinesConsentRedirect(makeUser({ needsGuidelinesConsent: true }))).toBe('/consent');
+  });
+});
+
+describe('postAuthRedirect', () => {
+  it('returns null for a fully set-up, consented user', () => {
+    expect(postAuthRedirect(makeUser())).toBeNull();
+  });
+
+  it('returns null for a null user', () => {
+    expect(postAuthRedirect(null)).toBeNull();
+  });
+
+  it('routes a consent-pending user to /consent', () => {
+    // Regression: the post-login navigation used to ignore consent and lean on
+    // OnboardingGate, which raced the lazy target route and showed a blank
+    // screen. The resolver must surface /consent so auth screens navigate there.
+    expect(postAuthRedirect(makeUser({ needsGuidelinesConsent: true }))).toBe('/consent');
+  });
+
+  it('prioritises password setup over consent when both are pending', () => {
+    const target = postAuthRedirect(
+      makeUser({ needsOnboarding: true, displayName: '', needsGuidelinesConsent: true }),
+    );
+    expect(target).toBe('/onboarding');
+  });
+
+  it('prioritises /new-password over consent for a reset user with name + email', () => {
+    const target = postAuthRedirect(
+      makeUser({ needsPasswordReset: true, needsGuidelinesConsent: true }),
+    );
+    expect(target).toBe('/new-password');
+  });
+});

--- a/frontend/src/models/user.ts
+++ b/frontend/src/models/user.ts
@@ -70,3 +70,23 @@ export function guidelinesConsentRedirect(user: User | null): '/consent' | null 
   if (!user) return null;
   return user.needsGuidelinesConsent ? '/consent' : null;
 }
+
+/**
+ * The single gate screen a freshly-authenticated user must be sent to before
+ * the app proper, or null if nothing is pending. Combines the password-setup
+ * and consent gates in the SAME priority order OnboardingGate uses (password
+ * setup first, then consent).
+ *
+ * Auth screens (LoginScreen, MagicLoginScreen) call this and navigate to the
+ * result DIRECTLY rather than navigating to a protected route and leaning on
+ * OnboardingGate to bounce. Leaning on the gate races: the target route (often
+ * lazy-loaded) can render a blank Suspense fallback before the gate re-evaluates
+ * with the new auth state, so a pending user sees a blank screen until refresh.
+ * Navigating to the gate target up-front avoids that race entirely; the gate
+ * remains the backstop for every later navigation.
+ */
+export function postAuthRedirect(
+  user: User | null,
+): '/new-password' | '/onboarding' | '/consent' | null {
+  return passwordSetupRedirect(user) ?? guidelinesConsentRedirect(user);
+}

--- a/frontend/src/screens/auth/LoginScreen.tsx
+++ b/frontend/src/screens/auth/LoginScreen.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/Button';
 import { PasswordField } from '@/components/ui/PasswordField';
 import { PhoneField } from '@/components/ui/PhoneField';
 import { useAuthStore } from '@/auth/store';
+import { postAuthRedirect } from '@/models/user';
 import { checkPhone } from '@/api/join';
 import { extractApiError } from '@/utils/errors';
 import { RequestLoginLinkDialog } from './RequestLoginLinkDialog';
@@ -89,6 +90,17 @@ export default function LoginScreen() {
           setStep('phone');
         }}
         onSuccess={() => {
+          // Route based on the fresh user. Sending a pending user (password
+          // setup / consent) to their gate screen directly — instead of to the
+          // redirect/calendar and leaning on OnboardingGate to bounce — avoids
+          // a race where the lazy target renders a blank Suspense fallback
+          // before the gate re-evaluates with the new auth state.
+          const gateTarget = postAuthRedirect(useAuthStore.getState().user);
+          if (gateTarget) {
+            void navigate(gateTarget, { replace: true });
+            return;
+          }
+          // safeRedirect guards against open-redirect via the redirect param.
           void navigate(safeRedirect(params.get('redirect')), { replace: true });
         }}
         loginFn={login}

--- a/frontend/src/screens/auth/MagicLoginScreen.test.tsx
+++ b/frontend/src/screens/auth/MagicLoginScreen.test.tsx
@@ -50,6 +50,7 @@ function renderAt(token: string) {
         <Route path="/magic-login/:token" element={<MagicLoginScreen />} />
         <Route path="/new-password" element={<div>new password page</div>} />
         <Route path="/onboarding" element={<div>onboarding page</div>} />
+        <Route path="/consent" element={<div>consent page</div>} />
         <Route path="/calendar" element={<div>calendar page</div>} />
       </Routes>
     </MemoryRouter>,
@@ -73,6 +74,22 @@ describe('MagicLoginScreen', () => {
     // which the gate then bounced to /onboarding. Both must now agree.
     currentUser = makeUser({ needsPasswordReset: true, displayName: 'Alice', email: '' });
     renderAt('tok-noemail');
+    expect(await screen.findByText('onboarding page')).toBeInTheDocument();
+  });
+
+  it('routes a needsGuidelinesConsent user to /consent', async () => {
+    currentUser = makeUser({ needsGuidelinesConsent: true });
+    renderAt('tok-consent');
+    expect(await screen.findByText('consent page')).toBeInTheDocument();
+  });
+
+  it('routes password setup before consent when both are pending', async () => {
+    currentUser = makeUser({
+      needsOnboarding: true,
+      displayName: '',
+      needsGuidelinesConsent: true,
+    });
+    renderAt('tok-both');
     expect(await screen.findByText('onboarding page')).toBeInTheDocument();
   });
 

--- a/frontend/src/screens/auth/MagicLoginScreen.tsx
+++ b/frontend/src/screens/auth/MagicLoginScreen.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { AxiosError } from 'axios';
 import { Navigate, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { useAuthStore } from '@/auth/store';
-import { passwordSetupRedirect } from '@/models/user';
+import { postAuthRedirect } from '@/models/user';
 import { AuthLayout } from './AuthLayout';
 import { Button } from '@/components/ui/Button';
 import { RequestLoginLinkDialog } from './RequestLoginLinkDialog';
@@ -28,14 +28,15 @@ export default function MagicLoginScreen() {
     void magicLogin(token)
       .then(() => {
         // Route based on the fresh user in the store. Doing this here (instead
-        // of leaning on OnboardingGate) avoids a race where /calendar renders
-        // before the gate re-evaluates with the new auth state.
+        // of leaning on OnboardingGate) avoids a race where the target route
+        // renders before the gate re-evaluates with the new auth state.
         const user = useAuthStore.getState().user;
-        // Same shared decision as OnboardingGate, so the two can't disagree (a
-        // no-email user must reach /onboarding, not /new-password).
-        const setupTarget = passwordSetupRedirect(user);
-        if (setupTarget) {
-          void navigate(setupTarget, { replace: true });
+        // Same shared decision as OnboardingGate, so the two can't disagree —
+        // covers password setup (/onboarding, /new-password) AND consent
+        // (/consent) in the same priority order.
+        const gateTarget = postAuthRedirect(user);
+        if (gateTarget) {
+          void navigate(gateTarget, { replace: true });
           return;
         }
         const redirect = params.get('redirect');


### PR DESCRIPTION
## the bug

On staging, a consent-pending user who logged in and landed on a protected route (e.g. `/profile` via the `redirect` param) saw a **blank screen with no consent modal** — until they refreshed, at which point the modal appeared.

## root cause

Login navigated to the target route and relied on `OnboardingGate` to bounce the user to `/consent`. That's a **render race**: the lazy-loaded target route renders a blank `Suspense` fallback before the gate re-evaluates with the freshly-set auth state. A refresh works because `AuthBoot`/`restoreSession` populates the user *before* the route tree renders, so the gate evaluates correctly from the first paint.

This race was **already known** — `MagicLoginScreen` worked around it (comment: *"avoids a race where /calendar renders before the gate re-evaluates"*) by computing the redirect itself. But it only handled password setup, never consent — and the regular `LoginScreen` did the workaround for neither, leaning entirely on the gate.

## the fix

- **`postAuthRedirect(user)`** — one shared resolver for "where must a freshly-authenticated user go before the app?", combining password setup (`/onboarding`, `/new-password`) **and** consent (`/consent`) in the same priority order `OnboardingGate` uses.
- **`LoginScreen` and `MagicLoginScreen`** now navigate to `postAuthRedirect()` **directly** after auth, instead of navigating to a protected route and leaning on the gate. The gate stays the backstop for every later navigation.

No backend changes. `OnboardingGate` and `GatedJWTAuth` are unchanged.

## verification

- `make agent-frontend-test` — ✅ 512 passed (1 skipped)
- `make agent-frontend-lint` / `agent-frontend-format-check` / `agent-frontend-typecheck` — ✅ all clean

New tests: `user.test.ts` covers the resolver (priority order, consent inclusion, null cases); `MagicLoginScreen.test.tsx` gains consent-path + password-before-consent coverage.

### a note on test coverage
I drafted a full `LoginScreen` form-driven integration test but removed it — `react-phone-number-input` is a controlled third-party widget that `userEvent`/`fireEvent` can't reliably drive in jsdom, making the test flaky. The changed logic is a 4-line mirror of the already-tested `MagicLoginScreen` path and is fully covered by the `postAuthRedirect` unit tests. Happy to revisit with a Playwright e2e if you'd prefer real-browser coverage of the login form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)