### PR TITLE
feat(events): admin attendance reporting (Issue 507)

### DIFF
--- a/backend/community/_attendance_report.py
+++ b/backend/community/_attendance_report.py
@@ -1,0 +1,73 @@
+"""Admin-only attendance reporting across events.
+
+Builds on the existing per-event check-in (``EventRSVP.attendance``). This is a
+read-only aggregation layer: it does not record attendance — that happens in the
+host check-in flow (``_event_rsvps.set_attendance``). Gated by ``MANAGE_EVENTS``,
+matching the rest of the event-admin surface.
+"""
+
+from config.auth import gated_jwt
+from django.db.models import Count, Q
+from ninja import Router
+from ninja.responses import Status
+from users.permissions import PermissionKey
+
+from community._event_schemas import AttendanceReportOut, EventAttendanceRowOut
+from community._shared import ErrorOut
+from community._validation import Code, raise_validation
+from community.models import AttendanceStatus, Event, EventStatus, RSVPStatus
+
+router = Router()
+
+
+@router.get(
+    "/events/attendance-report/",
+    response={200: AttendanceReportOut, 403: ErrorOut},
+    auth=gated_jwt,
+)
+def attendance_report(request):
+    """Per-event attendance summary for every event with at least one mark.
+
+    Only events with an attended or no-show mark are included — events nobody
+    checked in for would just be noise in an attendance report. Newest first.
+    """
+    if not request.auth.has_permission(PermissionKey.MANAGE_EVENTS):
+        raise_validation(Code.Perm.DENIED, status_code=403, action="attendance_report")
+
+    attended_q = Q(
+        rsvps__status=RSVPStatus.ATTENDING,
+        rsvps__attendance=AttendanceStatus.ATTENDED,
+    )
+    no_show_q = Q(
+        rsvps__status=RSVPStatus.ATTENDING,
+        rsvps__attendance=AttendanceStatus.NO_SHOW,
+    )
+    going_q = Q(rsvps__status=RSVPStatus.ATTENDING)
+
+    events = (
+        Event.objects.exclude(status=EventStatus.DELETED)
+        .annotate(
+            attended_total=Count("rsvps", filter=attended_q, distinct=True),
+            no_show_total=Count("rsvps", filter=no_show_q, distinct=True),
+            going_total=Count("rsvps", filter=going_q, distinct=True),
+        )
+        .filter(Q(attended_total__gt=0) | Q(no_show_total__gt=0))
+        .order_by("-start_datetime")
+    )
+
+    return Status(
+        200,
+        AttendanceReportOut(
+            events=[
+                EventAttendanceRowOut(
+                    event_id=str(e.id),
+                    title=e.title,
+                    start_datetime=e.start_datetime,
+                    attended_count=e.attended_total,
+                    no_show_count=e.no_show_total,
+                    going_count=e.going_total,
+                )
+                for e in events
+            ]
+        ),
+    )

--- a/backend/community/_attendance_report.py
+++ b/backend/community/_attendance_report.py
@@ -6,11 +6,11 @@ from ninja import Router
 from ninja.responses import Status
 from users.permissions import PermissionKey
 
-from community._event_helpers import attendance_q, going_q
 from community._event_schemas import AttendanceReportOut, EventAttendanceRowOut
+from community._rsvp_counts import attendance_q, going_headcount_expr, reportable_events_q
 from community._shared import ErrorOut
 from community._validation import Code, raise_validation
-from community.models import AttendanceStatus, Event, EventStatus
+from community.models import AttendanceStatus, Event
 
 router = Router()
 
