### PR TITLE
refactor(events): return promoted user ids from waitlist promotion (Issue 493)

### DIFF
--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -153,15 +153,17 @@ def _cancellations(event: Event) -> list[CancellationOut]:
     return rows
 
 
-def promote_from_waitlist(event: Event) -> None:
+def promote_from_waitlist(event: Event) -> list[str]:
     """Promote oldest waitlisted users to attending (FIFO by created_at).
 
     Must be called inside a transaction.atomic() block with the event row locked.
+    Returns the list of promoted user ids so callers that need to follow up per
+    promoted user (e.g. emailing promoted non-members) can do so after commit.
     """
     from notifications.service import create_waitlist_promoted_notifications
 
     if event.max_attendees is None:
-        return
+        return []
     promoted_user_ids: list[str] = []
     while True:
         headcount = _attending_headcount_db(event)
@@ -179,6 +181,7 @@ def promote_from_waitlist(event: Event) -> None:
         promoted_user_ids.append(str(oldest.user_id))
     if promoted_user_ids:
         create_waitlist_promoted_notifications(event, promoted_user_ids)
+    return promoted_user_ids
 
 
 def _has_attendees(event: Event) -> bool:

--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -102,8 +102,14 @@ def _validate_rsvp_status(status: str) -> None:
         )
 
 
-def _apply_rsvp_in_transaction(event_id, user, status: str, has_plus_one: bool) -> str:
-    """Execute RSVP upsert inside a locked transaction. Returns final_status.
+def _apply_rsvp_in_transaction(
+    event_id, user, status: str, has_plus_one: bool
+) -> tuple[str, list[str]]:
+    """Execute RSVP upsert inside a locked transaction.
+
+    Returns (final_status, promoted_user_ids). promoted_user_ids is the list of
+    users promoted off the waitlist by this change (empty unless a spot freed),
+    surfaced so callers can follow up per promoted user after commit.
 
     Raises ValidationException on failure.
     """
@@ -133,10 +139,9 @@ def _apply_rsvp_in_transaction(event_id, user, status: str, has_plus_one: bool) 
     spot_freed = (was_attending and final_status != RSVPStatus.ATTENDING) or (
         was_attending and had_plus_one and not final_plus_one
     )
-    if spot_freed:
-        promote_from_waitlist(event)
+    promoted_user_ids = promote_from_waitlist(event) if spot_freed else []
 
-    return final_status
+    return final_status, promoted_user_ids
 
 
 @router.post(
@@ -154,7 +159,7 @@ def upsert_rsvp(request, event_id: UUID, payload: RSVPIn):
     _validate_rsvp_status(payload.status)
 
     with transaction.atomic():
-        final_status = _apply_rsvp_in_transaction(
+        final_status, _promoted_user_ids = _apply_rsvp_in_transaction(
             event_id, request.auth, payload.status, payload.has_plus_one
         )
 


### PR DESCRIPTION
**Stack 1/5 for splitting #562** (Issue 493, epic #490 stage 3). Each PR targets the previous one; review/merge bottom-up.

## Summary
`promote_from_waitlist` and `_apply_rsvp_in_transaction` now return the ids of users promoted off the waitlist, so callers can follow up per promoted user (e.g. emailing promoted non-members) after the transaction commits.

Backward-compatible: the authenticated `upsert_rsvp` caller ignores the new return value. **No behavior change.**

## Stack
1. **this PR** — promoted-user-ids return
2. RSVP email senders + templates → `split-493-2-email-infra`
3. public RSVP endpoint + wiring → `split-493-3-endpoint`
4. dedup/gating tests → `split-493-4-tests-dedup`
5. capacity/promotion tests → `split-493-5-tests-capacity`

## Test plan
- [ ] `make agent-ci` on GitHub (Postgres). Locally: typecheck clean; 1000 backend tests pass (16 failures are pre-existing on `main` — Postgres-only `contains`/SSE features against the local DB, unrelated to this change).