### PR TITLE
fix(photos): drop unsupported heic uploads and surface crop decode errors (Issue 505)

### DIFF
--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -404,11 +404,12 @@ class EventPatchIn(BaseModel):
 
 
 _MAX_EVENT_PHOTO_SIZE = 10 * 1024 * 1024  # 10 MB
+# heic/heif are intentionally excluded: the frontend crops via a browser canvas
+# that can't decode them, so such uploads can only arrive via a hand-crafted
+# request and would never round-trip through the real UI (issue 505).
 _ALLOWED_IMAGE_TYPES = {
     "image/jpeg",
     "image/png",
     "image/webp",
     "image/gif",
-    "image/heic",
-    "image/heif",
 }

--- a/backend/tests/test_photos.py
+++ b/backend/tests/test_photos.py
@@ -100,6 +100,12 @@ class TestProfilePhoto:
         response = api_client.post("/api/auth/me/photo/", {"photo": big}, **_auth(member))
         assert response.status_code == 400
 
+    def test_upload_rejects_heic(self, api_client, member):
+        # heic can't be cropped client-side, so we don't accept it (issue 505).
+        heic = SimpleUploadedFile("photo.heic", b"fake heic bytes", content_type="image/heic")
+        response = api_client.post("/api/auth/me/photo/", {"photo": heic}, **_auth(member))
+        assert response.status_code == 400
+
     def test_delete_photo(self, api_client, member):
         photo = _make_test_image()
         api_client.post("/api/auth/me/photo/", {"photo": photo}, **_auth(member))
@@ -170,6 +176,16 @@ class TestEventPhoto:
         response = api_client.post(
             f"/api/community/events/{event.id}/photo/",
             {"photo": big},
+            **_auth(member),
+        )
+        assert response.status_code == 400
+
+    def test_upload_rejects_heic(self, api_client, member, event):
+        # heic can't be cropped client-side, so we don't accept it (issue 505).
+        heic = SimpleUploadedFile("photo.heic", b"fake heic bytes", content_type="image/heic")
+        response = api_client.post(
+            f"/api/community/events/{event.id}/photo/",
+            {"photo": heic},
             **_auth(member),
         )
         assert response.status_code == 400

--- a/backend/users/_auth.py
+++ b/backend/users/_auth.py
@@ -44,13 +44,14 @@ logger = logging.getLogger("pda.auth")
 router = Router()
 
 _MAX_PHOTO_SIZE = 5 * 1024 * 1024  # 5 MB
+# heic/heif are intentionally excluded: the frontend crops via a browser canvas
+# that can't decode them, so such uploads can only arrive via a hand-crafted
+# request and would never round-trip through the real UI (issue 505).
 _ALLOWED_IMAGE_TYPES = {
     "image/jpeg",
     "image/png",
     "image/webp",
     "image/gif",
-    "image/heic",
-    "image/heif",
 }
 
 

