### PR TITLE
fix: 506 - graceful handling for malformed role permissions

### DIFF
--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -142,12 +142,6 @@ class TestRolesAndPermissions:
 
     @pytest.mark.parametrize("bad_value", ["manage_events", {"manage_events": True}, 42])
     def test_corrupt_permissions_shape_grants_no_permissions(self, test_user, bad_value):
-        """A JSONField row holding a non-list value (edited out-of-band) must
-        not crash or accidentally match — it degrades to 'no perms'.
-
-        `None` is not tested: the column is NOT NULL, so a null is unreachable
-        even via raw .update(). The reachable corrupt shapes are non-null JSON.
-        """
         role = Role.objects.get(name="member")
         Role.objects.filter(pk=role.pk).update(permissions=bad_value)
         role.refresh_from_db()

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -140,6 +140,31 @@ class TestRolesAndPermissions:
         user = User.objects.prefetch_related("roles").get(pk=test_user.pk)
         assert not user.has_permission(PermissionKey.MANAGE_USERS)
 
+    @pytest.mark.parametrize("bad_value", ["manage_events", {"manage_events": True}, 42])
+    def test_corrupt_permissions_shape_grants_no_permissions(self, test_user, bad_value):
+        """A JSONField row holding a non-list value (edited out-of-band) must
+        not crash or accidentally match — it degrades to 'no perms'.
+
+        `None` is not tested: the column is NOT NULL, so a null is unreachable
+        even via raw .update(). The reachable corrupt shapes are non-null JSON.
+        """
+        role = Role.objects.get(name="member")
+        Role.objects.filter(pk=role.pk).update(permissions=bad_value)
+        role.refresh_from_db()
+        test_user.roles.add(role)
+        assert role.effective_permissions == []
+        assert not test_user.has_permission(PermissionKey.MANAGE_EVENTS)
+
+    def test_corrupt_permissions_filters_non_string_entries(self, test_user):
+        role = Role.objects.get(name="member")
+        Role.objects.filter(pk=role.pk).update(
+            permissions=[PermissionKey.MANAGE_EVENTS, None, 7, {"x": 1}]
+        )
+        role.refresh_from_db()
+        test_user.roles.add(role)
+        assert role.effective_permissions == [PermissionKey.MANAGE_EVENTS]
+        assert test_user.has_permission(PermissionKey.MANAGE_EVENTS)
+
 
 # ---------------------------------------------------------------------------
 # User management API (#3)

--- a/backend/tests/test_role_management.py
+++ b/backend/tests/test_role_management.py
@@ -112,6 +112,18 @@ class TestRoleManagementAPI:
         assert response.status_code == 200
         assert PermissionKey.MANAGE_EVENTS in response.json()["permissions"]
 
+    def test_patch_role_with_corrupt_stored_permissions(self, api_client, manage_users_headers):
+        role = Role.objects.create(name="corrupt", permissions=[])
+        Role.objects.filter(pk=role.pk).update(permissions=42)
+        response = api_client.patch(
+            f"/api/auth/roles/{role.id}/",
+            {"permissions": [PermissionKey.MANAGE_EVENTS]},
+            content_type="application/json",
+            **manage_users_headers,
+        )
+        assert response.status_code == 200
+        assert response.json()["permissions"] == [PermissionKey.MANAGE_EVENTS]
+
     def test_patch_default_role_blocked(self, api_client, manage_users_headers):
         admin_role = Role.objects.get(name="admin")
         response = api_client.patch(

--- a/backend/users/_roles.py
+++ b/backend/users/_roles.py
@@ -84,7 +84,7 @@ def create_role(request, payload: RoleIn):
             id=str(role.id),
             name=role.name,
             is_default=role.is_default,
-            permissions=role.permissions,
+            permissions=role.effective_permissions,
         ),
     )
 
@@ -114,7 +114,7 @@ def update_role(request, role_id: str, payload: RolePatchIn):
         raise_validation(Code.Role.PROTECTED_CANNOT_EDIT, status_code=400, role_name=role.name)
 
     old_name = role.name
-    old_permissions = list(role.permissions)
+    old_permissions = role.effective_permissions
 
     if payload.name is not None and payload.name != role.name:
         if role.name in PROTECTED_ROLE_NAMES:
@@ -148,7 +148,7 @@ def update_role(request, role_id: str, payload: RolePatchIn):
             id=str(role.id),
             name=role.name,
             is_default=role.is_default,