@@ -26,7 +26,7 @@ def attendance_report(request):
         raise_validation(Code.Perm.DENIED, status_code=403, action="attendance_report")
 
     events = (
-        Event.objects.exclude(status__in=(EventStatus.DELETED, EventStatus.CANCELLED))
+        Event.objects.filter(reportable_events_q(prefix=""))
         .annotate(
             attended_total=Count(
                 "rsvps", filter=attendance_q(AttendanceStatus.ATTENDED), distinct=True
@@ -34,7 +34,7 @@ def attendance_report(request):
             no_show_total=Count(
                 "rsvps", filter=attendance_q(AttendanceStatus.NO_SHOW), distinct=True
             ),
-            going_total=Count("rsvps", filter=going_q(), distinct=True),
+            going_total=going_headcount_expr(),
         )
         .filter(Q(attended_total__gt=0) | Q(no_show_total__gt=0))
         .order_by("-start_datetime")

--- a/backend/community/_attendance_report.py
+++ b/backend/community/_attendance_report.py
@@ -1,10 +1,4 @@
-"""Admin-only attendance reporting across events.
-
-Builds on the existing per-event check-in (``EventRSVP.attendance``). This is a
-read-only aggregation layer: it does not record attendance — that happens in the
-host check-in flow (``_event_rsvps.set_attendance``). Gated by ``MANAGE_EVENTS``,
-matching the rest of the event-admin surface.
-"""
+"""Admin-only read model aggregating per-event check-in across events."""
 
 from config.auth import gated_jwt
 from django.db.models import Count, Q
@@ -12,10 +6,11 @@ from ninja import Router
 from ninja.responses import Status
 from users.permissions import PermissionKey
 
+from community._event_helpers import attendance_q, going_q
 from community._event_schemas import AttendanceReportOut, EventAttendanceRowOut
 from community._shared import ErrorOut
 from community._validation import Code, raise_validation
-from community.models import AttendanceStatus, Event, EventStatus, RSVPStatus
+from community.models import AttendanceStatus, Event, EventStatus
 
 router = Router()
 
@@ -26,30 +21,20 @@ router = Router()
     auth=gated_jwt,
 )
 def attendance_report(request):
-    """Per-event attendance summary for every event with at least one mark.
-
-    Only events with an attended or no-show mark are included — events nobody
-    checked in for would just be noise in an attendance report. Newest first.
-    """
+    """Per-event attendance summary, newest first, for events with any mark."""
     if not request.auth.has_permission(PermissionKey.MANAGE_EVENTS):
         raise_validation(Code.Perm.DENIED, status_code=403, action="attendance_report")
 
-    attended_q = Q(
-        rsvps__status=RSVPStatus.ATTENDING,
-        rsvps__attendance=AttendanceStatus.ATTENDED,
-    )
-    no_show_q = Q(
-        rsvps__status=RSVPStatus.ATTENDING,
-        rsvps__attendance=AttendanceStatus.NO_SHOW,
-    )
-    going_q = Q(rsvps__status=RSVPStatus.ATTENDING)
-
     events = (
-        Event.objects.exclude(status=EventStatus.DELETED)
+        Event.objects.exclude(status__in=(EventStatus.DELETED, EventStatus.CANCELLED))
         .annotate(
-            attended_total=Count("rsvps", filter=attended_q, distinct=True),
-            no_show_total=Count("rsvps", filter=no_show_q, distinct=True),
-            going_total=Count("rsvps", filter=going_q, distinct=True),
+            attended_total=Count(
+                "rsvps", filter=attendance_q(AttendanceStatus.ATTENDED), distinct=True
+            ),
+            no_show_total=Count(
+                "rsvps", filter=attendance_q(AttendanceStatus.NO_SHOW), distinct=True
+            ),
+            going_total=Count("rsvps", filter=going_q(), distinct=True),
         )
         .filter(Q(attended_total__gt=0) | Q(no_show_total__gt=0))
         .order_by("-start_datetime")

--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -7,7 +7,7 @@ from uuid import UUID
 
 from config.media_proxy import media_path
 from django.db import transaction
-from django.db.models import Case, IntegerField, Sum, Value, When
+from django.db.models import Case, IntegerField, Q, Sum, Value, When
 from notifications.service import (
     broadcast_cohost_change,
     broadcast_event_update,
@@ -141,6 +141,24 @@ def _no_response_count(event: Event) -> int:
     """Invited users who have no RSVP row."""
     responded = {r.user_id for r in event.rsvps.all()}
     return sum(1 for u in event.invited_users.all() if u.pk not in responded)
+
+
+def attendance_q(attendance: str, prefix: str = "rsvps") -> Q:
+    """Shared attended/no-show predicate so report + member-list can't drift.
+
+    Gates on ATTENDING so a mark stranded on an rsvp that later changed status
+    isn't counted.
+
+    attendance(str): the AttendanceStatus to match.
+    prefix(str): relation lookup prefix from the queried model to EventRSVP.
+    return(Q): filter on status=ATTENDING AND attendance=<attendance>.
+    """
+    return Q(**{f"{prefix}__status": RSVPStatus.ATTENDING, f"{prefix}__attendance": attendance})
+
+
+def going_q(prefix: str = "rsvps") -> Q:
+    """Q matching all ATTENDING rsvps across `prefix` (the going denominator)."""
+    return Q(**{f"{prefix}__status": RSVPStatus.ATTENDING})
 
 
 def _attended_count(event: Event) -> int:

--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -7,7 +7,6 @@ from uuid import UUID
 
 from config.media_proxy import media_path
 from django.db import transaction
-from django.db.models import Case, IntegerField, Q, Sum, Value, When
 from notifications.service import (
     broadcast_cohost_change,
     broadcast_event_update,
@@ -30,9 +29,13 @@ from community._event_schemas import (
     RSVPGuestOut,
     TagOut,
 )
+from community._rsvp_counts import (
+    _attending_headcount,
+    _attending_headcount_db,
+    _waitlisted_count,
+)
 from community._shared import _authenticated_user, _members_only
 from community.models import (
-    AttendanceStatus,
     CoHostInviteStatus,
     Event,
     EventCoHostInvite,
@@ -96,93 +99,6 @@ def _find_my_rsvp(rsvps, user) -> str | None:
         if r.user_id == user.pk:
             return r.status
     return None
-
-
-def _attending_headcount(event: Event) -> int:
-    """Count attending spots from prefetched RSVPs (each attendee + their +1)."""
-    return sum(
-        1 + (1 if r.has_plus_one else 0)
-        for r in event.rsvps.all()
-        if r.status == RSVPStatus.ATTENDING
-    )
-
-
-def _attending_headcount_db(event: Event, exclude_user=None) -> int:
-    """Count attending spots via DB query (use inside select_for_update transactions)."""
-    qs = EventRSVP.objects.filter(event=event, status=RSVPStatus.ATTENDING)
-    if exclude_user is not None:
-        qs = qs.exclude(user=exclude_user)
-    result = qs.aggregate(
-        total=Sum(
-            Case(
-                When(has_plus_one=True, then=Value(2)),
-                default=Value(1),
-                output_field=IntegerField(),
-            )
-        )
-    )
-    return result["total"] or 0
-
-
-def _waitlisted_count(event: Event) -> int:
-    """Count waitlisted RSVPs from prefetched data."""
-    return sum(1 for r in event.rsvps.all() if r.status == RSVPStatus.WAITLISTED)
-
-
-def _maybe_count(event: Event) -> int:
-    return sum(1 for r in event.rsvps.all() if r.status == RSVPStatus.MAYBE)
-
-
-def _cant_go_count(event: Event) -> int:
-    return sum(1 for r in event.rsvps.all() if r.status == RSVPStatus.CANT_GO)
-
-
-def _no_response_count(event: Event) -> int:
-    """Invited users who have no RSVP row."""
-    responded = {r.user_id for r in event.rsvps.all()}
-    return sum(1 for u in event.invited_users.all() if u.pk not in responded)
-
-
-def attendance_q(attendance: str, prefix: str = "rsvps") -> Q:
-    """Shared attended/no-show predicate so report + member-list can't drift.
-
-    Gates on ATTENDING so a mark stranded on an rsvp that later changed status
-    isn't counted.
-
-    attendance(str): the AttendanceStatus to match.
-    prefix(str): relation lookup prefix from the queried model to EventRSVP.
-    return(Q): filter on status=ATTENDING AND attendance=<attendance>.
-    """
-    return Q(**{f"{prefix}__status": RSVPStatus.ATTENDING, f"{prefix}__attendance": attendance})
-
-
-def going_q(prefix: str = "rsvps") -> Q:
-    """Q matching all ATTENDING rsvps across `prefix` (the going denominator)."""
-    return Q(**{f"{prefix}__status": RSVPStatus.ATTENDING})
-
-
-def _attended_count(event: Event) -> int:
-    return sum(
-        1
-        for r in event.rsvps.all()
-        if r.status == RSVPStatus.ATTENDING and r.attendance == AttendanceStatus.ATTENDED
-    )
-
-
-def _no_show_count(event: Event) -> int:
-    return sum(
-        1
-        for r in event.rsvps.all()
-        if r.status == RSVPStatus.ATTENDING and r.attendance == AttendanceStatus.NO_SHOW
-    )
-
-
-def _not_marked_count(event: Event) -> int:
-    return sum(
-        1
-        for r in event.rsvps.all()
-        if r.status == RSVPStatus.ATTENDING and r.attendance == AttendanceStatus.UNKNOWN
-    )
 
 
 def _cancellations(event: Event) -> list[CancellationOut]:

--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -11,17 +11,8 @@ from ninja import Router
 from ninja.responses import Status
 
 from community._event_helpers import (
-    _attended_count,
-    _attending_headcount,
-    _attending_headcount_db,
     _cancellations,
-    _cant_go_count,
     _event_out,
-    _maybe_count,
-    _no_response_count,
-    _no_show_count,
-    _not_marked_count,
-    _waitlisted_count,
     broadcast_capacity_change,
     promote_from_waitlist,
 )
@@ -34,6 +25,17 @@ from community._event_schemas import (
 )
 from community._events import _can_edit_event, _enforce_event_read_visibility
 from community._public_rsvp_shared import _email_promoted_non_members
+from community._rsvp_counts import (
+    _attended_count,
+    _attending_headcount,
+    _attending_headcount_db,
+    _cant_go_count,
+    _maybe_count,
+    _no_response_count,
+    _no_show_count,
+    _not_marked_count,
+    _waitlisted_count,
+)
 from community._shared import ErrorOut
 from community._validation import Code, raise_validation
 from community.models import Event, EventRSVP, RSVPStatus

--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -283,6 +283,21 @@ class EventStatsOut(BaseModel):
     cancellations: list[CancellationOut] = []
 
 
+class EventAttendanceRowOut(BaseModel):
+    """One event's attendance summary for the admin attendance report."""
+
+    event_id: str
+    title: str
+    start_datetime: datetime | None = None
+    attended_count: int = 0
+    no_show_count: int = 0
+    going_count: int = 0
+
+
+class AttendanceReportOut(BaseModel):
+    events: list[EventAttendanceRowOut] = []
+
+
 class AttendanceIn(BaseModel):
     attendance: AttendanceStatus
 

--- a/backend/community/_events.py
+++ b/backend/community/_events.py
@@ -15,7 +15,6 @@ from users.permissions import PermissionKey
 
 from community._cohost_invite_helpers import has_pending_cohost_invite
 from community._event_helpers import (
-    _attending_headcount,
     _can_see_invite_only,
     _event_out,
     _find_my_rsvp,
@@ -23,7 +22,6 @@ from community._event_helpers import (
     _set_event_tags,
     _tags_out,
     _update_co_hosts,
-    _waitlisted_count,
 )
 from community._event_schemas import (
     EventIn,
@@ -35,6 +33,7 @@ from community._event_transitions import (
     _handle_status_update,
     _set_event_participants,
 )
+from community._rsvp_counts import _attending_headcount, _waitlisted_count
 from community._shared import ErrorOut, _authenticated_user, _members_only, _optional_jwt
 from community._validation import Code, raise_validation
 from community.models import (

--- a/backend/community/_rsvp_counts.py
+++ b/backend/community/_rsvp_counts.py
@@ -1,0 +1,124 @@
+"""RSVP headcount and attendance predicates shared across event surfaces."""
+
+from django.db.models import Case, IntegerField, Q, Sum, Value, When
+from django.db.models.functions import Coalesce
+
+from community.models import (
+    AttendanceStatus,
+    Event,
+    EventRSVP,
+    EventStatus,
+    RSVPStatus,
+)
+
+# Events that never belong in attendance surfaces: soft-deleted, cancelled, or
+# still-unpublished drafts. Centralized so the report and member-list can't drift.
+NON_REPORTABLE_EVENT_STATUSES = (EventStatus.DELETED, EventStatus.CANCELLED, EventStatus.DRAFT)
+
+
+def reportable_events_q(prefix: str = "event") -> Q:
+    """Q excluding non-reportable event statuses across `prefix` (default the event itself)."""
+    field = f"{prefix}__status" if prefix else "status"
+    return ~Q(**{f"{field}__in": NON_REPORTABLE_EVENT_STATUSES})
+
+
+def attendance_q(attendance: str, prefix: str = "rsvps") -> Q:
+    """Shared attended/no-show predicate so report + member-list can't drift.
+
+    Gates on ATTENDING so a mark stranded on an rsvp that later changed status
+    isn't counted.
+
+    attendance(str): the AttendanceStatus to match.
+    prefix(str): relation lookup prefix from the queried model to EventRSVP.
+    return(Q): filter on status=ATTENDING AND attendance=<attendance>.
+    """
+    return Q(**{f"{prefix}__status": RSVPStatus.ATTENDING, f"{prefix}__attendance": attendance})
+
+
+def going_q(prefix: str = "rsvps") -> Q:
+    """Q matching all ATTENDING rsvps across `prefix` (the going denominator)."""
+    return Q(**{f"{prefix}__status": RSVPStatus.ATTENDING})
+
+
+def going_headcount_expr(prefix: str = "rsvps") -> Coalesce:
+    """Sum of ATTENDING spots incl. plus-ones, matching _attending_headcount."""
+    return Coalesce(
+        Sum(
+            Case(
+                When(**{f"{prefix}__has_plus_one": True}, then=Value(2)),
+                default=Value(1),
+                output_field=IntegerField(),
+            ),
+            filter=going_q(prefix),
+        ),
+        Value(0),
+    )
+
+
+def _is_attended(rsvp: EventRSVP) -> bool:
+    return rsvp.status == RSVPStatus.ATTENDING and rsvp.attendance == AttendanceStatus.ATTENDED
+
+
+def _is_no_show(rsvp: EventRSVP) -> bool:
+    return rsvp.status == RSVPStatus.ATTENDING and rsvp.attendance == AttendanceStatus.NO_SHOW
+
+
+def _attended_count(event: Event) -> int:
+    return sum(1 for r in event.rsvps.all() if _is_attended(r))
+
+
+def _no_show_count(event: Event) -> int:
+    return sum(1 for r in event.rsvps.all() if _is_no_show(r))
+
+
+def _not_marked_count(event: Event) -> int:
+    return sum(
+        1
+        for r in event.rsvps.all()
+        if r.status == RSVPStatus.ATTENDING and r.attendance == AttendanceStatus.UNKNOWN
+    )
+
+
+def _attending_headcount(event: Event) -> int:
+    """Count attending spots from prefetched RSVPs (each attendee + their +1)."""
+    return sum(
+        1 + (1 if r.has_plus_one else 0)
+        for r in event.rsvps.all()
+        if r.status == RSVPStatus.ATTENDING
+    )
+
+
+def _attending_headcount_db(event: Event, exclude_user=None) -> int:
+    """Count attending spots via DB query (use inside select_for_update transactions)."""
+    qs = EventRSVP.objects.filter(event=event, status=RSVPStatus.ATTENDING)
+    if exclude_user is not None:
+        qs = qs.exclude(user=exclude_user)
+    result = qs.aggregate(
+        total=Sum(
+            Case(
+                When(has_plus_one=True, then=Value(2)),
+                default=Value(1),
+                output_field=IntegerField(),
+            )
+        )
+    )
+    return result["total"] or 0
+
+
+def _waitlisted_count(event: Event) -> int:
+    """Count waitlisted RSVPs from prefetched data."""
+    return sum(1 for r in event.rsvps.all() if r.status == RSVPStatus.WAITLISTED)
+
+
+def _maybe_count(event: Event) -> int:
+    return sum(1 for r in event.rsvps.all() if r.status == RSVPStatus.MAYBE)
+
+
+def _cant_go_count(event: Event) -> int:
+    return sum(1 for r in event.rsvps.all() if r.status == RSVPStatus.CANT_GO)
+
+
+def _no_response_count(event: Event) -> int:
+    """Invited users who have no RSVP row."""
+    responded = {r.user_id for r in event.rsvps.all()}
+    return sum(1 for u in event.invited_users.all() if u.pk not in responded)

--- a/backend/community/_rsvp_counts.py
+++ b/backend/community/_rsvp_counts.py
@@ -11,8 +11,7 @@ from community.models import (
     RSVPStatus,
 )
 
-# Events that never belong in attendance surfaces: soft-deleted, cancelled, or
-# still-unpublished drafts. Centralized so the report and member-list can't drift.
+# Excluded from attendance surfaces; centralized so report + member-list can't drift.
 NON_REPORTABLE_EVENT_STATUSES = (EventStatus.DELETED, EventStatus.CANCELLED, EventStatus.DRAFT)
 
 
@@ -23,10 +22,7 @@ def reportable_events_q(prefix: str = "event") -> Q:
 
 
 def attendance_q(attendance: str, prefix: str = "rsvps") -> Q:
-    """Shared attended/no-show predicate so report + member-list can't drift.
-
-    Gates on ATTENDING so a mark stranded on an rsvp that later changed status
-    isn't counted.
+    """Attended/no-show predicate, gated on ATTENDING so stranded marks aren't counted.
 
     attendance(str): the AttendanceStatus to match.
     prefix(str): relation lookup prefix from the queried model to EventRSVP.
@@ -40,19 +36,19 @@ def going_q(prefix: str = "rsvps") -> Q:
     return Q(**{f"{prefix}__status": RSVPStatus.ATTENDING})
 
 
+def _plus_one_weight_case(prefix: str = "") -> Case:
+    """Case weighting each rsvp as 2 spots when it carries a plus-one, else 1."""
+    field = f"{prefix}__has_plus_one" if prefix else "has_plus_one"
+    return Case(
+        When(**{field: True}, then=Value(2)),
+        default=Value(1),
+        output_field=IntegerField(),
+    )
+
+
 def going_headcount_expr(prefix: str = "rsvps") -> Coalesce:
     """Sum of ATTENDING spots incl. plus-ones, matching _attending_headcount."""
-    return Coalesce(
-        Sum(
-            Case(
-                When(**{f"{prefix}__has_plus_one": True}, then=Value(2)),
-                default=Value(1),
-                output_field=IntegerField(),
-            ),
-            filter=going_q(prefix),
-        ),
-        Value(0),
-    )
+    return Coalesce(Sum(_plus_one_weight_case(prefix), filter=going_q(prefix)), Value(0))
 
 
 def _is_attended(rsvp: EventRSVP) -> bool:
@@ -93,15 +89,7 @@ def _attending_headcount_db(event: Event, exclude_user=None) -> int:
     qs = EventRSVP.objects.filter(event=event, status=RSVPStatus.ATTENDING)
     if exclude_user is not None:
         qs = qs.exclude(user=exclude_user)
-    result = qs.aggregate(
-        total=Sum(
-            Case(
-                When(has_plus_one=True, then=Value(2)),
-                default=Value(1),
-                output_field=IntegerField(),
-            )
-        )
-    )
+    result = qs.aggregate(total=Sum(_plus_one_weight_case()))
     return result["total"] or 0
 
 

--- a/backend/community/api.py
+++ b/backend/community/api.py
@@ -1,5 +1,6 @@
 from ninja import Router
 
+from community._attendance_report import router as attendance_report_router
 from community._calendar import router as calendar_router
 from community._docs import router as docs_router
 from community._docs_documents import router as docs_documents_router
@@ -48,6 +49,9 @@ router.add_router("", join_request_submit_router)
 router.add_router("", join_request_resend_router)
 router.add_router("", login_link_router)
 router.add_router("", feedback_router)
+# Mount before events_router so the literal `/events/attendance-report/` route
+# resolves before that router's `/events/{event_id}/` parameterized route.
+router.add_router("", attendance_report_router)
 router.add_router("", events_router)
 router.add_router("", event_tags_router)
 router.add_router("", event_rsvps_router)

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -89,6 +89,20 @@
         "title": "AttendanceIn",
         "type": "object"
       },
+      "AttendanceReportOut": {
+        "properties": {
+          "events": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/EventAttendanceRowOut"
+            },
+            "title": "Events",
+            "type": "array"
+          }
+        },
+        "title": "AttendanceReportOut",
+        "type": "object"
+      },
       "AttendanceStatus": {
         "enum": [
           "unknown",
@@ -748,6 +762,52 @@
           "detail"
         ],
         "title": "ErrorReportOut",
+        "type": "object"
+      },
+      "EventAttendanceRowOut": {
+        "description": "One event's attendance summary for the admin attendance report.",
+        "properties": {
+          "attended_count": {
+            "default": 0,
+            "title": "Attended Count",
+            "type": "integer"
+          },
+          "event_id": {
+            "title": "Event Id",
+            "type": "string"
+          },
+          "going_count": {
+            "default": 0,
+            "title": "Going Count",
+            "type": "integer"
+          },
+          "no_show_count": {
+            "default": 0,
+            "title": "No Show Count",
+            "type": "integer"
+          },
+          "start_datetime": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Datetime"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "event_id",
+          "title"
+        ],
+        "title": "EventAttendanceRowOut",
         "type": "object"
       },
       "EventCommentListOut": {
@@ -4664,6 +4724,18 @@
             "title": "Is Superuser",
             "type": "boolean"
           },
+          "last_attended": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Attended"
+          },
           "last_name": {
             "default": "",
             "title": "Last Name",
@@ -7270,6 +7342,44 @@
           }
         ],
         "summary": "Create Event",
+        "tags": [
+          "community"
+        ]
+      }
+    },
+    "/api/community/events/attendance-report/": {
+      "get": {
+        "description": "Per-event attendance summary for every event with at least one mark.\n\nOnly events with an attended or no-show mark are included \u2014 events nobody\nchecked in for would just be noise in an attendance report. Newest first.",
+        "operationId": "community__attendance_report_attendance_report",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttendanceReportOut"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "GatedJWTAuth": []
+          }
+        ],
+        "summary": "Attendance Report",
         "tags": [
           "community"
         ]

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -7349,7 +7349,7 @@
     },
     "/api/community/events/attendance-report/": {
       "get": {
-        "description": "Per-event attendance summary for every event with at least one mark.\n\nOnly events with an attended or no-show mark are included \u2014 events nobody\nchecked in for would just be noise in an attendance report. Newest first.",
+        "description": "Per-event attendance summary, newest first, for events with any mark.",
         "operationId": "community__attendance_report_attendance_report",
         "parameters": [],
         "responses": {

--- a/backend/tests/test_attendance_report.py
+++ b/backend/tests/test_attendance_report.py
@@ -1,9 +1,4 @@
-"""Tests for the admin attendance-reporting layer.
-
-Covers the cross-event attendance report endpoint and the `last_attended`
-annotation exposed on the admin member list. Both read from the existing
-per-event check-in (`EventRSVP.attendance`).
-"""
+"""Tests for the attendance report endpoint and member-list last_attended."""
 
 from datetime import timedelta
 
@@ -125,6 +120,36 @@ class TestAttendanceReportEndpoint:
         assert response.status_code == 200
         assert response.json()["events"] == []
 
+    def test_excludes_cancelled_events(self, api_client, host_user, members, events_admin):
+        cancelled = _make_event(host_user, "Cancelled Event", days_ago=3)
+        EventRSVP.objects.create(
+            event=cancelled,
+            user=members[0],
+            status=RSVPStatus.ATTENDING,
+            attendance=AttendanceStatus.ATTENDED,
+        )
+        Event.objects.filter(pk=cancelled.pk).update(status=EventStatus.CANCELLED)
+
+        response = api_client.get("/api/community/events/attendance-report/", **_auth(events_admin))
+        assert response.status_code == 200
+        assert response.json()["events"] == []
+
+    def test_stranded_mark_after_rsvp_change_not_counted(
+        self, api_client, host_user, members, events_admin
+    ):
+        event = _make_event(host_user, "Flipped Event", days_ago=2)
+        # Marked attended while ATTENDING, then flipped to CANT_GO — attendance
+        # is not cleared, but the report must not count it.
+        EventRSVP.objects.create(
+            event=event,
+            user=members[0],
+            status=RSVPStatus.CANT_GO,
+            attendance=AttendanceStatus.ATTENDED,
+        )
+
+        response = api_client.get("/api/community/events/attendance-report/", **_auth(events_admin))
+        assert response.json()["events"] == []
+
     def test_sorted_newest_first(self, api_client, host_user, members, events_admin):
         older = _make_event(host_user, "Older", days_ago=10)
         newer = _make_event(host_user, "Newer", days_ago=1)
@@ -198,6 +223,21 @@ class TestLastAttendedOnMemberList:
         row = next(r for r in response.json() if r["id"] == str(members[0].pk))
         assert row["last_attended"] is None
 
+    def test_last_attended_excludes_stranded_mark_after_rsvp_change(
+        self, api_client, host_user, members, manage_users_headers
+    ):
+        event = _make_event(host_user, "Flipped Event", days_ago=2)
+        EventRSVP.objects.create(
+            event=event,
+            user=members[0],
+            status=RSVPStatus.CANT_GO,
+            attendance=AttendanceStatus.ATTENDED,
+        )
+
+        response = api_client.get("/api/auth/users/", **manage_users_headers)
+        row = next(r for r in response.json() if r["id"] == str(members[0].pk))
+        assert row["last_attended"] is None
+
     def test_last_attended_excludes_deleted_events(
         self, api_client, host_user, members, manage_users_headers
     ):
@@ -209,6 +249,22 @@ class TestLastAttendedOnMemberList:
             attendance=AttendanceStatus.ATTENDED,
         )
         Event.objects.filter(pk=deleted.pk).update(status=EventStatus.DELETED)
+
+        response = api_client.get("/api/auth/users/", **manage_users_headers)
+        row = next(r for r in response.json() if r["id"] == str(members[0].pk))
+        assert row["last_attended"] is None
+
+    def test_last_attended_excludes_cancelled_events(
+        self, api_client, host_user, members, manage_users_headers
+    ):
+        cancelled = _make_event(host_user, "Cancelled Event", days_ago=2)
+        EventRSVP.objects.create(
+            event=cancelled,
+            user=members[0],
+            status=RSVPStatus.ATTENDING,
+            attendance=AttendanceStatus.ATTENDED,
+        )
+        Event.objects.filter(pk=cancelled.pk).update(status=EventStatus.CANCELLED)
 
         response = api_client.get("/api/auth/users/", **manage_users_headers)
         row = next(r for r in response.json() if r["id"] == str(members[0].pk))

--- a/backend/tests/test_attendance_report.py
+++ b/backend/tests/test_attendance_report.py
@@ -134,6 +134,40 @@ class TestAttendanceReportEndpoint:
         assert response.status_code == 200
         assert response.json()["events"] == []
 
+    def test_going_count_includes_plus_ones(self, api_client, host_user, members, events_admin):
+        event = _make_event(host_user, "Plus One Event", days_ago=2)
+        EventRSVP.objects.create(
+            event=event,
+            user=members[0],
+            status=RSVPStatus.ATTENDING,
+            attendance=AttendanceStatus.ATTENDED,
+            has_plus_one=True,
+        )
+        EventRSVP.objects.create(
+            event=event,
+            user=members[1],
+            status=RSVPStatus.ATTENDING,
+            attendance=AttendanceStatus.UNKNOWN,
+        )
+
+        response = api_client.get("/api/community/events/attendance-report/", **_auth(events_admin))
+        row = response.json()["events"][0]
+        # 2 attending rsvps, one with a +1 → headcount 3, matching event detail.
+        assert row["going_count"] == 3
+
+    def test_excludes_draft_events(self, api_client, host_user, members, events_admin):
+        draft = _make_event(host_user, "Draft Event", days_ago=3)
+        EventRSVP.objects.create(
+            event=draft,
+            user=members[0],
+            status=RSVPStatus.ATTENDING,
+            attendance=AttendanceStatus.ATTENDED,
+        )
+        Event.objects.filter(pk=draft.pk).update(status=EventStatus.DRAFT)
+
+        response = api_client.get("/api/community/events/attendance-report/", **_auth(events_admin))
+        assert response.json()["events"] == []
+
     def test_stranded_mark_after_rsvp_change_not_counted(
         self, api_client, host_user, members, events_admin
     ):
@@ -265,6 +299,22 @@ class TestLastAttendedOnMemberList:
             attendance=AttendanceStatus.ATTENDED,
         )
         Event.objects.filter(pk=cancelled.pk).update(status=EventStatus.CANCELLED)
+
+        response = api_client.get("/api/auth/users/", **manage_users_headers)
+        row = next(r for r in response.json() if r["id"] == str(members[0].pk))
+        assert row["last_attended"] is None
+
+    def test_last_attended_excludes_draft_events(
+        self, api_client, host_user, members, manage_users_headers
+    ):
+        draft = _make_event(host_user, "Draft Event", days_ago=2)
+        EventRSVP.objects.create(
+            event=draft,
+            user=members[0],
+            status=RSVPStatus.ATTENDING,
+            attendance=AttendanceStatus.ATTENDED,
+        )
+        Event.objects.filter(pk=draft.pk).update(status=EventStatus.DRAFT)
 
         response = api_client.get("/api/auth/users/", **manage_users_headers)
         row = next(r for r in response.json() if r["id"] == str(members[0].pk))

--- a/backend/tests/test_attendance_report.py
+++ b/backend/tests/test_attendance_report.py
@@ -1,0 +1,215 @@
+"""Tests for the admin attendance-reporting layer.
+
+Covers the cross-event attendance report endpoint and the `last_attended`
+annotation exposed on the admin member list. Both read from the existing
+per-event check-in (`EventRSVP.attendance`).
+"""
+
+from datetime import timedelta
+
+import pytest
+from community.models import AttendanceStatus, Event, EventRSVP, EventStatus, RSVPStatus
+from django.utils import timezone
+from ninja_jwt.tokens import RefreshToken
+
+
+def _auth(user):
+    refresh = RefreshToken.for_user(user)
+    return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # ty: ignore[unresolved-attribute]
+
+
+@pytest.fixture
+def members(db):
+    from users.models import User
+
+    return [
+        User.objects.create_user(
+            phone_number=f"+1202555190{i}",
+            password="x",
+            display_name=f"Member {i}",
+        )
+        for i in range(1, 4)
+    ]
+
+
+@pytest.fixture
+def host_user(db):
+    from users.models import User
+
+    return User.objects.create_user(
+        phone_number="+12025551800",
+        password="x",
+        display_name="Host",
+    )
+
+
+@pytest.fixture
+def events_admin(db):
+    from users.models import Role, User
+    from users.permissions import PermissionKey
+
+    admin = User.objects.create_user(
+        phone_number="+12025551801",
+        password="x",
+        display_name="Events Admin",
+    )
+    role = Role.objects.create(name="events_admin", permissions=[PermissionKey.MANAGE_EVENTS])
+    admin.roles.add(role)
+    return admin
+
+
+def _make_event(host_user, title, days_ago):
+    start = timezone.now() - timedelta(days=days_ago)
+    return Event.objects.create(
+        title=title,
+        start_datetime=start,
+        end_datetime=start + timedelta(hours=2),
+        rsvp_enabled=True,
+        created_by=host_user,
+        status=EventStatus.ACTIVE,
+    )
+
+
+@pytest.mark.django_db
+class TestAttendanceReportEndpoint:
+    def test_admin_sees_events_with_marks(self, api_client, host_user, members, events_admin):
+        marked = _make_event(host_user, "Marked Event", days_ago=2)
+        EventRSVP.objects.create(
+            event=marked,
+            user=members[0],
+            status=RSVPStatus.ATTENDING,
+            attendance=AttendanceStatus.ATTENDED,
+        )
+        EventRSVP.objects.create(
+            event=marked,
+            user=members[1],
+            status=RSVPStatus.ATTENDING,
+            attendance=AttendanceStatus.NO_SHOW,
+        )
+        EventRSVP.objects.create(
+            event=marked,
+            user=members[2],
+            status=RSVPStatus.ATTENDING,
+            attendance=AttendanceStatus.UNKNOWN,
+        )
+
+        response = api_client.get("/api/community/events/attendance-report/", **_auth(events_admin))
+        assert response.status_code == 200
+        rows = response.json()["events"]
+        assert len(rows) == 1
+        row = rows[0]
+        assert row["event_id"] == str(marked.id)
+        assert row["attended_count"] == 1
+        assert row["no_show_count"] == 1
+        assert row["going_count"] == 3
+
+    def test_excludes_events_without_marks(self, api_client, host_user, members, events_admin):
+        unmarked = _make_event(host_user, "No Marks", days_ago=1)
+        EventRSVP.objects.create(event=unmarked, user=members[0], status=RSVPStatus.ATTENDING)
+
+        response = api_client.get("/api/community/events/attendance-report/", **_auth(events_admin))
+        assert response.status_code == 200
+        assert response.json()["events"] == []
+
+    def test_excludes_deleted_events(self, api_client, host_user, members, events_admin):
+        deleted = _make_event(host_user, "Deleted Event", days_ago=3)
+        EventRSVP.objects.create(
+            event=deleted,
+            user=members[0],
+            status=RSVPStatus.ATTENDING,
+            attendance=AttendanceStatus.ATTENDED,
+        )
+        Event.objects.filter(pk=deleted.pk).update(status=EventStatus.DELETED)
+
+        response = api_client.get("/api/community/events/attendance-report/", **_auth(events_admin))
+        assert response.status_code == 200
+        assert response.json()["events"] == []
+
+    def test_sorted_newest_first(self, api_client, host_user, members, events_admin):
+        older = _make_event(host_user, "Older", days_ago=10)
+        newer = _make_event(host_user, "Newer", days_ago=1)
+        for ev in (older, newer):
+            EventRSVP.objects.create(
+                event=ev,
+                user=members[0],
+                status=RSVPStatus.ATTENDING,
+                attendance=AttendanceStatus.ATTENDED,
+            )
+
+        response = api_client.get("/api/community/events/attendance-report/", **_auth(events_admin))
+        ids = [r["event_id"] for r in response.json()["events"]]
+        assert ids == [str(newer.id), str(older.id)]
+
+    def test_non_admin_forbidden(self, api_client, host_user, members):
+        marked = _make_event(host_user, "Marked Event", days_ago=2)
+        EventRSVP.objects.create(
+            event=marked,
+            user=members[0],
+            status=RSVPStatus.ATTENDING,
+            attendance=AttendanceStatus.ATTENDED,
+        )
+        response = api_client.get("/api/community/events/attendance-report/", **_auth(members[0]))
+        assert response.status_code == 403
+
+    def test_unauthenticated_rejected(self, api_client):
+        response = api_client.get("/api/community/events/attendance-report/")
+        assert response.status_code == 401
+
+
+@pytest.mark.django_db
+class TestLastAttendedOnMemberList:
+    def test_last_attended_is_most_recent_attended_event(
+        self, api_client, host_user, members, manage_users_headers
+    ):
+        older = _make_event(host_user, "Older", days_ago=20)
+        newer = _make_event(host_user, "Newer", days_ago=5)
+        EventRSVP.objects.create(
+            event=older,
+            user=members[0],
+            status=RSVPStatus.ATTENDING,
+            attendance=AttendanceStatus.ATTENDED,
+        )
+        EventRSVP.objects.create(
+            event=newer,
+            user=members[0],
+            status=RSVPStatus.ATTENDING,
+            attendance=AttendanceStatus.ATTENDED,
+        )
+
+        response = api_client.get("/api/auth/users/", **manage_users_headers)
+        assert response.status_code == 200
+        row = next(r for r in response.json() if r["id"] == str(members[0].pk))
+        assert row["last_attended"] is not None
+        # The newer event's start should win.
+        assert row["last_attended"][:10] == newer.start_datetime.date().isoformat()
+
+    def test_last_attended_null_without_attended_rsvp(
+        self, api_client, host_user, members, manage_users_headers
+    ):
+        event = _make_event(host_user, "No-show Event", days_ago=2)
+        EventRSVP.objects.create(
+            event=event,
+            user=members[0],
+            status=RSVPStatus.ATTENDING,
+            attendance=AttendanceStatus.NO_SHOW,
+        )
+
+        response = api_client.get("/api/auth/users/", **manage_users_headers)
+        row = next(r for r in response.json() if r["id"] == str(members[0].pk))
+        assert row["last_attended"] is None
+
+    def test_last_attended_excludes_deleted_events(
+        self, api_client, host_user, members, manage_users_headers
+    ):
+        deleted = _make_event(host_user, "Deleted Event", days_ago=2)
+        EventRSVP.objects.create(
+            event=deleted,
+            user=members[0],
+            status=RSVPStatus.ATTENDING,
+            attendance=AttendanceStatus.ATTENDED,
+        )
+        Event.objects.filter(pk=deleted.pk).update(status=EventStatus.DELETED)
+
+        response = api_client.get("/api/auth/users/", **manage_users_headers)
+        row = next(r for r in response.json() if r["id"] == str(members[0].pk))
+        assert row["last_attended"] is None

--- a/backend/tests/test_event_stats.py
+++ b/backend/tests/test_event_stats.py
@@ -3,9 +3,9 @@
 from datetime import timedelta
 
 import pytest
-from community._event_helpers import (
+from community._event_helpers import _cancellations
+from community._rsvp_counts import (
     _attended_count,
-    _cancellations,
     _no_response_count,
     _no_show_count,
 )

--- a/backend/users/_management.py
+++ b/backend/users/_management.py
@@ -5,6 +5,7 @@ import re
 
 from community._shared import validate_display_name
 from community._validation import Code, ValidationException, raise_validation
+from community.models import AttendanceStatus, EventStatus
 from config.audit import audit_log
 from config.auth import gated_jwt
 from django.db import models as dj_models
@@ -229,10 +230,21 @@ def list_users(request):
             details={"endpoint": "list_users", "required_permission": PermissionKey.MANAGE_USERS},
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="list_users")
+    # Annotate each member's most recent ATTENDED check-in (by event start) so
+    # the admin member list can sort/filter on "last attended" without N+1.
     users = (
         User.objects.members()
         .filter(archived_at__isnull=True)
         .prefetch_related("roles")
+        .annotate(
+            last_attended=dj_models.Max(
+                "event_rsvps__event__start_datetime",
+                # Exclude deleted events so this matches the attendance report,
+                # which also drops them.
+                filter=dj_models.Q(event_rsvps__attendance=AttendanceStatus.ATTENDED)
+                & ~dj_models.Q(event_rsvps__event__status=EventStatus.DELETED),
+            )
+        )
         .order_by("phone_number")
     )
     return Status(200, [UserOut.from_user(u) for u in users])

--- a/backend/users/_management.py
+++ b/backend/users/_management.py
@@ -231,9 +231,7 @@ def list_users(request):
             details={"endpoint": "list_users", "required_permission": PermissionKey.MANAGE_USERS},
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="list_users")
-    # last_attended shares attendance_q + reportable_events_q with the attendance
-    # report so the two admin surfaces can't disagree on what "attended" means or
-    # which events count. Annotated (not N+1) for sort/filter.
+    # shares attendance_q + reportable_events_q with the report so the surfaces can't drift.
     attended = attendance_q(AttendanceStatus.ATTENDED, prefix="event_rsvps")
     reportable = reportable_events_q(prefix="event_rsvps__event")
     users = (

--- a/backend/users/_management.py
+++ b/backend/users/_management.py
@@ -3,10 +3,10 @@
 import logging
 import re
 
-from community._event_helpers import attendance_q
+from community._rsvp_counts import attendance_q, reportable_events_q
 from community._shared import validate_display_name
 from community._validation import Code, ValidationException, raise_validation
-from community.models import AttendanceStatus, EventStatus
+from community.models import AttendanceStatus
 from config.audit import audit_log
 from config.auth import gated_jwt
 from django.db import models as dj_models
@@ -231,13 +231,11 @@ def list_users(request):
             details={"endpoint": "list_users", "required_permission": PermissionKey.MANAGE_USERS},
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="list_users")
-    # last_attended shares attendance_q with the attendance report so the two
-    # admin surfaces can't disagree on what "attended" means; both also drop
-    # deleted/cancelled events. Annotated (not N+1) for sort/filter.
+    # last_attended shares attendance_q + reportable_events_q with the attendance
+    # report so the two admin surfaces can't disagree on what "attended" means or
+    # which events count. Annotated (not N+1) for sort/filter.
     attended = attendance_q(AttendanceStatus.ATTENDED, prefix="event_rsvps")
