### PR TITLE
feat(public-rsvp): public RSVP submit endpoint + dedup + confirmation email (Issue 493)

### DIFF
--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -153,15 +153,17 @@ def _cancellations(event: Event) -> list[CancellationOut]:
     return rows
 
 
-def promote_from_waitlist(event: Event) -> None:
+def promote_from_waitlist(event: Event) -> list[str]:
     """Promote oldest waitlisted users to attending (FIFO by created_at).
 
     Must be called inside a transaction.atomic() block with the event row locked.
+    Returns the list of promoted user ids so callers that need to follow up per
+    promoted user (e.g. emailing promoted non-members) can do so after commit.
     """
     from notifications.service import create_waitlist_promoted_notifications
 
     if event.max_attendees is None:
-        return
+        return []
     promoted_user_ids: list[str] = []
     while True:
         headcount = _attending_headcount_db(event)
@@ -179,6 +181,7 @@ def promote_from_waitlist(event: Event) -> None:
         promoted_user_ids.append(str(oldest.user_id))
     if promoted_user_ids:
         create_waitlist_promoted_notifications(event, promoted_user_ids)
+    return promoted_user_ids
 
 
 def _has_attendees(event: Event) -> bool:

--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -102,8 +102,14 @@ def _validate_rsvp_status(status: str) -> None:
         )
 
 