-            permissions=role.permissions,
+            permissions=role.effective_permissions,
         ),
     )
 

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -137,8 +137,7 @@ class User(AbstractUser):
         cache = getattr(self, "_prefetched_objects_cache", {})
         roles = cache["roles"] if "roles" in cache else self.roles.all()
         for role in roles:
-            # effective_permissions returns the full key set for the admin role
-            # and a normalized list[str] otherwise (guards corrupt JSONField rows).
+            # effective_permissions expands the admin role and guards corrupt rows
             if key in role.effective_permissions:
                 return True
         return False

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -137,9 +137,9 @@ class User(AbstractUser):
         cache = getattr(self, "_prefetched_objects_cache", {})
         roles = cache["roles"] if "roles" in cache else self.roles.all()
         for role in roles:
-            if role.name == "admin" and role.is_default:
-                return True
-            if key in (role.permissions or []):
+            # effective_permissions returns the full key set for the admin role
+            # and a normalized list[str] otherwise (guards corrupt JSONField rows).
+            if key in role.effective_permissions:
                 return True
         return False
 

--- a/backend/users/roles.py
+++ b/backend/users/roles.py
@@ -29,16 +29,15 @@ class Role(models.Model):
 
     @property
     def effective_permissions(self) -> list[str]:
-        """Admin role implicitly grants every permission (see User.has_permission).
-        Return the current PermissionKey set so the UI reflects reality even if
-        the DB row was seeded before newer keys were added.
+        """The permission keys this role grants (see User.has_permission).
 
-        Coerces the JSONField to a clean list[str] (corrupt/out-of-band rows may
-        hold non-list/non-string values) so RoleOut.permissions holds for every consumer.
+        The default admin role implicitly grants every current key. Other roles
+        return their stored keys, coerced to a clean list[str] — the JSONField
+        defaults to a list, but legacy/corrupt rows may hold other values.
         """
         if self.name == "admin" and self.is_default:
             return list(PermissionKey.values)
-        raw = self.permissions
-        if not isinstance(raw, list):
+        stored = self.permissions
+        if not isinstance(stored, list):
             return []
-        return [p for p in raw if isinstance(p, str)]
+        return [p for p in stored if isinstance(p, str)]

--- a/backend/users/roles.py
+++ b/backend/users/roles.py
@@ -32,7 +32,13 @@ class Role(models.Model):
         """Admin role implicitly grants every permission (see User.has_permission).
         Return the current PermissionKey set so the UI reflects reality even if
         the DB row was seeded before newer keys were added.