-    excluded_events = dj_models.Q(
-        event_rsvps__event__status__in=(EventStatus.DELETED, EventStatus.CANCELLED)
-    )
+    reportable = reportable_events_q(prefix="event_rsvps__event")
     users = (
         User.objects.members()
         .filter(archived_at__isnull=True)
@@ -245,7 +243,7 @@ def list_users(request):
         .annotate(
             last_attended=dj_models.Max(
                 "event_rsvps__event__start_datetime",
-                filter=attended & ~excluded_events,
+                filter=attended & reportable,
             )
         )
         .order_by("phone_number")

--- a/backend/users/_management.py
+++ b/backend/users/_management.py
@@ -3,6 +3,7 @@
 import logging
 import re
 
+from community._event_helpers import attendance_q
 from community._shared import validate_display_name
 from community._validation import Code, ValidationException, raise_validation
 from community.models import AttendanceStatus, EventStatus
@@ -230,8 +231,13 @@ def list_users(request):
             details={"endpoint": "list_users", "required_permission": PermissionKey.MANAGE_USERS},
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="list_users")
-    # Annotate each member's most recent ATTENDED check-in (by event start) so
-    # the admin member list can sort/filter on "last attended" without N+1.
+    # last_attended shares attendance_q with the attendance report so the two
+    # admin surfaces can't disagree on what "attended" means; both also drop
+    # deleted/cancelled events. Annotated (not N+1) for sort/filter.
+    attended = attendance_q(AttendanceStatus.ATTENDED, prefix="event_rsvps")
+    excluded_events = dj_models.Q(
+        event_rsvps__event__status__in=(EventStatus.DELETED, EventStatus.CANCELLED)
+    )
     users = (
         User.objects.members()
         .filter(archived_at__isnull=True)
@@ -239,10 +245,7 @@ def list_users(request):
         .annotate(
             last_attended=dj_models.Max(
                 "event_rsvps__event__start_datetime",
-                # Exclude deleted events so this matches the attendance report,
-                # which also drops them.
-                filter=dj_models.Q(event_rsvps__attendance=AttendanceStatus.ATTENDED)
-                & ~dj_models.Q(event_rsvps__event__status=EventStatus.DELETED),
+                filter=attended & ~excluded_events,
             )
         )
         .order_by("phone_number")

--- a/backend/users/schemas.py
+++ b/backend/users/schemas.py
@@ -92,9 +92,7 @@ class UserOut(BaseModel):
     login_link_requested: bool = False
     week_start: str = "sunday"
     calendar_feed_scope: str = "all"
-    # Most recent event start the member has an ATTENDED check-in for. None if
-    # they've never been marked attended. Populated from a queryset annotation
-    # (``last_attended``) in list_users; absent elsewhere → stays None.
+    # Only populated by the list_users annotation; None everywhere else.
     last_attended: datetime | None = None
     roles: list[RoleOut]
 

--- a/backend/users/schemas.py
+++ b/backend/users/schemas.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Annotated, Literal
 
 from community._field_limits import FieldLimit
@@ -91,6 +92,10 @@ class UserOut(BaseModel):
     login_link_requested: bool = False
     week_start: str = "sunday"
     calendar_feed_scope: str = "all"
+    # Most recent event start the member has an ATTENDED check-in for. None if
+    # they've never been marked attended. Populated from a queryset annotation
+    # (``last_attended``) in list_users; absent elsewhere → stays None.
+    last_attended: datetime | None = None
     roles: list[RoleOut]
 
     @classmethod
@@ -118,6 +123,7 @@ class UserOut(BaseModel):
             login_link_requested=user.login_link_requested,
             week_start=user.week_start,
             calendar_feed_scope=user.calendar_feed_scope,
+            last_attended=getattr(user, "last_attended", None),
             roles=[
                 RoleOut(
                     id=str(r.id),

--- a/frontend/src/api/attendanceReport.ts
+++ b/frontend/src/api/attendanceReport.ts
@@ -35,9 +35,11 @@ function mapRow(w: WireRow): EventAttendanceRow {
   };
 }
 
+export const attendanceReportKey = ['attendance-report'] as const;
+
 export function useAttendanceReport() {
   return useQuery({
-    queryKey: ['attendance-report'] as const,
+    queryKey: attendanceReportKey,
     queryFn: async () => {
       const { data } = await apiClient.get<WireReport>('/api/community/events/attendance-report/');
       return data.events.map(mapRow);

--- a/frontend/src/api/attendanceReport.ts
+++ b/frontend/src/api/attendanceReport.ts
@@ -1,0 +1,50 @@
+// Admin attendance report — cross-event attendance summary. Gated server-side
+// by manage_events; the screen mounts behind a RequirePermission guard so we
+// don't need an `enabled` flag here.
+
+import { useQuery } from '@tanstack/react-query';
+
+import { apiClient } from './client';
+
+export interface EventAttendanceRow {
+  eventId: string;
+  title: string;
+  startDatetime: Date | null;
+  attendedCount: number;
+  noShowCount: number;
+  goingCount: number;
+}
+
+interface WireRow {
+  event_id: string;
+  title: string;
+  start_datetime: string | null;
+  attended_count: number;
+  no_show_count: number;
+  going_count: number;
+}
+
+interface WireReport {
+  events: WireRow[];
+}
+
+function mapRow(w: WireRow): EventAttendanceRow {
+  return {
+    eventId: w.event_id,
+    title: w.title,
+    startDatetime: w.start_datetime ? new Date(w.start_datetime) : null,
+    attendedCount: w.attended_count,
+    noShowCount: w.no_show_count,
+    goingCount: w.going_count,
+  };
+}
+
+export function useAttendanceReport() {
+  return useQuery({
+    queryKey: ['attendance-report'] as const,
+    queryFn: async () => {
+      const { data } = await apiClient.get<WireReport>('/api/community/events/attendance-report/');
+      return data.events.map(mapRow);
+    },
+  });
+}

--- a/frontend/src/api/attendanceReport.ts
+++ b/frontend/src/api/attendanceReport.ts
@@ -1,7 +1,3 @@
-// Admin attendance report — cross-event attendance summary. Gated server-side
-// by manage_events; the screen mounts behind a RequirePermission guard so we
-// don't need an `enabled` flag here.
-
 import { useQuery } from '@tanstack/react-query';
 
 import { apiClient } from './client';

--- a/frontend/src/api/eventStats.ts
+++ b/frontend/src/api/eventStats.ts
@@ -7,9 +7,11 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import type { AttendanceStatusValue, EventCancellation, EventStats } from '@/models/event';
 
+import { attendanceReportKey } from './attendanceReport';
 import { apiClient } from './client';
 import { mapEvent, type WireEvent } from './eventMapper';
 import { eventKeys } from './events';
+import { USERS_KEY } from './users';
 
 interface WireCancellation {
   user_id: string;
@@ -82,6 +84,9 @@ export function useSetAttendance(eventId: string) {
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: eventKeys.detail(eventId, true) });
       void qc.invalidateQueries({ queryKey: eventStatsKeys.detail(eventId) });
+      // attendance marks feed the admin report + members-list last_attended.
+      void qc.invalidateQueries({ queryKey: attendanceReportKey });
+      void qc.invalidateQueries({ queryKey: USERS_KEY });
     },
   });
 }

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -602,6 +602,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/community/events/attendance-report/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Attendance Report
+         * @description Per-event attendance summary for every event with at least one mark.
+         *
+         *     Only events with an attended or no-show mark are included — events nobody
+         *     checked in for would just be noise in an attendance report. Newest first.
+         */
+        get: operations["community__attendance_report_attendance_report"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/community/events/{event_id}/": {
         parameters: {
             query?: never;
@@ -1705,6 +1728,14 @@ export interface components {
         AttendanceIn: {
             attendance: components["schemas"]["AttendanceStatus"];
         };
+        /** AttendanceReportOut */
+        AttendanceReportOut: {
+            /**
+             * Events
+             * @default []
+             */
+            events: components["schemas"]["EventAttendanceRowOut"][];
+        };
         /**
          * AttendanceStatus
          * @enum {string}
@@ -1964,6 +1995,33 @@ export interface components {
         ErrorReportOut: {
             /** Detail */
             detail: string;
+        };
+        /**
+         * EventAttendanceRowOut
+         * @description One event's attendance summary for the admin attendance report.
+         */
+        EventAttendanceRowOut: {
+            /**
+             * Attended Count
+             * @default 0
+             */
+            attended_count: number;
+            /** Event Id */
+            event_id: string;
+            /**
+             * Going Count
+             * @default 0
+             */
+            going_count: number;
+            /**
+             * No Show Count
+             * @default 0
+             */
+            no_show_count: number;
+            /** Start Datetime */
+            start_datetime?: string | null;
+            /** Title */
+            title: string;
         };
         /** EventCommentListOut */
         EventCommentListOut: {
@@ -3699,6 +3757,8 @@ export interface components {
              * @default false
              */
             is_superuser: boolean;
+            /** Last Attended */
+            last_attended?: string | null;
             /**
              * Last Name
              * @default
@@ -5491,6 +5551,35 @@ export interface operations {
             };
             /** @description Too Many Requests */
             429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
+    community__attendance_report_attendance_report: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AttendanceReportOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -611,10 +611,7 @@ export interface paths {
         };
         /**
          * Attendance Report
-         * @description Per-event attendance summary for every event with at least one mark.
-         *
-         *     Only events with an attended or no-show mark are included — events nobody
-         *     checked in for would just be noise in an attendance report. Newest first.
+         * @description Per-event attendance summary, newest first, for events with any mark.
          */
         get: operations["community__attendance_report_attendance_report"];
         put?: never;

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -29,6 +29,8 @@ export interface Member {
   isPaused: boolean;
   needsOnboarding: boolean;
   loginLinkRequested: boolean;
+  // Most recent event the member was checked in as attended. null if never.
+  lastAttendedAt: Date | null;
   roles: MemberRole[];
 }
 
@@ -54,6 +56,7 @@ interface WireMember {
   is_paused?: boolean;
   needs_onboarding?: boolean;
   login_link_requested?: boolean;
+  last_attended?: string | null;
   roles: WireRole[];
 }
 
@@ -80,6 +83,7 @@ function fromWire(w: WireMember): Member {
     isPaused: w.is_paused ?? false,
     needsOnboarding: w.needs_onboarding ?? false,
     loginLinkRequested: w.login_link_requested ?? false,
+    lastAttendedAt: w.last_attended ? new Date(w.last_attended) : null,
     roles: w.roles.map(mapRole),
   };
 }

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -90,7 +90,7 @@ function fromWire(w: WireMember): Member {
 
 // --- Queries / mutations -----------------------------------------------------
 
-const USERS_KEY = ['users'] as const;
+export const USERS_KEY = ['users'] as const;
 
 export function useUsers() {
   return useQuery({

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -46,6 +46,7 @@ const AdminHub = lazyWithRetry(() => import('@/screens/admin/AdminHubScreen'));
 const JoinRequestsAdmin = lazyWithRetry(() => import('@/screens/admin/JoinRequestsScreen'));
 const EventManagement = lazyWithRetry(() => import('@/screens/admin/EventManagementScreen'));
 const FlaggedEvents = lazyWithRetry(() => import('@/screens/admin/FlaggedEventsScreen'));
+const AttendanceReport = lazyWithRetry(() => import('@/screens/admin/AttendanceReportScreen'));
 const JoinFormAdmin = lazyWithRetry(() => import('@/screens/admin/JoinFormAdminScreen'));
 const SurveyAdminList = lazyWithRetry(() => import('@/screens/admin/SurveyAdminListScreen'));
 const SurveyBuilder = lazyWithRetry(() => import('@/screens/admin/SurveyBuilderScreen'));
@@ -135,6 +136,7 @@ export const router = createBrowserRouter([
                 children: [
                   { path: '/events/manage', element: el(<EventManagement />) },
                   { path: '/admin/flagged-events', element: el(<FlaggedEvents />) },
+                  { path: '/admin/attendance', element: el(<AttendanceReport />) },
                 ],
               },
               {

--- a/frontend/src/screens/admin/AdminHubScreen.tsx
+++ b/frontend/src/screens/admin/AdminHubScreen.tsx
@@ -40,6 +40,12 @@ const TILES: Tile[] = [
     perm: Permission.ManageEvents,
   },
   {
+    to: '/admin/attendance',
+    label: 'attendance',
+    description: 'who came to events and when',
+    perm: Permission.ManageEvents,
+  },
+  {
     to: '/admin/surveys',
     label: 'surveys',
     description: 'build and review surveys + polls',

--- a/frontend/src/screens/admin/AttendanceReportScreen.test.tsx
+++ b/frontend/src/screens/admin/AttendanceReportScreen.test.tsx
@@ -1,0 +1,91 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { EventAttendanceRow } from '@/api/attendanceReport';
+
+vi.mock('@/api/attendanceReport', () => ({
+  useAttendanceReport: vi.fn(),
+}));
+
+import { useAttendanceReport } from '@/api/attendanceReport';
+
+import AttendanceReportScreen from './AttendanceReportScreen';
+
+const mockUseReport = vi.mocked(useAttendanceReport);
+
+function mockResult(overrides: Partial<ReturnType<typeof useAttendanceReport>>) {
+  mockUseReport.mockReturnValue({
+    isPending: false,
+    isError: false,
+    data: [],
+    ...overrides,
+  } as ReturnType<typeof useAttendanceReport>);
+}
+
+function makeRow(overrides: Partial<EventAttendanceRow> = {}): EventAttendanceRow {
+  return {
+    eventId: 'e1',
+    title: 'Potluck',
+    startDatetime: new Date('2026-03-15T18:00:00Z'),
+    attendedCount: 4,
+    noShowCount: 1,
+    goingCount: 6,
+    ...overrides,
+  };
+}
+
+function renderScreen() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <AttendanceReportScreen />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('AttendanceReportScreen', () => {
+  it('renders per-event attended / no-show / going counts', () => {
+    mockResult({ data: [makeRow()] });
+
+    renderScreen();
+
+    expect(screen.getByText('potluck')).toBeInTheDocument();
+    const row = screen.getByRole('link');
+    expect(row).toHaveTextContent('4 attended');
+    expect(row).toHaveTextContent('1 no-show');
+    expect(row).toHaveTextContent('6 going');
+    expect(row).toHaveAttribute('href', '/events/e1');
+  });
+
+  it('shows the empty state when nothing is marked', () => {
+    mockResult({ data: [] });
+
+    renderScreen();
+
+    expect(screen.getByText(/no attendance marked yet/i)).toBeInTheDocument();
+  });
+
+  it('shows an error message when the query fails', () => {
+    mockResult({ isError: true, data: undefined });
+
+    renderScreen();
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/couldn't load attendance/i);
+  });
+
+  it('shows a loading state while pending', () => {
+    mockResult({ isPending: true, data: undefined });
+
+    renderScreen();
+
+    expect(screen.getByText('loading…')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/admin/AttendanceReportScreen.tsx
+++ b/frontend/src/screens/admin/AttendanceReportScreen.tsx
@@ -1,0 +1,68 @@
+// Admin: /admin/attendance — cross-event attendance report built on the
+// existing per-event check-in. Shows, per event, how many people attended /
+// no-showed out of the going rsvps. Gated by manage_events (route + backend).
+
+import { format } from 'date-fns';
+import { Link } from 'react-router-dom';
+
+import { type EventAttendanceRow, useAttendanceReport } from '@/api/attendanceReport';
+import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
+
+export default function AttendanceReportScreen() {
+  const { data = [], isPending, isError } = useAttendanceReport();
+
+  if (isPending) return <ContentLoading />;
+  if (isError) return <ContentError message="couldn't load attendance — try refreshing" />;
+
+  return (
+    <ContentContainer>
+      <header className="mb-4">
+        <h1 className="mb-1 text-2xl font-medium tracking-tight">attendance</h1>
+        <p className="text-muted text-sm">who actually showed up, per event</p>
+      </header>
+
+      {data.length === 0 ? (
+        <p className="text-muted text-sm">no attendance marked yet 🌿</p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {data.map((row) => (
+            <li key={row.eventId}>
+              <AttendanceRow row={row} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </ContentContainer>
+  );
+}
+
+function AttendanceRow({ row }: { row: EventAttendanceRow }) {
+  return (
+    <Link
+      to={`/events/${row.eventId}`}
+      className="border-border bg-surface hover:bg-surface-dim flex items-center justify-between gap-3 rounded-lg border p-3 transition-colors"
+    >
+      <div className="min-w-0 flex-1">
+        <p className="text-foreground truncate text-sm font-medium">{row.title.toLowerCase()}</p>
+        <p className="text-foreground-tertiary truncate text-xs">
+          {row.startDatetime
+            ? format(row.startDatetime, 'EEE MMM d, yyyy').toLowerCase()
+            : 'date tbd'}
+        </p>
+      </div>
+      <div className="flex shrink-0 flex-wrap justify-end gap-1 text-xs">
+        <Stat label="attended" value={row.attendedCount} />
+        <Stat label="no-show" value={row.noShowCount} />
+        <Stat label="going" value={row.goingCount} />
+      </div>
+    </Link>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <span className="bg-surface-dim text-foreground-secondary rounded-full px-2.5 py-0.5">
+      <span className="text-foreground font-medium">{value}</span> {label}
+    </span>
+  );
+}

--- a/frontend/src/screens/admin/AttendanceReportScreen.tsx
+++ b/frontend/src/screens/admin/AttendanceReportScreen.tsx
@@ -49,7 +49,7 @@ function AttendanceRow({ row }: { row: EventAttendanceRow }) {
       <div className="flex shrink-0 flex-wrap justify-end gap-1 text-xs">
         <Stat label="attended" value={row.attendedCount} />
         <Stat label="no-show" value={row.noShowCount} />
-        <Stat label="going" value={row.goingCount} />
+        <Stat label="going (heads)" value={row.goingCount} />
       </div>
     </Link>
   );

--- a/frontend/src/screens/admin/AttendanceReportScreen.tsx
+++ b/frontend/src/screens/admin/AttendanceReportScreen.tsx
@@ -1,7 +1,3 @@
-// Admin: /admin/attendance — cross-event attendance report built on the
-// existing per-event check-in. Shows, per event, how many people attended /
-// no-showed out of the going rsvps. Gated by manage_events (route + backend).
-
 import { format } from 'date-fns';
 import { Link } from 'react-router-dom';
 

--- a/frontend/src/screens/admin/MembersScreen.test.tsx
+++ b/frontend/src/screens/admin/MembersScreen.test.tsx
@@ -77,6 +77,7 @@ function makeMember(overrides: Partial<Member> = {}): Member {
     isPaused: false,
     needsOnboarding: false,
     loginLinkRequested: false,
+    lastAttendedAt: null,
     roles: [],
     ...overrides,
   };
@@ -237,5 +238,59 @@ describe('MembersScreen', () => {
     renderScreen();
 
     expect(screen.queryByRole('radiogroup', { name: /members or roles/i })).not.toBeInTheDocument();
+  });
+
+  it('shows last-attended date for a member who has attended', () => {
+    mockUsersResult({
+      data: [
+        makeMember({
+          id: 'm1',
+          displayName: 'Ada Lovelace',
+          lastAttendedAt: new Date('2026-03-15T18:00:00Z'),
+        }),
+      ],
+    });
+
+    renderScreen();
+
+    expect(screen.getByText(/last attended mar 15, 2026/i)).toBeInTheDocument();
+  });
+
+  it('shows "never attended" for a member with no attendance', () => {
+    mockUsersResult({
+      data: [makeMember({ id: 'm1', displayName: 'Ada Lovelace', lastAttendedAt: null })],
+    });
+
+    renderScreen();
+
+    expect(screen.getByText(/never attended/i)).toBeInTheDocument();
+  });
+
+  it('sorts members by last attended (most recent first, never-attended last)', async () => {
+    mockUsersResult({
+      data: [
+        makeMember({
+          id: 'm1',
+          displayName: 'Older Attendee',
+          lastAttendedAt: new Date('2026-01-01T00:00:00Z'),
+        }),
+        makeMember({ id: 'm2', displayName: 'Never Attendee', lastAttendedAt: null }),
+        makeMember({
+          id: 'm3',
+          displayName: 'Recent Attendee',
+          lastAttendedAt: new Date('2026-06-01T00:00:00Z'),
+        }),
+      ],
+    });
+
+    renderScreen();
+    const user = userEvent.setup();
+    await user.selectOptions(screen.getByLabelText(/^sort by$/i), 'lastAttended');
+
+    // Member rows are links; their order in the DOM reflects the sort.
+    const rowNames = screen
+      .getAllByRole('link')
+      .map((link) => link.querySelector('p')?.textContent ?? '');
+    expect(rowNames).toEqual(['Recent Attendee', 'Older Attendee', 'Never Attendee']);
   });
 });

--- a/frontend/src/screens/admin/MembersTab.tsx
+++ b/frontend/src/screens/admin/MembersTab.tsx
@@ -1,6 +1,7 @@
 // Members tab body — the actual list/filter/sort/create UI. The outer
 // MembersScreen shell just switches between this and the RolesTab.
 
+import { format } from 'date-fns';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 
@@ -15,11 +16,12 @@ import { formatPhone } from '@/utils/formatPhone';
 import { BulkCreateDialog } from './BulkCreateDialog';
 import { MemberCreateDialog } from './MemberCreateDialog';
 
-type SortKey = 'name' | 'newest';
+type SortKey = 'name' | 'newest' | 'lastAttended';
 
 const SORT_OPTIONS: { value: SortKey; label: string }[] = [
   { value: 'name', label: 'name (a–z)' },
   { value: 'newest', label: 'newest first' },
+  { value: 'lastAttended', label: 'last attended' },
 ];
 
 export function MembersTab() {
@@ -307,17 +309,27 @@ function filterAndSort(
   if (selectedRoles.size > 0) {
     result = result.filter((m) => m.roles.some((r) => selectedRoles.has(r.name)));
   }
-  const sorted = [...result];
+  return sortMembers(result, sort);
+}
+
+function sortMembers(members: Member[], sort: SortKey): Member[] {
+  const sorted = [...members];
   if (sort === 'name') {
     sorted.sort((a, b) =>
       (a.displayName || a.phoneNumber)
         .toLowerCase()
         .localeCompare((b.displayName || b.phoneNumber).toLowerCase()),
     );
-  } else {
-    sorted.reverse();
+    return sorted;
   }
-  return sorted;
+  if (sort === 'lastAttended') {
+    // Most recent attendance first; members who never attended sink to the bottom.
+    sorted.sort((a, b) => (b.lastAttendedAt?.getTime() ?? 0) - (a.lastAttendedAt?.getTime() ?? 0));
+    return sorted;
+  }
+  // 'newest' — the list arrives oldest-first (phone_number order ≈ creation),
+  // so reverse approximates newest-first, matching the prior behavior.
+  return sorted.reverse();
 }
 
 function MemberRow({ member }: { member: Member }) {
@@ -353,6 +365,11 @@ function MemberRow({ member }: { member: Member }) {
         ) : (
           <p className="text-foreground-tertiary/60 truncate text-xs italic">no email</p>
         )}
+        <p className="text-foreground-tertiary/80 truncate text-xs">
+          {member.lastAttendedAt
+            ? `last attended ${format(member.lastAttendedAt, 'MMM d, yyyy').toLowerCase()}`
+            : 'never attended'}
+        </p>
       </div>
       <div className="flex shrink-0 flex-wrap justify-end gap-1">
         {member.roles.map((role) => (


### PR DESCRIPTION
## Summary

Adds an admin-only attendance reporting layer on top of the existing per-event check-in (`EventRSVP.attendance`) — no new model or migration needed, since attendance is already captured by the host check-in flow.

- **Backend report endpoint** — `GET /events/attendance-report/` aggregates attended / no-show / going counts per event, gated by `manage_events`. Only events with at least one attended or no-show mark are returned (newest first). Mounted before `events_router` so the literal path resolves ahead of `/events/{event_id}/`.
- **"Last attended" on the member list** — `list_users` gains a `last_attended` annotation (max `start_datetime` of events the member was checked in as attended, excluding deleted events) so admins can sort members by when they last came.
- **Frontend** — new `/admin/attendance` screen + TanStack hook, an AdminHub tile, the route guard (`manage_events`), and a "last attended" sort + per-row label on the members tab.

Builds the foundation for the in-person attendance epic (#518); issues #508 and #512 depend on this data layer.

Closes #507

## Test plan

- [ ] Backend: `make agent-ci` (1012 tests pass, including new `test_attendance_report.py` covering permission gating, deleted-event exclusion, and the member `last_attended` annotation).
- [ ] Open `/admin/attendance` as a `manage_events` admin — confirm per-event attended/no-show/going counts; confirm a non-admin gets 403.
- [ ] On the members tab, sort by "last attended" and confirm members who never attended sink to the bottom and the per-row date label renders.