### PR TITLE
refactor(frontend): 529 - enforce import ordering

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -5,6 +5,7 @@ import reactRefresh from 'eslint-plugin-react-refresh';
 import jsxA11y from 'eslint-plugin-jsx-a11y';
 import tseslint from 'typescript-eslint';
 import prettier from 'eslint-config-prettier';
+import simpleImportSort from 'eslint-plugin-simple-import-sort';
 import { defineConfig, globalIgnores } from 'eslint/config';
 
 export default defineConfig([
@@ -20,6 +21,9 @@ export default defineConfig([
       jsxA11y.flatConfigs.recommended,
       prettier,
     ],
+    plugins: {
+      'simple-import-sort': simpleImportSort,
+    },
     languageOptions: {
       ecmaVersion: 2023,
       globals: globals.browser,
@@ -29,6 +33,24 @@ export default defineConfig([
       },
     },
     rules: {
+      // Enforce a consistent import order: side-effect imports, then external
+      // packages, then path-alias (`@/...`) imports, then relative imports.
+      'simple-import-sort/imports': [
+        'error',
+        {
+          groups: [
+            // Side-effect imports (e.g. `import './styles.css'`).
+            ['^\\u0000'],
+            // External packages (node builtins + anything not `@/` or relative).
+            ['^node:', '^@?\\w'],
+            // Path-alias imports.
+            ['^@/'],
+            // Relative imports.
+            ['^\\.'],
+          ],
+        },
+      ],
+      'simple-import-sort/exports': 'error',
       '@typescript-eslint/consistent-type-imports': [
         'error',
         { prefer: 'type-imports', fixStyle: 'inline-type-imports' },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,6 +68,7 @@
     "eslint-plugin-jsx-a11y": "^6.10.2",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
+    "eslint-plugin-simple-import-sort": "^13.0.0",
     "globals": "^17.5.0",
     "jsdom": "^29.0.2",
     "openapi-typescript": "^7.13.0",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -150,6 +150,9 @@ importers:
       eslint-plugin-react-refresh:
         specifier: ^0.5.2
         version: 0.5.2(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-simple-import-sort:
+        specifier: ^13.0.0
+        version: 13.0.0(eslint@9.39.4(jiti@2.6.1))
       globals:
         specifier: ^17.5.0
         version: 17.5.0
@@ -1399,6 +1402,11 @@ packages:
     resolution: {integrity: sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA==}
     peerDependencies:
       eslint: ^9 || ^10
+
+  eslint-plugin-simple-import-sort@13.0.0:
+    resolution: {integrity: sha512-McAc+/Nlvcg4byY/CABGH8kqnefWBj8s3JA2okEtz8ixbECQgU46p0HkTUKa4YS7wvgGceimlc34p1nXqbWqtA==}
+    peerDependencies:
+      eslint: '>=5.0.0'
 
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
@@ -4032,6 +4040,10 @@ snapshots:
       - supports-color
 
   eslint-plugin-react-refresh@0.5.2(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.6.1)
+
+  eslint-plugin-simple-import-sort@13.0.0(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       eslint: 9.39.4(jiti@2.6.1)
 

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,8 +1,9 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
-import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import LoginScreen from './screens/auth/LoginScreen';
 
 const loginMock = vi.fn();

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,12 @@
+import '@/auth/store';
+import '@/accessibility/store';
+
 import { QueryClientProvider } from '@tanstack/react-query';
 import { RouterProvider } from 'react-router-dom';
 import { Toaster } from 'sonner';
+
 import { queryClient } from '@/api/queryClient';
 import { router } from '@/router/routes';
-import '@/auth/store';
-import '@/accessibility/store';
 
 export default function App() {
   return (

--- a/frontend/src/accessibility/store.test.ts
+++ b/frontend/src/accessibility/store.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 // Provide a proper localStorage stub before the module loads — Zustand persist
 // calls setItem on every setState, which fails with jsdom's default Storage.

--- a/frontend/src/api/apiErrors.test.ts
+++ b/frontend/src/api/apiErrors.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
+
 import { extractApiError, extractApiErrorOr, getApiStatus, hasErrorCode } from './apiErrors';
 import { Code } from './validationCodes';
 

--- a/frontend/src/api/apiErrors.ts
+++ b/frontend/src/api/apiErrors.ts
@@ -9,7 +9,8 @@
 // becomes UI copy.
 
 import { isAxiosError } from 'axios';
-import { messagesFromFieldErrors, type FieldError } from './validationCodes';
+
+import { type FieldError, messagesFromFieldErrors } from './validationCodes';
 
 /**
  * Extract a user-facing message from any API error.

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -2,9 +2,11 @@
 // responses — centralizes the mapping from backend snake_case to frontend camelCase.
 
 import { useMutation } from '@tanstack/react-query';
-import { apiClient, authClient, getCurrentAccessToken } from './client';
+
+import type { Role, User } from '@/models/user';
 import { CalendarFeedScope, type CalendarFeedScopeValue } from '@/models/user';
-import type { User, Role } from '@/models/user';
+
+import { apiClient, authClient, getCurrentAccessToken } from './client';
 
 // --- Wire types (snake_case, server-shaped). ----------------------------------
 

--- a/frontend/src/api/calendar.test.ts
+++ b/frontend/src/api/calendar.test.ts
@@ -1,7 +1,7 @@
-import React from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
@@ -10,6 +10,7 @@ vi.mock('@/api/client', () => ({
 }));
 
 import { apiClient } from '@/api/client';
+
 import { useCalendarToken, useRegenerateCalendarToken } from './calendar';
 
 const mockedGet = vi.mocked(apiClient.get);

--- a/frontend/src/api/calendar.ts
+++ b/frontend/src/api/calendar.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
 import { apiClient } from './client';
 
 export interface CalendarToken {

--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -5,8 +5,9 @@
 //   - failed refresh fires onSessionExpired and rethrows
 //   - retried requests aren't retried again (no infinite loop)
 
-import { describe, it, expect, beforeEach, vi } from 'vitest';
 import MockAdapter from 'axios-mock-adapter';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { apiClient, authClient, setAuthBridge } from './client';
 
 let accessToken: string | null = null;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -11,11 +11,12 @@
 // reaches the server on cross-origin dev (React :3000 → Django :8000).
 
 import axios, {
-  isAxiosError,
   type AxiosError,
   type AxiosInstance,
   type InternalAxiosRequestConfig,
+  isAxiosError,
 } from 'axios';
+
 import { API_BASE_URL } from '@/config/env';
 
 interface RetryableConfig extends InternalAxiosRequestConfig {

--- a/frontend/src/api/cohostInvites.ts
+++ b/frontend/src/api/cohostInvites.ts
@@ -5,12 +5,14 @@
 // disappears but the host row hasn't refetched yet.
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { apiClient } from './client';
+
 import { useAuthStore } from '@/auth/store';
-import { mapEvent } from './eventMapper';
-import type { WireEvent } from './eventMapper';
-import { eventKeys } from './events';
 import type { Event } from '@/models/event';
+
+import { apiClient } from './client';
+import type { WireEvent } from './eventMapper';
+import { mapEvent } from './eventMapper';
+import { eventKeys } from './events';
 
 interface CohostInviteArgs {
   eventId: string;

--- a/frontend/src/api/content.test.ts
+++ b/frontend/src/api/content.test.ts
@@ -1,7 +1,7 @@
-import React from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
@@ -15,7 +15,8 @@ vi.mock('@/auth/store', () => ({
 }));
 
 import { apiClient } from '@/api/client';
-import { useHome, useUpdateHome, useGuidelines, useUpdateGuidelines } from './content';
+
+import { useGuidelines, useHome, useUpdateGuidelines, useUpdateHome } from './content';
 
 const mockedGet = vi.mocked(apiClient.get);
 const mockedPatch = vi.mocked(apiClient.patch);

--- a/frontend/src/api/content.ts
+++ b/frontend/src/api/content.ts
@@ -3,8 +3,10 @@
 // server-rendered content_html.
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { apiClient } from './client';
+
 import { useAuthStore } from '@/auth/store';
+
+import { apiClient } from './client';
 
 export interface HomePage {
   content: string;

--- a/frontend/src/api/docs.mutations.test.ts
+++ b/frontend/src/api/docs.mutations.test.ts
@@ -1,7 +1,7 @@
-import React from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn(), put: vi.fn() },
@@ -10,6 +10,7 @@ vi.mock('@/api/client', () => ({
 }));
 
 import { apiClient } from '@/api/client';
+
 import {
   useCreateDocFolder,
   useCreateDocument,

--- a/frontend/src/api/docs.ts
+++ b/frontend/src/api/docs.ts
@@ -1,6 +1,7 @@
 // Docs API. Reads used everywhere; writes gated by manage_documents.
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
 import { apiClient } from './client';
 
 export interface DocSummary {

--- a/frontend/src/api/eventComments.test.ts
+++ b/frontend/src/api/eventComments.test.ts
@@ -1,7 +1,7 @@
-import React from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
@@ -23,6 +23,7 @@ vi.mock('@/auth/store', () => {
 });
 
 import { apiClient } from '@/api/client';
+
 import { type WireCommentList } from './eventCommentMapper';
 import { eventCommentKeys, useEventComments } from './eventComments';
 

--- a/frontend/src/api/eventComments.ts
+++ b/frontend/src/api/eventComments.ts
@@ -3,9 +3,7 @@
 // require auth + an EventRSVP on the event.
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { apiClient } from './client';
-import { eventKeys } from './events';
-import { mapComment, mapCommentList, mapReply, type WireCommentList } from './eventCommentMapper';
+
 import { useAuthStore } from '@/auth/store';
 import type {
   EventComment,
@@ -13,6 +11,10 @@ import type {
   EventCommentReply,
   ReactionEmojiValue,
 } from '@/models/eventComment';
+
+import { apiClient } from './client';
+import { mapComment, mapCommentList, mapReply, type WireCommentList } from './eventCommentMapper';
+import { eventKeys } from './events';
 
 // ---------------------------------------------------------------------------
 // Wire types for write responses (not exported by the mapper)

--- a/frontend/src/api/eventFlags.ts
+++ b/frontend/src/api/eventFlags.ts
@@ -6,8 +6,9 @@
 // Transitions: pending → dismissed | actioned. Cannot go back to pending.
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { apiClient } from './client';
+
 import { getApiStatus, hasErrorCode } from './apiErrors';
+import { apiClient } from './client';
 import { Code } from './validationCodes';
 
 export type FlagStatus = 'pending' | 'dismissed' | 'actioned';

--- a/frontend/src/api/eventMapper.test.ts
+++ b/frontend/src/api/eventMapper.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
+
 import { mapEvent, type WireEvent } from './eventMapper';
 
 function wireEvent(overrides: Partial<WireEvent> = {}): WireEvent {

--- a/frontend/src/api/eventPolls.test.ts
+++ b/frontend/src/api/eventPolls.test.ts
@@ -1,8 +1,8 @@
-import React from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
 import type { AxiosError } from 'axios';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
@@ -24,9 +24,10 @@ vi.mock('@/auth/store', () => {
 });
 
 import { apiClient } from '@/api/client';
+import { VoteChoice } from '@/models/eventPoll';
+
 import { mapEventPoll, type WireEventPoll } from './eventPollMapper';
 import { eventPollKeys, useEventPoll, useVotePoll } from './eventPolls';
-import { VoteChoice } from '@/models/eventPoll';
 
 const mockedGet = vi.mocked(apiClient.get);
 const mockedPost = vi.mocked(apiClient.post);

--- a/frontend/src/api/eventPolls.ts
+++ b/frontend/src/api/eventPolls.ts
@@ -3,12 +3,14 @@
 // viewers see counts but not their own votes.
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { apiClient } from './client';
-import { extractApiErrorOr, getApiStatus } from './apiErrors';
-import { eventKeys } from './events';
-import { mapEventPoll, type WireEventPoll } from './eventPollMapper';
+
 import { useAuthStore } from '@/auth/store';
-import { VoteChoice, type EventPoll } from '@/models/eventPoll';
+import { type EventPoll, VoteChoice } from '@/models/eventPoll';
+
+import { extractApiErrorOr, getApiStatus } from './apiErrors';
+import { apiClient } from './client';
+import { mapEventPoll, type WireEventPoll } from './eventPollMapper';
+import { eventKeys } from './events';
 
 export const eventPollKeys = {
   all: ['event-poll'] as const,

--- a/frontend/src/api/eventStats.ts
+++ b/frontend/src/api/eventStats.ts
@@ -4,10 +4,12 @@
 // the `enabled` flag on host status themselves to avoid noisy error toasts.
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { apiClient } from './client';
-import { eventKeys } from './events';
-import { mapEvent, type WireEvent } from './eventMapper';
+
 import type { AttendanceStatusValue, EventCancellation, EventStats } from '@/models/event';
+
+import { apiClient } from './client';
+import { mapEvent, type WireEvent } from './eventMapper';
+import { eventKeys } from './events';
 
 interface WireCancellation {
   user_id: string;

--- a/frontend/src/api/eventWrites.test.ts
+++ b/frontend/src/api/eventWrites.test.ts
@@ -1,14 +1,16 @@
 // Pure-helper tests for the event write layer: enum-coercion on the inbound
 // side (eventToFormValues) and per-field PATCH body building (toPartialWireBody).
-import { describe, it, expect } from 'vitest';
-import { eventToFormValues, toPartialWireBody } from './eventWrites';
+import { describe, expect, it } from 'vitest';
+
 import {
+  type Event,
   EventStatus,
   EventType,
   EventVisibility,
   InvitePermission,
-  type Event,
 } from '@/models/event';
+
+import { eventToFormValues, toPartialWireBody } from './eventWrites';
 
 function makeEvent(overrides: Partial<Event> = {}): Event {
   return {

--- a/frontend/src/api/eventWrites.ts
+++ b/frontend/src/api/eventWrites.ts
@@ -5,20 +5,22 @@
 // dedicated error so the UI can show a sane message.
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { apiClient } from './client';
-import { extractApiErrorOr, getApiStatus } from './apiErrors';
+
 import { useAuthStore } from '@/auth/store';
-import { eventKeys } from './events';
-import { mapEvent, type WireEvent } from './eventMapper';
 import {
+  type Event,
   EventStatus as EventStatusEnum,
   EventType as EventTypeEnum,
   EventVisibility,
   InvitePermission,
-  type Event,
 } from '@/models/event';
 import { reportError } from '@/utils/errorReporter';
 import { fromCashAppUrl, fromVenmoUrl, toCashAppUrl, toVenmoUrl } from '@/utils/paymentHandle';
+
+import { extractApiErrorOr, getApiStatus } from './apiErrors';
+import { apiClient } from './client';
+import { mapEvent, type WireEvent } from './eventMapper';
+import { eventKeys } from './events';
 
 const ROUTE = '/events';
 

--- a/frontend/src/api/events.ts
+++ b/frontend/src/api/events.ts
@@ -6,10 +6,12 @@
 // the query key to the accessToken presence, not the user id.
 
 import { useQuery } from '@tanstack/react-query';
-import { apiClient } from './client';
+
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
 import type { EventStatus } from '@/models/event';
+
+import { apiClient } from './client';
 import { mapEvent, type WireEvent } from './eventMapper';
 
 type EventListStatus = typeof EventStatus.Draft | typeof EventStatus.Cancelled;

--- a/frontend/src/api/feedback.test.ts
+++ b/frontend/src/api/feedback.test.ts
@@ -1,13 +1,14 @@
-import React from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
 }));
 
 import { apiClient } from '@/api/client';
+
 import { useSubmitFeedback } from './feedback';
 
 const mockedPost = vi.mocked(apiClient.post);

--- a/frontend/src/api/feedback.ts
+++ b/frontend/src/api/feedback.ts
@@ -5,6 +5,7 @@
 // the user's perspective both failure modes surface the same toast.
 
 import { useMutation } from '@tanstack/react-query';
+
 import { apiClient } from './client';
 
 export type FeedbackType = 'bug' | 'feature request';

--- a/frontend/src/api/join.test.ts
+++ b/frontend/src/api/join.test.ts
@@ -1,14 +1,15 @@
-import React from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
 }));
 
 import { apiClient } from '@/api/client';
-import { useJoinRequests, useSubmitJoinRequest, AlreadyInvitedError } from './join';
+
+import { AlreadyInvitedError, useJoinRequests, useSubmitJoinRequest } from './join';
 
 const mockedGet = vi.mocked(apiClient.get);
 const mockedPost = vi.mocked(apiClient.post);

--- a/frontend/src/api/join.ts
+++ b/frontend/src/api/join.ts
@@ -8,8 +8,9 @@
 //   409 email.already_exists  — email matches another user → surfaced inline on the form
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { apiClient } from './client';
+
 import { hasErrorCode } from './apiErrors';
+import { apiClient } from './client';
 import { Code } from './validationCodes.gen';
 
 export type JoinQuestionType = 'text' | 'select';

--- a/frontend/src/api/notifications.test.ts
+++ b/frontend/src/api/notifications.test.ts
@@ -1,7 +1,7 @@
-import React from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
@@ -17,7 +17,8 @@ vi.mock('@/auth/store', () => ({
 }));
 
 import { apiClient } from '@/api/client';
-import { useNotifications, useUnreadCount, useMarkAllNotificationsRead } from './notifications';
+
+import { useMarkAllNotificationsRead, useNotifications, useUnreadCount } from './notifications';
 
 const mockedGet = vi.mocked(apiClient.get);
 const mockedPost = vi.mocked(apiClient.post);

--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -6,9 +6,11 @@
 // is handled by TanStack Query's refetchIntervalInBackground: false.
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { apiClient } from './client';
+
 import { useAuthStore } from '@/auth/store';
 import type { AppNotification } from '@/models/notification';
+
+import { apiClient } from './client';
 
 interface WireNotification {
   id: string;

--- a/frontend/src/api/roles.test.ts
+++ b/frontend/src/api/roles.test.ts
@@ -1,7 +1,7 @@
-import React from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
@@ -10,7 +10,8 @@ vi.mock('@/api/client', () => ({
 }));
 
 import { apiClient } from '@/api/client';
-import { useRoles, useCreateRole, useUpdateRole, useDeleteRole } from './roles';
+
+import { useCreateRole, useDeleteRole, useRoles, useUpdateRole } from './roles';
 
 const mockedGet = vi.mocked(apiClient.get);
 const mockedPost = vi.mocked(apiClient.post);

--- a/frontend/src/api/roles.ts
+++ b/frontend/src/api/roles.ts
@@ -4,6 +4,7 @@
 // role names) — plain members get a 403.
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
 import { apiClient } from './client';
 
 export interface Role {

--- a/frontend/src/api/rsvp.ts
+++ b/frontend/src/api/rsvp.ts
@@ -7,14 +7,16 @@
 // over capacity.
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { apiClient } from './client';
+
 import { useAuthStore } from '@/auth/store';
-import { eventCommentKeys } from './eventComments';
-import { eventKeys } from './events';
-import { eventStatsKeys } from './eventStats';
-import { mapEvent, type WireEvent } from './eventMapper';
 import type { Event } from '@/models/event';
 import type { RsvpStatus } from '@/models/event';
+
+import { apiClient } from './client';
+import { eventCommentKeys } from './eventComments';
+import { mapEvent, type WireEvent } from './eventMapper';
+import { eventKeys } from './events';
+import { eventStatsKeys } from './eventStats';
 
 type RsvpInput = (typeof RsvpStatus)[keyof typeof RsvpStatus];
 

--- a/frontend/src/api/surveyAdmin.tallies.test.ts
+++ b/frontend/src/api/surveyAdmin.tallies.test.ts
@@ -1,7 +1,7 @@
-import React from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
@@ -10,7 +10,8 @@ vi.mock('@/api/client', () => ({
 }));
 
 import { apiClient } from '@/api/client';
-import { useSurveyPollTallies, useFinalizeSurveyPoll } from './surveyAdmin';
+
+import { useFinalizeSurveyPoll, useSurveyPollTallies } from './surveyAdmin';
 
 const mockedGet = vi.mocked(apiClient.get);
 const mockedPost = vi.mocked(apiClient.post);

--- a/frontend/src/api/surveyAdmin.ts
+++ b/frontend/src/api/surveyAdmin.ts
@@ -4,6 +4,7 @@
 // backend (organizer/co-host/etc.).
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
 import { apiClient } from './client';
 import type { SurveyQuestion, SurveyQuestionType } from './surveys';
 

--- a/frontend/src/api/surveys.ts
+++ b/frontend/src/api/surveys.ts
@@ -9,6 +9,7 @@
 // either client is readable by the other.
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
 import { apiClient } from './client';
 
 export type SurveyQuestionType =

--- a/frontend/src/api/userSearch.ts
+++ b/frontend/src/api/userSearch.ts
@@ -1,6 +1,7 @@
 // Member search — used by co-host picker and invite picker in the event form.
 
 import { useQuery } from '@tanstack/react-query';
+
 import { apiClient } from './client';
 
 export interface MemberSearchResult {

--- a/frontend/src/api/users.test.ts
+++ b/frontend/src/api/users.test.ts
@@ -1,7 +1,7 @@
-import React from 'react';
-import { renderHook, waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
@@ -10,14 +10,15 @@ vi.mock('@/api/client', () => ({
 }));
 
 import { apiClient } from '@/api/client';
+
 import {
-  useUsers,
-  useCreateUser,
-  useUpdateUser,
-  useBulkCreateUsers,
   useArchiveUser,
+  useBulkCreateUsers,
+  useCreateUser,
   useSendMemberMagicLink,
   useUpdateMemberRoles,
+  useUpdateUser,
+  useUsers,
 } from './users';
 
 const mockedGet = vi.mocked(apiClient.get);

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -2,6 +2,7 @@
 // Mirrors backend/users/_management.py.
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
 import { apiClient } from './client';
 
 // --- Domain types (camelCase) ------------------------------------------------

--- a/frontend/src/api/validationCodes.test.ts
+++ b/frontend/src/api/validationCodes.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { Code, messageForCode, messagesFromFieldErrors, type FieldError } from './validationCodes';
+
+import { Code, type FieldError, messageForCode, messagesFromFieldErrors } from './validationCodes';
 
 describe('messageForCode', () => {
   it('returns friendly copy for known event-form codes', () => {

--- a/frontend/src/api/version.ts
+++ b/frontend/src/api/version.ts
@@ -1,4 +1,5 @@
 import { useQuery } from '@tanstack/react-query';
+
 import { apiClient } from './client';
 
 export interface VersionInfo {

--- a/frontend/src/api/whatsapp.ts
+++ b/frontend/src/api/whatsapp.ts
@@ -2,6 +2,7 @@
 // track `hasSecret` instead, and sending a value in the PATCH rotates it.
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
 import { apiClient } from './client';
 
 export interface WhatsappConfig {

--- a/frontend/src/auth/guards.test.tsx
+++ b/frontend/src/auth/guards.test.tsx
@@ -1,10 +1,12 @@
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
-import { useAuthStore } from './store';
-import { RequireAuth, RequirePermission, OnboardingGate, EmailGate } from './guards';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { Permission } from '@/models/permissions';
 import type { User } from '@/models/user';
+
+import { EmailGate, OnboardingGate, RequireAuth, RequirePermission } from './guards';
+import { useAuthStore } from './store';
 
 // Prevent the store from wiring up real axios interceptors.
 vi.mock('@/api/client', () => ({

--- a/frontend/src/auth/guards.tsx
+++ b/frontend/src/auth/guards.tsx
@@ -10,12 +10,14 @@
 // The onboarding gate wraps the WHOLE app so it applies on every navigation,
 // matching the Flutter behavior.
 
-import { useEffect, type ReactNode } from 'react';
+import { type ReactNode, useEffect } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
+
 import { RequireEmail } from '@/components/RequireEmail';
-import { useAuthStore } from './store';
 import { hasPermission, type PermissionKey } from '@/models/permissions';
 import { guidelinesConsentRedirect, passwordSetupRedirect } from '@/models/user';
+
+import { useAuthStore } from './store';
 
 // ----------------------------------------------------------------------------
 // AuthBoot — kick off session restore exactly once on mount.

--- a/frontend/src/auth/store.test.ts
+++ b/frontend/src/auth/store.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { useAuthStore } from './store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import type { User } from '@/models/user';
+
+import { useAuthStore } from './store';
 
 // Mock the api/auth module so no real HTTP calls are made.
 vi.mock('@/api/auth', () => ({

--- a/frontend/src/auth/store.ts
+++ b/frontend/src/auth/store.ts
@@ -11,6 +11,7 @@
 // calls /api/auth/refresh/ (cookie is sent automatically) and rehydrates.
 
 import { create } from 'zustand';
+
 import * as authApi from '@/api/auth';
 import { setAuthBridge } from '@/api/client';
 import { queryClient } from '@/api/queryClient';

--- a/frontend/src/auth/useAuth.ts
+++ b/frontend/src/auth/useAuth.ts
@@ -1,9 +1,10 @@
-import { useAuthStore } from './store';
 import {
-  hasPermission as check,
   hasAnyAdminPermission as checkAdmin,
+  hasPermission as check,
   type PermissionKey,
 } from '@/models/permissions';
+
+import { useAuthStore } from './store';
 
 export function useHasPermission(key: PermissionKey): boolean {
   return useAuthStore((s) => check(s.user, key));

--- a/frontend/src/components/AutosaveStatus.tsx
+++ b/frontend/src/components/AutosaveStatus.tsx
@@ -1,5 +1,5 @@
-import { cn } from '@/utils/cn';
 import type { AutosaveStatus as Status } from '@/hooks/useAutosave';
+import { cn } from '@/utils/cn';
 
 interface Props {
   status: Status;

--- a/frontend/src/components/EditableHtmlBlock.tsx
+++ b/frontend/src/components/EditableHtmlBlock.tsx
@@ -5,11 +5,13 @@
 // can all reuse it.
 
 import { useState } from 'react';
-import { RichEditor } from './RichEditor/RichEditor';
-import { HtmlContent } from './HtmlContent';
-import { AutosaveStatus } from './AutosaveStatus';
-import { Button } from './ui/Button';
+
 import { useAutosave } from '@/hooks/useAutosave';
+
+import { AutosaveStatus } from './AutosaveStatus';
+import { HtmlContent } from './HtmlContent';
+import { RichEditor } from './RichEditor/RichEditor';
+import { Button } from './ui/Button';
 
 interface Props {
   canEdit: boolean;

--- a/frontend/src/components/FeedbackButton.a11y.test.tsx
+++ b/frontend/src/components/FeedbackButton.a11y.test.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
+
 import { useAuthStore } from '@/auth/store';
 import type { User } from '@/models/user';
 

--- a/frontend/src/components/FeedbackButton.test.tsx
+++ b/frontend/src/components/FeedbackButton.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { useAuthStore } from '@/auth/store';
 import type { User } from '@/models/user';
 
@@ -25,6 +26,7 @@ vi.mock('sonner', () => ({
 }));
 
 import { useSubmitFeedback } from '@/api/feedback';
+
 import { FeedbackButton } from './FeedbackButton';
 
 const mockedUseSubmitFeedback = vi.mocked(useSubmitFeedback);

--- a/frontend/src/components/FeedbackButton.tsx
+++ b/frontend/src/components/FeedbackButton.tsx
@@ -9,11 +9,12 @@
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { toast } from 'sonner';
-import { useSubmitFeedback, type FeedbackType } from '@/api/feedback';
+
+import { type FeedbackType, useSubmitFeedback } from '@/api/feedback';
 import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
-import { TextField } from '@/components/ui/TextField';
 import { Textarea } from '@/components/ui/Textarea';
+import { TextField } from '@/components/ui/TextField';
 
 const TITLE_MAX = 150;
 const DESCRIPTION_MAX = 2000;

--- a/frontend/src/components/HtmlContent.test.tsx
+++ b/frontend/src/components/HtmlContent.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
+
 import { HtmlContent } from './HtmlContent';
 
 describe('HtmlContent', () => {

--- a/frontend/src/components/HtmlContent.tsx
+++ b/frontend/src/components/HtmlContent.tsx
@@ -3,8 +3,9 @@
 // DOMPurify + a consistent prose stylesheet.
 
 import { useMemo } from 'react';
-import { sanitizeHtml } from '@/utils/sanitize';
+
 import { cn } from '@/utils/cn';
+import { sanitizeHtml } from '@/utils/sanitize';
 
 interface Props {
   html: string;

--- a/frontend/src/components/ImageCropDialog.a11y.test.tsx
+++ b/frontend/src/components/ImageCropDialog.a11y.test.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
 import { render } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
 
 vi.mock('react-image-crop', () => ({

--- a/frontend/src/components/ImageCropDialog.test.tsx
+++ b/frontend/src/components/ImageCropDialog.test.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // react-image-crop uses pointer events + ResizeObserver that jsdom doesn't
 // fully support. Stub it so it renders a simple sentinel element that

--- a/frontend/src/components/ImageCropDialog.tsx
+++ b/frontend/src/components/ImageCropDialog.tsx
@@ -1,10 +1,13 @@
 // Crop dialog for avatar uploads (round, 1:1 circular mask) and event covers
 // (rect, free-form). Built on react-image-crop; returns a PNG blob via onCrop.
 
+import 'react-image-crop/dist/ReactCrop.css';
+
 import { useRef, useState } from 'react';
 import ReactCrop, { type Crop, type PercentCrop, type PixelCrop } from 'react-image-crop';
-import 'react-image-crop/dist/ReactCrop.css';
+
 import { cropImage } from '@/utils/cropImage';
+
 import { initialCrop, MAX_PREVIEW_PX } from './initialCrop';
 import { Button } from './ui/Button';
 

--- a/frontend/src/components/MemberPicker.tsx
+++ b/frontend/src/components/MemberPicker.tsx
@@ -2,10 +2,12 @@
 // form's co-host and invited-user pickers.
 
 import { useState } from 'react';
-import { useUserSearch, type MemberSearchResult } from '@/api/userSearch';
-import { TextField } from './ui/TextField';
+
+import { type MemberSearchResult, useUserSearch } from '@/api/userSearch';
 import { cn } from '@/utils/cn';
 import { formatPhone } from '@/utils/formatPhone';
+
+import { TextField } from './ui/TextField';
 
 interface Props {
   label: string;

--- a/frontend/src/components/RequireEmail.test.tsx
+++ b/frontend/src/components/RequireEmail.test.tsx
@@ -1,9 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { RequireEmail } from './RequireEmail';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { updateProfile } from '@/api/auth';
 import { useAuthStore } from '@/auth/store';
+
+import { RequireEmail } from './RequireEmail';
 
 vi.mock('@/api/auth', () => ({
   updateProfile: vi.fn(),

--- a/frontend/src/components/RequireEmail.tsx
+++ b/frontend/src/components/RequireEmail.tsx
@@ -2,9 +2,10 @@
 // There is intentionally no close button — the user must supply an email
 // before the guard layer allows them to proceed.
 
-import { useState, type SyntheticEvent } from 'react';
-import { updateProfile } from '@/api/auth';
+import { type SyntheticEvent, useState } from 'react';
+
 import { extractApiErrorOr } from '@/api/apiErrors';
+import { updateProfile } from '@/api/auth';
 import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import { TextField } from '@/components/ui/TextField';

--- a/frontend/src/components/RichEditor/CtaDialog.tsx
+++ b/frontend/src/components/RichEditor/CtaDialog.tsx
@@ -1,11 +1,13 @@
 // Dialog for inserting or editing a CTA button node in the editor.
 
-import { useState, type SyntheticEvent } from 'react';
+import { type SyntheticEvent, useState } from 'react';
+
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import { Select } from '@/components/ui/Select';
 import { TextField } from '@/components/ui/TextField';
 import { ensureHttps } from '@/utils/url';
+
 import type { CtaAttrs, CtaVariant } from './CtaExtension';
 
 interface Props {

--- a/frontend/src/components/RichEditor/RichEditor.tsx
+++ b/frontend/src/components/RichEditor/RichEditor.tsx
@@ -2,11 +2,13 @@
 // JSObjects) to match the backend wire format — the content_pm column is a
 // TextField, not a JSONField.
 
-import { useEditor, EditorContent, type JSONContent } from '@tiptap/react';
+import { EditorContent, type JSONContent, useEditor } from '@tiptap/react';
 import { useEffect } from 'react';
-import { pdaExtensions } from './tiptapConfig';
-import { RichEditorToolbar } from './RichEditorToolbar';
+
 import { cn } from '@/utils/cn';
+
+import { RichEditorToolbar } from './RichEditorToolbar';
+import { pdaExtensions } from './tiptapConfig';
 
 interface Props {
   /** ProseMirror JSON as a string. Empty string → start blank. */

--- a/frontend/src/components/RichEditor/RichEditorToolbar.tsx
+++ b/frontend/src/components/RichEditor/RichEditorToolbar.tsx
@@ -1,6 +1,8 @@
 import type { Editor } from '@tiptap/react';
 import { useEffect, useRef, useState } from 'react';
+
 import { cn } from '@/utils/cn';
+
 import { CtaDialog } from './CtaDialog';
 import type { CtaAttrs } from './CtaExtension';
 

--- a/frontend/src/components/RichEditor/tiptapConfig.ts
+++ b/frontend/src/components/RichEditor/tiptapConfig.ts
@@ -2,10 +2,11 @@
 // we enable here must also have a handler in backend/community/_prosemirror_html.py,
 // otherwise it will be silently dropped on render.
 
-import StarterKit from '@tiptap/starter-kit';
 import Link from '@tiptap/extension-link';
 import TextAlign from '@tiptap/extension-text-align';
 import type { Extensions } from '@tiptap/react';
+import StarterKit from '@tiptap/starter-kit';
+
 import { CtaExtension } from './CtaExtension';
 
 export function pdaExtensions(): Extensions {

--- a/frontend/src/components/SortableList.tsx
+++ b/frontend/src/components/SortableList.tsx
@@ -7,17 +7,17 @@
 // aria-label so screen readers announce it.
 
 import {
+  closestCenter,
   DndContext,
+  type DragEndEvent,
   KeyboardSensor,
   PointerSensor,
-  closestCenter,
   useSensor,
   useSensors,
-  type DragEndEvent,
 } from '@dnd-kit/core';
 import {
-  SortableContext,
   arrayMove,
+  SortableContext,
   sortableKeyboardCoordinates,
   useSortable,
   verticalListSortingStrategy,

--- a/frontend/src/components/initialCrop.test.ts
+++ b/frontend/src/components/initialCrop.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
+
 import { initialCrop } from './initialCrop';
 
 // Regression for issue 428: the round crop was sized off image *width*, so for any

--- a/frontend/src/components/initialCrop.ts
+++ b/frontend/src/components/initialCrop.ts
@@ -5,6 +5,7 @@
 // with the displayed image. See issue 428.
 
 import { centerCrop, type PercentCrop } from 'react-image-crop';
+
 import type { CropShape } from './ImageCropDialog';
 
 // Max rendered preview height (20rem). The single source of truth for the cap;

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,4 +1,5 @@
 import type { ButtonHTMLAttributes } from 'react';
+
 import { cn } from '@/utils/cn';
 
 type Variant = 'primary' | 'secondary' | 'ghost';

--- a/frontend/src/components/ui/CollapsibleCard.tsx
+++ b/frontend/src/components/ui/CollapsibleCard.tsx
@@ -9,7 +9,8 @@
 //
 // Reusable anywhere we want a "cute, friendly" expandable block.
 
-import { useId, useState, type ReactNode } from 'react';
+import { type ReactNode, useId, useState } from 'react';
+
 import { cn } from '@/utils/cn';
 
 interface Props {

--- a/frontend/src/components/ui/DateTimePicker.a11y.test.tsx
+++ b/frontend/src/components/ui/DateTimePicker.a11y.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
+
 import { DateTimePicker } from './DateTimePicker';
 
 describe('DateTimePicker accessibility', () => {

--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -3,7 +3,7 @@
 // we only need this for a handful of small forms in phase 3, so keeping it
 // inline avoids another dep.
 
-import { useEffect, type ReactNode } from 'react';
+import { type ReactNode, useEffect } from 'react';
 
 interface Props {
   open: boolean;

--- a/frontend/src/components/ui/LocationField.tsx
+++ b/frontend/src/components/ui/LocationField.tsx
@@ -4,7 +4,8 @@
 // still works — coords stay null if no result is picked.
 
 import { useEffect, useRef, useState } from 'react';
-import { searchLocations, type PhotonResult } from '@/api/geocode';
+
+import { type PhotonResult, searchLocations } from '@/api/geocode';
 
 interface Props {
   label: string;

--- a/frontend/src/components/ui/PasswordField.tsx
+++ b/frontend/src/components/ui/PasswordField.tsx
@@ -1,4 +1,5 @@
-import { forwardRef, useState, type InputHTMLAttributes } from 'react';
+import { forwardRef, type InputHTMLAttributes, useState } from 'react';
+
 import { TextField } from './TextField';
 
 type BaseProps = Omit<InputHTMLAttributes<HTMLInputElement>, 'type'>;

--- a/frontend/src/components/ui/PhoneField.tsx
+++ b/frontend/src/components/ui/PhoneField.tsx
@@ -1,7 +1,9 @@
+import 'react-phone-number-input/style.css';
+
 import type { InputHTMLAttributes } from 'react';
 import PhoneInput, { type Country, type Value } from 'react-phone-number-input';
 import flags from 'react-phone-number-input/flags';
-import 'react-phone-number-input/style.css';
+
 import { cn } from '@/utils/cn';
 
 interface Props {

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, type SelectHTMLAttributes } from 'react';
+
 import { cn } from '@/utils/cn';
 
 interface Option {

--- a/frontend/src/components/ui/TextField.tsx
+++ b/frontend/src/components/ui/TextField.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, type InputHTMLAttributes, type ReactNode } from 'react';
+
 import { cn } from '@/utils/cn';
 
 interface Props extends InputHTMLAttributes<HTMLInputElement> {

--- a/frontend/src/components/ui/Textarea.tsx
+++ b/frontend/src/components/ui/Textarea.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, type TextareaHTMLAttributes } from 'react';
+
 import { cn } from '@/utils/cn';
 
 interface Props extends TextareaHTMLAttributes<HTMLTextAreaElement> {

--- a/frontend/src/components/ui/useConfirm.tsx
+++ b/frontend/src/components/ui/useConfirm.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from 'react';
+
 import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 
 interface ConfirmOptions {

--- a/frontend/src/hooks/useEventSource.ts
+++ b/frontend/src/hooks/useEventSource.ts
@@ -15,8 +15,9 @@
 //   });
 
 import { useEffect, useRef } from 'react';
-import { API_BASE_URL } from '@/config/env';
+
 import { refreshAccessToken } from '@/api/client';
+import { API_BASE_URL } from '@/config/env';
 
 type Handler = (event: MessageEvent<string>) => void;
 

--- a/frontend/src/layout/AppShell.test.tsx
+++ b/frontend/src/layout/AppShell.test.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Routes, Route, useLocation } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { useAuthStore } from '@/auth/store';
 
 // Stub modules that reach out to the network or browser APIs the AppShell

--- a/frontend/src/layout/AppShell.tsx
+++ b/frontend/src/layout/AppShell.tsx
@@ -5,8 +5,10 @@
 
 import { useState } from 'react';
 import { Outlet } from 'react-router-dom';
+
 import { useAuthStore } from '@/auth/store';
 import { FeedbackButton } from '@/components/FeedbackButton';
+
 import { BottomNav } from './BottomNav';
 import { NotificationBell } from './NotificationBell';
 import { PdaMenuSheet } from './PdaMenuSheet';

--- a/frontend/src/layout/BottomNav.test.tsx
+++ b/frontend/src/layout/BottomNav.test.tsx
@@ -5,7 +5,8 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
+
 import { BottomNav } from './BottomNav';
 
 function LocationDisplay() {

--- a/frontend/src/layout/BottomNav.tsx
+++ b/frontend/src/layout/BottomNav.tsx
@@ -6,6 +6,7 @@
 // survives the color-blind-friendly rule (not color-only).
 
 import { NavLink, useLocation, useNavigate } from 'react-router-dom';
+
 import { useAuthStore } from '@/auth/store';
 import { cn } from '@/utils/cn';
 

--- a/frontend/src/layout/NotificationBell.test.tsx
+++ b/frontend/src/layout/NotificationBell.test.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { afterEach, describe, it, expect, vi, beforeEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { useAuthStore } from '@/auth/store';
 import { NotificationType } from '@/models/notification';
 
@@ -32,11 +33,12 @@ vi.mock('@/utils/errorReporter', () => ({
 }));
 
 import {
-  useUnreadCount,
-  useNotifications,
-  useMarkNotificationRead,
   useMarkAllNotificationsRead,
+  useMarkNotificationRead,
+  useNotifications,
+  useUnreadCount,
 } from '@/api/notifications';
+
 import { NotificationBell } from './NotificationBell';
 
 const mockUseUnreadCount = vi.mocked(useUnreadCount);

--- a/frontend/src/layout/NotificationBell.tsx
+++ b/frontend/src/layout/NotificationBell.tsx
@@ -3,10 +3,10 @@
 // count refetch. Polling is a fallback (30s when SSE is disconnected, 5 min
 // when connected).
 
+import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useQueryClient } from '@tanstack/react-query';
-import { useAuthStore } from '@/auth/store';
+
 import {
   notificationKeys,
   useMarkAllNotificationsRead,
@@ -14,8 +14,9 @@ import {
   useNotifications,
   useUnreadCount,
 } from '@/api/notifications';
+import { useAuthStore } from '@/auth/store';
 import { useEventSource } from '@/hooks/useEventSource';
-import { NotificationType, type AppNotification } from '@/models/notification';
+import { type AppNotification, NotificationType } from '@/models/notification';
 import { cn } from '@/utils/cn';
 import { reportError } from '@/utils/errorReporter';
 

--- a/frontend/src/layout/PdaMenuSheet.tsx
+++ b/frontend/src/layout/PdaMenuSheet.tsx
@@ -6,9 +6,10 @@
 import { useEffect } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
+
 import { useAuthStore } from '@/auth/store';
-import { extractApiError } from '@/utils/errors';
 import { cn } from '@/utils/cn';
+import { extractApiError } from '@/utils/errors';
 
 interface Props {
   open: boolean;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,6 +1,8 @@
+import './index.css';
+
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
-import './index.css';
+
 import App from './App.tsx';
 
 const rootElement = document.getElementById('root');

--- a/frontend/src/models/event.test.ts
+++ b/frontend/src/models/event.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { eventClass, EventStatus, EventType, EventVisibility, type Event } from './event';
+import { describe, expect, it } from 'vitest';
+
+import { type Event, eventClass, EventStatus, EventType, EventVisibility } from './event';
 
 function makeEvent(overrides: Partial<Event> = {}): Event {
   return {

--- a/frontend/src/models/permissions.test.ts
+++ b/frontend/src/models/permissions.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { Permission, hasPermission, hasAnyAdminPermission, type UserLike } from './permissions';
+import { describe, expect, it } from 'vitest';
+
+import { hasAnyAdminPermission, hasPermission, Permission, type UserLike } from './permissions';
 
 function user(opts: Partial<UserLike> = {}): UserLike {
   return {

--- a/frontend/src/models/user.test.ts
+++ b/frontend/src/models/user.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
+
 import {
   guidelinesConsentRedirect,
   passwordSetupRedirect,

--- a/frontend/src/router/RootRouteError.tsx
+++ b/frontend/src/router/RootRouteError.tsx
@@ -1,7 +1,9 @@
 import { useEffect } from 'react';
 import { isRouteErrorResponse, useLocation, useNavigate, useRouteError } from 'react-router-dom';
-import { reportError } from '@/utils/errorReporter';
+
 import { Button } from '@/components/ui/Button';
+import { reportError } from '@/utils/errorReporter';
+
 import { isChunkLoadError } from './lazyRoute';
 
 const CHUNK_RELOAD_FLAG = 'chunk-error-reload-attempted';

--- a/frontend/src/router/lazyRoute.tsx
+++ b/frontend/src/router/lazyRoute.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, type ComponentType, type ReactNode } from 'react';
+import { type ComponentType, lazy, type ReactNode, Suspense } from 'react';
 
 function FallbackSpinner() {
   return (

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -6,9 +6,11 @@
 // All screens are lazy-loaded (React.lazy) — 1:1 replacement for DeferredScreen.
 
 import { createBrowserRouter } from 'react-router-dom';
+
 import { AuthBoot, EmailGate, OnboardingGate, RequireAuth, RequirePermission } from '@/auth/guards';
 import { AppShell } from '@/layout/AppShell';
 import { Permission } from '@/models/permissions';
+
 import { lazyEl as el, lazyWithRetry } from './lazyRoute';
 import { RootRouteError } from './RootRouteError';
 

--- a/frontend/src/screens/admin/AdminHubScreen.tsx
+++ b/frontend/src/screens/admin/AdminHubScreen.tsx
@@ -2,8 +2,9 @@
 // permissions. Mirrors the flutter admin_screen.dart tile layout.
 
 import { Link } from 'react-router-dom';
+
 import { useAuthStore } from '@/auth/store';
-import { Permission, hasPermission, type PermissionKey } from '@/models/permissions';
+import { hasPermission, Permission, type PermissionKey } from '@/models/permissions';
 import { ContentContainer } from '@/screens/public/ContentContainer';
 
 interface Tile {

--- a/frontend/src/screens/admin/ApprovalCredentialsDialog.test.tsx
+++ b/frontend/src/screens/admin/ApprovalCredentialsDialog.test.tsx
@@ -1,8 +1,10 @@
-import { render, screen } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { useAuthStore } from '@/auth/store';
 import type { User } from '@/models/user';
+
 import { ApprovalCredentialsDialog } from './ApprovalCredentialsDialog';
 
 vi.mock('@/api/client', () => ({

--- a/frontend/src/screens/admin/ApprovalCredentialsDialog.tsx
+++ b/frontend/src/screens/admin/ApprovalCredentialsDialog.tsx
@@ -4,8 +4,9 @@
 // new link from the members screen.
 
 import { useState } from 'react';
-import { useAuthStore } from '@/auth/store';
+
 import { useWelcomeTemplate } from '@/api/content';
+import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import { hasPermission, Permission } from '@/models/permissions';
@@ -13,10 +14,11 @@ import { formatPhone } from '@/utils/formatPhone';
 import {
   buildMagicLinkUrl,
   buildSmsHref,
-  buildWhatsAppHref,
   buildWelcomeMessage,
+  buildWhatsAppHref,
   renderWelcomeMessage,
 } from '@/utils/welcomeMessage';
+
 import { WelcomeTemplateEditorDialog } from './WelcomeTemplateEditorDialog';
 
 interface Props {

--- a/frontend/src/screens/admin/BulkCreateDialog.tsx
+++ b/frontend/src/screens/admin/BulkCreateDialog.tsx
@@ -4,12 +4,13 @@
 // view lists one-time magic-login links for each newly created row and
 // any per-row errors so the admin can retry the failed entries.
 
-import { useState, type SyntheticEvent } from 'react';
+import { type SyntheticEvent, useState } from 'react';
+
 import { extractApiErrorOr } from '@/api/apiErrors';
+import { type BulkCreateResponse, type BulkCreateResult, useBulkCreateUsers } from '@/api/users';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import { Textarea } from '@/components/ui/Textarea';
-import { useBulkCreateUsers, type BulkCreateResponse, type BulkCreateResult } from '@/api/users';
 import { formatPhone } from '@/utils/formatPhone';
 import { buildMagicLinkUrl, buildSmsHref, buildWelcomeMessage } from '@/utils/welcomeMessage';
 

--- a/frontend/src/screens/admin/EventManagementScreen.tsx
+++ b/frontend/src/screens/admin/EventManagementScreen.tsx
@@ -3,15 +3,16 @@
 // `sort` query param — it's a flat fetch and the Flutter app works the
 // same way.
 
-import { useMemo, useState } from 'react';
 import { format } from 'date-fns';
+import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
+
 import { useEvents } from '@/api/events';
-import type { Event } from '@/models/event';
 import { Button } from '@/components/ui/Button';
 import { SegmentedControl } from '@/components/ui/SegmentedControl';
 import { Select } from '@/components/ui/Select';
 import { TextField } from '@/components/ui/TextField';
+import type { Event } from '@/models/event';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 
 type Bucket = 'upcoming' | 'past' | 'drafts' | 'cancelled';

--- a/frontend/src/screens/admin/FlaggedEventsScreen.tsx
+++ b/frontend/src/screens/admin/FlaggedEventsScreen.tsx
@@ -1,11 +1,12 @@
-import { useState } from 'react';
 import { format } from 'date-fns';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
+
 import { extractApiErrorOr } from '@/api/apiErrors';
-import { useDecideFlag, useEventFlags, type FlagStatus, type EventFlag } from '@/api/eventFlags';
+import { type EventFlag, type FlagStatus, useDecideFlag, useEventFlags } from '@/api/eventFlags';
 import { Button } from '@/components/ui/Button';
-import { cn } from '@/utils/cn';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
+import { cn } from '@/utils/cn';
 
 const FILTERS: { value: FlagStatus | 'all'; label: string }[] = [
   { value: 'pending', label: 'pending' },

--- a/frontend/src/screens/admin/JoinFormAdminScreen.tsx
+++ b/frontend/src/screens/admin/JoinFormAdminScreen.tsx
@@ -3,12 +3,14 @@
 // order which replaces the optimistic cache.
 
 import { useState } from 'react';
+
 import type { JoinQuestion } from '@/api/join';
 import { useDeleteJoinQuestion, useJoinQuestions, useReorderJoinQuestions } from '@/api/join';
+import { SortableList } from '@/components/SortableList';
 import { Button } from '@/components/ui/Button';
 import { useConfirm } from '@/components/ui/useConfirm';
-import { SortableList } from '@/components/SortableList';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
+
 import { JoinQuestionDialog } from './JoinQuestionDialog';
 
 export default function JoinFormAdminScreen() {

--- a/frontend/src/screens/admin/JoinQuestionDialog.tsx
+++ b/frontend/src/screens/admin/JoinQuestionDialog.tsx
@@ -2,14 +2,15 @@
 // parent screen stays focused on list semantics + reorder.
 
 import { useState } from 'react';
+
 import { extractApiErrorOr } from '@/api/apiErrors';
 import type { JoinQuestion, JoinQuestionInput, JoinQuestionType } from '@/api/join';
 import { useCreateJoinQuestion, useUpdateJoinQuestion } from '@/api/join';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import { Select } from '@/components/ui/Select';
-import { TextField } from '@/components/ui/TextField';
 import { Textarea } from '@/components/ui/Textarea';
+import { TextField } from '@/components/ui/TextField';
 
 interface Props {
   open: boolean;

--- a/frontend/src/screens/admin/JoinRequestsScreen.tsx
+++ b/frontend/src/screens/admin/JoinRequestsScreen.tsx
@@ -1,20 +1,22 @@
-import { useMemo, useState } from 'react';
 import { format, formatDistanceToNow } from 'date-fns';
+import { useMemo, useState } from 'react';
+
 import { extractApiErrorOr } from '@/api/apiErrors';
 import {
   JoinRequestStatus,
+  type JoinRequestSummary,
   useDecideJoinRequest,
   useJoinRequests,
   useResendMagicLink,
   useUnrejectJoinRequest,
-  type JoinRequestSummary,
 } from '@/api/join';
 import { Button } from '@/components/ui/Button';
-import { useConfirm } from '@/components/ui/useConfirm';
 import { SegmentedControl } from '@/components/ui/SegmentedControl';
+import { useConfirm } from '@/components/ui/useConfirm';
+import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 import { cn } from '@/utils/cn';
 import { formatPhone } from '@/utils/formatPhone';
-import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
+
 import { ApprovalCredentialsDialog } from './ApprovalCredentialsDialog';
 
 const Filter = {

--- a/frontend/src/screens/admin/MemberCreateDialog.test.tsx
+++ b/frontend/src/screens/admin/MemberCreateDialog.test.tsx
@@ -1,9 +1,11 @@
-import React from 'react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemberCreateDialog } from './MemberCreateDialog';
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { useCreateUser } from '@/api/users';
+
+import { MemberCreateDialog } from './MemberCreateDialog';
 
 vi.mock('@/api/users', () => ({
   useCreateUser: vi.fn(),

--- a/frontend/src/screens/admin/MemberCreateDialog.tsx
+++ b/frontend/src/screens/admin/MemberCreateDialog.tsx
@@ -2,12 +2,13 @@
 // same welcome-credentials view used after approving a join request so the
 // admin can copy the magic-login link before leaving the dialog.
 
-import { useState, type SyntheticEvent } from 'react';
+import { type SyntheticEvent, useState } from 'react';
+
 import { extractApiErrorOr } from '@/api/apiErrors';
+import { type CreateUserResult, useCreateUser } from '@/api/users';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import { TextField } from '@/components/ui/TextField';
-import { useCreateUser, type CreateUserResult } from '@/api/users';
 import { formatPhone } from '@/utils/formatPhone';
 import { buildMagicLinkUrl, buildSmsHref, buildWelcomeMessage } from '@/utils/welcomeMessage';
 

--- a/frontend/src/screens/admin/MemberDetailScreen.tsx
+++ b/frontend/src/screens/admin/MemberDetailScreen.tsx
@@ -2,26 +2,27 @@
 // list (no dedicated detail endpoint exists on the backend) and lets admins
 // edit display name / email / phone + pause/unpause the account.
 
-import { useState, type SyntheticEvent } from 'react';
+import { type SyntheticEvent, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'sonner';
+
 import { extractApiErrorOr } from '@/api/apiErrors';
-import { Button } from '@/components/ui/Button';
-import { useConfirm } from '@/components/ui/useConfirm';
-import { TextField } from '@/components/ui/TextField';
-import { Toggle } from '@/components/ui/Toggle';
-import { formatPhone } from '@/utils/formatPhone';
+import { useRoles } from '@/api/roles';
 import {
+  type Member,
   useArchiveUser,
   useSendMemberMagicLink,
   useUpdateMemberRoles,
   useUpdateUser,
   useUsers,
-  type Member,
 } from '@/api/users';
-import { useRoles } from '@/api/roles';
+import { Button } from '@/components/ui/Button';
+import { TextField } from '@/components/ui/TextField';
+import { Toggle } from '@/components/ui/Toggle';
+import { useConfirm } from '@/components/ui/useConfirm';
 import { ADMIN_ROLE_NAME } from '@/models/permissions';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
+import { formatPhone } from '@/utils/formatPhone';
 import { buildMagicLinkUrl, buildSmsHref, buildWelcomeMessage } from '@/utils/welcomeMessage';
 
 export default function MemberDetailScreen() {

--- a/frontend/src/screens/admin/MembersScreen.test.tsx
+++ b/frontend/src/screens/admin/MembersScreen.test.tsx
@@ -1,13 +1,14 @@
-import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Member } from '@/api/users';
 import { useAuthStore } from '@/auth/store';
 import { Permission } from '@/models/permissions';
 import type { User } from '@/models/user';
-import type { Member } from '@/api/users';
 
 // Mock the users API module so we can drive loading / error / data states
 // without hitting the network. useCreateUser is only pulled in transitively
@@ -21,8 +22,9 @@ vi.mock('@/api/users', () => ({
   })),
 }));
 
-import MembersScreen from './MembersScreen';
 import { useUsers } from '@/api/users';
+
+import MembersScreen from './MembersScreen';
 
 const mockUseUsers = vi.mocked(useUsers);
 

--- a/frontend/src/screens/admin/MembersScreen.tsx
+++ b/frontend/src/screens/admin/MembersScreen.tsx
@@ -2,10 +2,12 @@
 // role management. Mirrors the Flutter TabController(length:2) layout.
 
 import { useState } from 'react';
+
 import { useAuthStore } from '@/auth/store';
 import { SegmentedControl } from '@/components/ui/SegmentedControl';
-import { Permission, hasPermission } from '@/models/permissions';
+import { hasPermission, Permission } from '@/models/permissions';
 import { ContentContainer } from '@/screens/public/ContentContainer';
+
 import { MembersTab } from './MembersTab';
 import { RolesTab } from './RolesTab';
 

--- a/frontend/src/screens/admin/MembersTab.tsx
+++ b/frontend/src/screens/admin/MembersTab.tsx
@@ -3,13 +3,15 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
+
 import { useRoles } from '@/api/roles';
-import { useUsers, type Member } from '@/api/users';
+import { type Member, useUsers } from '@/api/users';
 import { Button } from '@/components/ui/Button';
 import { Select } from '@/components/ui/Select';
 import { TextField } from '@/components/ui/TextField';
 import { ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 import { formatPhone } from '@/utils/formatPhone';
+
 import { BulkCreateDialog } from './BulkCreateDialog';
 import { MemberCreateDialog } from './MemberCreateDialog';
 

--- a/frontend/src/screens/admin/RoleFormDialog.tsx
+++ b/frontend/src/screens/admin/RoleFormDialog.tsx
@@ -3,13 +3,14 @@
 // are read-only — opened only so admins can see which permissions
 // are checked.
 
-import { useState, type SyntheticEvent } from 'react';
+import { type SyntheticEvent, useState } from 'react';
+
+import { type Role, useCreateRole, useUpdateRole } from '@/api/roles';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import { TextField } from '@/components/ui/TextField';
 import { Permission } from '@/models/permissions';
 import { extractApiError } from '@/utils/errors';
-import { useCreateRole, useUpdateRole, type Role } from '@/api/roles';
 
 interface Props {
   open: boolean;

--- a/frontend/src/screens/admin/RolesTab.tsx
+++ b/frontend/src/screens/admin/RolesTab.tsx
@@ -3,11 +3,13 @@
 
 import { useState } from 'react';
 import { toast } from 'sonner';
+
 import { extractApiErrorOr } from '@/api/apiErrors';
-import { useDeleteRole, useRoles, type Role } from '@/api/roles';
+import { type Role, useDeleteRole, useRoles } from '@/api/roles';
 import { Button } from '@/components/ui/Button';
 import { useConfirm } from '@/components/ui/useConfirm';
 import { ContentError, ContentLoading } from '@/screens/public/ContentContainer';
+
 import { RoleFormDialog } from './RoleFormDialog';
 
 const PROTECTED_ROLE_NAMES = new Set(['admin', 'member']);

--- a/frontend/src/screens/admin/SurveyAdminListScreen.tsx
+++ b/frontend/src/screens/admin/SurveyAdminListScreen.tsx
@@ -1,22 +1,23 @@
-import { useState } from 'react';
 import { format } from 'date-fns';
+import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
+
 import { extractApiErrorOr } from '@/api/apiErrors';
 import {
+  type SurveyInput,
+  type SurveySummary,
   useAdminSurveys,
   useCreateSurvey,
   useDeleteSurvey,
-  type SurveyInput,
-  type SurveySummary,
 } from '@/api/surveyAdmin';
 import { Button } from '@/components/ui/Button';
-import { useConfirm } from '@/components/ui/useConfirm';
 import { Dialog } from '@/components/ui/Dialog';
 import { Select } from '@/components/ui/Select';
-import { TextField } from '@/components/ui/TextField';
 import { Textarea } from '@/components/ui/Textarea';
-import { cn } from '@/utils/cn';
+import { TextField } from '@/components/ui/TextField';
+import { useConfirm } from '@/components/ui/useConfirm';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
+import { cn } from '@/utils/cn';
 
 export default function SurveyAdminListScreen() {
   const { data = [], isPending, isError } = useAdminSurveys();

--- a/frontend/src/screens/admin/SurveyBuilderScreen.tsx
+++ b/frontend/src/screens/admin/SurveyBuilderScreen.tsx
@@ -1,16 +1,18 @@
 import { useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
+
 import {
+  type SurveyQuestion,
   useAdminSurvey,
   useDeleteSurveyQuestion,
   useReorderSurveyQuestions,
   useUpdateSurvey,
-  type SurveyQuestion,
 } from '@/api/surveyAdmin';
+import { SortableList } from '@/components/SortableList';
 import { Button } from '@/components/ui/Button';
 import { useConfirm } from '@/components/ui/useConfirm';
-import { SortableList } from '@/components/SortableList';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
+
 import { SurveyQuestionDialog } from './SurveyQuestionDialog';
 
 export default function SurveyBuilderScreen() {

--- a/frontend/src/screens/admin/SurveyQuestionDialog.tsx
+++ b/frontend/src/screens/admin/SurveyQuestionDialog.tsx
@@ -2,19 +2,20 @@
 // textarea appears only for types that use them.
 
 import { useState } from 'react';
+
 import { extractApiErrorOr } from '@/api/apiErrors';
 import {
-  useCreateSurveyQuestion,
-  useUpdateSurveyQuestion,
   type SurveyQuestion,
   type SurveyQuestionInput,
   type SurveyQuestionType,
+  useCreateSurveyQuestion,
+  useUpdateSurveyQuestion,
 } from '@/api/surveyAdmin';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import { Select } from '@/components/ui/Select';
-import { TextField } from '@/components/ui/TextField';
 import { Textarea } from '@/components/ui/Textarea';
+import { TextField } from '@/components/ui/TextField';
 
 const TYPES: { value: SurveyQuestionType; label: string; wantsOptions: boolean }[] = [
   { value: 'text', label: 'short text', wantsOptions: false },

--- a/frontend/src/screens/admin/SurveyResponsesScreen.tsx
+++ b/frontend/src/screens/admin/SurveyResponsesScreen.tsx
@@ -5,16 +5,17 @@ import { format } from 'date-fns';
 import { useMemo, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { toast } from 'sonner';
+
 import { extractApiErrorOr } from '@/api/apiErrors';
-import { Button } from '@/components/ui/Button';
-import { Dialog } from '@/components/ui/Dialog';
 import {
+  type SurveyPollTallyRow,
   useAdminSurvey,
   useFinalizeSurveyPoll,
   useSurveyPollTallies,
   useSurveyResponses,
-  type SurveyPollTallyRow,
 } from '@/api/surveyAdmin';
+import { Button } from '@/components/ui/Button';
+import { Dialog } from '@/components/ui/Dialog';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 
 export default function SurveyResponsesScreen() {

--- a/frontend/src/screens/admin/WelcomeTemplateEditorDialog.test.tsx
+++ b/frontend/src/screens/admin/WelcomeTemplateEditorDialog.test.tsx
@@ -1,10 +1,12 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi } from 'vitest';
 import { AxiosError, type AxiosResponse } from 'axios';
-import { WelcomeTemplateEditorDialog } from './WelcomeTemplateEditorDialog';
+import { describe, expect, it, vi } from 'vitest';
+
 import type { WelcomeTemplate } from '@/api/content';
+
+import { WelcomeTemplateEditorDialog } from './WelcomeTemplateEditorDialog';
 
 const mutateAsyncMock = vi.fn();
 

--- a/frontend/src/screens/admin/WelcomeTemplateEditorDialog.tsx
+++ b/frontend/src/screens/admin/WelcomeTemplateEditorDialog.tsx
@@ -3,8 +3,9 @@
 // placeholders ${NAME}, ${SENDER_NAME}, ${MAGIC_LINK} are substituted at
 // render time by renderWelcomeMessage().
 
-import { useState, type SyntheticEvent } from 'react';
+import { type SyntheticEvent, useState } from 'react';
 import { toast } from 'sonner';
+
 import { extractApiErrorOr } from '@/api/apiErrors';
 import { useUpdateWelcomeTemplate, type WelcomeTemplate } from '@/api/content';
 import { Button } from '@/components/ui/Button';

--- a/frontend/src/screens/admin/WhatsappConfigScreen.tsx
+++ b/frontend/src/screens/admin/WhatsappConfigScreen.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+
 import { extractApiErrorOr } from '@/api/apiErrors';
 import {
   useUpdateWhatsappConfig,
@@ -9,6 +10,7 @@ import {
 import { Button } from '@/components/ui/Button';
 import { TextField } from '@/components/ui/TextField';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
+
 import { WhatsappSetupInstructions } from './WhatsappSetupInstructions';
 
 export default function WhatsappConfigScreen() {

--- a/frontend/src/screens/auth/ConsentScreen.test.tsx
+++ b/frontend/src/screens/auth/ConsentScreen.test.tsx
@@ -1,10 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter } from 'react-router-dom';
 import type * as RouterDom from 'react-router-dom';
-import ConsentScreen from './ConsentScreen';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { useAuthStore } from '@/auth/store';
+
+import ConsentScreen from './ConsentScreen';
 
 const navigate = vi.fn();
 vi.mock('react-router-dom', async (importActual) => {

--- a/frontend/src/screens/auth/ConsentScreen.tsx
+++ b/frontend/src/screens/auth/ConsentScreen.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { AuthLayout } from './AuthLayout';
-import { Button } from '@/components/ui/Button';
+
 import { useAuthStore } from '@/auth/store';
+import { Button } from '@/components/ui/Button';
 import { extractApiError } from '@/utils/errors';
+
+import { AuthLayout } from './AuthLayout';
 
 // Guidelines-consent gate. Modeled on OnboardingScreen — same AuthLayout shell.
 // Blocks login completion: the only ways forward are to accept (clears

--- a/frontend/src/screens/auth/LoginScreen.a11y.test.tsx
+++ b/frontend/src/screens/auth/LoginScreen.a11y.test.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
 
 vi.mock('@/api/join', () => ({
@@ -15,8 +15,9 @@ vi.mock('@/api/client', () => ({
   setAuthBridge: vi.fn(),
 }));
 
-import LoginScreen from './LoginScreen';
 import { useAuthStore } from '@/auth/store';
+
+import LoginScreen from './LoginScreen';
 
 function renderWith(component: React.ReactElement) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/frontend/src/screens/auth/LoginScreen.tsx
+++ b/frontend/src/screens/auth/LoginScreen.tsx
@@ -1,20 +1,22 @@
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { useNavigate, useSearchParams, Link } from 'react-router-dom';
+import { isValidPhoneNumber } from 'react-phone-number-input';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 import { z } from 'zod';
-import { isValidPhoneNumber } from 'react-phone-number-input';
-import { AuthLayout } from './AuthLayout';
+
+import { checkPhone } from '@/api/join';
+import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import { PasswordField } from '@/components/ui/PasswordField';
 import { PhoneField } from '@/components/ui/PhoneField';
-import { useAuthStore } from '@/auth/store';
 import { postAuthRedirect } from '@/models/user';
-import { checkPhone } from '@/api/join';
 import { extractApiError } from '@/utils/errors';
-import { RequestLoginLinkDialog } from './RequestLoginLinkDialog';
+
+import { AuthLayout } from './AuthLayout';
 import { safeRedirect } from './redirect';
+import { RequestLoginLinkDialog } from './RequestLoginLinkDialog';
 
 type Step = 'phone' | 'password' | 'pending';
 

--- a/frontend/src/screens/auth/MagicLoginScreen.test.tsx
+++ b/frontend/src/screens/auth/MagicLoginScreen.test.tsx
@@ -1,7 +1,9 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import type { User } from '@/models/user';
+
 import MagicLoginScreen from './MagicLoginScreen';
 
 // MagicLoginScreen calls the store's magicLogin action, then reads

--- a/frontend/src/screens/auth/MagicLoginScreen.tsx
+++ b/frontend/src/screens/auth/MagicLoginScreen.tsx
@@ -1,10 +1,12 @@
-import { useEffect, useRef, useState } from 'react';
 import { AxiosError } from 'axios';
+import { useEffect, useRef, useState } from 'react';
 import { Navigate, useNavigate, useParams, useSearchParams } from 'react-router-dom';
+
 import { useAuthStore } from '@/auth/store';
-import { postAuthRedirect } from '@/models/user';
-import { AuthLayout } from './AuthLayout';
 import { Button } from '@/components/ui/Button';
+import { postAuthRedirect } from '@/models/user';
+
+import { AuthLayout } from './AuthLayout';
 import { RequestLoginLinkDialog } from './RequestLoginLinkDialog';
 
 type State = 'pending' | 'expired' | 'cross_user';

--- a/frontend/src/screens/auth/NewPasswordScreen.test.tsx
+++ b/frontend/src/screens/auth/NewPasswordScreen.test.tsx
@@ -1,9 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import NewPasswordScreen from './NewPasswordScreen';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { useAuthStore } from '@/auth/store';
+
+import NewPasswordScreen from './NewPasswordScreen';
 
 vi.mock('@/auth/store', () => ({
   useAuthStore: vi.fn(),

--- a/frontend/src/screens/auth/NewPasswordScreen.tsx
+++ b/frontend/src/screens/auth/NewPasswordScreen.tsx
@@ -1,15 +1,17 @@
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
 import { useNavigate } from 'react-router-dom';
 import { z } from 'zod';
-import { AuthLayout } from './AuthLayout';
+
+import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import { PasswordField } from '@/components/ui/PasswordField';
-import { useAuthStore } from '@/auth/store';
 import { extractApiError } from '@/utils/errors';
-import { passwordRule } from './passwordRule';
+
+import { AuthLayout } from './AuthLayout';
 import { PasswordChecklist } from './PasswordChecklist';
+import { passwordRule } from './passwordRule';
 
 const schema = z
   .object({

--- a/frontend/src/screens/auth/OnboardingScreen.test.tsx
+++ b/frontend/src/screens/auth/OnboardingScreen.test.tsx
@@ -1,10 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import type { User } from '@/models/user';
-import OnboardingScreen from './OnboardingScreen';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { useAuthStore } from '@/auth/store';
+import type { User } from '@/models/user';
+
+import OnboardingScreen from './OnboardingScreen';
 
 vi.mock('@/auth/store', () => ({
   useAuthStore: vi.fn(),

--- a/frontend/src/screens/auth/OnboardingScreen.tsx
+++ b/frontend/src/screens/auth/OnboardingScreen.tsx
@@ -1,17 +1,19 @@
+import { zodResolver } from '@hookform/resolvers/zod';
 import { useState } from 'react';
 import { useForm, useWatch } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
 import { Link, useNavigate } from 'react-router-dom';
 import { z } from 'zod';
-import { AuthLayout } from './AuthLayout';
+
+import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import { PasswordField } from '@/components/ui/PasswordField';
 import { TextField } from '@/components/ui/TextField';
-import { useAuthStore } from '@/auth/store';
-import { extractApiError } from '@/utils/errors';
 import { postAuthRedirect } from '@/models/user';
-import { passwordRule } from './passwordRule';
+import { extractApiError } from '@/utils/errors';
+
+import { AuthLayout } from './AuthLayout';
 import { PasswordChecklist } from './PasswordChecklist';
+import { passwordRule } from './passwordRule';
 
 const schema = z.object({
   displayName: z.string().min(1, 'name required').max(64),

--- a/frontend/src/screens/auth/PasswordChecklist.tsx
+++ b/frontend/src/screens/auth/PasswordChecklist.tsx
@@ -1,4 +1,5 @@
 import { cn } from '@/utils/cn';
+
 import { passwordChecks } from './passwordRule';
 
 export function PasswordChecklist({ value }: { value: string }) {

--- a/frontend/src/screens/auth/RequestLoginLinkDialog.test.tsx
+++ b/frontend/src/screens/auth/RequestLoginLinkDialog.test.tsx
@@ -1,8 +1,10 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { RequestLoginLinkDialog } from './RequestLoginLinkDialog';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { useRequestLoginLink } from '@/api/auth';
+
+import { RequestLoginLinkDialog } from './RequestLoginLinkDialog';
 
 vi.mock('@/api/auth', () => ({
   useRequestLoginLink: vi.fn(),

--- a/frontend/src/screens/auth/RequestLoginLinkDialog.tsx
+++ b/frontend/src/screens/auth/RequestLoginLinkDialog.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
 import { isValidPhoneNumber } from 'react-phone-number-input';
+
+import { type RequestLoginLinkDelivery, useRequestLoginLink } from '@/api/auth';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import { PhoneField } from '@/components/ui/PhoneField';
-import { useRequestLoginLink, type RequestLoginLinkDelivery } from '@/api/auth';
 import { extractApiError } from '@/utils/errors';
 
 interface Props {

--- a/frontend/src/screens/auth/redirect.test.ts
+++ b/frontend/src/screens/auth/redirect.test.ts
@@ -1,5 +1,6 @@
 // Open-redirect guard for the post-login `redirect` query param.
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
+
 import { safeRedirect } from './redirect';
 
 const DEFAULT = '/calendar';

--- a/frontend/src/screens/calendar/AgendaList.test.tsx
+++ b/frontend/src/screens/calendar/AgendaList.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
+
 import { AgendaList } from './AgendaList';
 
 function makeEvent(overrides: Partial<Event> = {}): Event {

--- a/frontend/src/screens/calendar/AgendaList.tsx
+++ b/frontend/src/screens/calendar/AgendaList.tsx
@@ -2,10 +2,11 @@
 // event type. No rbc date/time columns; title sits on top, date + time line
 // sits underneath. Mirrors the "cleaner" list layout the user asked for.
 
-import { useMemo, useState } from 'react';
 import { format, isSameDay } from 'date-fns';
-import { EventType, eventClass, type Event as PdaEvent } from '@/models/event';
+import { useMemo, useState } from 'react';
+
 import { SegmentedControl } from '@/components/ui/SegmentedControl';
+import { type Event as PdaEvent, eventClass, EventType } from '@/models/event';
 import { cn } from '@/utils/cn';
 
 type TypeFilter = 'all' | typeof EventType.Official | typeof EventType.Community;

--- a/frontend/src/screens/calendar/CalendarScreen.test.tsx
+++ b/frontend/src/screens/calendar/CalendarScreen.test.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { useAuthStore } from '@/auth/store';
 
 // react-big-calendar is a heavy component that requires CSS imports and relies
@@ -26,6 +27,7 @@ vi.mock('@/api/events', () => ({
 }));
 
 import { useEvents } from '@/api/events';
+
 import CalendarScreen from './CalendarScreen';
 
 const mockUseEvents = vi.mocked(useEvents);

--- a/frontend/src/screens/calendar/CalendarScreen.tsx
+++ b/frontend/src/screens/calendar/CalendarScreen.tsx
@@ -1,21 +1,24 @@
+import 'react-big-calendar/lib/css/react-big-calendar.css';
+
 import { addDays, format as dfFormat, startOfWeek } from 'date-fns';
 import { useMemo, useState } from 'react';
 import { Calendar, type View } from 'react-big-calendar';
-import 'react-big-calendar/lib/css/react-big-calendar.css';
 import { useNavigate } from 'react-router-dom';
+
 import { useEvents } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
 import { useIsWideScreen } from '@/hooks/useResponsive';
-import { eventClass, type Event as PdaEvent } from '@/models/event';
-import { CalendarToolbar } from './CalendarToolbar';
-import { makeLocalizer } from './calendarLocalizer';
+import { type Event as PdaEvent, eventClass } from '@/models/event';
+
 import { AgendaList } from './AgendaList';
+import { makeLocalizer } from './calendarLocalizer';
+import { CalendarToolbar } from './CalendarToolbar';
 import { DayEventList } from './DayEventList';
 import { NarrowWeekView } from './NarrowWeekView';
-import { WideWeekView } from './WideWeekView';
 import { TodayIconButton } from './TodayIconButton';
 import type { BigCalEvent } from './types';
 import { ViewSwitcher } from './ViewSwitcher';
+import { WideWeekView } from './WideWeekView';
 
 function toBigCalEvent(e: PdaEvent): BigCalEvent | null {
   // TBD events have no date — skip them on the calendar.

--- a/frontend/src/screens/calendar/CalendarToolbar.tsx
+++ b/frontend/src/screens/calendar/CalendarToolbar.tsx
@@ -1,5 +1,7 @@
 import type { ToolbarProps } from 'react-big-calendar';
+
 import { cn } from '@/utils/cn';
+
 import { TodayIconButton } from './TodayIconButton';
 import type { BigCalEvent } from './types';
 

--- a/frontend/src/screens/calendar/CalendarViews.a11y.test.tsx
+++ b/frontend/src/screens/calendar/CalendarViews.a11y.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
+
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
+
 import { AgendaList } from './AgendaList';
 import { DayEventList } from './DayEventList';
 

--- a/frontend/src/screens/calendar/DayEventList.tsx
+++ b/frontend/src/screens/calendar/DayEventList.tsx
@@ -4,7 +4,8 @@
 // description preview. Empty state reads "nothing today 🌿".
 
 import { format, isSameDay } from 'date-fns';
-import { eventClass, type Event as PdaEvent } from '@/models/event';
+
+import { type Event as PdaEvent, eventClass } from '@/models/event';
 import { cn } from '@/utils/cn';
 
 interface Props {

--- a/frontend/src/screens/calendar/NarrowWeekView.tsx
+++ b/frontend/src/screens/calendar/NarrowWeekView.tsx
@@ -4,7 +4,8 @@
 // colored chips on the right. Multi-day events only show on their start day.
 
 import { addDays, format, isSameDay, startOfWeek } from 'date-fns';
-import { eventClass, type Event as PdaEvent } from '@/models/event';
+
+import { type Event as PdaEvent, eventClass } from '@/models/event';
 import { cn } from '@/utils/cn';
 
 interface Props {

--- a/frontend/src/screens/calendar/ViewSwitcher.tsx
+++ b/frontend/src/screens/calendar/ViewSwitcher.tsx
@@ -1,5 +1,6 @@
-import { SegmentedControl } from '@/components/ui/SegmentedControl';
 import type { View } from 'react-big-calendar';
+
+import { SegmentedControl } from '@/components/ui/SegmentedControl';
 
 interface Props {
   value: View;

--- a/frontend/src/screens/calendar/WideWeekView.tsx
+++ b/frontend/src/screens/calendar/WideWeekView.tsx
@@ -6,7 +6,8 @@
 
 import { addDays, format, isSameDay, startOfWeek } from 'date-fns';
 import { useLayoutEffect, useRef, useState } from 'react';
-import { eventClass, type Event as PdaEvent } from '@/models/event';
+
+import { type Event as PdaEvent, eventClass } from '@/models/event';
 import { cn } from '@/utils/cn';
 
 interface Props {

--- a/frontend/src/screens/calendar/calendarLocalizer.ts
+++ b/frontend/src/screens/calendar/calendarLocalizer.ts
@@ -2,9 +2,9 @@
 // preference (Sunday=0 | Monday=1), defaulting to Sunday to match the project
 // rule that weekStart is user-configurable on the profile.
 
-import { dateFnsLocalizer } from 'react-big-calendar';
-import { format, parse, startOfWeek, getDay } from 'date-fns';
+import { format, getDay, parse, startOfWeek } from 'date-fns';
 import { enUS } from 'date-fns/locale';
+import { dateFnsLocalizer } from 'react-big-calendar';
 
 export function makeLocalizer(weekStartsOn: 0 | 1) {
   const locales = { 'en-US': enUS };

--- a/frontend/src/screens/docs/DocDetailScreen.tsx
+++ b/frontend/src/screens/docs/DocDetailScreen.tsx
@@ -1,8 +1,9 @@
 import { Link, useParams } from 'react-router-dom';
+
 import { useDocument, useUpdateDocument } from '@/api/docs';
 import { useAuthStore } from '@/auth/store';
 import { EditableHtmlBlock } from '@/components/EditableHtmlBlock';
-import { Permission, hasPermission } from '@/models/permissions';
+import { hasPermission, Permission } from '@/models/permissions';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 
 export default function DocDetailScreen() {

--- a/frontend/src/screens/docs/DocsScreen.tsx
+++ b/frontend/src/screens/docs/DocsScreen.tsx
@@ -1,23 +1,24 @@
 // Docs tree: nested folders and documents. Members with manage_documents can
 // create folders and docs, delete, and drag-reorder within the tree.
 
-import { useMemo, useState, type ElementType } from 'react';
+import { type ElementType, useMemo, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
-import { useAuthStore } from '@/auth/store';
+
 import {
+  type DocFolder,
   useCreateDocFolder,
   useCreateDocument,
   useDeleteDocFolder,
   useDeleteDocument,
   useDocFolders,
   useReorderDocuments,
-  type DocFolder,
 } from '@/api/docs';
+import { useAuthStore } from '@/auth/store';
 import { SortableList } from '@/components/SortableList';
 import { Button } from '@/components/ui/Button';
-import { useConfirm } from '@/components/ui/useConfirm';
 import { TextField } from '@/components/ui/TextField';
+import { useConfirm } from '@/components/ui/useConfirm';
 import { hasPermission, Permission } from '@/models/permissions';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 

--- a/frontend/src/screens/events/AddCoHostDialog.tsx
+++ b/frontend/src/screens/events/AddCoHostDialog.tsx
@@ -2,10 +2,11 @@
 // co-hosts can open this from the hosts section.
 
 import { useState } from 'react';
+
 import { extractApiErrorOr } from '@/api/apiErrors';
 import { useUpdateEvent } from '@/api/eventWrites';
-import { MemberPicker } from '@/components/MemberPicker';
 import type { MemberSearchResult } from '@/api/userSearch';
+import { MemberPicker } from '@/components/MemberPicker';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import type { Event } from '@/models/event';

--- a/frontend/src/screens/events/CohostInviteBanner.test.tsx
+++ b/frontend/src/screens/events/CohostInviteBanner.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
 

--- a/frontend/src/screens/events/CohostInviteBanner.tsx
+++ b/frontend/src/screens/events/CohostInviteBanner.tsx
@@ -4,6 +4,7 @@
 // clears via lazy expiration once the event ends.
 
 import { toast } from 'sonner';
+
 import { hasErrorCode } from '@/api/apiErrors';
 import { useAcceptCohostInvite, useDeclineCohostInvite } from '@/api/cohostInvites';
 import { Code } from '@/api/validationCodes';

--- a/frontend/src/screens/events/EventActions.tsx
+++ b/frontend/src/screens/events/EventActions.tsx
@@ -5,6 +5,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
+
 import type { Event } from '@/models/event';
 import { appleCalendarUrl, googleCalendarUrl, icsUrl, shareEventUrl } from '@/utils/eventCalendar';
 

--- a/frontend/src/screens/events/EventAdminActions.test.tsx
+++ b/frontend/src/screens/events/EventAdminActions.test.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';

--- a/frontend/src/screens/events/EventAdminActions.tsx
+++ b/frontend/src/screens/events/EventAdminActions.tsx
@@ -3,6 +3,7 @@
 
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+
 import { extractApiErrorOr } from '@/api/apiErrors';
 import { useCancelEvent, useDeleteEvent, useUpdateEvent } from '@/api/eventWrites';
 import { useAuthStore } from '@/auth/store';
@@ -10,7 +11,7 @@ import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import type { Event } from '@/models/event';
 import { EventStatus } from '@/models/event';
-import { Permission, hasPermission } from '@/models/permissions';
+import { hasPermission, Permission } from '@/models/permissions';
 
 interface Props {
   event: Event;

--- a/frontend/src/screens/events/EventAttendancePanel.test.tsx
+++ b/frontend/src/screens/events/EventAttendancePanel.test.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
 import type { Event, EventStats } from '@/models/event';
 import {
   AttendanceStatus,
@@ -20,6 +21,7 @@ vi.mock('@/api/eventStats', () => ({
 }));
 
 import { useEventStats } from '@/api/eventStats';
+
 import { EventAttendancePanel } from './EventAttendancePanel';
 
 const BASE_EVENT: Event = {

--- a/frontend/src/screens/events/EventAttendancePanel.tsx
+++ b/frontend/src/screens/events/EventAttendancePanel.tsx
@@ -8,7 +8,8 @@
 // for users who flipped statuses (see docs/event-attendance-stats-plan.md).
 
 import { useState } from 'react';
-import { useSetAttendance, useEventStats } from '@/api/eventStats';
+
+import { useEventStats, useSetAttendance } from '@/api/eventStats';
 import { CollapsibleCard } from '@/components/ui/CollapsibleCard';
 import type {
   AttendanceStatusValue,

--- a/frontend/src/screens/events/EventCreateScreen.tsx
+++ b/frontend/src/screens/events/EventCreateScreen.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom';
+
 import { EventForm } from './form/EventForm';
 
 export default function EventCreateScreen() {

--- a/frontend/src/screens/events/EventDetailScreen.test.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.test.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
@@ -31,6 +32,7 @@ vi.mock('@/utils/datetime', () => ({
 }));
 
 import { useEvent } from '@/api/events';
+
 import EventDetailScreen from './EventDetailScreen';
 
 const mockUseEvent = vi.mocked(useEvent);

--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -1,12 +1,14 @@
 import { Link, useParams } from 'react-router-dom';
+
 import { extractApiError, getApiStatus } from '@/api/apiErrors';
 import { useEvent } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility } from '@/models/event';
+import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 import { formatEventDateTime } from '@/utils/datetime';
 import { linkifyText } from '@/utils/linkifyText';
-import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
+
 import { CohostInviteBanner } from './CohostInviteBanner';
 import { EventActions } from './EventActions';
 import { EventMemberSection } from './EventMemberSection';

--- a/frontend/src/screens/events/EventEditScreen.tsx
+++ b/frontend/src/screens/events/EventEditScreen.tsx
@@ -1,6 +1,8 @@
 import { useNavigate, useParams } from 'react-router-dom';
+
 import { useEvent } from '@/api/events';
 import { ContentError, ContentLoading } from '@/screens/public/ContentContainer';
+
 import { EventForm } from './form/EventForm';
 
 export default function EventEditScreen() {

--- a/frontend/src/screens/events/EventFlagDialog.tsx
+++ b/frontend/src/screens/events/EventFlagDialog.tsx
@@ -4,6 +4,7 @@
 
 import { useState } from 'react';
 import { toast } from 'sonner';
+
 import { FlagEventError, useFlagEvent } from '@/api/eventFlags';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';

--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -5,24 +5,26 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { toast } from 'sonner';
+
 import { extractApiError } from '@/api/apiErrors';
 import { useRescindCohostInvite } from '@/api/cohostInvites';
-import { RsvpSection } from './RsvpSection';
-import { InvitedList } from './RsvpGuestList';
-import { EventAdminActions } from './EventAdminActions';
-import { EventCommentsCard } from './comments/EventCommentsCard';
-import { EventAttendancePanel } from './EventAttendancePanel';
-import { EventFlagDialog } from './EventFlagDialog';
-import { InviteDialog } from './InviteDialog';
-import { AddCoHostDialog } from './AddCoHostDialog';
-import { hasPermission } from '@/models/permissions';
-import { Permission } from '@/models/permissions';
-import type { Event, PendingCohostInvite } from '@/models/event';
-import { EventStatus, InvitePermission } from '@/models/event';
 import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import { useConfirm } from '@/components/ui/useConfirm';
+import type { Event, PendingCohostInvite } from '@/models/event';
+import { EventStatus, InvitePermission } from '@/models/event';
+import { hasPermission } from '@/models/permissions';
+import { Permission } from '@/models/permissions';
 import { ensureHttps } from '@/utils/url';
+
+import { AddCoHostDialog } from './AddCoHostDialog';
+import { EventCommentsCard } from './comments/EventCommentsCard';
+import { EventAdminActions } from './EventAdminActions';
+import { EventAttendancePanel } from './EventAttendancePanel';
+import { EventFlagDialog } from './EventFlagDialog';
+import { InviteDialog } from './InviteDialog';
+import { InvitedList } from './RsvpGuestList';
+import { RsvpSection } from './RsvpSection';
 
 interface Props {
   event: Event;

--- a/frontend/src/screens/events/InviteDialog.tsx
+++ b/frontend/src/screens/events/InviteDialog.tsx
@@ -4,10 +4,11 @@
 // invite_permission=all_members) can invite.
 
 import { useState } from 'react';
+
 import { extractApiErrorOr } from '@/api/apiErrors';
 import { useInviteToEvent } from '@/api/eventWrites';
-import { MemberPicker } from '@/components/MemberPicker';
 import type { MemberSearchResult } from '@/api/userSearch';
+import { MemberPicker } from '@/components/MemberPicker';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import type { Event } from '@/models/event';

--- a/frontend/src/screens/events/MyEventsScreen.tsx
+++ b/frontend/src/screens/events/MyEventsScreen.tsx
@@ -4,14 +4,15 @@
 // cancelled events come from dedicated `?status=` queries; backend already
 // scopes those to events the user created or co-hosts.
 
-import { useMemo, useState } from 'react';
 import { format } from 'date-fns';
+import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
+
 import { useEvents } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
+import { SegmentedControl } from '@/components/ui/SegmentedControl';
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, RsvpStatus } from '@/models/event';
-import { SegmentedControl } from '@/components/ui/SegmentedControl';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 
 type Filter = 'upcoming' | 'past' | 'drafts' | 'cancelled';

--- a/frontend/src/screens/events/RsvpGuestList.tsx
+++ b/frontend/src/screens/events/RsvpGuestList.tsx
@@ -3,9 +3,10 @@
 
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { cn } from '@/utils/cn';
+
 import type { Event, EventGuest } from '@/models/event';
 import { AttendanceStatus, RsvpServerStatus } from '@/models/event';
+import { cn } from '@/utils/cn';
 
 type Tab = 'going' | 'maybe' | 'cant' | 'waitlist' | 'invited';
 

--- a/frontend/src/screens/events/RsvpSection.test.tsx
+++ b/frontend/src/screens/events/RsvpSection.test.tsx
@@ -1,17 +1,18 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { useAuthStore } from '@/auth/store';
 import {
   AttendanceStatus,
+  type Event,
+  type EventGuest,
   EventStatus,
   EventType,
   EventVisibility,
   InvitePermission,
   RsvpServerStatus,
-  type Event,
-  type EventGuest,
 } from '@/models/event';
 import type { User } from '@/models/user';
 

--- a/frontend/src/screens/events/RsvpSection.tsx
+++ b/frontend/src/screens/events/RsvpSection.tsx
@@ -5,13 +5,15 @@
 //   - +1 is a second POST with the same status + hasPlusOne: true
 //   - waitlisted state shows only "leave waitlist" (no maybe/can't pills)
 
-import { extractApiErrorOr } from '@/api/apiErrors';
 import { useState } from 'react';
-import { RsvpStatus, RsvpServerStatus, type Event } from '@/models/event';
+
+import { extractApiErrorOr } from '@/api/apiErrors';
 import { useRemoveRsvp, useSetRsvp } from '@/api/rsvp';
 import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
+import { type Event, RsvpServerStatus, RsvpStatus } from '@/models/event';
 import { cn } from '@/utils/cn';
+
 import { RsvpGuestList } from './RsvpGuestList';
 
 interface Props {

--- a/frontend/src/screens/events/comments/CommentItem.test.tsx
+++ b/frontend/src/screens/events/comments/CommentItem.test.tsx
@@ -16,6 +16,7 @@ vi.mock('@/auth/store', () => ({
 }));
 
 import type { EventComment } from '@/models/eventComment';
+
 import { CommentItem } from './CommentItem';
 
 function wrap(ui: React.ReactNode) {

--- a/frontend/src/screens/events/comments/CommentItem.tsx
+++ b/frontend/src/screens/events/comments/CommentItem.tsx
@@ -1,9 +1,8 @@
 import { useState } from 'react';
-
 import { toast } from 'sonner';
 
-import { useDeleteComment, usePostReply, useToggleReaction } from '@/api/eventComments';
 import { extractApiError } from '@/api/apiErrors';
+import { useDeleteComment, usePostReply, useToggleReaction } from '@/api/eventComments';
 import type { EventComment, ReactionEmojiValue } from '@/models/eventComment';
 
 import { CommentComposer } from './CommentComposer';

--- a/frontend/src/screens/events/comments/EventCommentsCard.test.tsx
+++ b/frontend/src/screens/events/comments/EventCommentsCard.test.tsx
@@ -28,6 +28,7 @@ vi.mock('@/auth/store', () => {
 
 // Import after mocks
 import { apiClient } from '@/api/client';
+
 import { EventCommentsCard } from './EventCommentsCard';
 
 const eventId = '11111111-1111-1111-1111-111111111111';

--- a/frontend/src/screens/events/comments/EventCommentsCard.tsx
+++ b/frontend/src/screens/events/comments/EventCommentsCard.tsx
@@ -1,7 +1,7 @@
 import { toast } from 'sonner';
 
-import { useEventComments, usePostComment } from '@/api/eventComments';
 import { extractApiError } from '@/api/apiErrors';
+import { useEventComments, usePostComment } from '@/api/eventComments';
 import type { CannotPostReason } from '@/models/eventComment';
 
 import { CommentComposer } from './CommentComposer';

--- a/frontend/src/screens/events/form/EventForm.tsx
+++ b/frontend/src/screens/events/form/EventForm.tsx
@@ -11,24 +11,26 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
+
 import { apiClient } from '@/api/client';
-import type { MemberSearchResult } from '@/api/userSearch';
 import {
   emptyEventFormValues,
+  type EventFormValues,
   eventToFormValues,
   extractEventError,
   useCreateEvent,
+  useDeleteEventPhoto,
   useUpdateEvent,
   useUploadEventPhoto,
-  useDeleteEventPhoto,
-  type EventFormValues,
 } from '@/api/eventWrites';
+import type { MemberSearchResult } from '@/api/userSearch';
 import { useAuthStore } from '@/auth/store';
+import { MemberPicker } from '@/components/MemberPicker';
 import { Button } from '@/components/ui/Button';
 import { CollapsibleCard } from '@/components/ui/CollapsibleCard';
-import { MemberPicker } from '@/components/MemberPicker';
 import type { Event } from '@/models/event';
-import { Permission, hasPermission } from '@/models/permissions';
+import { hasPermission, Permission } from '@/models/permissions';
+
 import { EventFormBasics } from './EventFormBasics';
 import { EventFormDetails } from './EventFormDetails';
 import { EventFormLinks, EventFormMoney } from './EventFormLinksAndCost';

--- a/frontend/src/screens/events/form/EventFormBasics.tsx
+++ b/frontend/src/screens/events/form/EventFormBasics.tsx
@@ -14,8 +14,9 @@
 //     which POSTs immediately. Once the poll exists the parent re-renders
 //     with timeLocked=true and the button disappears.
 
-import { useState } from 'react';
 import { format } from 'date-fns';
+import { useState } from 'react';
+
 import type { EventFormValues } from '@/api/eventWrites';
 import { Button } from '@/components/ui/Button';
 import { DateTimePicker } from '@/components/ui/DateTimePicker';

--- a/frontend/src/screens/events/form/EventFormPhoto.tsx
+++ b/frontend/src/screens/events/form/EventFormPhoto.tsx
@@ -6,6 +6,7 @@
 // returns an id; on edit it uploads immediately.
 
 import { useRef, useState } from 'react';
+
 import { extractApiErrorOr } from '@/api/apiErrors';
 import { ImageCropDialog } from '@/components/ImageCropDialog';
 import { cn } from '@/utils/cn';

--- a/frontend/src/screens/events/form/datetimeUtils.test.ts
+++ b/frontend/src/screens/events/form/datetimeUtils.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
+
 import { isoToLocalInput, localInputToIso } from './datetimeUtils';
 
 describe('isoToLocalInput', () => {

--- a/frontend/src/screens/events/form/validateEventForm.test.ts
+++ b/frontend/src/screens/events/form/validateEventForm.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
+
 import type { EventFormValues } from '@/api/eventWrites';
+
 import { validateEventForm } from './validateEventForm';
 
 function validValues(overrides: Partial<EventFormValues> = {}): EventFormValues {

--- a/frontend/src/screens/events/poll/EventPollCard.tsx
+++ b/frontend/src/screens/events/poll/EventPollCard.tsx
@@ -3,14 +3,16 @@
 // viewer is and what state the poll is in. Dialog bodies live in sibling
 // files (Phase 3); this file stays focused on branching + layout.
 
+import { format } from 'date-fns';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
-import { format } from 'date-fns';
+
 import { useEventPoll } from '@/api/eventPolls';
 import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import type { Event } from '@/models/event';
 import { hasPermission, Permission, type UserLike } from '@/models/permissions';
+
 import { PollFinalizeDialog } from './PollFinalizeDialog';
 import { PollManageDialog } from './PollManageDialog';
 import { PollOptionStrip } from './PollOptionStrip';

--- a/frontend/src/screens/events/poll/PollCreateDialog.tsx
+++ b/frontend/src/screens/events/poll/PollCreateDialog.tsx
@@ -10,10 +10,11 @@
 
 import { useState } from 'react';
 import { toast } from 'sonner';
-import { useCreatePoll, extractPollError } from '@/api/eventPolls';
+
+import { extractPollError, useCreatePoll } from '@/api/eventPolls';
 import { Button } from '@/components/ui/Button';
-import { Dialog } from '@/components/ui/Dialog';
 import { DateTimePicker } from '@/components/ui/DateTimePicker';
+import { Dialog } from '@/components/ui/Dialog';
 
 interface Props {
   open: boolean;

--- a/frontend/src/screens/events/poll/PollFinalizeDialog.tsx
+++ b/frontend/src/screens/events/poll/PollFinalizeDialog.tsx
@@ -2,14 +2,16 @@
 // pre-selected. Warns if event.endDatetime is set (backend finalize won't
 // update end-time; host has to fix it after).
 
-import { useState } from 'react';
 import { format } from 'date-fns';
+import { useState } from 'react';
 import { toast } from 'sonner';
+
 import { extractPollError, useFinalizePoll } from '@/api/eventPolls';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import type { Event } from '@/models/event';
 import type { EventPoll } from '@/models/eventPoll';
+
 import { pickFinalizeDefault, sortOptionsChrono } from './pollHelpers';
 
 interface Props {

--- a/frontend/src/screens/events/poll/PollManageDialog.tsx
+++ b/frontend/src/screens/events/poll/PollManageDialog.tsx
@@ -3,9 +3,10 @@
 // mutation fires on a per-row "save" so the host can leave mid-edit
 // without losing other changes.
 
-import { useState } from 'react';
 import { format } from 'date-fns';
+import { useState } from 'react';
 import { toast } from 'sonner';
+
 import {
   extractPollError,
   useAddPollOption,
@@ -14,9 +15,10 @@ import {
   useUpdatePollOption,
 } from '@/api/eventPolls';
 import { Button } from '@/components/ui/Button';
-import { Dialog } from '@/components/ui/Dialog';
 import { DateTimePicker } from '@/components/ui/DateTimePicker';
+import { Dialog } from '@/components/ui/Dialog';
 import type { EventPoll, EventPollOption } from '@/models/eventPoll';
+
 import { sortOptionsChrono } from './pollHelpers';
 
 interface Props {

--- a/frontend/src/screens/events/poll/PollOptionCard.tsx
+++ b/frontend/src/screens/events/poll/PollOptionCard.tsx
@@ -2,10 +2,12 @@
 // numeric counts below. No fill bar, no progress indicator. Click to toggle
 // the voter popover for that option.
 
-import { useState } from 'react';
 import { format } from 'date-fns';
-import { cn } from '@/utils/cn';
+import { useState } from 'react';
+
 import type { EventPollOption } from '@/models/eventPoll';
+import { cn } from '@/utils/cn';
+
 import { PollVoterPopover } from './PollVoterPopover';
 
 interface Props {

--- a/frontend/src/screens/events/poll/PollOptionStrip.tsx
+++ b/frontend/src/screens/events/poll/PollOptionStrip.tsx
@@ -2,6 +2,7 @@
 // option lists don't wrap into a messy grid.
 
 import type { EventPoll } from '@/models/eventPoll';
+
 import { sortOptionsByVotes } from './pollHelpers';
 import { PollOptionCard } from './PollOptionCard';
 

--- a/frontend/src/screens/events/poll/PollRespondDialog.tsx
+++ b/frontend/src/screens/events/poll/PollRespondDialog.tsx
@@ -5,11 +5,13 @@
 
 import { format } from 'date-fns';
 import { toast } from 'sonner';
+
 import { extractPollError, useVotePoll } from '@/api/eventPolls';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
+import { ALL_VOTE_CHOICES, type EventPoll, VoteChoice } from '@/models/eventPoll';
 import { cn } from '@/utils/cn';
-import { ALL_VOTE_CHOICES, VoteChoice, type EventPoll } from '@/models/eventPoll';
+
 import { sortOptionsChrono } from './pollHelpers';
 
 interface Props {

--- a/frontend/src/screens/events/poll/PollVoterPopover.tsx
+++ b/frontend/src/screens/events/poll/PollVoterPopover.tsx
@@ -3,6 +3,7 @@
 // Dismisses on outside-click + Escape.
 
 import { useEffect, useRef } from 'react';
+
 import type { EventPollOption, PollVoter } from '@/models/eventPoll';
 
 interface Props {

--- a/frontend/src/screens/events/poll/pollHelpers.test.ts
+++ b/frontend/src/screens/events/poll/pollHelpers.test.ts
@@ -1,6 +1,8 @@
-import { describe, it, expect } from 'vitest';
-import { sortOptionsChrono, pickFinalizeDefault, sortOptionsByVotes } from './pollHelpers';
+import { describe, expect, it } from 'vitest';
+
 import type { EventPollOption } from '@/models/eventPoll';
+
+import { pickFinalizeDefault, sortOptionsByVotes, sortOptionsChrono } from './pollHelpers';
 
 function opt(overrides: Partial<EventPollOption> = {}): EventPollOption {
   return {

--- a/frontend/src/screens/members/MemberProfileScreen.tsx
+++ b/frontend/src/screens/members/MemberProfileScreen.tsx
@@ -3,7 +3,8 @@
 // show_phone / show_email settings, so we just check truthiness here.
 
 import { useParams } from 'react-router-dom';
-import { useMemberProfile, type MemberProfile } from '@/api/users';
+
+import { type MemberProfile, useMemberProfile } from '@/api/users';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 import { formatPhone } from '@/utils/formatPhone';
 

--- a/frontend/src/screens/members/MembersDirectoryScreen.tsx
+++ b/frontend/src/screens/members/MembersDirectoryScreen.tsx
@@ -4,7 +4,8 @@
 
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { useMembersDirectory, type DirectoryMember } from '@/api/users';
+
+import { type DirectoryMember, useMembersDirectory } from '@/api/users';
 import { TextField } from '@/components/ui/TextField';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 import { formatPhone } from '@/utils/formatPhone';

--- a/frontend/src/screens/profile/BioEditDialog.tsx
+++ b/frontend/src/screens/profile/BioEditDialog.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
+
+import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import { Textarea } from '@/components/ui/Textarea';
-import { useAuthStore } from '@/auth/store';
 
 const MAX_BIO = 500;
 

--- a/frontend/src/screens/profile/ProfileScreen.tsx
+++ b/frontend/src/screens/profile/ProfileScreen.tsx
@@ -4,13 +4,15 @@
 
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
-import { Button } from '@/components/ui/Button';
+
 import { useAuthStore } from '@/auth/store';
 import { useHasAnyAdminPermission } from '@/auth/useAuth';
+import { Button } from '@/components/ui/Button';
 import { ContentContainer } from '@/screens/public/ContentContainer';
 import { AvatarUpload } from '@/screens/settings/AvatarUpload';
 import { cn } from '@/utils/cn';
 import { formatPhone } from '@/utils/formatPhone';
+
 import { BioEditDialog } from './BioEditDialog';
 
 export default function ProfileScreen() {

--- a/frontend/src/screens/public/DonateScreen.tsx
+++ b/frontend/src/screens/public/DonateScreen.tsx
@@ -4,7 +4,8 @@ import { useAuthStore } from '@/auth/store';
 import { EditableHtmlBlock } from '@/components/EditableHtmlBlock';
 // Editing EditablePage (including donate/volunteer) is gated by the same
 // permission as guidelines per _pages.py.
-import { Permission, hasPermission } from '@/models/permissions';
+import { hasPermission, Permission } from '@/models/permissions';
+
 import { ContentContainer, ContentError, ContentLoading } from './ContentContainer';
 
 export default function DonateScreen() {

--- a/frontend/src/screens/public/FaqScreen.test.tsx
+++ b/frontend/src/screens/public/FaqScreen.test.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { useAuthStore } from '@/auth/store';
 import type { User } from '@/models/user';
 
@@ -15,8 +16,9 @@ vi.mock('@/components/RichEditor/RichEditor', () => ({
   RichEditor: () => <div data-testid="rich-editor" />,
 }));
 
-import FaqScreen from './FaqScreen';
 import { useFaq } from '@/api/content';
+
+import FaqScreen from './FaqScreen';
 
 const mockUseFaq = vi.mocked(useFaq);
 

--- a/frontend/src/screens/public/FaqScreen.tsx
+++ b/frontend/src/screens/public/FaqScreen.tsx
@@ -1,7 +1,8 @@
 import { useFaq, useUpdateFaq } from '@/api/content';
 import { useAuthStore } from '@/auth/store';
 import { EditableHtmlBlock } from '@/components/EditableHtmlBlock';
-import { Permission, hasPermission } from '@/models/permissions';
+import { hasPermission, Permission } from '@/models/permissions';
+
 import { ContentContainer, ContentError, ContentLoading } from './ContentContainer';
 
 export default function FaqScreen() {

--- a/frontend/src/screens/public/GuidelinesScreen.test.tsx
+++ b/frontend/src/screens/public/GuidelinesScreen.test.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { useAuthStore } from '@/auth/store';
 import type { User } from '@/models/user';
 
@@ -15,8 +16,9 @@ vi.mock('@/components/RichEditor/RichEditor', () => ({
   RichEditor: () => <div data-testid="rich-editor" />,
 }));
 
-import GuidelinesScreen from './GuidelinesScreen';
 import { useGuidelines } from '@/api/content';
+
+import GuidelinesScreen from './GuidelinesScreen';
 
 const mockUseGuidelines = vi.mocked(useGuidelines);
 

--- a/frontend/src/screens/public/GuidelinesScreen.tsx
+++ b/frontend/src/screens/public/GuidelinesScreen.tsx
@@ -1,7 +1,8 @@
 import { useGuidelines, useUpdateGuidelines } from '@/api/content';
 import { useAuthStore } from '@/auth/store';
 import { EditableHtmlBlock } from '@/components/EditableHtmlBlock';
-import { Permission, hasPermission } from '@/models/permissions';
+import { hasPermission, Permission } from '@/models/permissions';
+
 import { ContentContainer, ContentError, ContentLoading } from './ContentContainer';
 
 export default function GuidelinesScreen() {

--- a/frontend/src/screens/public/HomeScreen.test.tsx
+++ b/frontend/src/screens/public/HomeScreen.test.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { useAuthStore } from '@/auth/store';
 import type { User } from '@/models/user';
 
@@ -17,8 +18,9 @@ vi.mock('@/components/RichEditor/RichEditor', () => ({
   RichEditor: () => <div data-testid="rich-editor" />,
 }));
 
-import HomeScreen from './HomeScreen';
 import { useHome } from '@/api/content';
+
+import HomeScreen from './HomeScreen';
 
 const mockUseHome = vi.mocked(useHome);
 

--- a/frontend/src/screens/public/HomeScreen.tsx
+++ b/frontend/src/screens/public/HomeScreen.tsx
@@ -1,7 +1,8 @@
 import { useHome, useUpdateHome } from '@/api/content';
 import { useAuthStore } from '@/auth/store';
 import { EditableHtmlBlock } from '@/components/EditableHtmlBlock';
-import { Permission, hasPermission } from '@/models/permissions';
+import { hasPermission, Permission } from '@/models/permissions';
+
 import { ContentContainer, ContentError, ContentLoading } from './ContentContainer';
 
 export default function HomeScreen() {

--- a/frontend/src/screens/public/InstallAppScreen.a11y.test.tsx
+++ b/frontend/src/screens/public/InstallAppScreen.a11y.test.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
-import { render } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
 import { axe } from 'vitest-axe';
+
 import InstallAppScreen from './InstallAppScreen';
 
 function renderWith(component: React.ReactElement) {

--- a/frontend/src/screens/public/InstallAppScreen.test.tsx
+++ b/frontend/src/screens/public/InstallAppScreen.test.tsx
@@ -1,10 +1,12 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect, beforeEach } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it } from 'vitest';
+
 import { useAuthStore } from '@/auth/store';
 import type { User } from '@/models/user';
+
 import InstallAppScreen from './InstallAppScreen';
 
 const baseUser: User = {

--- a/frontend/src/screens/public/InstallAppScreen.tsx
+++ b/frontend/src/screens/public/InstallAppScreen.tsx
@@ -2,6 +2,7 @@
 // the web and Flutter apps stay consistent while both are in production.
 
 import { useMemo, useState } from 'react';
+
 import { ContentContainer } from './ContentContainer';
 
 interface Step {

--- a/frontend/src/screens/public/JoinScreen.a11y.test.tsx
+++ b/frontend/src/screens/public/JoinScreen.a11y.test.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
 
 vi.mock('@/api/join', () => ({
@@ -16,8 +16,9 @@ vi.mock('@/api/join', () => ({
   },
 }));
 
-import JoinScreen from './JoinScreen';
 import { useJoinQuestions, useSubmitJoinRequest } from '@/api/join';
+
+import JoinScreen from './JoinScreen';
 
 const mockUseJoinQuestions = vi.mocked(useJoinQuestions);
 const mockUseSubmitJoinRequest = vi.mocked(useSubmitJoinRequest);

--- a/frontend/src/screens/public/JoinScreen.test.tsx
+++ b/frontend/src/screens/public/JoinScreen.test.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import React from 'react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/join', () => ({
   useJoinQuestions: vi.fn(),
@@ -16,9 +16,10 @@ vi.mock('@/api/join', () => ({
   },
 }));
 
+import { useJoinQuestions, useSubmitJoinRequest } from '@/api/join';
+
 import JoinScreen from './JoinScreen';
 import JoinSuccessScreen from './JoinSuccessScreen';
-import { useJoinQuestions, useSubmitJoinRequest } from '@/api/join';
 
 const mockUseJoinQuestions = vi.mocked(useJoinQuestions);
 const mockUseSubmitJoinRequest = vi.mocked(useSubmitJoinRequest);

--- a/frontend/src/screens/public/JoinScreen.tsx
+++ b/frontend/src/screens/public/JoinScreen.tsx
@@ -1,15 +1,17 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
+
 import { extractApiErrorOr } from '@/api/apiErrors';
-import { AlreadyInvitedError, useJoinQuestions, useSubmitJoinRequest } from '@/api/join';
 import type { JoinQuestion } from '@/api/join';
+import { AlreadyInvitedError, useJoinQuestions, useSubmitJoinRequest } from '@/api/join';
 import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import { PhoneField } from '@/components/ui/PhoneField';
 import { Select } from '@/components/ui/Select';
 import { Textarea } from '@/components/ui/Textarea';
 import { TextField } from '@/components/ui/TextField';
+
 import { ContentContainer, ContentError, ContentLoading } from './ContentContainer';
 
 // Mirrors backend FieldLimit constants.

--- a/frontend/src/screens/public/JoinSuccessScreen.tsx
+++ b/frontend/src/screens/public/JoinSuccessScreen.tsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+
 import { ContentContainer } from './ContentContainer';
 
 export default function JoinSuccessScreen() {

--- a/frontend/src/screens/public/VolunteerScreen.tsx
+++ b/frontend/src/screens/public/VolunteerScreen.tsx
@@ -2,7 +2,8 @@ import { getApiStatus } from '@/api/apiErrors';
 import { useEditablePage, useUpdateEditablePage } from '@/api/content';
 import { useAuthStore } from '@/auth/store';
 import { EditableHtmlBlock } from '@/components/EditableHtmlBlock';
-import { Permission, hasPermission } from '@/models/permissions';
+import { hasPermission, Permission } from '@/models/permissions';
+
 import { ContentContainer, ContentError, ContentLoading } from './ContentContainer';
 
 export default function VolunteerScreen() {

--- a/frontend/src/screens/settings/AvatarUpload.tsx
+++ b/frontend/src/screens/settings/AvatarUpload.tsx
@@ -1,7 +1,8 @@
 import { useRef, useState } from 'react';
+
 import { extractApiErrorOr } from '@/api/apiErrors';
-import { ImageCropDialog } from '@/components/ImageCropDialog';
 import { useAuthStore } from '@/auth/store';
+import { ImageCropDialog } from '@/components/ImageCropDialog';
 import { cn } from '@/utils/cn';
 
 const MAX_FILE_BYTES = 5 * 1024 * 1024;

--- a/frontend/src/screens/settings/CalendarFeedSubscription.tsx
+++ b/frontend/src/screens/settings/CalendarFeedSubscription.tsx
@@ -1,7 +1,8 @@
 import { toast } from 'sonner';
+
+import { useCalendarToken, useRegenerateCalendarToken } from '@/api/calendar';
 import { Button } from '@/components/ui/Button';
 import { useConfirm } from '@/components/ui/useConfirm';
-import { useCalendarToken, useRegenerateCalendarToken } from '@/api/calendar';
 
 export function CalendarFeedSubscription() {
   const tokenQ = useCalendarToken();

--- a/frontend/src/screens/settings/ChangePasswordDialog.tsx
+++ b/frontend/src/screens/settings/ChangePasswordDialog.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
+
 import { extractApiErrorOr } from '@/api/apiErrors';
+import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import { TextField } from '@/components/ui/TextField';
-import { useAuthStore } from '@/auth/store';
-import { passwordRule } from '@/screens/auth/passwordRule';
 import { PasswordChecklist } from '@/screens/auth/PasswordChecklist';
+import { passwordRule } from '@/screens/auth/passwordRule';
 
 interface Props {
   open: boolean;

--- a/frontend/src/screens/settings/SettingsScreen.test.tsx
+++ b/frontend/src/screens/settings/SettingsScreen.test.tsx
@@ -22,14 +22,15 @@ const storageMock = vi.hoisted(() => {
   return mock;
 });
 
-import React from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { useAuthStore } from '@/auth/store';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
 import { useAccessibilityStore } from '@/accessibility/store';
+import { useAuthStore } from '@/auth/store';
 import type { User } from '@/models/user';
 
 // Stub heavy sub-components that have their own API/DOM dependencies

--- a/frontend/src/screens/settings/SettingsScreen.tsx
+++ b/frontend/src/screens/settings/SettingsScreen.tsx
@@ -1,18 +1,20 @@
 import { useState } from 'react';
+
+import { type TextScale, type ThemeMode, useAccessibilityStore } from '@/accessibility/store';
+import { extractApiErrorOr } from '@/api/apiErrors';
+import { useVersion } from '@/api/version';
+import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import { SegmentedControl as SharedSegmentedControl } from '@/components/ui/SegmentedControl';
 import { TextField } from '@/components/ui/TextField';
-import { useAuthStore } from '@/auth/store';
-import { useAccessibilityStore, type ThemeMode, type TextScale } from '@/accessibility/store';
 import { CalendarFeedScope, type CalendarFeedScopeValue } from '@/models/user';
-import { useVersion } from '@/api/version';
-import { extractApiErrorOr } from '@/api/apiErrors';
 import { ContentContainer } from '@/screens/public/ContentContainer';
+import { cn } from '@/utils/cn';
+import { formatPhone } from '@/utils/formatPhone';
+
 import { AvatarUpload } from './AvatarUpload';
 import { CalendarFeedSubscription } from './CalendarFeedSubscription';
 import { ChangePasswordDialog } from './ChangePasswordDialog';
-import { cn } from '@/utils/cn';
-import { formatPhone } from '@/utils/formatPhone';
 
 export default function SettingsScreen() {
   const user = useAuthStore((s) => s.user);

--- a/frontend/src/screens/surveys/SurveyQuestionField.tsx
+++ b/frontend/src/screens/surveys/SurveyQuestionField.tsx
@@ -1,10 +1,10 @@
 // Renders one survey question by type. Returns the answer as the exact
 // shape the backend expects (strings for most, dict for datetime_poll).
 
-import type { SurveyQuestion, AnswerValue } from '@/api/surveys';
+import type { AnswerValue, SurveyQuestion } from '@/api/surveys';
 import { Select } from '@/components/ui/Select';
-import { TextField } from '@/components/ui/TextField';
 import { Textarea } from '@/components/ui/Textarea';
+import { TextField } from '@/components/ui/TextField';
 import { cn } from '@/utils/cn';
 
 interface Props {

--- a/frontend/src/screens/surveys/SurveyScreen.tsx
+++ b/frontend/src/screens/surveys/SurveyScreen.tsx
@@ -1,9 +1,11 @@
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
+
 import { extractApiErrorOr } from '@/api/apiErrors';
-import { useSubmitSurvey, useSurvey, type AnswerValue, type Survey } from '@/api/surveys';
+import { type AnswerValue, type Survey, useSubmitSurvey, useSurvey } from '@/api/surveys';
 import { Button } from '@/components/ui/Button';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
+
 import { SurveyQuestionField } from './SurveyQuestionField';
 
 export default function SurveyScreen() {

--- a/frontend/src/test/gestureDetectorAudit.test.ts
+++ b/frontend/src/test/gestureDetectorAudit.test.ts
@@ -4,7 +4,7 @@
 
 import { readdirSync, readFileSync, statSync } from 'node:fs';
 import { join, relative } from 'node:path';
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 const SRC = join(__dirname, '..');
 

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,8 +1,9 @@
 import '@testing-library/jest-dom/vitest';
 import 'vitest-axe/extend-expect';
-import * as axeMatchers from 'vitest-axe/matchers';
-import { afterEach, expect } from 'vitest';
+
 import { cleanup } from '@testing-library/react';
+import { afterEach, expect } from 'vitest';
+import * as axeMatchers from 'vitest-axe/matchers';
 
 expect.extend(axeMatchers);
 

--- a/frontend/src/utils/cn.test.ts
+++ b/frontend/src/utils/cn.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
+
 import { cn } from './cn';
 
 describe('cn', () => {

--- a/frontend/src/utils/cn.ts
+++ b/frontend/src/utils/cn.ts
@@ -1,4 +1,4 @@
-import { clsx, type ClassValue } from 'clsx';
+import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]): string {

--- a/frontend/src/utils/datetime.test.ts
+++ b/frontend/src/utils/datetime.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { parseIsoDate, formatEventDateTime, formatDayHeader } from './datetime';
+import { describe, expect, it } from 'vitest';
+
+import { formatDayHeader, formatEventDateTime, parseIsoDate } from './datetime';
 
 describe('parseIsoDate', () => {
   it('parses ISO 8601 string', () => {

--- a/frontend/src/utils/errorReporter.test.ts
+++ b/frontend/src/utils/errorReporter.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
@@ -8,6 +8,7 @@ vi.mock('@/api/client', () => ({
 
 import { apiClient } from '@/api/client';
 import { useAuthStore } from '@/auth/store';
+
 import { reportError } from './errorReporter';
 
 const mockedPost = vi.mocked(apiClient.post);

--- a/frontend/src/utils/eventCalendar.test.ts
+++ b/frontend/src/utils/eventCalendar.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
+
 import type { Event } from '@/models/event';
+
 import { googleCalendarUrl, icsUrl } from './eventCalendar';
 
 describe('googleCalendarUrl', () => {

--- a/frontend/src/utils/eventColors.test.ts
+++ b/frontend/src/utils/eventColors.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
+
 import type { EventType, Visibility } from './eventColors';
 import { getEventColors } from './eventColors';
 

--- a/frontend/src/utils/formatPhone.test.ts
+++ b/frontend/src/utils/formatPhone.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
+
 import { formatPhone } from './formatPhone';
 
 describe('formatPhone', () => {

--- a/frontend/src/utils/linkifyText.test.tsx
+++ b/frontend/src/utils/linkifyText.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
+
 import { linkifyText } from './linkifyText';
 
 function renderText(text: string) {

--- a/frontend/src/utils/validators.test.ts
+++ b/frontend/src/utils/validators.test.ts
@@ -1,14 +1,15 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
+
 import {
   displayName,
-  password,
+  maxLength,
+  minLength,
   optionalDisplayName,
   optionalEmail,
   optionalUrl,
-  roleName,
+  password,
   required,
-  maxLength,
-  minLength,
+  roleName,
 } from './validators';
 
 describe('displayName', () => {

--- a/frontend/src/utils/welcomeMessage.test.ts
+++ b/frontend/src/utils/welcomeMessage.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, afterEach, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
 import {
   buildSmsHref,
   buildWelcomeMessage,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
-import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
 
 export default defineConfig({
   plugins: [react()],

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,6 +1,6 @@
 import path from 'node:path';
-import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   plugins: [react()],


### PR DESCRIPTION
## Overview

Imports were inconsistently ordered across the frontend with no lint rule to keep them in shape. This wires up `eslint-plugin-simple-import-sort` in `frontend/eslint.config.js` with explicit groups — side-effect imports → external packages → `@/` path-alias imports → relative imports — and applies the autofix across `frontend/src` (~223 files). The change is **pure import reordering with no behavior change**.

Scope note (per the issue's guidance to split this into reviewable chunks rather than one giant diff): this PR is the **frontend** chunk. Backend import ordering is **already enforced** via ruff's isort rule (`I` is in `select` in `pyproject.toml`, and `ruff check --select I` passes clean). The backend function-local import audit — hoisting the safe ones and adding one-line justifications to the deliberate `community ↔ notifications.service` circular-avoidance imports — is a distinct, risk-bearing chunk that warrants its own focused diff and is left as a tracked follow-up.

### What this PR covers (acceptance criteria)
- [x] An import-ordering lint rule is configured and enforced for the frontend (ESLint `simple-import-sort`). Backend (ruff isort) was already enforced.
- [x] Frontend imports are top-of-file and consistently ordered/grouped; the only remaining dynamic imports are the intentional `lazyWithRetry` route code-splitting in `router/routes.tsx`.
- [x] No behavior change; `make agent-frontend-ci` passes (eslint, prettier-check, 546 vitest tests, tsc).

### Tracked follow-up (separate PR)
- [ ] Backend function-local/mid-file import triage: hoist where safe, add a one-line justification to each deliberate inline import (e.g. circular-import avoidance), verify no cycle introduced.

Part of #529

## Test plan

- [x] `make agent-frontend-ci` — eslint, prettier `--check`, vitest (546 passed / 1 skipped), `tsc -b --noEmit` all green
- [x] `ruff check backend/ --select I` — still passes (backend untouched)
- [x] Code review (no behavior change): verified side-effect import hoisting in `App.tsx` and three CSS imports preserves evaluation/cascade order; type-only / inline-type imports intact; only the new dev dependency added to package.json/lockfile
