### PR TITLE
feat(public-rsvp): enforce non-members never hold a role (Issue 525)

### DIFF
--- a/.claude/task.md
+++ b/.claude/task.md
@@ -1,19 +1,18 @@
-# Task — issue #555
-**Goal:** public-rsvp: recognize returning non-members and extend existing token on new RSVP
+# Task — issue #525
+**Goal:** feat(public-rsvp): enforce non-members never hold a role + trustworthy role counts
 **Source:** label
-**Labels:** backend,feature,auto,database,p1
-**Acceptance criteria:** see issue #555 body.
+**Labels:** backend,RSVP & Attendance,auto
+**Acceptance criteria:** see issue #525 body.
 
 ## Pipeline stage
-pickup
-triage
-work
-review
-ci
+done
 
 ## Restart count
-0
+1
 
 ## Progress log
 - dispatched
-- triage: model-layer change only; public RSVP submission endpoints (stages 3/4) not built yet. Implementing issue_or_extend() on NonMemberRsvpToken to handle extend-vs-create. User get-or-create-by-phone (AC#1) belongs to the unbuilt endpoint; noted as out of scope here.
+- work: added m2m_changed pre_add guard (reject_role_for_non_member) on User.roles.through; added is_member=True to list_roles/delete_role counts; added TestNonMemberCannotHoldRole
+- review: code-reviewer clean (no high); applied medium fixes (docstring note + member-swap/reverse-set tests). 23 tests pass.
+- ci: backend make agent-ci passed (1026 tests, typecheck, complexity, schema); frontend lint/format/typecheck/types-check clean after pnpm install
+- PR: https://github.com/ProteinDeficientsAnonymous/pda/pull/557 (draft)

--- a/backend/tests/test_role_management.py
+++ b/backend/tests/test_role_management.py
@@ -164,3 +164,88 @@ class TestRoleManagementAPI:
         assert response.status_code == 200
         popular = next(r for r in response.json() if r["name"] == "popular")
         assert popular["user_count"] == 1
+
+
+@pytest.mark.django_db
+class TestNonMemberCannotHoldRole:
+    """Issue 525: a non-member (is_member=False) must never hold a role, and the
+    role member-counts must reflect members only."""
+
+    def _make_non_member(self):
+        from users.models import User
+
+        # is_member=False overrides the conftest autouse default (is_member=True).
+        return User.objects.create_user(
+            phone_number="+12025559001",
+            display_name="Non Member",
+            is_member=False,
+        )
+
+    # The guard raises inside the m2m operation's atomic block, which marks the
+    # surrounding transaction as broken — so we cannot query the DB after the
+    # raise in the same test. pytest.raises is sufficient proof the write aborted.
+    def test_roles_add_rejects_non_member(self):
+        non_member = self._make_non_member()
+        role = Role.objects.create(name="contributor", permissions=[])
+        with pytest.raises(ValueError, match="non-member"):
+            non_member.roles.add(role)
+
+    def test_roles_set_rejects_non_member(self):
+        non_member = self._make_non_member()
+        role = Role.objects.create(name="contributor", permissions=[])
+        with pytest.raises(ValueError, match="non-member"):
+            non_member.roles.set([role])
+
+    def test_reverse_users_add_rejects_non_member(self):
+        non_member = self._make_non_member()
+        role = Role.objects.create(name="contributor", permissions=[])
+        with pytest.raises(ValueError, match="non-member"):
+            role.users.add(non_member)
+
+    def test_reverse_users_set_rejects_non_member(self):
+        non_member = self._make_non_member()
+        role = Role.objects.create(name="contributor", permissions=[])
+        with pytest.raises(ValueError, match="non-member"):
+            role.users.set([non_member])
+
+    def test_member_can_still_hold_role(self, test_user):
+        # The guard must not block legitimate member assignment.
+        role = Role.objects.create(name="contributor", permissions=[])
+        test_user.roles.add(role)
+        assert test_user.roles.filter(name="contributor").exists()
+
+    def test_member_can_swap_roles_via_set(self, test_user):
+        # Regression guard: set() emits pre_remove alongside pre_add, so a member
+        # replacing one role set with another must not trip the membership check.
+        first = Role.objects.create(name="first", permissions=[])
+        second = Role.objects.create(name="second", permissions=[])
+        test_user.roles.set([first])
+        test_user.roles.set([second])
+        names = set(test_user.roles.values_list("name", flat=True))
+        assert names == {"second"}
+
+    def test_update_user_roles_404s_for_non_member(self, api_client, manage_users_headers):
+        non_member = self._make_non_member()
+        member_role = Role.objects.get(name="member")
+        response = api_client.patch(
+            f"/api/auth/users/{non_member.id}/roles/",
+            {"role_ids": [str(member_role.id)]},
+            content_type="application/json",
+            **manage_users_headers,
+        )
+        assert response.status_code == 404
+        assert_error_code(response, Code.User.NOT_FOUND)
+
+    def test_list_roles_count_excludes_non_member(
+        self, api_client, manage_users_headers, test_user
+    ):
+        # Force a non-member onto a role at the DB level (bypassing the guard)
+        # to prove the read-side count defends itself anyway.
+        role = Role.objects.create(name="counted", permissions=[])
+        test_user.roles.add(role)
+        non_member = self._make_non_member()
+        role.users.through.objects.create(user=non_member, role=role)
+        response = api_client.get("/api/auth/roles/", **manage_users_headers)
+        assert response.status_code == 200
+        counted = next(r for r in response.json() if r["name"] == "counted")
+        assert counted["user_count"] == 1

--- a/backend/tests/test_role_management.py
+++ b/backend/tests/test_role_management.py
@@ -181,9 +181,7 @@ class TestNonMemberCannotHoldRole:
             is_member=False,
         )
 