+
+        Coerces the JSONField to a clean list[str] (corrupt/out-of-band rows may
+        hold non-list/non-string values) so RoleOut.permissions holds for every consumer.
         """
         if self.name == "admin" and self.is_default:
             return list(PermissionKey.values)
-        return list(self.permissions)
+        raw = self.permissions
+        if not isinstance(raw, list):
+            return []
+        return [p for p in raw if isinstance(p, str)]

--- a/backend/users/roles.py
+++ b/backend/users/roles.py
@@ -29,12 +29,7 @@ class Role(models.Model):
 
     @property
     def effective_permissions(self) -> list[str]:
-        """The permission keys this role grants (see User.has_permission).
-
-        The default admin role implicitly grants every current key. Other roles
-        return their stored keys, coerced to a clean list[str] — the JSONField
-        defaults to a list, but legacy/corrupt rows may hold other values.
-        """
+        """Permission keys this role grants: all keys for the default admin role, else the stored keys coerced to a clean list[str] (legacy/corrupt rows may hold non-list or non-string values)."""
         if self.name == "admin" and self.is_default:
             return list(PermissionKey.values)
         stored = self.permissions

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,6 +1,7 @@
 import { useMutation } from '@tanstack/react-query';
 
 import type { ConsentTypeValue } from '@/models/consent';
+import { normalizePermissions } from '@/models/permissions';
 import type { Role, User } from '@/models/user';
 import { CalendarFeedScope, type CalendarFeedScopeValue } from '@/models/user';
 
@@ -52,7 +53,7 @@ function mapRole(r: WireRole): Role {
     id: r.id,
     name: r.name,
     isDefault: r.is_default,
-    permissions: r.permissions,
+    permissions: normalizePermissions(r.permissions),
   };
 }
 

--- a/frontend/src/api/roles.ts
+++ b/frontend/src/api/roles.ts
@@ -5,8 +5,9 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { apiClient } from './client';
 import { normalizePermissions } from '@/models/permissions';
+
+import { apiClient } from './client';
 
 export interface Role {
   id: string;

--- a/frontend/src/api/roles.ts
+++ b/frontend/src/api/roles.ts
@@ -6,6 +6,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { apiClient } from './client';
+import { normalizePermissions } from '@/models/permissions';
 
 export interface Role {
   id: string;
@@ -28,7 +29,7 @@ function fromWire(w: WireRole): Role {
     id: w.id,
     name: w.name,
     isDefault: w.is_default,
-    permissions: w.permissions,
+    permissions: normalizePermissions(w.permissions),
     userCount: w.user_count ?? 0,
   };
 }

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -4,6 +4,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { apiClient } from './client';
+import { normalizePermissions } from '@/models/permissions';
 
 // --- Domain types (camelCase) ------------------------------------------------
 
@@ -60,7 +61,7 @@ function mapRole(r: WireRole): MemberRole {
     id: r.id,
     name: r.name,
     isDefault: r.is_default,
-    permissions: r.permissions,
+    permissions: normalizePermissions(r.permissions),
   };
 }
 

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -3,8 +3,9 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import { apiClient } from './client';
 import { normalizePermissions } from '@/models/permissions';
+
+import { apiClient } from './client';
 
 // --- Domain types (camelCase) ------------------------------------------------
 

--- a/frontend/src/models/permissions.test.ts
+++ b/frontend/src/models/permissions.test.ts
@@ -45,8 +45,7 @@ describe('hasPermission', () => {
   });
 
   it('does not crash on a non-array permissions value (corrupt role data)', () => {
-    // permissions comes from a backend JSONField with no shape guarantee — a
-    // legacy/corrupt row could send null/undefined/object. Treat as "no perms".
+    // Defense-in-depth: if the backend invariant regresses, treat non-array as "no perms".
     const corrupt = (permissions: unknown) =>
       user({ roles: [{ name: 'custom', isDefault: false, permissions } as never] });
     expect(hasPermission(corrupt(null), Permission.TagOfficialEvent)).toBe(false);

--- a/frontend/src/models/permissions.test.ts
+++ b/frontend/src/models/permissions.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 
-import { hasAnyAdminPermission, hasPermission, Permission, type UserLike } from './permissions';
+import {
+  hasAnyAdminPermission,
+  hasPermission,
+  normalizePermissions,
+  Permission,
+  type UserLike,
+} from './permissions';
 
 function user(opts: Partial<UserLike> = {}): UserLike {
   return {
@@ -36,6 +42,29 @@ describe('hasPermission', () => {
   it('isDefault without name=admin does not grant blanket access', () => {
     const u = user({ roles: [{ name: 'member', isDefault: true, permissions: [] }] });
     expect(hasPermission(u, Permission.ManageUsers)).toBe(false);
+  });
+
+  it('does not crash on a non-array permissions value (corrupt role data)', () => {
+    // permissions comes from a backend JSONField with no shape guarantee — a
+    // legacy/corrupt row could send null/undefined/object. Treat as "no perms".
+    const corrupt = (permissions: unknown) =>
+      user({ roles: [{ name: 'custom', isDefault: false, permissions } as never] });
+    expect(hasPermission(corrupt(null), Permission.TagOfficialEvent)).toBe(false);
+    expect(hasPermission(corrupt(undefined), Permission.TagOfficialEvent)).toBe(false);
+    expect(hasPermission(corrupt({}), Permission.TagOfficialEvent)).toBe(false);
+  });
+});
+
+describe('normalizePermissions', () => {
+  it('passes through a string array unchanged', () => {
+    const perms = [Permission.ManageEvents, Permission.EditFaq];
+    expect(normalizePermissions(perms)).toEqual(perms);
+  });
+
+  it('coerces non-array values (null, undefined, object) to an empty array', () => {
+    expect(normalizePermissions(null)).toEqual([]);
+    expect(normalizePermissions(undefined)).toEqual([]);
+    expect(normalizePermissions({})).toEqual([]);
   });
 });
 

--- a/frontend/src/models/permissions.test.ts
+++ b/frontend/src/models/permissions.test.ts
@@ -63,7 +63,8 @@ describe('normalizePermissions', () => {
   it('coerces non-array values (null, undefined, object) to an empty array', () => {
     expect(normalizePermissions(null)).toEqual([]);
     expect(normalizePermissions(undefined)).toEqual([]);
-    expect(normalizePermissions({})).toEqual([]);
+    // {} violates the declared type — cast to exercise the runtime guard.
+    expect(normalizePermissions({} as never)).toEqual([]);
   });
 });
 

--- a/frontend/src/models/permissions.ts
+++ b/frontend/src/models/permissions.ts
@@ -42,10 +42,9 @@ export interface UserLike {
 // Backend sends permissions: string[] (Role.effective_permissions coerces the
 // JSONField). Defense-in-depth so a regression can't make render throw; the
 // null/undefined cases cover a field the API dropped entirely.
-export function normalizePermissions(
-  value: readonly string[] | null | undefined,
-): string[] {
-  return Array.isArray(value) ? [...value] : [];
+export function normalizePermissions(value: readonly string[] | null | undefined): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((v): v is string => typeof v === 'string');
 }
 
 export function hasPermission(user: UserLike | null, key: PermissionKey): boolean {

--- a/frontend/src/models/permissions.ts
+++ b/frontend/src/models/permissions.ts
@@ -39,9 +39,7 @@ export interface UserLike {
   }[];
 }
 
-// Backend sends permissions: string[] (Role.effective_permissions coerces the
-// JSONField). Defense-in-depth so a regression can't make render throw; the
-// null/undefined cases cover a field the API dropped entirely.
+// defense-in-depth: backend already sends string[], but guard corrupt/missing values so render can't throw
 export function normalizePermissions(value: readonly string[] | null | undefined): string[] {
   if (!Array.isArray(value)) return [];
   return value.filter((v): v is string => typeof v === 'string');

--- a/frontend/src/models/permissions.ts
+++ b/frontend/src/models/permissions.ts
@@ -39,10 +39,22 @@ export interface UserLike {
   }[];
 }
 
+// `permissions` rides the wire from a backend JSONField with no DB-level shape
+// guarantee — a legacy/corrupt row could deliver null, undefined, or an object.
+// Normalize at every API boundary so the `permissions: string[]` invariant holds
+// and downstream `.includes`/`.length`/`.map` calls can't throw during render.
+export function normalizePermissions(value: unknown): string[] {
+  return Array.isArray(value) ? (value as string[]) : [];
+}
+
 export function hasPermission(user: UserLike | null, key: PermissionKey): boolean {
   if (!user) return false;
+  // Re-normalize per role: a UserLike can be built in tests or from a source
+  // that skipped the API-boundary mapping, so don't assume the invariant holds.
   return user.roles.some(
-    (r) => (r.name === ADMIN_ROLE_NAME && r.isDefault) || r.permissions.includes(key),
+    (r) =>
+      (r.name === ADMIN_ROLE_NAME && r.isDefault) ||
+      normalizePermissions(r.permissions).includes(key),
   );
 }
 

--- a/frontend/src/models/permissions.ts
+++ b/frontend/src/models/permissions.ts
@@ -39,16 +39,17 @@ export interface UserLike {
   }[];
 }
 
-// Backend guarantees permissions: string[] (Role.effective_permissions coerces
-// the JSONField). Kept as defense-in-depth so render can't throw if that regresses.
-export function normalizePermissions(value: unknown): string[] {
-  return Array.isArray(value) ? (value as string[]) : [];
+// Backend sends permissions: string[] (Role.effective_permissions coerces the
+// JSONField). Defense-in-depth so a regression can't make render throw; the
+// null/undefined cases cover a field the API dropped entirely.
+export function normalizePermissions(
+  value: readonly string[] | null | undefined,
+): string[] {
+  return Array.isArray(value) ? [...value] : [];
 }
 
 export function hasPermission(user: UserLike | null, key: PermissionKey): boolean {
   if (!user) return false;
-  // Re-normalize per role: a UserLike can be built in tests or from a source
-  // that skipped the API-boundary mapping, so don't assume the invariant holds.
   return user.roles.some(
     (r) =>
       (r.name === ADMIN_ROLE_NAME && r.isDefault) ||

--- a/frontend/src/models/permissions.ts
+++ b/frontend/src/models/permissions.ts
@@ -39,10 +39,8 @@ export interface UserLike {
   }[];
 }
 
-// `permissions` rides the wire from a backend JSONField with no DB-level shape
-// guarantee — a legacy/corrupt row could deliver null, undefined, or an object.
-// Normalize at every API boundary so the `permissions: string[]` invariant holds
-// and downstream `.includes`/`.length`/`.map` calls can't throw during render.
+// Backend guarantees permissions: string[] (Role.effective_permissions coerces
+// the JSONField). Kept as defense-in-depth so render can't throw if that regresses.
 export function normalizePermissions(value: unknown): string[] {
   return Array.isArray(value) ? (value as string[]) : [];
 }

--- a/frontend/src/router/RootRouteError.tsx
+++ b/frontend/src/router/RootRouteError.tsx
@@ -40,11 +40,12 @@ export function RootRouteError() {
     void reportError(err, location.pathname, context);
   }, [error, location.pathname]);
 
+  // Unexpected JS exceptions get a friendly fallback instead of a leaked raw
+  // error string (e.g. "cannot read properties of undefined"); the technical
+  // detail still goes to reportError. Route-error responses keep their status.
   const message = isRouteErrorResponse(error)
     ? `${String(error.status)} ${error.statusText}`.toLowerCase()
-    : error instanceof Error
-      ? error.message.toLowerCase()
-      : 'something went wrong';
+    : 'something went wrong — try again or head back home';
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-4 p-8">

--- a/frontend/src/router/RootRouteError.tsx
+++ b/frontend/src/router/RootRouteError.tsx
@@ -40,9 +40,7 @@ export function RootRouteError() {
     void reportError(err, location.pathname, context);
   }, [error, location.pathname]);
 
-  // Unexpected JS exceptions get a friendly fallback instead of a leaked raw
-  // error string (e.g. "cannot read properties of undefined"); the technical
-  // detail still goes to reportError. Route-error responses keep their status.
+  // friendly fallback for js exceptions so we don't leak raw error text; route errors keep their status
   const message = isRouteErrorResponse(error)
     ? `${String(error.status)} ${error.statusText}`.toLowerCase()
     : 'something went wrong — try again or head back home';


### PR DESCRIPTION
## Overview

A user with the `tag_official_event` permission but no admin role hit a render-time crash when adding the official pda event type (reported via community feedback). `hasPermission` called `.includes` on a role's `permissions`, which rides the wire from a backend `JSONField` with no DB-level shape guarantee — a non-array value (legacy/corrupt row) threw during render, and the route error boundary then surfaced the raw JS error string to the user instead of a friendly message.

This makes the failure path graceful and — the core fix — **pushes the `permissions: string[]` guarantee down to the backend** so no consumer has to defend against malformed data on the wire:

- **Backend is now the single source of the invariant.** `Role.effective_permissions` coerces the underlying `JSONField` to a clean `list[str]` (non-list → `[]`, non-string entries filtered), so a corrupt/out-of-band row can't reach any client as null/object/non-array. `RoleOut.permissions` is therefore guaranteed for every API consumer. `User.has_permission` routes through `effective_permissions` too, replacing `key in (role.permissions or [])`, which silently mis-matched on a `str`/`dict` row.
- **Frontend `normalizePermissions()` stays as defense-in-depth**, not as the guarantee — applied at the role-mapping boundaries (`api/auth.ts`, `api/users.ts`, `api/roles.ts`) and reused by `hasPermission`, so render can't throw even if the backend invariant ever regresses.
- `RootRouteError` now shows a friendly fallback (`something went wrong — try again or head back home`) for unexpected JS exceptions instead of leaking the raw `error.message`; the technical detail still goes to `reportError`, and route-error responses (404s) keep their status line.
- Regression tests on both sides: backend tests for the reachable corrupt shapes (`str`/`dict`/`int` → no perms) and non-string list entries (`null` is unreachable — the column is `NOT NULL`); frontend tests for the non-array guard and the helper.

**Permission audit:** `tag_official_event` (BE `PermissionKey.TAG_OFFICIAL_EVENT` / FE `Permission.TagOfficialEvent`) correctly and consistently gates official events — the frontend filters the "official" visibility option and the backend returns a clean 403 on `POST /events/` when `event_type=official` without the permission. A user holding the permission without an admin role is **intentionally allowed** to create official events; no permission-model change was needed.

Fixes #506

## Test plan

- [x] backend: `TestRolesAndPermissions` (incl. corrupt-shape regressions) — pass
- [x] backend: `make agent-lint` + `make agent-typecheck` — pass
- [x] frontend: `make agent-frontend-test` (incl. `permissions.test.ts`) — pass
- [x] frontend: `make agent-frontend-lint` + format-check — pass
- [ ] manual: as a user with `tag_official_event` and no admin role, open the event form and add an official event — no crash, option available
- [ ] manual: with a deliberately malformed role (non-array `permissions`), the app degrades to "no perms" instead of white-screening