-def _apply_rsvp_in_transaction(event_id, user, status: str, has_plus_one: bool) -> str:
-    """Execute RSVP upsert inside a locked transaction. Returns final_status.
+def _apply_rsvp_in_transaction(
+    event_id, user, status: str, has_plus_one: bool
+) -> tuple[str, list[str]]:
+    """Execute RSVP upsert inside a locked transaction.
+
+    Returns (final_status, promoted_user_ids). promoted_user_ids is the list of
+    users promoted off the waitlist by this change (empty unless a spot freed),
+    surfaced so callers can follow up per promoted user after commit.
 
     Raises ValidationException on failure.
     """
@@ -133,10 +139,9 @@ def _apply_rsvp_in_transaction(event_id, user, status: str, has_plus_one: bool) 
     spot_freed = (was_attending and final_status != RSVPStatus.ATTENDING) or (
         was_attending and had_plus_one and not final_plus_one
     )
-    if spot_freed:
-        promote_from_waitlist(event)
+    promoted_user_ids = promote_from_waitlist(event) if spot_freed else []
 
-    return final_status
+    return final_status, promoted_user_ids
 
 
 @router.post(
@@ -154,7 +159,7 @@ def upsert_rsvp(request, event_id: UUID, payload: RSVPIn):
     _validate_rsvp_status(payload.status)
 
     with transaction.atomic():
-        final_status = _apply_rsvp_in_transaction(
+        final_status, _promoted_user_ids = _apply_rsvp_in_transaction(
             event_id, request.auth, payload.status, payload.has_plus_one
         )
 

--- a/backend/community/_public_rsvp.py
+++ b/backend/community/_public_rsvp.py
@@ -1,0 +1,306 @@
+"""Public (no-auth) non-member RSVP submission.
+
+Anonymous visitors RSVP to OFFICIAL, PUBLIC, active, rsvp-enabled events without
+an account. A non-member ``User`` row backs each RSVP so the entire existing
+RSVP machinery (capacity, plus-ones, waitlist, promotion) is reused unchanged.
+A scoped ``NonMemberRsvpToken`` is emailed (never returned in the response) so
+the visitor can manage their RSVP at ``/my-rsvps?token=...``.
+"""
+
+import logging
+
+from config.audit import audit_log
+from config.ratelimit import client_ip, rate_limit
+from django.conf import settings
+from django.db import IntegrityError, transaction
+from django.utils import timezone
+from ninja import Router
+from ninja.responses import Status
+from notifications._email_helpers import (
+    RsvpEmailDetails,
+    send_rsvp_confirmation_email,
+    send_rsvp_waitlist_promoted_email,
+)
+from notifications.email_sender import get_email_sender
+from pydantic import BaseModel, EmailStr, Field
+from users.models import NonMemberRsvpToken, User
+
+from community._event_helpers import _event_out
+from community._event_rsvps import _apply_rsvp_in_transaction, _validate_rsvp_status
+from community._event_schemas import EventOut
+from community._field_limits import FieldLimit
+from community._shared import ErrorOut, _validate_phone, logger, validate_display_name
+from community._validation import Code, raise_validation
+from community.models import Event, EventStatus, EventType, PageVisibility, RSVPStatus
+
+router = Router()
+
+
+class PublicRsvpIn(BaseModel):
+    name: str = Field(max_length=FieldLimit.DISPLAY_NAME)
+    email: EmailStr
+    phone_number: str = Field(max_length=FieldLimit.PHONE)
+    status: str = Field(max_length=FieldLimit.CHOICE)
+    has_plus_one: bool = False
+    # Honeypot: hidden field humans never fill in. A non-empty value is spam.
+    website: str = Field(default="", max_length=FieldLimit.DISPLAY_NAME)
+
+
+class PublicRsvpStateOut(BaseModel):
+    status: str
+    has_plus_one: bool
+
+
+class PublicRsvpOut(BaseModel):
+    event: EventOut
+    rsvp: PublicRsvpStateOut
+
+
+def _public_rsvp_decoy(event: Event, status: str, has_plus_one: bool) -> PublicRsvpOut:
+    """Mimic a real submission's shape so bots register success and stop retrying.
+
+    No User/RSVP/token row is created and no email is sent. The event payload is
+    the anonymous (un-RSVP'd) view, so gated details stay hidden.
+    """
+    return PublicRsvpOut(
+        event=_event_out(event, None),
+        rsvp=PublicRsvpStateOut(status=status, has_plus_one=has_plus_one),
+    )
+
+
+def _load_public_rsvp_event(event_id) -> Event:
+    """Fetch an event eligible for public RSVP, else 404.
+
+    Every ineligible state collapses to Code.Event.NOT_FOUND so the endpoint
+    never leaks the existence of non-public events.
+    """
+    event = Event.objects.prefetch_related("co_hosts", "invited_users").filter(id=event_id).first()
+    if (
+        event is None
+        or event.event_type != EventType.OFFICIAL
+        or event.status != EventStatus.ACTIVE
+        or event.visibility != PageVisibility.PUBLIC
+        or not event.rsvp_enabled
+        or event.is_past
+    ):
+        raise_validation(Code.Event.NOT_FOUND, status_code=404)
+    return event
+
+
+def _reuse_phone_match(phone_match: User, email: str) -> User:
+    # Save the submitted email only if blank — never overwrite an existing email
+    # (avoids identity churn for a returning non-member).
+    if email and not phone_match.email:
+        phone_match.email = email
+        phone_match.save(update_fields=["email"])
+    return phone_match
+
+
+def _reuse_email_match(email_match: User, phone: str) -> User:
+    # Phone is required for non-members; backfill it only if somehow blank.
+    if not email_match.phone_number:
+        email_match.phone_number = phone
+        email_match.save(update_fields=["phone_number"])
+    return email_match
+
+
+def _create_non_member(name: str, email: str, phone: str) -> User:
+    # Relies on the unique phone constraint for race safety — a concurrent
+    # IntegrityError loser is re-fetched by get_or_create's own SELECT. The
+    # email is dropped on a unique-email collision (e.g. an archived row holds
+    # it) inside a savepoint so the outer transaction survives; the RSVP still
+    # succeeds, just without an email saved on the new row.
+    defaults = {"display_name": name, "is_member": False}
+    try:
+        with transaction.atomic():
+            user, created = User.objects.get_or_create(
+                phone_number=phone, defaults={**defaults, "email": email or None}
+            )
+    except IntegrityError:
+        user, created = User.objects.get_or_create(phone_number=phone, defaults=defaults)
+    if created:
+        user.set_unusable_password()
+        user.save(update_fields=["password"])
+    return user
+
+
+def _resolve_both_match(request, phone_match: User, email_match: User) -> User:
+    if phone_match.pk == email_match.pk:
+        return phone_match  # Same non-member row — reuse, no change.
+    # Phone and email point at different non-member rows. Phone is the canonical
+    # identifier in this app — reuse it, leave its email as-is, flag for admins.
+    audit_log(
+        logging.WARNING,
+        "public_rsvp_contact_ambiguous",
+        request,
+        target_type="user",
+        target_id=str(phone_match.pk),
+        details={"email_user_id": str(email_match.pk)},
+    )
+    return phone_match
+
+
+def _resolve_non_member(*, request, name: str, email: str, phone: str) -> User:
+    """Resolve (or create) the non-member User backing this RSVP.
+
+    Implements the spec's phone/email collision table. Members → 409. Returns a
+    non-member User. Must run inside the surrounding transaction.
+    """
+    phone_match = User.objects.filter(phone_number=phone, archived_at__isnull=True).first()
+    # iexact, not exact: stored emails aren't guaranteed lowercased (the admin
+    # members screen stores them verbatim), so an exact match on the normalized
+    # input could miss a member and bypass the MEMBER_CONTACT_MUST_SIGN_IN gate.
+    email_match = (
+        User.objects.filter(email__iexact=email, archived_at__isnull=True).first()
+        if email
+        else None
+    )
+
+    # Either contact belongs to a member → redirect to the authenticated flow.
+    if (phone_match and phone_match.is_member) or (email_match and email_match.is_member):
+        raise_validation(Code.Event.MEMBER_CONTACT_MUST_SIGN_IN, status_code=409)
+
+    if phone_match and email_match:
+        return _resolve_both_match(request, phone_match, email_match)
+    if phone_match:
+        return _reuse_phone_match(phone_match, email)
+    if email_match:
+        return _reuse_email_match(email_match, phone)
+    return _create_non_member(name, email, phone)
+
+
+def _format_event_when(event: Event) -> str:
+    if event.datetime_tbd or event.start_datetime is None:
+        return "to be decided"
+    local = timezone.localtime(event.start_datetime)
+    return local.strftime("%A, %B %d at %I:%M %p").replace(" 0", " ")
+
+
+def _event_links(event: Event) -> list[str]:
+    return [link for link in (event.whatsapp_link, event.partiful_link, event.other_link) if link]
+
+
+def _email_details(event: Event, user: User, token_str: str) -> RsvpEmailDetails:
+    return RsvpEmailDetails(
+        to=user.email,
+        display_name=user.display_name,
+        event_title=event.title,
+        event_when=_format_event_when(event),
+        event_location=event.location,
+        event_links=_event_links(event),
+        manage_url=f"{settings.FRONTEND_BASE_URL}/my-rsvps?token={token_str}",
+    )
+
+
+def _log_email_failure(request, event: Event, user: User, exc: Exception) -> None:
+    logger.warning("public rsvp email failed", exc_info=True)
+    audit_log(
+        logging.WARNING,
+        "public_rsvp_email_failed",
+        request,
+        target_type="event",
+        target_id=str(event.id),
+        details={"user_id": str(user.pk), "error": str(exc)},
+    )
+
+
+def _send_confirmation_email(
+    request, event: Event, user: User, token_str: str, waitlisted: bool
+) -> None:
+    """Best-effort confirmation email. A send failure must NOT roll back the RSVP."""
+    if not user.email:
+        return
+    try:
+        result = send_rsvp_confirmation_email(
+            sender=get_email_sender(),
+            details=_email_details(event, user, token_str),
+            waitlisted=waitlisted,
+        )
+        if not result.success:
+            raise RuntimeError(result.error or "send returned failure")
+    except Exception as exc:
+        _log_email_failure(request, event, user, exc)
+
+
+def _email_promoted_non_members(request, event: Event, promoted_user_ids: list[str]) -> None:
+    """Email any promoted non-members a fresh manage link. Best-effort per user."""
+    if not promoted_user_ids:
+        return
+    promoted = User.objects.filter(id__in=promoted_user_ids, is_member=False, email__isnull=False)
+    for user in promoted:
+        if not user.email:
+            continue
+        try:
+            token = NonMemberRsvpToken.issue(user)
+            result = send_rsvp_waitlist_promoted_email(
+                sender=get_email_sender(),
+                details=_email_details(event, user, token.token),
+            )
+            if not result.success:
+                raise RuntimeError(result.error or "send returned failure")
+        except Exception as exc:
+            _log_email_failure(request, event, user, exc)
+
+
+@router.post(
+    "/public/events/{event_id}/rsvp/",
+    response={200: PublicRsvpOut, 400: ErrorOut, 404: ErrorOut, 409: ErrorOut, 429: ErrorOut},
+    auth=None,
+)
+@rate_limit(key_func=client_ip, rate="5/h")
+def submit_public_rsvp(request, event_id, payload: PublicRsvpIn):
+    event = _load_public_rsvp_event(event_id)
+
+    # Honeypot trip — decoy 200 without persisting. Checked before field
+    # validation so a bot gets no validation feedback to iterate against.
+    if payload.website.strip():
+        audit_log(
+            logging.WARNING,
+            "public_rsvp_honeypot_tripped",
+            request,
+            target_type="event",
+            target_id=str(event_id),
+        )
+        return Status(200, _public_rsvp_decoy(event, payload.status, payload.has_plus_one))
+
+    name = payload.name.strip()
+    validate_display_name(name, field="name")
+    validated_phone = _validate_phone(payload.phone_number)
+    normalized_email = payload.email.strip().lower()
+    _validate_rsvp_status(payload.status)
+
+    with transaction.atomic():
+        user = _resolve_non_member(
+            request=request, name=name, email=normalized_email, phone=validated_phone
+        )
+        final_status, promoted_user_ids = _apply_rsvp_in_transaction(
+            event.id, user, payload.status, payload.has_plus_one
+        )
+        token = NonMemberRsvpToken.issue(user)
+
+    audit_log(
+        logging.INFO,
+        "public_rsvp_created",
+        request,
+        target_type="event",
+        target_id=str(event.id),
+        details={"user_id": str(user.pk), "status": final_status},
+    )
+
+    waitlisted = final_status == RSVPStatus.WAITLISTED
+    _send_confirmation_email(request, event, user, token.token, waitlisted)
+    _email_promoted_non_members(request, event, promoted_user_ids)
+
+    fresh_event = (
+        Event.objects.select_related("created_by")
+        .prefetch_related("co_hosts", "invited_users", "rsvps__user")
+        .get(id=event.id)
+    )
+    final_rsvp = user.event_rsvps.get(event=fresh_event)
+    return Status(
+        200,
+        PublicRsvpOut(
+            event=_event_out(fresh_event, user),
+            rsvp=PublicRsvpStateOut(status=final_rsvp.status, has_plus_one=final_rsvp.has_plus_one),
+        ),
+    )

--- a/backend/community/_validation.py
+++ b/backend/community/_validation.py
@@ -48,6 +48,10 @@ class Code:
         RSVP_INVALID_STATUS = "event.rsvp_invalid_status"
         NO_PLUS_ONE_SPOTS = "event.no_plus_one_spots"
         RSVP_NOT_FOUND = "event.rsvp_not_found"
+        # Raised by the public (non-member) RSVP endpoint when the submitted
+        # phone or email already belongs to a member — they must use the
+        # authenticated flow rather than the scoped non-member path.
+        MEMBER_CONTACT_MUST_SIGN_IN = "event.member_contact_must_sign_in"
         ATTENDANCE_OPENS_LATER = "event.attendance_opens_later"
         ATTENDANCE_ONLY_FOR_GOING_RSVPS = "event.attendance_only_for_going_rsvps"
         PERM_DENIED = "event.perm_denied"  # params: { action?: str }

--- a/backend/community/api.py
+++ b/backend/community/api.py
@@ -30,6 +30,7 @@ from community._join_requests import router as join_requests_router
 from community._login_link import router as login_link_router
 from community._pages import router as pages_router
 from community._polls import router as polls_router
+from community._public_rsvp import router as public_rsvp_router
 from community._surveys import router as surveys_router
 from community._surveys_public import router as surveys_public_router
 from community._version import router as version_router
@@ -46,6 +47,7 @@ router.add_router("", login_link_router)
 router.add_router("", feedback_router)
 router.add_router("", events_router)
 router.add_router("", event_rsvps_router)
+router.add_router("", public_rsvp_router)
 router.add_router("", event_actions_router)
 router.add_router("", event_cohost_invites_router)
 router.add_router("", event_invitations_router)

--- a/backend/community/validation_codes.json
+++ b/backend/community/validation_codes.json
@@ -122,6 +122,11 @@
         "params": []
       },
       {
+        "name": "MEMBER_CONTACT_MUST_SIGN_IN",
+        "value": "event.member_contact_must_sign_in",
+        "params": []
+      },
+      {
         "name": "ATTENDANCE_OPENS_LATER",
         "value": "event.attendance_opens_later",
         "params": []

--- a/backend/notifications/_email_helpers.py
+++ b/backend/notifications/_email_helpers.py
@@ -5,9 +5,75 @@ Each helper renders its templates and dispatches via the injected
 paths or context shapes — they just say "send a magic-login email."
 """
 
+from dataclasses import dataclass
+
 from django.template.loader import render_to_string
 
 from notifications.email_sender import EmailSender, SendResult
+
+
+@dataclass(frozen=True)
+class RsvpEmailDetails:
+    """Event + recipient details shared by the non-member RSVP emails.
+
+    Bundling these keeps the send helpers to a handful of arguments and gives
+    callers one place to assemble the per-event context.
+    """
+
+    to: str
+    display_name: str
+    event_title: str
+    event_when: str
+    event_location: str
+    event_links: list[str]
+    manage_url: str
+
+    def template_context(self) -> dict:
+        return {
+            "display_name": self.display_name or "",
+            "event_title": self.event_title,
+            "event_when": self.event_when,
+            "event_location": self.event_location,
+            "event_links": self.event_links,
+            "manage_url": self.manage_url,
+        }
+
+
+def send_rsvp_confirmation_email(
+    *,
+    sender: EmailSender,
+    details: RsvpEmailDetails,
+    waitlisted: bool,
+) -> SendResult:
+    """Render and send the non-member RSVP confirmation email (Email 1).
+
+    `details.manage_url` is the scoped /my-rsvps?token=... magic link. When
+    `waitlisted` the subject and body reflect that the RSVP landed on the waitlist.
+    """
+    context = {**details.template_context(), "waitlisted": waitlisted}
+    html = render_to_string("emails/rsvp_confirmation.html", context)
+    text = render_to_string("emails/rsvp_confirmation.txt", context)
+    title = details.event_title.lower()
+    subject = f"you're on the waitlist for {title}" if waitlisted else f"you're in for {title}"
+    return sender.send(to=details.to, subject=subject, html=html, text=text)
+
+
+def send_rsvp_waitlist_promoted_email(
+    *,
+    sender: EmailSender,
+    details: RsvpEmailDetails,
+) -> SendResult:
+    """Render and send the "you're off the waitlist" email (Email 3) to a
+    non-member promoted off an event's waitlist."""
+    context = details.template_context()
+    html = render_to_string("emails/rsvp_waitlist_promoted.html", context)
+    text = render_to_string("emails/rsvp_waitlist_promoted.txt", context)
+    return sender.send(
+        to=details.to,
+        subject=f"you're off the waitlist for {details.event_title.lower()}",
+        html=html,
+        text=text,
+    )
 
 
 def send_magic_login_email(

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -3240,6 +3240,83 @@
         "title": "PollResultsOut",
         "type": "object"
       },
+      "PublicRsvpIn": {
+        "properties": {
+          "email": {
+            "format": "email",
+            "title": "Email",
+            "type": "string"
+          },
+          "has_plus_one": {
+            "default": false,
+            "title": "Has Plus One",
+            "type": "boolean"
+          },
+          "name": {
+            "maxLength": 64,
+            "title": "Name",
+            "type": "string"
+          },
+          "phone_number": {
+            "maxLength": 20,
+            "title": "Phone Number",
+            "type": "string"
+          },
+          "status": {
+            "maxLength": 20,
+            "title": "Status",
+            "type": "string"
+          },
+          "website": {
+            "default": "",
+            "maxLength": 64,
+            "title": "Website",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "email",
+          "phone_number",
+          "status"
+        ],
+        "title": "PublicRsvpIn",
+        "type": "object"
+      },
+      "PublicRsvpOut": {
+        "properties": {
+          "event": {
+            "$ref": "#/components/schemas/EventOut"
+          },
+          "rsvp": {
+            "$ref": "#/components/schemas/PublicRsvpStateOut"
+          }
+        },
+        "required": [
+          "event",
+          "rsvp"
+        ],
+        "title": "PublicRsvpOut",
+        "type": "object"
+      },
+      "PublicRsvpStateOut": {
+        "properties": {
+          "has_plus_one": {
+            "title": "Has Plus One",
+            "type": "boolean"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "has_plus_one"
+        ],
+        "title": "PublicRsvpStateOut",
+        "type": "object"
+      },
       "RSVPGuestOut": {
         "properties": {
           "attendance": {
@@ -9670,6 +9747,88 @@
           }
         ],
         "summary": "Update Page",
+        "tags": [
+          "community"
+        ]
+      }
+    },
+    "/api/community/public/events/{event_id}/rsvp/": {
+      "post": {
+        "operationId": "community__public_rsvp_submit_public_rsvp",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "event_id",
+            "required": true,
+            "schema": {
+              "title": "Event Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PublicRsvpIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicRsvpOut"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          }
+        },
+        "summary": "Submit Public Rsvp",
         "tags": [
           "community"
         ]

--- a/backend/templates/emails/rsvp_confirmation.html
+++ b/backend/templates/emails/rsvp_confirmation.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<body style="margin: 0; padding: 24px; background: #f5f5f3; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #222;">
+  <div style="max-width: 480px; margin: 0 auto; background: #ffffff; border-radius: 8px; padding: 32px;">
+    <p style="margin: 0 0 16px;">hi{% if display_name %} {{ display_name|lower }}{% endif %} —</p>
+    {% if waitlisted %}
+    <p style="margin: 0 0 24px;">you're on the waitlist for <strong>{{ event_title|lower }}</strong>. we'll email you if a spot opens up.</p>
+    {% else %}
+    <p style="margin: 0 0 24px;">you're in for <strong>{{ event_title|lower }}</strong> 🌱</p>
+    {% endif %}
+    {% if event_when %}<p style="margin: 0 0 8px;">when: {{ event_when|lower }}</p>{% endif %}
+    {% if event_location %}<p style="margin: 0 0 8px;">where: {{ event_location|lower }}</p>{% endif %}
+    {% for link in event_links %}<p style="margin: 0 0 8px; font-size: 13px; word-break: break-all;"><a href="{{ link }}" style="color: #3c6939;">{{ link }}</a></p>{% endfor %}
+    <p style="margin: 24px 0 16px;">manage or change your rsvp anytime:</p>
+    <p style="margin: 0 0 24px;">
+      <a href="{{ manage_url }}" style="display: inline-block; background: #3c6939; color: #ffffff; text-decoration: none; padding: 12px 24px; border-radius: 6px; font-weight: 500;">manage my rsvp</a>
+    </p>
+    <p style="margin: 0 0 8px; font-size: 13px; color: #666;">or paste this into your browser:</p>
+    <p style="margin: 0 0 24px; font-size: 13px; word-break: break-all;"><a href="{{ manage_url }}" style="color: #3c6939;">{{ manage_url }}</a></p>
+    <p style="margin: 0; font-size: 13px; color: #666;">rsvping doesn't make you a pda member. want to join? reply to a host or visit the site to request to join.</p>
+  </div>
+  <p style="text-align: center; margin: 16px 0 0; font-size: 12px; color: #888;">— pda</p>
+</body>
+</html>

--- a/backend/templates/emails/rsvp_confirmation.txt
+++ b/backend/templates/emails/rsvp_confirmation.txt
@@ -1,0 +1,15 @@
+hi{% if display_name %} {{ display_name|lower }}{% endif %} —
+
+{% if waitlisted %}you're on the waitlist for {{ event_title|lower }}. we'll email you if a spot opens up.{% else %}you're in for {{ event_title|lower }} 🌱{% endif %}
+{% if event_when %}
+when: {{ event_when|lower }}{% endif %}{% if event_location %}
+where: {{ event_location|lower }}{% endif %}
+{% for link in event_links %}{{ link }}
+{% endfor %}
+manage or change your rsvp anytime:
+
+{{ manage_url }}
+
+rsvping doesn't make you a pda member. want to join? reply to a host or visit the site to request to join.
+
+— pda

--- a/backend/templates/emails/rsvp_waitlist_promoted.html
+++ b/backend/templates/emails/rsvp_waitlist_promoted.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+<body style="margin: 0; padding: 24px; background: #f5f5f3; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #222;">
+  <div style="max-width: 480px; margin: 0 auto; background: #ffffff; border-radius: 8px; padding: 32px;">
+    <p style="margin: 0 0 16px;">hi{% if display_name %} {{ display_name|lower }}{% endif %} —</p>
+    <p style="margin: 0 0 24px;">good news — a spot opened up and you're off the waitlist for <strong>{{ event_title|lower }}</strong> 🌱</p>
+    {% if event_when %}<p style="margin: 0 0 8px;">when: {{ event_when|lower }}</p>{% endif %}
+    {% if event_location %}<p style="margin: 0 0 8px;">where: {{ event_location|lower }}</p>{% endif %}
+    {% for link in event_links %}<p style="margin: 0 0 8px; font-size: 13px; word-break: break-all;"><a href="{{ link }}" style="color: #3c6939;">{{ link }}</a></p>{% endfor %}
+    <p style="margin: 24px 0 16px;">manage or change your rsvp anytime:</p>
+    <p style="margin: 0 0 24px;">
+      <a href="{{ manage_url }}" style="display: inline-block; background: #3c6939; color: #ffffff; text-decoration: none; padding: 12px 24px; border-radius: 6px; font-weight: 500;">manage my rsvp</a>
+    </p>
+    <p style="margin: 0 0 8px; font-size: 13px; color: #666;">or paste this into your browser:</p>
+    <p style="margin: 0 0 24px; font-size: 13px; word-break: break-all;"><a href="{{ manage_url }}" style="color: #3c6939;">{{ manage_url }}</a></p>
+    <p style="margin: 0; font-size: 13px; color: #666;">rsvping doesn't make you a pda member. want to join? reply to a host or visit the site to request to join.</p>
+  </div>
+  <p style="text-align: center; margin: 16px 0 0; font-size: 12px; color: #888;">— pda</p>
+</body>
+</html>

--- a/backend/templates/emails/rsvp_waitlist_promoted.txt
+++ b/backend/templates/emails/rsvp_waitlist_promoted.txt
@@ -1,0 +1,15 @@
+hi{% if display_name %} {{ display_name|lower }}{% endif %} —
+
+good news — a spot opened up and you're off the waitlist for {{ event_title|lower }} 🌱
+{% if event_when %}
+when: {{ event_when|lower }}{% endif %}{% if event_location %}
+where: {{ event_location|lower }}{% endif %}
+{% for link in event_links %}{{ link }}
+{% endfor %}
+manage or change your rsvp anytime:
+
+{{ manage_url }}
+
+rsvping doesn't make you a pda member. want to join? reply to a host or visit the site to request to join.
+
+— pda

--- a/backend/tests/_public_rsvp_helpers.py
+++ b/backend/tests/_public_rsvp_helpers.py
@@ -1,0 +1,69 @@
+"""Shared helpers for the public-RSVP endpoint tests.
+
+POST /api/community/public/events/{event_id}/rsvp/ — split across
+test_public_rsvp.py (submission/dedup/gating/validation) and
+test_public_rsvp_capacity.py (capacity/waitlist/robustness) to stay under the
+per-file line limit. The common request builders and factories live here.
+"""
+
+from community.models import (
+    Event,
+    EventStatus,
+    EventType,
+    PageVisibility,
+    RSVPStatus,
+)
+from users.models import User
+
+from tests.conftest import future_iso
+
+URL_TEMPLATE = "/api/community/public/events/{event_id}/rsvp/"
+
+
+def url(event):
+    return URL_TEMPLATE.format(event_id=event.id)
+
+
+def payload(**overrides):
+    base = {
+        "name": "Sam Green",
+        "email": "sam@example.com",
+        "phone_number": "+14155550123",
+        "status": RSVPStatus.ATTENDING,
+        "has_plus_one": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def post(api_client, event, **overrides):
+    return api_client.post(url(event), payload(**overrides), content_type="application/json")
+
+
+def first_code(response) -> str:
+    return response.json()["detail"][0]["code"]
+
+
+def make_official_event(**overrides):
+    base = {
+        "title": "Official Public Event",
+        "start_datetime": future_iso(days=30),
+        "event_type": EventType.OFFICIAL,
+        "visibility": PageVisibility.PUBLIC,
+        "status": EventStatus.ACTIVE,
+        "rsvp_enabled": True,
+    }
+    base.update(overrides)
+    return Event.objects.create(**base)
+
+
+def make_non_member(phone, email, name="Existing Nonmember"):
+    user = User.objects.create_user(
+        phone_number=phone,
+        display_name=name,
+        email=email,
+        is_member=False,
+    )
+    user.set_unusable_password()
+    user.save(update_fields=["password"])
+    return user

--- a/backend/tests/test_public_rsvp.py
+++ b/backend/tests/test_public_rsvp.py
@@ -1,0 +1,330 @@
+"""Tests for the public (non-member) RSVP submission endpoint.
+
+POST /api/community/public/events/{event_id}/rsvp/ — no auth. Backs each RSVP
+with a non-member User row so the existing RSVP machinery is reused, issues a
+scoped NonMemberRsvpToken, and emails a confirmation with a /my-rsvps magic link.
+
+Capacity / waitlist / robustness cases live in test_public_rsvp_capacity.py.
+"""
+
+import pytest
+from community._validation import Code
+from community.models import EventRSVP, EventStatus, EventType, PageVisibility, RSVPStatus
+from users.models import NonMemberRsvpToken, User
+
+from tests._public_rsvp_helpers import (
+    URL_TEMPLATE,
+    first_code,
+    make_non_member,
+    make_official_event,
+    payload,
+    post,
+)
+from tests.conftest import future_iso, past_iso
+
+
+@pytest.fixture
+def official_event(db):
+    return make_official_event(
+        location="123 Vegan Way", whatsapp_link="https://chat.whatsapp.com/abc123"
+    )
+
+
+@pytest.mark.django_db
+class TestPublicRsvpHappyPath:
+    def test_creates_user_rsvp_token_and_emails(
+        self, api_client, official_event, fake_email_sender
+    ):
+        response = post(api_client, official_event)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["rsvp"]["status"] == RSVPStatus.ATTENDING
+        assert body["rsvp"]["has_plus_one"] is False
+        # Token must NOT leak into the response — email only.
+        assert "token" not in body
+        assert "token" not in body["rsvp"]
+
+        user = User.objects.get(phone_number="+14155550123")
+        assert user.is_member is False
+        assert user.email == "sam@example.com"
+        assert user.display_name == "Sam Green"
+        assert not user.has_usable_password()
+        assert EventRSVP.objects.filter(event=official_event, user=user).count() == 1
+        assert NonMemberRsvpToken.objects.filter(user=user).count() == 1
+
+        fake_email_sender.send.assert_called_once()
+        sent = fake_email_sender.send.call_args.kwargs
+        assert sent["to"] == "sam@example.com"
+        assert "you're in" in sent["subject"]
+        token = NonMemberRsvpToken.objects.get(user=user)
+        assert token.token in sent["text"]
+
+    def test_response_exposes_gated_event_details(
+        self, api_client, official_event, fake_email_sender
+    ):
+        # A successful RSVP entitles the non-member to the gated fields.
+        response = post(api_client, official_event)
+        event_out = response.json()["event"]
+        assert event_out["location"] == "123 Vegan Way"
+        assert event_out["whatsapp_link"] == "https://chat.whatsapp.com/abc123"
+
+
+@pytest.mark.django_db
+class TestPublicRsvpDedup:
+    def test_returning_by_phone_reuses_row(self, api_client, official_event, fake_email_sender):
+        existing = make_non_member("+14155550123", "old@example.com")
+
+        response = post(api_client, official_event, email="new@example.com")
+
+        assert response.status_code == 200
+        assert User.objects.filter(phone_number="+14155550123").count() == 1
+        existing.refresh_from_db()
+        # Email already set → never overwritten.
+        assert existing.email == "old@example.com"
+        assert NonMemberRsvpToken.objects.filter(user=existing).count() == 1
+
+    def test_returning_by_phone_saves_email_if_blank(
+        self, api_client, official_event, fake_email_sender
+    ):
+        existing = make_non_member("+14155550123", None)
+
+        post(api_client, official_event, email="sam@example.com")
+
+        existing.refresh_from_db()
+        assert existing.email == "sam@example.com"
+
+    def test_returning_by_email_reuses_row(self, api_client, official_event, fake_email_sender):
+        existing = make_non_member("+14155550999", "sam@example.com")
+
+        response = post(api_client, official_event, phone_number="+14155550123")
+
+        assert response.status_code == 200
+        assert User.objects.filter(email="sam@example.com").count() == 1
+        # Phone already set → not overwritten; no new user for the new phone.
+        assert not User.objects.filter(phone_number="+14155550123").exists()
+        assert EventRSVP.objects.filter(user=existing).count() == 1
+
+    def test_both_match_same_row_no_change(self, api_client, official_event, fake_email_sender):
+        existing = make_non_member("+14155550123", "sam@example.com")
+
+        response = post(api_client, official_event)
+
+        assert response.status_code == 200
+        assert User.objects.filter(is_member=False).count() == 1
+        existing.refresh_from_db()
+        assert existing.email == "sam@example.com"
+
+    def test_phone_and_email_match_different_rows_phone_wins(
+        self, api_client, official_event, fake_email_sender
+    ):
+        phone_row = make_non_member("+14155550123", "phone@example.com", name="Phone Row")
+        email_row = make_non_member("+14155550888", "sam@example.com", name="Email Row")
+
+        response = post(api_client, official_event)
+
+        assert response.status_code == 200
+        # Phone wins: RSVP attached to the phone-matched row, email untouched.
+        assert EventRSVP.objects.filter(user=phone_row).exists()
+        assert not EventRSVP.objects.filter(user=email_row).exists()
+        phone_row.refresh_from_db()
+        assert phone_row.email == "phone@example.com"
+
+    def test_same_phone_twice_yields_one_user(self, api_client, official_event, fake_email_sender):
+        post(api_client, official_event)
+        post(api_client, official_event, status=RSVPStatus.MAYBE)
+
+        assert User.objects.filter(phone_number="+14155550123").count() == 1
+        user = User.objects.get(phone_number="+14155550123")
+        assert EventRSVP.objects.filter(event=official_event, user=user).count() == 1
+        assert EventRSVP.objects.get(event=official_event, user=user).status == RSVPStatus.MAYBE
+
+    def test_archived_email_holder_does_not_block_create(
+        self, api_client, official_event, fake_email_sender
+    ):
+        # An archived user holding the submitted email is ignored by the lookups;
+        # the create path must survive the unique-email collision and RSVP anyway.
+        from django.utils import timezone
+
+        archived = make_non_member("+14155550777", "sam@example.com", name="Archived")
+        archived.archived_at = timezone.now()
+        archived.save(update_fields=["archived_at"])
+
+        response = post(api_client, official_event)
+
+        assert response.status_code == 200
+        new_user = User.objects.get(phone_number="+14155550123")
+        assert new_user.pk != archived.pk
+        # Email dropped to avoid the collision; RSVP still created.
+        assert new_user.email is None
+        assert EventRSVP.objects.filter(user=new_user).exists()
+
+    def test_multiple_rsvps_accumulate_fresh_tokens(
+        self, api_client, official_event, fake_email_sender
+    ):
+        other_event = make_official_event(
+            title="Second Official", start_datetime=future_iso(days=20)
+        )
+        post(api_client, official_event)
+        post(api_client, other_event)
+
+        user = User.objects.get(phone_number="+14155550123")
+        assert EventRSVP.objects.filter(user=user).count() == 2
+        assert NonMemberRsvpToken.objects.filter(user=user).count() == 2
+
+
+@pytest.mark.django_db
+class TestPublicRsvpMemberCollision:
+    def test_phone_belongs_to_member(self, api_client, official_event, fake_email_sender):
+        User.objects.create_user(
+            phone_number="+14155550123", display_name="A Member", is_member=True
+        )
+
+        response = post(api_client, official_event)
+
+        assert response.status_code == 409
+        assert first_code(response) == Code.Event.MEMBER_CONTACT_MUST_SIGN_IN
+        assert not EventRSVP.objects.exists()
+        fake_email_sender.send.assert_not_called()
+
+    def test_email_belongs_to_member(self, api_client, official_event, fake_email_sender):
+        User.objects.create_user(
+            phone_number="+14155550555",
+            display_name="A Member",
+            email="sam@example.com",
+            is_member=True,
+        )
+
+        response = post(api_client, official_event)
+
+        assert response.status_code == 409
+        assert first_code(response) == Code.Event.MEMBER_CONTACT_MUST_SIGN_IN
+        assert not EventRSVP.objects.exists()
+
+    def test_member_email_match_is_case_insensitive(
+        self, api_client, official_event, fake_email_sender
+    ):
+        # Stored member emails aren't guaranteed lowercased; the gate must still
+        # catch a case-mismatched submission.
+        User.objects.create_user(
+            phone_number="+14155550555",
+            display_name="A Member",
+            email="Sam@Example.COM",
+            is_member=True,
+        )
+
+        response = post(api_client, official_event, email="sam@example.com")
+
+        assert response.status_code == 409
+        assert first_code(response) == Code.Event.MEMBER_CONTACT_MUST_SIGN_IN
+        assert not EventRSVP.objects.exists()
+
+
+@pytest.mark.django_db
+class TestPublicRsvpEventGating:
+    def test_community_event(self, api_client, fake_email_sender):
+        event = make_official_event(event_type=EventType.COMMUNITY)
+        assert post(api_client, event).status_code == 404
+
+    def test_members_only(self, api_client, fake_email_sender):
+        event = make_official_event(visibility=PageVisibility.MEMBERS_ONLY)
+        assert post(api_client, event).status_code == 404
+
+    def test_invite_only(self, api_client, fake_email_sender):
+        event = make_official_event(visibility=PageVisibility.INVITE_ONLY)
+        assert post(api_client, event).status_code == 404
+
+    def test_rsvp_disabled(self, api_client, fake_email_sender):
+        event = make_official_event(rsvp_enabled=False)
+        assert post(api_client, event).status_code == 404
+
+    def test_draft(self, api_client, fake_email_sender):
+        event = make_official_event(status=EventStatus.DRAFT)
+        assert post(api_client, event).status_code == 404
+
+    def test_cancelled(self, api_client, fake_email_sender):
+        event = make_official_event(status=EventStatus.CANCELLED)
+        assert post(api_client, event).status_code == 404
+
+    def test_past(self, api_client, fake_email_sender):
+        event = make_official_event(start_datetime=past_iso(days=2), end_datetime=past_iso(days=2))
+        assert post(api_client, event).status_code == 404
+
+    def test_nonexistent(self, api_client, fake_email_sender):
+        import uuid
+
+        response = api_client.post(
+            URL_TEMPLATE.format(event_id=uuid.uuid4()),
+            payload(),
+            content_type="application/json",
+        )
+        assert response.status_code == 404
+
+    def test_gating_returns_not_found_code(self, api_client, fake_email_sender):
+        event = make_official_event(event_type=EventType.COMMUNITY)
+        response = post(api_client, event)
+        assert first_code(response) == Code.Event.NOT_FOUND
+
+
+@pytest.mark.django_db
+class TestPublicRsvpValidation:
+    def test_missing_name(self, api_client, official_event):
+        response = api_client.post(
+            URL_TEMPLATE.format(event_id=official_event.id),
+            {k: v for k, v in payload().items() if k != "name"},
+            content_type="application/json",
+        )
+        assert response.status_code == 422
+
+    def test_blank_name(self, api_client, official_event):
+        response = post(api_client, official_event, name="   ")
+        assert response.status_code == 422
+
+    def test_missing_email(self, api_client, official_event):
+        response = api_client.post(
+            URL_TEMPLATE.format(event_id=official_event.id),
+            {k: v for k, v in payload().items() if k != "email"},
+            content_type="application/json",
+        )
+        assert response.status_code == 422
+
+    def test_invalid_email(self, api_client, official_event):
+        response = post(api_client, official_event, email="not-an-email")
+        assert response.status_code == 422
+
+    def test_invalid_phone(self, api_client, official_event):
+        response = post(api_client, official_event, phone_number="123")
+        assert response.status_code == 422
+        assert first_code(response) == Code.Phone.INVALID
+
+    def test_invalid_status(self, api_client, official_event):
+        response = post(api_client, official_event, status=RSVPStatus.WAITLISTED)
+        assert response.status_code == 400
+        assert first_code(response) == Code.Event.RSVP_INVALID_STATUS
+
+
+@pytest.mark.django_db
+class TestPublicRsvpHoneypot:
+    def test_honeypot_returns_decoy_no_side_effects(
+        self, api_client, official_event, fake_email_sender
+    ):
+        response = post(api_client, official_event, website="http://spam.example")
+
+        assert response.status_code == 200
+        assert not User.objects.filter(phone_number="+14155550123").exists()
+        assert not EventRSVP.objects.exists()
+        assert not NonMemberRsvpToken.objects.exists()
+        fake_email_sender.send.assert_not_called()
+
+
+@pytest.mark.django_db
+class TestPublicRsvpRateLimit:
+    def test_sixth_request_is_limited(self, api_client, official_event, fake_email_sender):
+        for i in range(5):
+            r = post(
+                api_client, official_event, phone_number=f"+1415555010{i}", email=f"u{i}@e.com"
+            )
+            assert r.status_code == 200, r.content
+        sixth = post(api_client, official_event, phone_number="+14155550199", email="u9@e.com")
+        assert sixth.status_code == 429
+        assert first_code(sixth) == Code.Rate.LIMITED

--- a/backend/tests/test_public_rsvp_capacity.py
+++ b/backend/tests/test_public_rsvp_capacity.py
@@ -1,0 +1,133 @@
+"""Capacity, waitlist, audit, and email-robustness cases for the public RSVP endpoint.
+
+Submission / dedup / gating / validation cases live in test_public_rsvp.py; the
+shared request builders and factories live in tests/_public_rsvp_helpers.py.
+"""
+
+import logging
+
+import pytest
+from community.models import EventRSVP, RSVPStatus
+from notifications.email_sender import SendResult
+from users.models import NonMemberRsvpToken, User
+
+from tests._public_rsvp_helpers import make_non_member, make_official_event, post
+
+
+def _capped_event(max_attendees=1):
+    return make_official_event(
+        title="Capped Official", allow_plus_ones=True, max_attendees=max_attendees
+    )
+
+
+@pytest.mark.django_db
+class TestPublicRsvpCapacity:
+    def test_at_cap_auto_waitlists(self, api_client, fake_email_sender):
+        event = _capped_event(max_attendees=1)
+        first = post(api_client, event, phone_number="+14155550101", email="a@e.com")
+        assert first.json()["rsvp"]["status"] == RSVPStatus.ATTENDING
+
+        second = post(api_client, event, phone_number="+14155550102", email="b@e.com")
+        assert second.status_code == 200
+        assert second.json()["rsvp"]["status"] == RSVPStatus.WAITLISTED
+        # Confirmation email reflects the waitlist.
+        assert "waitlist" in fake_email_sender.send.call_args.kwargs["subject"]
+
+    def test_plus_one_at_cap_auto_waitlists(self, api_client, fake_email_sender):
+        event = _capped_event(max_attendees=1)
+        post(api_client, event, phone_number="+14155550101", email="a@e.com")
+        # A new attendee with a +1 at cap is auto-waitlisted (not a 400). The 400
+        # NO_PLUS_ONE_SPOTS only fires for an already-attending toggler.
+        response = post(
+            api_client,
+            event,
+            phone_number="+14155550102",
+            email="b@e.com",
+            has_plus_one=True,
+        )
+        assert response.status_code == 200
+        assert response.json()["rsvp"]["status"] == RSVPStatus.WAITLISTED
+
+    def test_spot_freed_promotes_and_emails_non_member(self, api_client, fake_email_sender):
+        event = _capped_event(max_attendees=1)
+        attendee = make_non_member("+14155550101", "a@e.com")
+        EventRSVP.objects.create(event=event, user=attendee, status=RSVPStatus.ATTENDING)
+        waited = make_non_member("+14155550102", "b@e.com", name="Waited")
+        EventRSVP.objects.create(event=event, user=waited, status=RSVPStatus.WAITLISTED)
+
+        # Attendee changes to can't-go via the public endpoint → frees the spot.
+        response = post(
+            api_client,
+            event,
+            name="A",
+            phone_number="+14155550101",
+            email="a@e.com",
+            status=RSVPStatus.CANT_GO,
+        )
+        assert response.status_code == 200
+
+        waited.refresh_from_db()
+        promoted_rsvp = EventRSVP.objects.get(event=event, user=waited)
+        assert promoted_rsvp.status == RSVPStatus.ATTENDING
+        # Promoted non-member was emailed a fresh manage link.
+        promoted_emails = [
+            c
+            for c in fake_email_sender.send.call_args_list
+            if c.kwargs["to"] == "b@e.com" and "off the waitlist" in c.kwargs["subject"]
+        ]
+        assert len(promoted_emails) == 1
+        assert NonMemberRsvpToken.objects.filter(user=waited).exists()
+
+
+def _capture_audit(caplog):
+    """Attach caplog's handler to the non-propagating pda.audit logger.
+
+    pda.audit has propagate=False (see settings LOGGING), so caplog's root
+    handler never sees its records. Attaching the handler directly captures them.
+    """
+    audit_logger = logging.getLogger("pda.audit")
+    audit_logger.addHandler(caplog.handler)
+    return audit_logger
+
+
+@pytest.fixture
+def official_event(db):
+    return make_official_event()
+
+
+@pytest.mark.django_db
+class TestPublicRsvpRobustness:
+    def test_audit_log_written(self, api_client, official_event, fake_email_sender, caplog):
+        audit_logger = _capture_audit(caplog)
+        try:
+            with caplog.at_level(logging.INFO, logger="pda.audit"):
+                post(api_client, official_event)
+        finally:
+            audit_logger.removeHandler(caplog.handler)
+
+        user = User.objects.get(phone_number="+14155550123")
+        records = [r for r in caplog.records if getattr(r, "action", None) == "public_rsvp_created"]
+        assert len(records) == 1
+        assert records[0].target_id == str(official_event.id)
+        assert records[0].details["user_id"] == str(user.pk)
+
+    def test_email_failure_does_not_roll_back_rsvp(
+        self, api_client, official_event, fake_email_sender, caplog
+    ):
+        fake_email_sender.send.return_value = SendResult(success=False, error="boom")
+
+        audit_logger = _capture_audit(caplog)
+        try:
+            with caplog.at_level(logging.WARNING, logger="pda.audit"):
+                response = post(api_client, official_event)
+        finally:
+            audit_logger.removeHandler(caplog.handler)
+
+        assert response.status_code == 200
+        user = User.objects.get(phone_number="+14155550123")
+        assert EventRSVP.objects.filter(event=official_event, user=user).exists()
+        assert NonMemberRsvpToken.objects.filter(user=user).exists()
+        failures = [
+            r for r in caplog.records if getattr(r, "action", None) == "public_rsvp_email_failed"
+        ]
+        assert len(failures) == 1

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -1215,6 +1215,23 @@ export interface paths {
         patch: operations["community__pages_update_page"];
         trace?: never;
     };
+    "/api/community/public/events/{event_id}/rsvp/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Submit Public Rsvp */
+        post: operations["community__public_rsvp_submit_public_rsvp"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/community/request-login-link/": {
         parameters: {
             query?: never;
@@ -2951,6 +2968,42 @@ export interface components {
             voters: {
                 [key: string]: components["schemas"]["VoterOut"][];
             };
+        };
+        /** PublicRsvpIn */
+        PublicRsvpIn: {
+            /**
+             * Email
+             * Format: email
+             */
+            email: string;
+            /**
+             * Has Plus One
+             * @default false
+             */
+            has_plus_one: boolean;
+            /** Name */
+            name: string;
+            /** Phone Number */
+            phone_number: string;
+            /** Status */
+            status: string;
+            /**
+             * Website
+             * @default
+             */
+            website: string;
+        };
+        /** PublicRsvpOut */
+        PublicRsvpOut: {
+            event: components["schemas"]["EventOut"];
+            rsvp: components["schemas"]["PublicRsvpStateOut"];
+        };
+        /** PublicRsvpStateOut */
+        PublicRsvpStateOut: {
+            /** Has Plus One */
+            has_plus_one: boolean;
+            /** Status */
+            status: string;
         };
         /** RSVPGuestOut */
         RSVPGuestOut: {
@@ -7178,6 +7231,68 @@ export interface operations {
             };
             /** @description Forbidden */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
+    community__public_rsvp_submit_public_rsvp: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                event_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PublicRsvpIn"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PublicRsvpOut"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/api/validationCodes.gen.ts
+++ b/frontend/src/api/validationCodes.gen.ts
@@ -31,6 +31,7 @@ export const Code = {
     RsvpInvalidStatus: 'event.rsvp_invalid_status',
     NoPlusOneSpots: 'event.no_plus_one_spots',
     RsvpNotFound: 'event.rsvp_not_found',
+    MemberContactMustSignIn: 'event.member_contact_must_sign_in',
     AttendanceOpensLater: 'event.attendance_opens_later',
     AttendanceOnlyForGoingRsvps: 'event.attendance_only_for_going_rsvps',
     PermDenied: 'event.perm_denied',
@@ -223,6 +224,7 @@ export type ValidationCode =
   | 'event.rsvp_invalid_status'
   | 'event.no_plus_one_spots'
   | 'event.rsvp_not_found'
+  | 'event.member_contact_must_sign_in'
   | 'event.attendance_opens_later'
   | 'event.attendance_only_for_going_rsvps'
   | 'event.perm_denied'
@@ -365,6 +367,7 @@ export const CODE_PARAMS: Record<ValidationCode, readonly string[]> = {
   'event.rsvp_invalid_status': [],
   'event.no_plus_one_spots': [],
   'event.rsvp_not_found': [],
+  'event.member_contact_must_sign_in': [],
   'event.attendance_opens_later': [],
   'event.attendance_only_for_going_rsvps': [],
   'event.perm_denied': ['action'],

--- a/frontend/src/api/validationCodes.ts
+++ b/frontend/src/api/validationCodes.ts
@@ -115,6 +115,8 @@ function messageForKnownCode(code: KnownCode, err: FieldError): string {
       return 'no spots available for a +1';
     case Code.Event.RsvpNotFound:
       return 'rsvp not found';
+    case Code.Event.MemberContactMustSignIn:
+      return 'looks like you already have an account — sign in to rsvp';
     case Code.Event.AttendanceOpensLater:
       return 'check-in opens an hour before the event starts';
     case Code.Event.AttendanceOnlyForGoingRsvps:


### PR DESCRIPTION
## Summary

Part of epic #490, stage 3/8. Adds `POST /api/community/public/events/{event_id}/rsvp/` — a no-auth endpoint that lets anonymous visitors RSVP to official public events. Each RSVP is backed by a non-member `User` row so the entire existing RSVP machinery (capacity, plus-ones, waitlist, promotion) is reused unchanged.

- **Strict event gating** — OFFICIAL + ACTIVE + PUBLIC + `rsvp_enabled` + not past. Every ineligible state returns `404 Code.Event.NOT_FOUND` so the endpoint never leaks the existence of non-public events.
- **Phone/email dedup collision table** — a member contact → `409 Code.Event.MEMBER_CONTACT_MUST_SIGN_IN` (new code); phone wins on ambiguity (warning logged); email lookup is case-insensitive; existing emails are never overwritten; `get_or_create` on the unique phone for new non-members, with a savepoint fallback if an archived row holds the email.
- **Scoped token, email-only** — issues a fresh `NonMemberRsvpToken` and emails a confirmation (Email 1) with a `/my-rsvps?token=...` magic link. The token never appears in the response (keeps it out of browser history / referer).
- **Email send failure does not roll back the RSVP** — audit-logs `public_rsvp_email_failed` and continues. Non-members promoted off the waitlist get a "you're off the waitlist" email.
- Audit-logs `public_rsvp_created`; honeypot returns a decoy with no side effects; rate limit `5/h` per IP.

`promote_from_waitlist` / `_apply_rsvp_in_transaction` now also return the promoted user ids (backward-compatible — the authenticated caller ignores them) so the public endpoint can email promoted non-members after commit.

### Notable decisions (vs spec wording)
- The spec names the path `/api/public/...` and the code `Code.RSVP.MEMBER_CONTACT_MUST_SIGN_IN`, but this codebase has no `/api/public/` prefix (public endpoints live under the community router) and no `Code.RSVP` namespace (RSVP codes live under `Code.Event`). Followed the actual codebase conventions: path `/api/community/public/events/{event_id}/rsvp/`, code `Code.Event.MEMBER_CONTACT_MUST_SIGN_IN`.

Out of scope (later stages): manage endpoints (`/my-rsvps`), frontend, join-flow integration.

## Test plan
- [ ] `make agent-ci` (green locally: 1051 backend tests, 546 frontend, lint/typecheck/complexity/file-size/codes-sync)
- [ ] New tests in `backend/tests/test_public_rsvp.py` + `test_public_rsvp_capacity.py` cover: happy path, returning non-member by phone/email, phone-wins ambiguity, member-contact collision (incl. case-insensitive), all event-state 404s, validation 422/400, honeypot decoy, rate-limit 6th→429, capacity auto-waitlist + plus-one-at-cap + promotion email, audit log, email-failure-no-rollback, archived-email create guard.