### PR TITLE
chore(sms): note deferred automated send in twilio consent comments (Issue 501)

### DIFF
--- a/backend/community/_join_requests.py
+++ b/backend/community/_join_requests.py
@@ -47,7 +47,9 @@ class JoinRequestIn(BaseModel):
     answers: dict[str, str] = {}
     # SMS consent. UI presents a required checkbox tied to /sms-policy;
     # we record consent timestamp on the join request as proof for Twilio's
-    # toll-free verification + ongoing TCPA defensibility.
+    # toll-free verification + ongoing TCPA defensibility. The automated SMS
+    # send path is deferred (see #501); consent is retained for manual
+    # group-texting and possible future automation.
     sms_consent: bool = False
     # Community-guidelines consent. UI presents a required checkbox tied to
     # /guidelines; we record the consent timestamp on the join request.

--- a/backend/community/models/join_form.py
+++ b/backend/community/models/join_form.py
@@ -59,7 +59,9 @@ class JoinRequest(models.Model):
     # Set when the user checks the SMS-consent box on the join form. Required
     # at the API level, but stored as nullable so historical pre-consent rows
     # remain queryable. Used as proof-of-consent for Twilio toll-free
-    # verification + ongoing TCPA defensibility.
+    # verification + ongoing TCPA defensibility. The automated SMS send path is
+    # deferred (see #501); consent is kept for manual group-texting and possible
+    # future automation.
     sms_consent_at = models.DateTimeField(null=True, blank=True)
     # Set when the user checks the community-guidelines box on the join form.
     # Required at the API level; nullable so historical pre-consent rows remain

--- a/backend/tests/test_join_request_submission.py
+++ b/backend/tests/test_join_request_submission.py
@@ -30,7 +30,8 @@ class TestJoinRequestSubmission:
         assert data["phone_number"] == "+12025551234"
         assert len(data["answers"]) >= 1
         # Consent timestamps recorded — sms proof for Twilio toll-free
-        # verification, guidelines proof of agreement.
+        # verification (automated send deferred, see #501), guidelines proof of
+        # agreement.
         jr = JoinRequest.objects.get(phone_number="+12025551234")
         assert jr.sms_consent_at is not None
         assert jr.guidelines_consent_at is not None

--- a/frontend/src/screens/public/SmsPolicyScreen.tsx
+++ b/frontend/src/screens/public/SmsPolicyScreen.tsx
@@ -1,7 +1,8 @@
 // Static SMS policy page. Linked from the join form's consent checkbox and
 // from the URL the org submits to Twilio's toll-free verification form. Stable
 // content — don't make this editable, since changing the policy mid-review
-// breaks Twilio's verification process.
+// breaks Twilio's verification process. The automated SMS send path is deferred
+// (see #501), but this policy page stays to back manual group-text consent.
 
 import { ContentContainer } from './ContentContainer';
 


### PR DESCRIPTION
## Summary
- Issue #501 scope reduced to its only `main`-side action: the actual Twilio SMS **send** machinery was never on `main` (it lived in draft PR #414, **already closed** by the maintainer). The email blasts (#499) and manual group-text deeplink (#500) supersede it.
- **All SMS-consent infrastructure is kept** and unchanged: the join-form consent checkbox + `sms_consent` schema field, the `/sms-policy` route + `SmsPolicyScreen`, the `SMS_CONSENT_REQUIRED` validation, and the `sms_consent_at` data.
- This reworks the four Twilio-referencing **comments** to note the *automated* send path is deferred (see #501) while consent is retained for manual group-texting and possible future automation. **Comment-only — no functional change.**

Relates to #501. Not auto-closing the issue: closing draft PR #414 (Part A) was done separately by a maintainer; this PR is only the optional Part-B comment cleanup.

## Test plan
- [x] `grep -i twilio` returns only the kept (now reworded) consent comments
- [x] backend tests pass (1003 passed, fresh DB)
- [x] frontend tests pass (546 passed / 1 skipped)
- [x] backend + frontend lint and typecheck clean
- [ ] confirm `/sms-policy` still resolves and the join-form consent checkbox still submits in the running app