-    # The guard raises inside the m2m operation's atomic block, which marks the
-    # surrounding transaction as broken — so we cannot query the DB after the
-    # raise in the same test. pytest.raises is sufficient proof the write aborted.
+    # The guard raises inside the m2m atomic block, so we can't query the DB after; pytest.raises proves the abort.
     def test_roles_add_rejects_non_member(self):
         non_member = self._make_non_member()
         role = Role.objects.create(name="contributor", permissions=[])

--- a/backend/users/_roles.py
+++ b/backend/users/_roles.py
@@ -32,9 +32,6 @@ def list_roles(request):
             details={"endpoint": "list_roles", "required_permission": PermissionKey.MANAGE_ROLES},
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="list_roles")
-    # Count members only. The m2m_changed guard (reject_role_for_non_member)
-    # makes a non-member holding a role impossible, but filter on is_member here
-    # too so a bug elsewhere can never silently inflate the per-role count.
     roles = Role.objects.annotate(
         user_count=Count(
             "users",
@@ -179,7 +176,6 @@ def delete_role(request, role_id: str):
     if role.name in PROTECTED_ROLE_NAMES:
         raise_validation(Code.Role.PROTECTED_CANNOT_DELETE, status_code=400, role_name=role.name)
     role_name = role.name
-    # Members only — keeps the audited affected-user count trustworthy.
     affected_user_count = role.users.filter(archived_at__isnull=True, is_member=True).count()
     role.delete()
     audit_log(

--- a/backend/users/_roles.py
+++ b/backend/users/_roles.py
@@ -179,8 +179,7 @@ def delete_role(request, role_id: str):
     if role.name in PROTECTED_ROLE_NAMES:
         raise_validation(Code.Role.PROTECTED_CANNOT_DELETE, status_code=400, role_name=role.name)
     role_name = role.name
-    # Members only — see the matching note in list_roles. Keeps the audited
-    # affected-user count trustworthy even if a non-member ever slipped a role.
+    # Members only — keeps the audited affected-user count trustworthy.
     affected_user_count = role.users.filter(archived_at__isnull=True, is_member=True).count()
     role.delete()
     audit_log(

--- a/backend/users/_roles.py
+++ b/backend/users/_roles.py
@@ -32,8 +32,14 @@ def list_roles(request):
             details={"endpoint": "list_roles", "required_permission": PermissionKey.MANAGE_ROLES},
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="list_roles")
+    # Count members only. The m2m_changed guard (reject_role_for_non_member)
+    # makes a non-member holding a role impossible, but filter on is_member here
+    # too so a bug elsewhere can never silently inflate the per-role count.
     roles = Role.objects.annotate(
-        user_count=Count("users", filter=Q(users__archived_at__isnull=True)),
+        user_count=Count(
+            "users",
+            filter=Q(users__archived_at__isnull=True, users__is_member=True),
+        ),
     )
     return Status(
         200,
@@ -173,7 +179,9 @@ def delete_role(request, role_id: str):
     if role.name in PROTECTED_ROLE_NAMES:
         raise_validation(Code.Role.PROTECTED_CANNOT_DELETE, status_code=400, role_name=role.name)
     role_name = role.name
-    affected_user_count = role.users.filter(archived_at__isnull=True).count()
+    # Members only — see the matching note in list_roles. Keeps the audited
+    # affected-user count trustworthy even if a non-member ever slipped a role.
+    affected_user_count = role.users.filter(archived_at__isnull=True, is_member=True).count()
     role.delete()
     audit_log(
         logging.WARNING,

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -291,26 +291,17 @@ class NonMemberRsvpToken(models.Model):
 
 @receiver(m2m_changed, sender=User.roles.through)
 def reject_role_for_non_member(sender, instance, action, reverse, pk_set, **kwargs):
-    """Enforce the invariant: a non-member (is_member=False) can never hold a role.
+    """Enforce the Issue 525 invariant: a non-member can never hold a role.
 
-    This is the call-site-independent guard for Issue 525 — it fires on
-    ``user.roles.add/set/create`` and the reverse ``role.users.add/set`` from
-    every path (API endpoints, seed, the superuser post_save above, and any
-    future code), so the read-side role counts in list_roles/delete_role can
-    stay simple and trustworthy. Raising in ``pre_add`` aborts the write before
-    the through-row is created.
-
-    Callers are expected to gate on membership first (e.g. update_user_roles
-    fetches via ``User.objects.members()`` and 404s a non-member). Reaching this
-    guard means a caller skipped that gate: the ``ValueError`` propagates out of
-    the m2m operation as an uncaught 500 — a deliberate loud failure, not a
-    clean 4xx. Fix the caller, don't catch this.
+    Fires on every role-assignment path (``user.roles.add``, ``role.users.add``,
+    etc.). Callers should gate on membership first; reaching this guard means one
+    didn't, so the ``ValueError`` surfaces as a loud 500 — fix the caller, don't
+    catch it.
     """
     if action != "pre_add" or not pk_set:
         return
-    # reverse=True means role.users.add(user...) — instance is the Role and
-    # pk_set holds User PKs. reverse=False means user.roles.add(...) — instance
-    # is the User and pk_set holds Role PKs.
+    # reverse=True: instance is the Role, pk_set holds User PKs.
+    # reverse=False: instance is the User, pk_set holds Role PKs.
     if reverse:
         if User.objects.filter(pk__in=pk_set, is_member=False).exists():
             raise ValueError("cannot assign a role to a non-member user")

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 from django.contrib.auth.models import AbstractUser, BaseUserManager
 from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models.signals import post_save
+from django.db.models.signals import m2m_changed, post_save
 from django.dispatch import receiver
 from django.utils import timezone
 
@@ -287,6 +287,35 @@ class NonMemberRsvpToken(models.Model):
         if row is None or not row.is_valid:
             return None
         return row.user
+
+
+@receiver(m2m_changed, sender=User.roles.through)
+def reject_role_for_non_member(sender, instance, action, reverse, pk_set, **kwargs):
+    """Enforce the invariant: a non-member (is_member=False) can never hold a role.
+
+    This is the call-site-independent guard for Issue 525 — it fires on
+    ``user.roles.add/set/create`` and the reverse ``role.users.add/set`` from
+    every path (API endpoints, seed, the superuser post_save above, and any
+    future code), so the read-side role counts in list_roles/delete_role can
+    stay simple and trustworthy. Raising in ``pre_add`` aborts the write before
+    the through-row is created.
+
+    Callers are expected to gate on membership first (e.g. update_user_roles
+    fetches via ``User.objects.members()`` and 404s a non-member). Reaching this
+    guard means a caller skipped that gate: the ``ValueError`` propagates out of
+    the m2m operation as an uncaught 500 — a deliberate loud failure, not a
+    clean 4xx. Fix the caller, don't catch this.
+    """
+    if action != "pre_add" or not pk_set:
+        return
+    # reverse=True means role.users.add(user...) — instance is the Role and
+    # pk_set holds User PKs. reverse=False means user.roles.add(...) — instance
+    # is the User and pk_set holds Role PKs.
+    if reverse:
+        if User.objects.filter(pk__in=pk_set, is_member=False).exists():
+            raise ValueError("cannot assign a role to a non-member user")
+    elif not instance.is_member:
+        raise ValueError("cannot assign a role to a non-member user")
 
 
 @receiver(post_save, sender=User)

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -300,9 +300,8 @@ def reject_role_for_non_member(sender, instance, action, reverse, pk_set, **kwar
     """
     if action != "pre_add" or not pk_set:
         return
-    # reverse=True: instance is the Role, pk_set holds User PKs.
-    # reverse=False: instance is the User, pk_set holds Role PKs.
-    if reverse:
+    instance_is_role = reverse
+    if instance_is_role:
         if User.objects.filter(pk__in=pk_set, is_member=False).exists():
             raise ValueError("cannot assign a role to a non-member user")
     elif not instance.is_member:

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -291,17 +291,21 @@ class NonMemberRsvpToken(models.Model):
 
 @receiver(m2m_changed, sender=User.roles.through)
 def reject_role_for_non_member(sender, instance, action, reverse, pk_set, **kwargs):
-    """Enforce the Issue 525 invariant: a non-member can never hold a role.
+    """Reject any role assignment where the user is not a member.
 
     Fires on every role-assignment path (``user.roles.add``, ``role.users.add``,
     etc.). Callers should gate on membership first; reaching this guard means one
     didn't, so the ``ValueError`` surfaces as a loud 500 — fix the caller, don't
     catch it.
+
+    ``reverse`` is part of Django's ``m2m_changed`` signature: it is ``True`` when
+    the signal fires from the role side (``role.users.add``) and ``False`` from
+    the user side (``user.roles.add``).
     """
     if action != "pre_add" or not pk_set:
         return
-    instance_is_role = reverse
-    if instance_is_role:
+    signal_from_role_side = reverse
+    if signal_from_role_side:
         if User.objects.filter(pk__in=pk_set, is_member=False).exists():
             raise ValueError("cannot assign a role to a non-member user")
     elif not instance.is_member:


### PR DESCRIPTION
## Summary
Closes #525. Part of epic #490, follow-up to PR #521 (stage 1: `is_member` / `members()`).

- **Write-time invariant:** new `reject_role_for_non_member` `m2m_changed` (`pre_add`) receiver on `User.roles.through` raises `ValueError` if any non-member (`is_member=False`) would be assigned a role. Call-site-independent — fires on `user.roles.add/set/create` and the reverse `role.users.add/set` from every path (API, seed, the superuser `post_save`, and any future code), in both `reverse=True`/`False` directions.
- **Trustworthy counts (defense-in-depth):** `list_roles` and `delete_role` member-counts now filter on `users__is_member=True`, so a bug elsewhere can never silently inflate per-role counts even if a non-member ever slipped a role at the DB level.
- Existing `update_user_roles` already 404s non-members via `User.objects.members()`; that gate is the expected first line — reaching the guard means a caller skipped it, so the `ValueError` surfaces as a loud 500 by design.

The frontend members-list acceptance point is satisfied trivially today: no non-member-creating path exists yet (lands in stage 3, #493), so non-members can't appear in the list to be offered roles.

## Test plan
- [x] `TestNonMemberCannotHoldRole`: forward `add`/`set`, reverse `users.add`/`users.set` all reject non-members; member assignment + member role-swap via `set()` still work; `update_user_roles` 404s a non-member; `list_roles` count excludes a DB-forced non-member.
- [x] `make agent-ci` green (1026 backend tests, typecheck, complexity, schema checks; frontend lint/format/typecheck/types-check).