--- a/frontend/src/components/ImageCropDialog.test.tsx
+++ b/frontend/src/components/ImageCropDialog.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -93,6 +93,23 @@ describe('ImageCropDialog', () => {
     await user.click(screen.getByRole('button', { name: /^cancel$/i }));
 
     expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('surfaces an error when the image fails to decode (e.g. heic) instead of failing silently', () => {
+    // The crop preview img can't decode some formats the OS hands us (heic).
+    // Without an onError handler the "save" button stays disabled with no
+    // explanation — a silent failure (issue 505).
+    const { container } = renderDialog();
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    fireEvent.error(img!);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/couldn't read that image/i);
+    // save stays disabled because the image never produced a crop area
+    expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled();
   });
 
   it('dialog container has role="dialog" and is accessible', () => {

--- a/frontend/src/components/ImageCropDialog.tsx
+++ b/frontend/src/components/ImageCropDialog.tsx
@@ -18,6 +18,13 @@ interface Props {
   onCrop: (blob: Blob) => Promise<void> | void;
 }
 
+// Some formats the OS hands us (notably heic/heif from apple photos) can't be
+// decoded by the browser's <img>/canvas pipeline, so the crop preview never
+// loads. Surface that as a clear error instead of leaving "save" silently
+// disabled forever (issue 505).
+const DECODE_ERROR =
+  "couldn't read that image — try a jpeg, png, webp, or gif (heic isn't supported here)";
+
 export function ImageCropDialog({
   file,
   shape = 'round',
@@ -30,11 +37,16 @@ export function ImageCropDialog({
   const [crop, setCrop] = useState<Crop | undefined>(undefined);
   const [completed, setCompleted] = useState<PixelCrop | null>(null);
   const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const imgRef = useRef<HTMLImageElement | null>(null);
 
   function onImageLoad(e: React.SyntheticEvent<HTMLImageElement>) {
     const { width, height } = e.currentTarget;
     setCrop(initialCrop(width, height, shape));
+  }
+
+  function onImageError() {
+    setError(DECODE_ERROR);
   }
 
   function handleCancel() {
@@ -91,9 +103,21 @@ export function ImageCropDialog({
               a tall image down — a wrapper cap would just clip it and let the crop be
               dragged into the off-screen remainder. See issue 428. */}
           <ReactCrop {...reactCropProps} style={{ maxHeight: MAX_PREVIEW_PX }}>
-            <img ref={imgRef} src={src} alt="" onLoad={onImageLoad} className="w-auto" />
+            <img
+              ref={imgRef}
+              src={src}
+              alt=""
+              onLoad={onImageLoad}
+              onError={onImageError}
+              className="w-auto"
+            />
           </ReactCrop>
         </div>
+        {error ? (
+          <p role="alert" className="text-destructive text-xs">
+            {error}
+          </p>
+        ) : null}
         <div className="flex justify-end gap-2">
           <Button variant="ghost" onClick={handleCancel} disabled={saving}>
             cancel

--- a/frontend/src/screens/events/form/EventFormPhoto.tsx
+++ b/frontend/src/screens/events/form/EventFormPhoto.tsx
@@ -10,17 +10,13 @@ import { extractApiErrorOr } from '@/api/apiErrors';
 import { ImageCropDialog } from '@/components/ImageCropDialog';
 import { cn } from '@/utils/cn';
 
-const ALLOWED_MIME = [
-  'image/jpeg',
-  'image/png',
-  'image/webp',
-  'image/gif',
-  'image/heic',
-  'image/heif',
-];
+// Only formats the browser can decode into a canvas for cropping. heic/heif
+// (apple photos default) can't be decoded client-side, so we don't offer them
+// — the crop step would silently fail otherwise (issue 505).
+const ALLOWED_MIME = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
 
 const MAX_PHOTO_BYTES = 10 * 1024 * 1024;
-const TYPE_ERROR = 'pick a jpeg, png, webp, gif, or heic image';
+const TYPE_ERROR = 'pick a jpeg, png, webp, or gif image';
 const SIZE_ERROR = 'photo must be under 10 MB';
 
 function validateFile(f: File): string | null {

--- a/frontend/src/screens/settings/AvatarUpload.tsx
+++ b/frontend/src/screens/settings/AvatarUpload.tsx
@@ -5,14 +5,10 @@ import { useAuthStore } from '@/auth/store';
 import { cn } from '@/utils/cn';
 
 const MAX_FILE_BYTES = 5 * 1024 * 1024;
-const ALLOWED_MIME = [
-  'image/jpeg',
-  'image/png',
-  'image/webp',
-  'image/gif',
-  'image/heic',
-  'image/heif',
-];
+// Only formats the browser can decode into a canvas for cropping. heic/heif
+// (apple photos default) can't be decoded client-side, so we don't offer them
+// — the crop step would silently fail otherwise (issue 505).
+const ALLOWED_MIME = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
 
 interface Props {
   size?: 'md' | 'lg';
@@ -44,7 +40,7 @@ export function AvatarUpload({ size = 'md' }: Props) {
     e.target.value = '';
     if (!f) return;
     if (!ALLOWED_MIME.includes(f.type)) {
-      setError('please pick a jpeg, png, webp, gif, or heic image');
+      setError('please pick a jpeg, png, webp, or gif image');
       return;
     }
     if (f.size > MAX_FILE_BYTES) {


### PR DESCRIPTION
## Summary

Closes #505

A user reported "event photo upload didn't work" from `/profile`. Root cause: the app **advertised heic/heif support it can't deliver**. The client-side crop pipeline (`ImageCropDialog` → `cropImage`) decodes images via a browser `<img>`/canvas, which **cannot decode heic/heif** — the default format for Apple/macOS photos. A macOS Chrome user (matching the issue's user agent) picked a `.heic` photo → it passed validation → the crop dialog's `<img>` never fired `onLoad` → the "save" button stayed permanently disabled with **no error**. A silent failure.

- **Drop heic/heif** from the frontend `accept`/validation (`AvatarUpload.tsx`, `EventFormPhoto.tsx`) and the backend allowed-type sets (`users/_auth.py`, `community/_event_schemas.py`), so the upload contract matches what the crop pipeline can actually process. Updated the user-facing format copy.
- **Surface decode failures**: added an `onError` handler + `role="alert"` message to `ImageCropDialog` so any image that fails to decode shows a clear error instead of a dead "save" button (satisfies the "clear error rather than silent failure" acceptance criterion).
- **Tests**: backend rejects heic on both the profile and event endpoints; a frontend test fires the img `error` event and asserts the alert appears and save stays disabled.

## Test plan

- [ ] backend: `cd backend && uv run pytest tests/test_photos.py --create-db -n 0` — 22 passed (full suite 1005 passed on a fresh DB)
- [ ] frontend: `cd frontend && pnpm test src/components/ImageCropDialog.test.tsx` — 5 passed; `pnpm lint`, `pnpm format:check`, `pnpm typecheck` clean
- [ ] manual: on a Mac, open `/profile` and `/settings`, pick a `.heic` photo → it's no longer offered in the file picker; pick a jpeg/png/webp/gif → crop + save persists
- [ ] manual: if an image fails to decode in the crop dialog, a clear error appears instead of a stuck "save" button

> Note: the local test DB carried an `is_member NOT NULL` column from another branch (Issue 491, not in this branch); run backend tests with `--create-db`. Parallel-load timeouts in the auth/join screen tests are pre-existing and unrelated to this diff (those files don't import anything changed here and pass in isolation).