### PR TITLE
fix(profile): seed crop on image load so save fires the upload (Issue 523)

### DIFF
--- a/frontend/src/components/ImageCropDialog.test.tsx
+++ b/frontend/src/components/ImageCropDialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -117,6 +117,27 @@ describe('ImageCropDialog', () => {
     await user.click(screen.getByRole('button', { name: /^cancel$/i }));
 
     expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('enables save and fires onCrop after the image loads, without a manual drag (issue 523)', async () => {
+    const onCrop = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    const { container } = renderDialog({ onCrop });
+
+    const save = screen.getByRole('button', { name: /^save$/i });
+    expect(save).toBeDisabled();
+
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    fireEvent.load(img!);
+
+    await waitFor(() => {
+      expect(save).toBeEnabled();
+    });
+
+    await user.click(save);
+
+    expect(onCrop).toHaveBeenCalledOnce();
   });
 
   it('dialog container has role="dialog" and is accessible', () => {

--- a/frontend/src/components/ImageCropDialog.tsx
+++ b/frontend/src/components/ImageCropDialog.tsx
@@ -14,6 +14,7 @@ import {
   defaultCoverAspect,
   initialCrop,
   MAX_PREVIEW_PX,
+  percentToPixelCrop,
   PORTRAIT_ASPECT,
   SQUARE_ASPECT,
 } from './initialCrop';
@@ -50,8 +51,10 @@ export function ImageCropDialog({
 
   function onImageLoad(e: React.SyntheticEvent<HTMLImageElement>) {
     const { width, height } = e.currentTarget;
-    setCrop(initialCrop(width, height, shape));
+    const pct = initialCrop(width, height, shape);
+    setCrop(pct);
     if (shape === 'rect') setAspect(defaultCoverAspect(width, height));
+    setCompleted(percentToPixelCrop(pct, width, height));
   }
 
   function selectAspect(next: number) {

--- a/frontend/src/components/initialCrop.test.ts
+++ b/frontend/src/components/initialCrop.test.ts
@@ -4,14 +4,10 @@ import {
   coverCrop,
   defaultCoverAspect,
   initialCrop,
+  percentToPixelCrop,
   PORTRAIT_ASPECT,
   SQUARE_ASPECT,
 } from './initialCrop';
-
-// Regression for issue 428: the round crop was sized off image *width*, so for any
-// non-portrait image the square was taller than the image and react-image-crop
-// clamped it into an unmovable band. The crop must always fit inside the image.
-// `width`/`height` are rendered preview dimensions, height-capped at 320 by the dialog.
 
 function fits(crop: { x: number; y: number; width: number; height: number }) {
   expect(crop.x).toBeGreaterThanOrEqual(0);
@@ -112,5 +108,25 @@ describe('initialCrop — rect (event cover)', () => {
     fits(crop);
     isCentered(crop);
     expect(pixelAspect(crop, w, h)).toBeCloseTo(PORTRAIT_ASPECT, 3);
+  });
+});
+
+describe('percentToPixelCrop — issue 523 seed conversion', () => {
+  it('converts percent crop to pixel crop against rendered size', () => {
+    // x/width are percentages of width; y/height of height.
+    const px = percentToPixelCrop({ unit: '%', x: 10, y: 25, width: 80, height: 50 }, 400, 200);
+    expect(px).toEqual({ unit: 'px', x: 40, y: 50, width: 320, height: 100 });
+  });
+
+  it('round-trips an initialCrop into a centered square in pixel space', () => {
+    const w = 427;
+    const h = 320;
+    const px = percentToPixelCrop(initialCrop(w, h, 'round'), w, h);
+    expect(px.unit).toBe('px');
+    // 80% of the shorter (height) edge, centered.
+    expect(px.width).toBeCloseTo(0.8 * h, 2);
+    expect(px.height).toBeCloseTo(0.8 * h, 2);
+    expect(px.x).toBeCloseTo((w - px.width) / 2, 2);
+    expect(px.y).toBeCloseTo((h - px.height) / 2, 2);
   });
 });

--- a/frontend/src/components/initialCrop.ts
+++ b/frontend/src/components/initialCrop.ts
@@ -1,7 +1,7 @@
 // Initial crop geometry for ImageCropDialog. `width`/`height` are the rendered
 // (height-capped at MAX_PREVIEW_PX) image dimensions; returns percent units.
 
-import { centerCrop, makeAspectCrop, type PercentCrop } from 'react-image-crop';
+import { centerCrop, makeAspectCrop, type PercentCrop, type PixelCrop } from 'react-image-crop';
 
 import type { CropShape } from './ImageCropDialog';
 
@@ -42,4 +42,14 @@ export function coverCrop(width: number, height: number, aspect: number): Percen
     width,
     height,
   );
+}
+
+export function percentToPixelCrop(pct: PercentCrop, width: number, height: number): PixelCrop {
+  return {
+    unit: 'px',
+    x: (pct.x / 100) * width,
+    y: (pct.y / 100) * height,
+    width: (pct.width / 100) * width,
+    height: (pct.height / 100) * height,
+  };
 }


### PR DESCRIPTION
## Summary

Closes #523

- Saving a freshly-picked profile photo silently did nothing — no network request fired. Root cause: `react-image-crop` seeds the crop selection programmatically on image load but only fires `onComplete` on **user interaction** (drag/resize). The dialog's `completed` PixelCrop stayed `null`, so `handleSave()` bailed at the `!completed` guard before ever calling `cropImage`/`onCrop`.
- `ImageCropDialog.onImageLoad` now seeds `completed` from the initial percent crop via a new `percentToPixelCrop` helper in `initialCrop.ts`, so pressing **save** immediately produces the cropped blob and fires the upload mutation.
- The save button is now enabled as soon as the image loads (previously it required a manual drag first).

The two existing consumers already handle the rest of the acceptance criteria: `AvatarUpload` updates the auth store on success (re-rendering the avatar with a cache-busted url) and surfaces failures via `setError` + `role="alert"`.

## Test plan

- [ ] pick a profile photo, then press **save** without dragging the crop box → an upload request fires and the avatar updates
- [ ] drag/resize the crop box, then save → still uploads the adjusted region
- [ ] simulate an upload failure → an error message appears instead of silently doing nothing
- [x] `ImageCropDialog.test.tsx` + `initialCrop.test.ts` pass (17 tests)
- [x] frontend typecheck + lint clean; full vitest suite passes (549) single-threaded