### PR TITLE
refactor(public-rsvp): 526 - active_members() member-visibility manager

### DIFF
--- a/backend/tests/users/test_user_members.py
+++ b/backend/tests/users/test_user_members.py
@@ -5,6 +5,7 @@ from importlib import import_module
 import pytest
 from django.db import IntegrityError, transaction
 from django.db.migrations import AddField, AlterField
+from django.utils import timezone
 from users.models import User
 
 
@@ -31,6 +32,50 @@ class TestMembersManager:
     def test_members_is_chainable(self, member, non_member):
         qs = User.objects.members().filter(phone_number=member.phone_number)
         assert list(qs.values_list("pk", flat=True)) == [member.pk]
+
+
+@pytest.mark.django_db
+class TestActiveMembersManager:
+    """active_members() bundles the full member-visibility predicate."""
+
+    def _active_member_ids(self):
+        return set(User.objects.active_members().values_list("pk", flat=True))
+
+    def test_includes_plain_member(self, member):
+        assert member.pk in self._active_member_ids()
+
+    def test_excludes_non_member(self, non_member):
+        assert non_member.pk not in self._active_member_ids()
+
+    def test_excludes_paused_member(self, member):
+        member.is_paused = True
+        member.save(update_fields=["is_paused"])
+        assert member.pk not in self._active_member_ids()
+
+    def test_excludes_archived_member(self, member):
+        member.archived_at = timezone.now()
+        member.save(update_fields=["archived_at"])
+        assert member.pk not in self._active_member_ids()
+
+    def test_excludes_inactive_member(self, member):
+        """is_active is Django's built-in flag, kept as defense-in-depth."""
+        member.is_active = False
+        member.save(update_fields=["is_active"])
+        assert member.pk not in self._active_member_ids()
+
+    def test_includes_onboarding_pending_member(self, member):
+        """needs_onboarding is NOT part of the base predicate — only the directory
+        excludes it. profile/search surfaces still see onboarding-pending members.
+        """
+        member.needs_onboarding = True
+        member.save(update_fields=["needs_onboarding"])
+        assert member.pk in self._active_member_ids()
+
+    def test_is_chainable(self, member):
+        member.needs_onboarding = True
+        member.save(update_fields=["needs_onboarding"])
+        qs = User.objects.active_members().filter(needs_onboarding=False)
+        assert member.pk not in set(qs.values_list("pk", flat=True))
 
 
 class TestMembersBackfillMigration:

--- a/backend/users/_auth.py
+++ b/backend/users/_auth.py
@@ -320,12 +320,8 @@ def delete_photo(request):
 def list_member_directory(request):
     """Authed-only member directory. Respects each user's show_phone/show_email flags."""
     users = (
-        User.objects.members()
-        .filter(
-            is_paused=False,
-            archived_at__isnull=True,
-            needs_onboarding=False,
-        )
+        User.objects.active_members()
+        .filter(needs_onboarding=False)
         .order_by("display_name", "phone_number")
     )
     return Status(
@@ -352,7 +348,7 @@ def list_member_directory(request):
 )
 def get_member_profile(request, user_id: str):
     try:
-        user = User.objects.members().get(pk=user_id, is_paused=False, archived_at__isnull=True)
+        user = User.objects.active_members().get(pk=user_id)
     except User.DoesNotExist:
         raise_validation(Code.Member.NOT_FOUND, status_code=404)
     is_own_profile = str(request.auth.pk) == user_id

--- a/backend/users/_management.py
+++ b/backend/users/_management.py
@@ -172,11 +172,7 @@ def bulk_create_users(request, payload: BulkUserCreateIn):
 
 @router.get("/users/search/", response={200: list[UserSearchOut]}, auth=gated_jwt)
 def search_users(request, q: str = ""):
-    qs = (
-        User.objects.members()
-        .filter(is_paused=False, archived_at__isnull=True)
-        .exclude(pk=request.auth.pk)
-    )
+    qs = User.objects.active_members().exclude(pk=request.auth.pk)
     q = q.strip()
     if q:
         digits = re.sub(r"\D", "", q)

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -33,6 +33,28 @@ class UserManager(BaseUserManager):
         """
         return self.get_queryset().filter(is_member=True)
 
+    def active_members(self):
+        """Members who should appear on member-facing surfaces.
+
+        Bundles the full visibility predicate so call sites can't forget part of
+        it (a bare ``members()`` would still leak paused/archived users). Use this
+        for member-facing directory, profile, and search lookups.
+
+        ``needs_onboarding`` is deliberately NOT filtered here — it's only excluded
+        by the directory, which adds ``needs_onboarding=False`` itself. The profile
+        and search surfaces intentionally include onboarding-pending members.
+
+        On ``is_active``: this is Django's built-in ``AbstractUser`` flag, which the
+        app never sets to False (``is_paused`` is the product's live suspension flag,
+        enforced at the auth gate). It's kept here as cheap defense-in-depth guarding
+        the only path that can deactivate a user — the Django admin.
+        """
+        return self.members().filter(
+            is_active=True,
+            is_paused=False,
+            archived_at__isnull=True,
+        )
+
     def create_user(self, phone_number, password=None, **extra_fields):
         if not phone_number:
             raise ValueError("Phone number is required")


### PR DESCRIPTION
## Overview

PR #521 added `User.objects.members()`, which filters only `is_member=True`. But the real "show this user on a member-facing surface" predicate is bigger, and it stayed duplicated inline at every call site — so a new endpoint could call `.members()` and still leak paused / archived / inactive users.

This adds `User.objects.active_members()`, which bundles the full visibility predicate (`is_member=True, is_active=True, is_paused=False, archived_at__isnull=True`), and migrates the three member-facing call sites:

- `list_member_directory` (`_auth.py`) — now `active_members().filter(needs_onboarding=False)`
- `get_member_profile` (`_auth.py`)
- `search_users` (`_management.py`)

### Decisions (documented on the manager method)

- **`is_active`** — kept in the predicate as cheap defense-in-depth. The app never sets `is_active=False` (the live suspension flag is `is_paused`, enforced at the auth gate); `is_active` is only reachable via the Django admin, and a user deactivated there should not appear on member-facing surfaces. This is option **(A)** from the issue. Note this is a (safe) behavior change: the three prior call sites did not explicitly filter `is_active`.
- **`needs_onboarding`** — deliberately NOT in the base predicate. Only the directory excludes onboarding-pending members (`needs_onboarding=False` added at that call site); profile and search keep their prior behavior of including them.

Out of scope (intentionally): the notification recipient lookups in `notifications/service.py` still use bare `members()` — they target admins/permission-holders, where excluding a temporarily-paused admin from notifications is a separate product decision.

Closes #526

## Test plan

- [x] New `TestActiveMembersManager` covers: includes plain member; excludes non-member / paused / archived / inactive; includes onboarding-pending member; chainable with `needs_onboarding=False`.
- [x] `make agent-ci` backend suite green (1025 passed); frontend lint + typecheck green.
- [ ] Note: `frontend/src/screens/public/JoinScreen.test.tsx` shows intermittent 5s-timeout flakes under the parallel CI load (CPU contention with the backend suite). It is unrelated to this backend-only change and passes 10/10 in isolation across repeated runs.
