### PR TITLE
test(events): freeze clock in EventAttendancePanel check-in tests (Issue 516)

### DIFF
--- a/frontend/src/screens/events/EventAttendancePanel.test.tsx
+++ b/frontend/src/screens/events/EventAttendancePanel.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Event, EventStats } from '@/models/event';
 import {
   AttendanceStatus,
@@ -123,9 +123,22 @@ function mockStats(stats: EventStats | null, state: 'loading' | 'error' | 'succe
   } as unknown as ReturnType<typeof useEventStats>);
 }
 
+// The check-in window opens 1h before start by comparing startDatetime against the
+// real Date.now(), so these tests freeze the clock to a fixed instant. "Now" sits a
+// week before BASE_EVENT (2026-06-01) — check-in closed — while soonEvent (now + 30m)
+// lands inside the window. Without this the suite rots as wall-clock time advances
+// past the hardcoded fixture dates (Issue 516).
+const FROZEN_NOW = new Date('2026-05-25T12:00:00Z');
+
 beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(FROZEN_NOW);
   setAttendanceMutate.mockClear();
   vi.mocked(useEventStats).mockReset();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe('EventAttendancePanel', () => {

--- a/frontend/src/screens/events/EventAttendancePanel.test.tsx
+++ b/frontend/src/screens/events/EventAttendancePanel.test.tsx
@@ -123,11 +123,8 @@ function mockStats(stats: EventStats | null, state: 'loading' | 'error' | 'succe
   } as unknown as ReturnType<typeof useEventStats>);
 }
 
-// The check-in window opens 1h before start by comparing startDatetime against the
-// real Date.now(), so these tests freeze the clock to a fixed instant. "Now" sits a
-// week before BASE_EVENT (2026-06-01) — check-in closed — while soonEvent (now + 30m)
-// lands inside the window. Without this the suite rots as wall-clock time advances
-// past the hardcoded fixture dates (Issue 516).
+// Freeze "now" a week before BASE_EVENT so the check-in window (open 1h before start,
+// vs real Date.now()) is deterministic instead of rotting with wall-clock time (Issue 516).
 const FROZEN_NOW = new Date('2026-05-25T12:00:00Z');
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary

Closes #516

`EventAttendancePanel.test.tsx` had a time-dependent test (`"hides check-in buttons until an hour before the event"`) that rotted against wall-clock time and started failing once the current date passed the hardcoded fixture date.

The component opens the check-in window an hour before start by comparing `event.startDatetime` against the real `Date.now()`. The "window closed" assertions relied on `BASE_EVENT`'s hardcoded `2026-06-01` being in the future — true when written, false now.

Fix: freeze the clock to a fixed instant (`2026-05-25T12:00:00Z`) in `beforeEach` via `vi.useFakeTimers()` + `vi.setSystemTime()`, and restore real timers in `afterEach`. "Now" sits a week before `BASE_EVENT` (check-in closed) while `soonEvent` (`now + 30m`) lands inside the window. The suite is now deterministic regardless of when CI runs.

## Test plan

- [x] `pnpm exec vitest run src/screens/events/EventAttendancePanel.test.tsx` — all 7 pass.
- [x] Full event-screen suite (`src/screens/events/`) — 106 pass, no regressions.
- [x] Full frontend suite — 534 pass, 1 skipped; the previously-failing test is now green.
- [x] `tsc --noEmit` + ESLint + Prettier clean.