### PR TITLE
feat(events): add curated event tags — frontend (Issue 511)

### DIFF
--- a/frontend/src/api/eventMapper.ts
+++ b/frontend/src/api/eventMapper.ts
@@ -1,6 +1,3 @@
-// Wire (snake_case, ISO strings) → Event (camelCase, Date objects) mapper.
-// Kept separate from events.ts so the caller module stays ≤150 lines.
-
 import type {
   AttendanceStatusValue,
   Event,

--- a/frontend/src/api/eventMapper.ts
+++ b/frontend/src/api/eventMapper.ts
@@ -1,7 +1,13 @@
 // Wire (snake_case, ISO strings) → Event (camelCase, Date objects) mapper.
 // Kept separate from events.ts so the caller module stays ≤150 lines.
 
-import type { AttendanceStatusValue, Event, EventGuest, PendingCohostInvite } from '@/models/event';
+import type {
+  AttendanceStatusValue,
+  Event,
+  EventGuest,
+  EventTag,
+  PendingCohostInvite,
+} from '@/models/event';
 import { AttendanceStatus } from '@/models/event';
 
 interface WireGuest {
@@ -67,8 +73,16 @@ export interface WireEvent {
   visibility?: string;
   photo_url?: string;
 
+  tags?: WireTag[];
+
   is_past?: boolean;
   status?: string;
+}
+
+interface WireTag {
+  id: string;
+  name: string;
+  slug: string;
 }
 
 interface WirePendingCohostInvite {
@@ -95,6 +109,10 @@ function mapGuest(g: WireGuest): EventGuest {
     hasPlusOne: g.has_plus_one ?? false,
     attendance: mapAttendance(g.attendance),
   };
+}
+
+function mapTag(t: WireTag): EventTag {
+  return { id: t.id, name: t.name, slug: t.slug };
 }
 
 function mapPendingCohostInvite(w: WirePendingCohostInvite): PendingCohostInvite {
@@ -160,6 +178,8 @@ export function mapEvent(e: WireEvent): Event {
     eventType: e.event_type ?? 'community',
     visibility: e.visibility ?? 'public',
     photoUrl: e.photo_url ?? '',
+
+    tags: (e.tags ?? []).map(mapTag),
 
     isPast: e.is_past ?? false,
     status: e.status ?? 'active',

--- a/frontend/src/api/eventTags.ts
+++ b/frontend/src/api/eventTags.ts
@@ -1,0 +1,28 @@
+// Event tags API — the curated, admin-managed tag set. Public endpoint, so it
+// works for both authed and unauthed callers (calendar filtering + display).
+
+import { useQuery } from '@tanstack/react-query';
+import { apiClient } from './client';
+import type { EventTag } from '@/models/event';
+
+interface WireTag {
+  id: string;
+  name: string;
+  slug: string;
+}
+
+export const eventTagKeys = {
+  all: ['event-tags'] as const,
+};
+
+export async function fetchEventTags(): Promise<EventTag[]> {
+  const { data } = await apiClient.get<WireTag[]>('/api/community/event-tags/');
+  return data.map((t) => ({ id: t.id, name: t.name, slug: t.slug }));
+}
+
+export function useEventTags() {
+  return useQuery({
+    queryKey: eventTagKeys.all,
+    queryFn: fetchEventTags,
+  });
+}

--- a/frontend/src/api/eventTags.ts
+++ b/frontend/src/api/eventTags.ts
@@ -1,9 +1,8 @@
-// Event tags API — the curated, admin-managed tag set. Public endpoint, so it
-// works for both authed and unauthed callers (calendar filtering + display).
-
 import { useQuery } from '@tanstack/react-query';
-import { apiClient } from './client';
+
 import type { EventTag } from '@/models/event';
+
+import { apiClient } from './client';
 
 interface WireTag {
   id: string;

--- a/frontend/src/api/eventWrites.test.ts
+++ b/frontend/src/api/eventWrites.test.ts
@@ -1,6 +1,6 @@
 // Pure-helper tests for the event write layer: enum-coercion on the inbound
 // side (eventToFormValues) and per-field PATCH body building (toPartialWireBody).
-import { describe, expect,it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import {
   type Event,

--- a/frontend/src/api/eventWrites.test.ts
+++ b/frontend/src/api/eventWrites.test.ts
@@ -1,14 +1,16 @@
 // Pure-helper tests for the event write layer: enum-coercion on the inbound
 // side (eventToFormValues) and per-field PATCH body building (toPartialWireBody).
-import { describe, it, expect } from 'vitest';
-import { eventToFormValues, toPartialWireBody } from './eventWrites';
+import { describe, expect,it } from 'vitest';
+
 import {
+  type Event,
   EventStatus,
   EventType,
   EventVisibility,
   InvitePermission,
-  type Event,
 } from '@/models/event';
+
+import { eventToFormValues, toPartialWireBody } from './eventWrites';
 
 function makeEvent(overrides: Partial<Event> = {}): Event {
   return {

--- a/frontend/src/api/eventWrites.test.ts
+++ b/frontend/src/api/eventWrites.test.ts
@@ -1,16 +1,14 @@
 // Pure-helper tests for the event write layer: enum-coercion on the inbound
 // side (eventToFormValues) and per-field PATCH body building (toPartialWireBody).
-import { describe, expect, it } from 'vitest';
-
+import { describe, it, expect } from 'vitest';
+import { eventToFormValues, toPartialWireBody } from './eventWrites';
 import {
-  type Event,
   EventStatus,
   EventType,
   EventVisibility,
   InvitePermission,
+  type Event,
 } from '@/models/event';
-
-import { eventToFormValues, toPartialWireBody } from './eventWrites';
 
 function makeEvent(overrides: Partial<Event> = {}): Event {
   return {
@@ -57,6 +55,7 @@ function makeEvent(overrides: Partial<Event> = {}): Event {
     eventType: EventType.Community,
     visibility: EventVisibility.Public,
     photoUrl: '',
+    tags: [],
     isPast: false,
     status: EventStatus.Active,
     ...overrides,
@@ -99,6 +98,18 @@ describe('eventToFormValues enum validation', () => {
     // community + public → 'public'
     expect(form.visibilityChoice).toBe('public');
   });
+
+  it('maps tags to tagIds', () => {
+    const form = eventToFormValues(
+      makeEvent({
+        tags: [
+          { id: 't1', name: 'walk', slug: 'walk' },
+          { id: 't2', name: 'restaurant meetup', slug: 'restaurant-meetup' },
+        ],
+      }),
+    );
+    expect(form.tagIds).toEqual(['t1', 't2']);
+  });
 });
 
 describe('toPartialWireBody', () => {
@@ -134,5 +145,10 @@ describe('toPartialWireBody', () => {
     // venmoLink is run through toVenmoUrl — the bare handle becomes a full url.
     expect(typeof body.venmo_link).toBe('string');
     expect(body.venmo_link).toContain('leah');
+  });
+
+  it('maps tagIds to tag_ids, including an empty list (clears tags)', () => {
+    expect(toPartialWireBody({ tagIds: ['t1', 't2'] })).toEqual({ tag_ids: ['t1', 't2'] });
+    expect(toPartialWireBody({ tagIds: [] })).toEqual({ tag_ids: [] });
   });
 });

--- a/frontend/src/api/eventWrites.ts
+++ b/frontend/src/api/eventWrites.ts
@@ -5,20 +5,22 @@
 // dedicated error so the UI can show a sane message.
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { apiClient } from './client';
-import { extractApiErrorOr, getApiStatus } from './apiErrors';
+
 import { useAuthStore } from '@/auth/store';
-import { eventKeys } from './events';
-import { mapEvent, type WireEvent } from './eventMapper';
 import {
+  type Event,
   EventStatus as EventStatusEnum,
   EventType as EventTypeEnum,
   EventVisibility,
   InvitePermission,
-  type Event,
 } from '@/models/event';
 import { reportError } from '@/utils/errorReporter';
 import { fromCashAppUrl, fromVenmoUrl, toCashAppUrl, toVenmoUrl } from '@/utils/paymentHandle';
+
+import { extractApiErrorOr, getApiStatus } from './apiErrors';
+import { apiClient } from './client';
+import { mapEvent, type WireEvent } from './eventMapper';
+import { eventKeys } from './events';
 
 const ROUTE = '/events';
 

--- a/frontend/src/api/eventWrites.ts
+++ b/frontend/src/api/eventWrites.ts
@@ -5,22 +5,20 @@
 // dedicated error so the UI can show a sane message.
 
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-
+import { apiClient } from './client';
+import { extractApiErrorOr, getApiStatus } from './apiErrors';
 import { useAuthStore } from '@/auth/store';
+import { eventKeys } from './events';
+import { mapEvent, type WireEvent } from './eventMapper';
 import {
-  type Event,
   EventStatus as EventStatusEnum,
   EventType as EventTypeEnum,
   EventVisibility,
   InvitePermission,
+  type Event,
 } from '@/models/event';
 import { reportError } from '@/utils/errorReporter';
 import { fromCashAppUrl, fromVenmoUrl, toCashAppUrl, toVenmoUrl } from '@/utils/paymentHandle';
-
-import { extractApiErrorOr, getApiStatus } from './apiErrors';
-import { apiClient } from './client';
-import { mapEvent, type WireEvent } from './eventMapper';
-import { eventKeys } from './events';
 
 const ROUTE = '/events';
 
@@ -68,6 +66,7 @@ export interface EventFormValues {
   cashappLink: string;
   zelleInfo: string;
   coHostIds: string[];
+  tagIds: string[];
   status: EventStatus;
 }
 
@@ -107,6 +106,7 @@ const FIELD_TO_WIRE: WireFieldMap = {
   cashappLink: ['cashapp_link', (v) => toCashAppUrl(v)],
   zelleInfo: ['zelle_info', (v) => v],
   coHostIds: ['co_host_ids', (v) => v],
+  tagIds: ['tag_ids', (v) => v],
   status: ['status', (v) => v],
 };
 
@@ -343,6 +343,7 @@ export function emptyEventFormValues(): EventFormValues {
     cashappLink: '',
     zelleInfo: '',
     coHostIds: [],
+    tagIds: [],
     status: 'active',
   };
 }
@@ -402,6 +403,7 @@ export function eventToFormValues(e: Event): EventFormValues {
     cashappLink: fromCashAppUrl(e.cashappLink),
     zelleInfo: e.zelleInfo,
     coHostIds: e.coHostIds,
+    tagIds: e.tags.map((t) => t.id),
     status: coerceEnum(e.status, FORM_STATUSES, EventStatusEnum.Active),
   };
 }

--- a/frontend/src/models/event.test.ts
+++ b/frontend/src/models/event.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'vitest';
-import { eventClass, EventStatus, EventType, EventVisibility, type Event } from './event';
+import { describe, expect,it } from 'vitest';
+
+import { type Event,eventClass, EventStatus, EventType, EventVisibility } from './event';
 
 function makeEvent(overrides: Partial<Event> = {}): Event {
   return {

--- a/frontend/src/models/event.test.ts
+++ b/frontend/src/models/event.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect,it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-import { type Event,eventClass, EventStatus, EventType, EventVisibility } from './event';
+import { type Event, eventClass, EventStatus, EventType, EventVisibility } from './event';
 
 function makeEvent(overrides: Partial<Event> = {}): Event {
   return {

--- a/frontend/src/models/event.test.ts
+++ b/frontend/src/models/event.test.ts
@@ -1,6 +1,5 @@
-import { describe, expect, it } from 'vitest';
-
-import { type Event, eventClass, EventStatus, EventType, EventVisibility } from './event';
+import { describe, it, expect } from 'vitest';
+import { eventClass, EventStatus, EventType, EventVisibility, type Event } from './event';
 
 function makeEvent(overrides: Partial<Event> = {}): Event {
   return {
@@ -47,6 +46,7 @@ function makeEvent(overrides: Partial<Event> = {}): Event {
     eventType: EventType.Community,
     visibility: EventVisibility.Public,
     photoUrl: '',
+    tags: [],
     isPast: false,
     status: EventStatus.Active,
     ...overrides,

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -47,6 +47,13 @@ export const AttendanceStatus = {
 } as const;
 export type AttendanceStatusValue = (typeof AttendanceStatus)[keyof typeof AttendanceStatus];
 
+// A curated, admin-managed event tag (e.g. "walk", "restaurant meetup").
+export interface EventTag {
+  id: string;
+  name: string;
+  slug: string;
+}
+
 export interface EventGuest {
   userId: string;
   name: string;
@@ -138,6 +145,9 @@ export interface Event {
   eventType: string;
   visibility: string;
   photoUrl: string;
+
+  // Curated tags assigned to the event. Present on both list and detail.
+  tags: EventTag[];
 
   isPast: boolean;
   status: string;

--- a/frontend/src/screens/calendar/AgendaList.test.tsx
+++ b/frontend/src/screens/calendar/AgendaList.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
+
 import { AgendaList } from './AgendaList';
 
 function makeEvent(overrides: Partial<Event> = {}): Event {

--- a/frontend/src/screens/calendar/AgendaList.test.tsx
+++ b/frontend/src/screens/calendar/AgendaList.test.tsx
@@ -1,10 +1,8 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
-
+import { describe, it, expect, vi } from 'vitest';
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
-
 import { AgendaList } from './AgendaList';
 
 function makeEvent(overrides: Partial<Event> = {}): Event {
@@ -54,6 +52,7 @@ function makeEvent(overrides: Partial<Event> = {}): Event {
     eventType: EventType.Community,
     visibility: EventVisibility.Public,
     photoUrl: '',
+    tags: [],
     isPast: false,
     status: EventStatus.Active,
     ...overrides,

--- a/frontend/src/screens/calendar/CalendarScreen.tsx
+++ b/frontend/src/screens/calendar/CalendarScreen.tsx
@@ -1,22 +1,25 @@
+import 'react-big-calendar/lib/css/react-big-calendar.css';
+
 import { addDays, format as dfFormat, startOfWeek } from 'date-fns';
 import { useMemo, useState } from 'react';
 import { Calendar, type View } from 'react-big-calendar';
-import 'react-big-calendar/lib/css/react-big-calendar.css';
 import { useNavigate } from 'react-router-dom';
+
 import { useEvents } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
 import { useIsWideScreen } from '@/hooks/useResponsive';
-import { eventClass, type Event as PdaEvent } from '@/models/event';
+import { type Event as PdaEvent,eventClass } from '@/models/event';
+
+import { AgendaList } from './AgendaList';
+import { makeLocalizer } from './calendarLocalizer';
 import { CalendarTagFilter } from './CalendarTagFilter';
 import { CalendarToolbar } from './CalendarToolbar';
-import { makeLocalizer } from './calendarLocalizer';
-import { AgendaList } from './AgendaList';
 import { DayEventList } from './DayEventList';
 import { NarrowWeekView } from './NarrowWeekView';
-import { WideWeekView } from './WideWeekView';
 import { TodayIconButton } from './TodayIconButton';
 import type { BigCalEvent } from './types';
 import { ViewSwitcher } from './ViewSwitcher';
+import { WideWeekView } from './WideWeekView';
 
 function toBigCalEvent(e: PdaEvent): BigCalEvent | null {
   // TBD events have no date — skip them on the calendar.

--- a/frontend/src/screens/calendar/CalendarScreen.tsx
+++ b/frontend/src/screens/calendar/CalendarScreen.tsx
@@ -8,7 +8,7 @@ import { useNavigate } from 'react-router-dom';
 import { useEvents } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
 import { useIsWideScreen } from '@/hooks/useResponsive';
-import { type Event as PdaEvent,eventClass } from '@/models/event';
+import { type Event as PdaEvent, eventClass } from '@/models/event';
 
 import { AgendaList } from './AgendaList';
 import { makeLocalizer } from './calendarLocalizer';

--- a/frontend/src/screens/calendar/CalendarScreen.tsx
+++ b/frontend/src/screens/calendar/CalendarScreen.tsx
@@ -1,24 +1,22 @@
-import 'react-big-calendar/lib/css/react-big-calendar.css';
-
 import { addDays, format as dfFormat, startOfWeek } from 'date-fns';
 import { useMemo, useState } from 'react';
 import { Calendar, type View } from 'react-big-calendar';
+import 'react-big-calendar/lib/css/react-big-calendar.css';
 import { useNavigate } from 'react-router-dom';
-
 import { useEvents } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
 import { useIsWideScreen } from '@/hooks/useResponsive';
-import { type Event as PdaEvent, eventClass } from '@/models/event';
-
-import { AgendaList } from './AgendaList';
-import { makeLocalizer } from './calendarLocalizer';
+import { eventClass, type Event as PdaEvent } from '@/models/event';
+import { CalendarTagFilter } from './CalendarTagFilter';
 import { CalendarToolbar } from './CalendarToolbar';
+import { makeLocalizer } from './calendarLocalizer';
+import { AgendaList } from './AgendaList';
 import { DayEventList } from './DayEventList';
 import { NarrowWeekView } from './NarrowWeekView';
+import { WideWeekView } from './WideWeekView';
 import { TodayIconButton } from './TodayIconButton';
 import type { BigCalEvent } from './types';
 import { ViewSwitcher } from './ViewSwitcher';
-import { WideWeekView } from './WideWeekView';
 
 function toBigCalEvent(e: PdaEvent): BigCalEvent | null {
   // TBD events have no date — skip them on the calendar.
@@ -68,15 +66,24 @@ export default function CalendarScreen() {
   const isWide = useIsWideScreen(720);
 
   const { data: events = [], isPending, isError, refetch } = useEvents();
+  const [tagFilter, setTagFilter] = useState<string[]>([]);
+  // OR semantics: an event matches when it carries any selected tag.
+  const filteredEvents = useMemo(
+    () =>
+      tagFilter.length === 0
+        ? events
+        : events.filter((e) => e.tags.some((t) => tagFilter.includes(t.id))),
+    [events, tagFilter],
+  );
   const bigCalEvents = useMemo<BigCalEvent[]>(
     () =>
-      events
+      filteredEvents
         .filter((e) => !e.datetimeTbd)
         .map(toBigCalEvent)
         .filter((e): e is BigCalEvent => e !== null),
-    [events],
+    [filteredEvents],
   );
-  const datedEvents = useMemo(() => events.filter((e) => !e.datetimeTbd), [events]);
+  const datedEvents = useMemo(() => filteredEvents.filter((e) => !e.datetimeTbd), [filteredEvents]);
 
   const [view, setView] = useState<View>('month');
   const [date, setDate] = useState<Date>(new Date());
@@ -99,6 +106,8 @@ export default function CalendarScreen() {
       <header className="mb-4 flex justify-center">
         <ViewSwitcher value={view} onChange={setView} />
       </header>
+
+      <CalendarTagFilter selected={tagFilter} onChange={setTagFilter} />
 
       {isError ? (
         <div className="border-destructive bg-destructive-subtle text-destructive mb-4 rounded-md border px-3 py-2 text-sm">

--- a/frontend/src/screens/calendar/CalendarTagFilter.tsx
+++ b/frontend/src/screens/calendar/CalendarTagFilter.tsx
@@ -1,0 +1,60 @@
+// Tag filter for the calendar — a row of toggle chips. An event matches when it
+// carries any selected tag (OR semantics). Renders nothing while tags are
+// loading or when the curated set is empty, so the calendar isn't cluttered.
+
+import { useEventTags } from '@/api/eventTags';
+
+interface Props {
+  selected: string[];
+  onChange: (next: string[]) => void;
+}
+
+export function CalendarTagFilter({ selected, onChange }: Props) {
+  const { data: tags } = useEventTags();
+
+  if (!tags || tags.length === 0) return null;
+
+  function toggle(id: string) {
+    onChange(selected.includes(id) ? selected.filter((t) => t !== id) : [...selected, id]);
+  }
+
+  return (
+    <div
+      className="mb-3 flex flex-wrap items-center justify-center gap-2"
+      role="group"
+      aria-label="filter by tag"
+    >
+      {tags.map((t) => {
+        const active = selected.includes(t.id);
+        return (
+          <button
+            key={t.id}
+            type="button"
+            aria-pressed={active}
+            onClick={() => {
+              toggle(t.id);
+            }}
+            className={
+              active
+                ? 'bg-brand-600 text-brand-on inline-flex items-center rounded-full px-3 py-1 text-xs'
+                : 'bg-surface-dim text-foreground-secondary hover:bg-surface-dim/70 inline-flex items-center rounded-full px-3 py-1 text-xs'
+            }
+          >
+            {t.name}
+          </button>
+        );
+      })}
+      {selected.length > 0 ? (
+        <button
+          type="button"
+          onClick={() => {
+            onChange([]);
+          }}
+          className="text-foreground-tertiary hover:text-brand-700 inline-flex items-center px-2 py-1 text-xs underline"
+        >
+          clear
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/screens/calendar/CalendarTagFilter.tsx
+++ b/frontend/src/screens/calendar/CalendarTagFilter.tsx
@@ -1,7 +1,3 @@
-// Tag filter for the calendar — a row of toggle chips. An event matches when it
-// carries any selected tag (OR semantics). Renders nothing while tags are
-// loading or when the curated set is empty, so the calendar isn't cluttered.
-
 import { useEventTags } from '@/api/eventTags';
 
 interface Props {

--- a/frontend/src/screens/calendar/CalendarViews.a11y.test.tsx
+++ b/frontend/src/screens/calendar/CalendarViews.a11y.test.tsx
@@ -1,10 +1,8 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it, vi } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { axe } from 'vitest-axe';
-
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
-
 import { AgendaList } from './AgendaList';
 import { DayEventList } from './DayEventList';
 
@@ -55,6 +53,7 @@ function makeEvent(overrides: Partial<Event> = {}): Event {
     eventType: EventType.Community,
     visibility: EventVisibility.Public,
     photoUrl: '',
+    tags: [],
     isPast: false,
     status: EventStatus.Active,
     ...overrides,

--- a/frontend/src/screens/calendar/CalendarViews.a11y.test.tsx
+++ b/frontend/src/screens/calendar/CalendarViews.a11y.test.tsx
@@ -1,8 +1,10 @@
 import { render, screen } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
+
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
+
 import { AgendaList } from './AgendaList';
 import { DayEventList } from './DayEventList';
 

--- a/frontend/src/screens/events/CohostInviteBanner.test.tsx
+++ b/frontend/src/screens/events/CohostInviteBanner.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent,render, screen } from '@testing-library/react';
+import { beforeEach,describe, expect, it, vi } from 'vitest';
+
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
 

--- a/frontend/src/screens/events/CohostInviteBanner.test.tsx
+++ b/frontend/src/screens/events/CohostInviteBanner.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent,render, screen } from '@testing-library/react';
-import { beforeEach,describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';

--- a/frontend/src/screens/events/CohostInviteBanner.test.tsx
+++ b/frontend/src/screens/events/CohostInviteBanner.test.tsx
@@ -1,7 +1,6 @@
+import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
 
@@ -60,6 +59,7 @@ const BASE_EVENT: Event = {
   eventType: EventType.Community,
   visibility: EventVisibility.Public,
   photoUrl: '',
+  tags: [],
   isPast: false,
   status: EventStatus.Active,
 };

--- a/frontend/src/screens/events/EventAdminActions.test.tsx
+++ b/frontend/src/screens/events/EventAdminActions.test.tsx
@@ -2,7 +2,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { beforeEach,describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';

--- a/frontend/src/screens/events/EventAdminActions.test.tsx
+++ b/frontend/src/screens/events/EventAdminActions.test.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach,describe, expect, it, vi } from 'vitest';
+
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';

--- a/frontend/src/screens/events/EventAdminActions.test.tsx
+++ b/frontend/src/screens/events/EventAdminActions.test.tsx
@@ -1,9 +1,8 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
 import React from 'react';
+import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
@@ -90,6 +89,7 @@ const BASE_EVENT: Event = {
   eventType: EventType.Community,
   visibility: EventVisibility.Public,
   photoUrl: '',
+  tags: [],
   isPast: false,
   status: EventStatus.Active,
 };

--- a/frontend/src/screens/events/EventAttendancePanel.test.tsx
+++ b/frontend/src/screens/events/EventAttendancePanel.test.tsx
@@ -1,8 +1,7 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-
+import { render, screen, fireEvent } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { Event, EventStats } from '@/models/event';
 import {
   AttendanceStatus,
@@ -21,7 +20,6 @@ vi.mock('@/api/eventStats', () => ({
 }));
 
 import { useEventStats } from '@/api/eventStats';
-
 import { EventAttendancePanel } from './EventAttendancePanel';
 
 const BASE_EVENT: Event = {
@@ -82,6 +80,7 @@ const BASE_EVENT: Event = {
   eventType: EventType.Community,
   visibility: EventVisibility.Public,
   photoUrl: '',
+  tags: [],
   isPast: false,
   status: EventStatus.Active,
 };

--- a/frontend/src/screens/events/EventAttendancePanel.test.tsx
+++ b/frontend/src/screens/events/EventAttendancePanel.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent,render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
-import { afterEach,beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Event, EventStats } from '@/models/event';
 import {

--- a/frontend/src/screens/events/EventAttendancePanel.test.tsx
+++ b/frontend/src/screens/events/EventAttendancePanel.test.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { fireEvent,render, screen } from '@testing-library/react';
+import React from 'react';
+import { afterEach,beforeEach, describe, expect, it, vi } from 'vitest';
+
 import type { Event, EventStats } from '@/models/event';
 import {
   AttendanceStatus,
@@ -20,6 +21,7 @@ vi.mock('@/api/eventStats', () => ({
 }));
 
 import { useEventStats } from '@/api/eventStats';
+
 import { EventAttendancePanel } from './EventAttendancePanel';
 
 const BASE_EVENT: Event = {

--- a/frontend/src/screens/events/EventDetailScreen.test.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.test.tsx
@@ -1,9 +1,8 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
@@ -32,7 +31,6 @@ vi.mock('@/utils/datetime', () => ({
 }));
 
 import { useEvent } from '@/api/events';
-
 import EventDetailScreen from './EventDetailScreen';
 
 const mockUseEvent = vi.mocked(useEvent);
@@ -81,6 +79,7 @@ const BASE_EVENT: Event = {
   eventType: EventType.Community,
   visibility: EventVisibility.Public,
   photoUrl: '',
+  tags: [],
   isPast: false,
   status: EventStatus.Active,
 };

--- a/frontend/src/screens/events/EventDetailScreen.test.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.test.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+import { MemoryRouter, Route,Routes } from 'react-router-dom';
+import { beforeEach,describe, expect, it, vi } from 'vitest';
+
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
@@ -31,6 +32,7 @@ vi.mock('@/utils/datetime', () => ({
 }));
 
 import { useEvent } from '@/api/events';
+
 import EventDetailScreen from './EventDetailScreen';
 
 const mockUseEvent = vi.mocked(useEvent);

--- a/frontend/src/screens/events/EventDetailScreen.test.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.test.tsx
@@ -1,8 +1,8 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { MemoryRouter, Route,Routes } from 'react-router-dom';
-import { beforeEach,describe, expect, it, vi } from 'vitest';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';

--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -1,17 +1,16 @@
 import { Link, useParams } from 'react-router-dom';
-
 import { extractApiError, getApiStatus } from '@/api/apiErrors';
 import { useEvent } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility } from '@/models/event';
-import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 import { formatEventDateTime } from '@/utils/datetime';
 import { linkifyText } from '@/utils/linkifyText';
-
+import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 import { CohostInviteBanner } from './CohostInviteBanner';
 import { EventActions } from './EventActions';
 import { EventMemberSection } from './EventMemberSection';
+import { EventTagChips } from './EventTagChips';
 import { EventPollCard } from './poll/EventPollCard';
 
 export default function EventDetailScreen() {
@@ -45,6 +44,7 @@ export default function EventDetailScreen() {
       </div>
 
       <WhenLine event={event} />
+      <EventTagChips tags={event.tags} className="mt-2" />
       <EventActions event={event} />
       {isAuthed ? <CohostInviteBanner event={event} /> : null}
       <EventPollCard event={event} />

--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -1,12 +1,14 @@
 import { Link, useParams } from 'react-router-dom';
+
 import { extractApiError, getApiStatus } from '@/api/apiErrors';
 import { useEvent } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility } from '@/models/event';
+import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 import { formatEventDateTime } from '@/utils/datetime';
 import { linkifyText } from '@/utils/linkifyText';
-import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
+
 import { CohostInviteBanner } from './CohostInviteBanner';
 import { EventActions } from './EventActions';
 import { EventMemberSection } from './EventMemberSection';

--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach,describe, expect, it, vi } from 'vitest';
+
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';

--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -1,8 +1,7 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
@@ -71,6 +70,7 @@ const BASE_EVENT: Event = {
   eventType: EventType.Community,
   visibility: EventVisibility.Public,
   photoUrl: '',
+  tags: [],
   isPast: false,
   status: EventStatus.Active,
 };

--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { beforeEach,describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';

--- a/frontend/src/screens/events/EventTagChips.test.tsx
+++ b/frontend/src/screens/events/EventTagChips.test.tsx
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { EventTag } from '@/models/event';
+import { EventTagChips } from './EventTagChips';
+
+const TAGS: EventTag[] = [
+  { id: 't1', name: 'walk', slug: 'walk' },
+  { id: 't2', name: 'restaurant meetup', slug: 'restaurant-meetup' },
+];
+
+describe('EventTagChips', () => {
+  it('renders a chip per tag', () => {
+    render(<EventTagChips tags={TAGS} />);
+    expect(screen.getByText('walk')).toBeInTheDocument();
+    expect(screen.getByText('restaurant meetup')).toBeInTheDocument();
+  });
+
+  it('renders nothing when there are no tags', () => {
+    const { container } = render(<EventTagChips tags={[]} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/frontend/src/screens/events/EventTagChips.test.tsx
+++ b/frontend/src/screens/events/EventTagChips.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect,it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import type { EventTag } from '@/models/event';
 

--- a/frontend/src/screens/events/EventTagChips.test.tsx
+++ b/frontend/src/screens/events/EventTagChips.test.tsx
@@ -1,6 +1,8 @@
-import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { describe, expect,it } from 'vitest';
+
 import type { EventTag } from '@/models/event';
+
 import { EventTagChips } from './EventTagChips';
 
 const TAGS: EventTag[] = [

--- a/frontend/src/screens/events/EventTagChips.tsx
+++ b/frontend/src/screens/events/EventTagChips.tsx
@@ -1,7 +1,3 @@
-// Read-only display of an event's tags as a row of neutral chips.
-// Neutral styling (no color-coding) keeps it color-blind safe — the tag name
-// itself carries the meaning. Renders nothing when there are no tags.
-
 import type { EventTag } from '@/models/event';
 
 interface Props {

--- a/frontend/src/screens/events/EventTagChips.tsx
+++ b/frontend/src/screens/events/EventTagChips.tsx
@@ -1,0 +1,26 @@
+// Read-only display of an event's tags as a row of neutral chips.
+// Neutral styling (no color-coding) keeps it color-blind safe — the tag name
+// itself carries the meaning. Renders nothing when there are no tags.
+
+import type { EventTag } from '@/models/event';
+
+interface Props {
+  tags: EventTag[];
+  className?: string;
+}
+
+export function EventTagChips({ tags, className }: Props) {
+  if (tags.length === 0) return null;
+  return (
+    <ul className={`flex flex-wrap gap-2 ${className ?? ''}`} aria-label="tags">
+      {tags.map((t) => (
+        <li
+          key={t.id}
+          className="bg-surface-dim text-foreground-secondary inline-flex items-center rounded-full px-2 py-1 text-xs"
+        >
+          {t.name}
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/frontend/src/screens/events/RsvpSection.test.tsx
+++ b/frontend/src/screens/events/RsvpSection.test.tsx
@@ -1,18 +1,17 @@
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { useAuthStore } from '@/auth/store';
 import {
   AttendanceStatus,
-  type Event,
-  type EventGuest,
   EventStatus,
   EventType,
   EventVisibility,
   InvitePermission,
   RsvpServerStatus,
+  type Event,
+  type EventGuest,
 } from '@/models/event';
 import type { User } from '@/models/user';
 
@@ -107,6 +106,7 @@ function makeEvent(overrides: Partial<Event>): Event {
     eventType: EventType.Community,
     visibility: EventVisibility.Public,
     photoUrl: '',
+    tags: [],
     isPast: false,
     status: EventStatus.Active,
     ...overrides,

--- a/frontend/src/screens/events/RsvpSection.test.tsx
+++ b/frontend/src/screens/events/RsvpSection.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent,render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { beforeEach,describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAuthStore } from '@/auth/store';
 import {

--- a/frontend/src/screens/events/RsvpSection.test.tsx
+++ b/frontend/src/screens/events/RsvpSection.test.tsx
@@ -1,17 +1,18 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fireEvent,render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach,describe, expect, it, vi } from 'vitest';
+
 import { useAuthStore } from '@/auth/store';
 import {
   AttendanceStatus,
+  type Event,
+  type EventGuest,
   EventStatus,
   EventType,
   EventVisibility,
   InvitePermission,
   RsvpServerStatus,
-  type Event,
-  type EventGuest,
 } from '@/models/event';
 import type { User } from '@/models/user';
 

--- a/frontend/src/screens/events/form/EventForm.tsx
+++ b/frontend/src/screens/events/form/EventForm.tsx
@@ -11,24 +11,26 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
+
 import { apiClient } from '@/api/client';
-import type { MemberSearchResult } from '@/api/userSearch';
 import {
   emptyEventFormValues,
+  type EventFormValues,
   eventToFormValues,
   extractEventError,
   useCreateEvent,
+  useDeleteEventPhoto,
   useUpdateEvent,
   useUploadEventPhoto,
-  useDeleteEventPhoto,
-  type EventFormValues,
 } from '@/api/eventWrites';
+import type { MemberSearchResult } from '@/api/userSearch';
 import { useAuthStore } from '@/auth/store';
+import { MemberPicker } from '@/components/MemberPicker';
 import { Button } from '@/components/ui/Button';
 import { CollapsibleCard } from '@/components/ui/CollapsibleCard';
-import { MemberPicker } from '@/components/MemberPicker';
 import type { Event } from '@/models/event';
-import { Permission, hasPermission } from '@/models/permissions';
+import { hasPermission,Permission } from '@/models/permissions';
+
 import { EventFormBasics } from './EventFormBasics';
 import { EventFormDetails } from './EventFormDetails';
 import { EventFormLinks, EventFormMoney } from './EventFormLinksAndCost';

--- a/frontend/src/screens/events/form/EventForm.tsx
+++ b/frontend/src/screens/events/form/EventForm.tsx
@@ -11,31 +11,30 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
-
 import { apiClient } from '@/api/client';
+import type { MemberSearchResult } from '@/api/userSearch';
 import {
   emptyEventFormValues,
-  type EventFormValues,
   eventToFormValues,
   extractEventError,
   useCreateEvent,
-  useDeleteEventPhoto,
   useUpdateEvent,
   useUploadEventPhoto,
+  useDeleteEventPhoto,
+  type EventFormValues,
 } from '@/api/eventWrites';
-import type { MemberSearchResult } from '@/api/userSearch';
 import { useAuthStore } from '@/auth/store';
-import { MemberPicker } from '@/components/MemberPicker';
 import { Button } from '@/components/ui/Button';
 import { CollapsibleCard } from '@/components/ui/CollapsibleCard';
+import { MemberPicker } from '@/components/MemberPicker';
 import type { Event } from '@/models/event';
-import { hasPermission, Permission } from '@/models/permissions';
-
+import { Permission, hasPermission } from '@/models/permissions';
 import { EventFormBasics } from './EventFormBasics';
 import { EventFormDetails } from './EventFormDetails';
 import { EventFormLinks, EventFormMoney } from './EventFormLinksAndCost';
 import { EventFormPhoto } from './EventFormPhoto';
 import { EventFormRsvp } from './EventFormRsvp';
+import { EventFormTags } from './EventFormTags';
 import { validateEventForm } from './validateEventForm';
 
 interface Props {
@@ -291,6 +290,17 @@ export function EventForm({ existing }: Props) {
           errors={errors}
           canTagOfficial={canTagOfficial}
         />
+      </CollapsibleCard>
+
+      <CollapsibleCard
+        title="tags"
+        summary={
+          values.tagIds.length > 0
+            ? `${String(values.tagIds.length)} tag${values.tagIds.length === 1 ? '' : 's'}`
+            : undefined
+        }
+      >
+        <EventFormTags values={values} onChange={patch} />
       </CollapsibleCard>
 
       <CollapsibleCard

--- a/frontend/src/screens/events/form/EventForm.tsx
+++ b/frontend/src/screens/events/form/EventForm.tsx
@@ -29,7 +29,7 @@ import { MemberPicker } from '@/components/MemberPicker';
 import { Button } from '@/components/ui/Button';
 import { CollapsibleCard } from '@/components/ui/CollapsibleCard';
 import type { Event } from '@/models/event';
-import { hasPermission,Permission } from '@/models/permissions';
+import { hasPermission, Permission } from '@/models/permissions';
 
 import { EventFormBasics } from './EventFormBasics';
 import { EventFormDetails } from './EventFormDetails';

--- a/frontend/src/screens/events/form/EventFormTags.tsx
+++ b/frontend/src/screens/events/form/EventFormTags.tsx
@@ -1,0 +1,62 @@
+// "tags" section — toggle chips for the curated, admin-managed tag set.
+// Rendered inside a CollapsibleCard by the parent form; this component only
+// owns the body layout. Selecting a chip toggles its id in `values.tagIds`.
+
+import { useEventTags } from '@/api/eventTags';
+import type { EventFormValues } from '@/api/eventWrites';
+
+interface Props {
+  values: EventFormValues;
+  onChange: (patch: Partial<EventFormValues>) => void;
+}
+
+export function EventFormTags({ values, onChange }: Props) {
+  const { data: tags, isPending, isError } = useEventTags();
+
+  function toggle(id: string) {
+    const next = values.tagIds.includes(id)
+      ? values.tagIds.filter((t) => t !== id)
+      : [...values.tagIds, id];
+    onChange({ tagIds: next });
+  }
+
+  if (isPending) {
+    return <p className="text-foreground-tertiary text-sm">loading tags…</p>;
+  }
+  if (isError) {
+    return <p className="text-foreground-tertiary text-sm">couldn't load tags — try again</p>;
+  }
+  if (tags.length === 0) {
+    return <p className="text-foreground-tertiary text-sm">no tags yet 🌿</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-foreground-secondary text-xs">
+        pick tags so people can find this at a glance
+      </p>
+      <div className="flex flex-wrap gap-2" role="group" aria-label="tags">
+        {tags.map((t) => {
+          const selected = values.tagIds.includes(t.id);
+          return (
+            <button
+              key={t.id}
+              type="button"
+              aria-pressed={selected}
+              onClick={() => {
+                toggle(t.id);
+              }}
+              className={
+                selected
+                  ? 'bg-brand-600 text-brand-on inline-flex items-center rounded-full px-3 py-1 text-sm'
+                  : 'bg-surface-dim text-foreground-secondary hover:bg-surface-dim/70 inline-flex items-center rounded-full px-3 py-1 text-sm'
+              }
+            >
+              {t.name}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/screens/events/form/EventFormTags.tsx
+++ b/frontend/src/screens/events/form/EventFormTags.tsx
@@ -1,7 +1,3 @@
-// "tags" section — toggle chips for the curated, admin-managed tag set.
-// Rendered inside a CollapsibleCard by the parent form; this component only
-// owns the body layout. Selecting a chip toggles its id in `values.tagIds`.
-
 import { useEventTags } from '@/api/eventTags';
 import type { EventFormValues } from '@/api/eventWrites';
 

--- a/frontend/src/screens/events/form/validateEventForm.test.ts
+++ b/frontend/src/screens/events/form/validateEventForm.test.ts
@@ -1,7 +1,5 @@
-import { describe, expect, it } from 'vitest';
-
+import { describe, it, expect } from 'vitest';
 import type { EventFormValues } from '@/api/eventWrites';
-
 import { validateEventForm } from './validateEventForm';
 
 function validValues(overrides: Partial<EventFormValues> = {}): EventFormValues {
@@ -30,6 +28,7 @@ function validValues(overrides: Partial<EventFormValues> = {}): EventFormValues 
     cashappLink: '',
     zelleInfo: '',
     coHostIds: [],
+    tagIds: [],
     status: 'active',
     ...overrides,
   };

--- a/frontend/src/screens/events/form/validateEventForm.test.ts
+++ b/frontend/src/screens/events/form/validateEventForm.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect,it } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import type { EventFormValues } from '@/api/eventWrites';
 

--- a/frontend/src/screens/events/form/validateEventForm.test.ts
+++ b/frontend/src/screens/events/form/validateEventForm.test.ts
@@ -1,5 +1,7 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect,it } from 'vitest';
+
 import type { EventFormValues } from '@/api/eventWrites';
+
 import { validateEventForm } from './validateEventForm';
 
 function validValues(overrides: Partial<EventFormValues> = {}): EventFormValues {


### PR DESCRIPTION
## Summary

Part 2 of 2 for Issue 511. Stacked on #552 (backend).

- `EventTag` type wired through mapper + write hooks (`tags` ↔ `tagIds`)
- `useEventTags` hook (`GET /event-tags/`)
- Toggle-chip tag picker as a collapsible section in the event form
- Neutral (color-blind-safe) tag chips on the event detail screen
- OR-semantics tag filter on the calendar

**Merge order:** #552 (backend) must merge first, then retarget this PR to `main` and merge.

## Test plan

- [ ] Frontend typecheck + lint + tests pass
- [ ] Create/edit an event, assign tags, confirm they show on the detail page
- [ ] Confirm the calendar tag filter narrows events (OR across selected tags)