### PR TITLE
feat(notifications): rsvp confirmation + waitlist-promoted email senders (Issue 493)

### DIFF
--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -153,15 +153,17 @@ def _cancellations(event: Event) -> list[CancellationOut]:
     return rows
 
 
-def promote_from_waitlist(event: Event) -> None:
+def promote_from_waitlist(event: Event) -> list[str]:
     """Promote oldest waitlisted users to attending (FIFO by created_at).
 
     Must be called inside a transaction.atomic() block with the event row locked.
+    Returns the list of promoted user ids so callers that need to follow up per
+    promoted user (e.g. emailing promoted non-members) can do so after commit.
     """
     from notifications.service import create_waitlist_promoted_notifications
 
     if event.max_attendees is None:
-        return
+        return []
     promoted_user_ids: list[str] = []
     while True:
         headcount = _attending_headcount_db(event)
@@ -179,6 +181,7 @@ def promote_from_waitlist(event: Event) -> None:
         promoted_user_ids.append(str(oldest.user_id))
     if promoted_user_ids:
         create_waitlist_promoted_notifications(event, promoted_user_ids)
+    return promoted_user_ids
 
 
 def _has_attendees(event: Event) -> bool:

--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -102,8 +102,14 @@ def _validate_rsvp_status(status: str) -> None:
         )
 
 
-def _apply_rsvp_in_transaction(event_id, user, status: str, has_plus_one: bool) -> str:
-    """Execute RSVP upsert inside a locked transaction. Returns final_status.
+def _apply_rsvp_in_transaction(
+    event_id, user, status: str, has_plus_one: bool
+) -> tuple[str, list[str]]:
+    """Execute RSVP upsert inside a locked transaction.
+
+    Returns (final_status, promoted_user_ids). promoted_user_ids is the list of
+    users promoted off the waitlist by this change (empty unless a spot freed),
+    surfaced so callers can follow up per promoted user after commit.
 
     Raises ValidationException on failure.
     """
@@ -133,10 +139,9 @@ def _apply_rsvp_in_transaction(event_id, user, status: str, has_plus_one: bool) 
     spot_freed = (was_attending and final_status != RSVPStatus.ATTENDING) or (
         was_attending and had_plus_one and not final_plus_one
     )
-    if spot_freed:
-        promote_from_waitlist(event)
+    promoted_user_ids = promote_from_waitlist(event) if spot_freed else []
 
-    return final_status
+    return final_status, promoted_user_ids
 
 
 @router.post(
@@ -154,7 +159,7 @@ def upsert_rsvp(request, event_id: UUID, payload: RSVPIn):
     _validate_rsvp_status(payload.status)
 
     with transaction.atomic():
-        final_status = _apply_rsvp_in_transaction(
+        final_status, _promoted_user_ids = _apply_rsvp_in_transaction(
             event_id, request.auth, payload.status, payload.has_plus_one
         )
 

--- a/backend/notifications/_email_helpers.py
+++ b/backend/notifications/_email_helpers.py
@@ -5,9 +5,75 @@ Each helper renders its templates and dispatches via the injected
 paths or context shapes — they just say "send a magic-login email."
 """
 
+from dataclasses import dataclass
+
 from django.template.loader import render_to_string
 
 from notifications.email_sender import EmailSender, SendResult
+
+
+@dataclass(frozen=True)
+class RsvpEmailDetails:
+    """Event + recipient details shared by the non-member RSVP emails.
+
+    Bundling these keeps the send helpers to a handful of arguments and gives
+    callers one place to assemble the per-event context.
+    """
+
+    to: str
+    display_name: str
+    event_title: str
+    event_when: str
+    event_location: str
+    event_links: list[str]
+    manage_url: str
+
+    def template_context(self) -> dict:
+        return {
+            "display_name": self.display_name or "",
+            "event_title": self.event_title,
+            "event_when": self.event_when,
+            "event_location": self.event_location,
+            "event_links": self.event_links,
+            "manage_url": self.manage_url,
+        }
+
+
+def send_rsvp_confirmation_email(
+    *,
+    sender: EmailSender,
+    details: RsvpEmailDetails,
+    waitlisted: bool,
+) -> SendResult:
+    """Render and send the non-member RSVP confirmation email (Email 1).
+
+    `details.manage_url` is the scoped /my-rsvps?token=... magic link. When
+    `waitlisted` the subject and body reflect that the RSVP landed on the waitlist.
+    """
+    context = {**details.template_context(), "waitlisted": waitlisted}
+    html = render_to_string("emails/rsvp_confirmation.html", context)
+    text = render_to_string("emails/rsvp_confirmation.txt", context)
+    title = details.event_title.lower()
+    subject = f"you're on the waitlist for {title}" if waitlisted else f"you're in for {title}"
+    return sender.send(to=details.to, subject=subject, html=html, text=text)
+
+
+def send_rsvp_waitlist_promoted_email(
+    *,
+    sender: EmailSender,
+    details: RsvpEmailDetails,
+) -> SendResult:
+    """Render and send the "you're off the waitlist" email (Email 3) to a
+    non-member promoted off an event's waitlist."""
+    context = details.template_context()
+    html = render_to_string("emails/rsvp_waitlist_promoted.html", context)
+    text = render_to_string("emails/rsvp_waitlist_promoted.txt", context)
+    return sender.send(
+        to=details.to,
+        subject=f"you're off the waitlist for {details.event_title.lower()}",
+        html=html,
+        text=text,
+    )
 
 
 def send_magic_login_email(

--- a/backend/templates/emails/rsvp_confirmation.html
+++ b/backend/templates/emails/rsvp_confirmation.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+<body style="margin: 0; padding: 24px; background: #f5f5f3; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #222;">
+  <div style="max-width: 480px; margin: 0 auto; background: #ffffff; border-radius: 8px; padding: 32px;">
+    <p style="margin: 0 0 16px;">hi{% if display_name %} {{ display_name|lower }}{% endif %} —</p>
+    {% if waitlisted %}
+    <p style="margin: 0 0 24px;">you're on the waitlist for <strong>{{ event_title|lower }}</strong>. we'll email you if a spot opens up.</p>
+    {% else %}
+    <p style="margin: 0 0 24px;">you're in for <strong>{{ event_title|lower }}</strong> 🌱</p>
+    {% endif %}
+    {% if event_when %}<p style="margin: 0 0 8px;">when: {{ event_when|lower }}</p>{% endif %}
+    {% if event_location %}<p style="margin: 0 0 8px;">where: {{ event_location|lower }}</p>{% endif %}
+    {% for link in event_links %}<p style="margin: 0 0 8px; font-size: 13px; word-break: break-all;"><a href="{{ link }}" style="color: #3c6939;">{{ link }}</a></p>{% endfor %}
+    <p style="margin: 24px 0 16px;">manage or change your rsvp anytime:</p>
+    <p style="margin: 0 0 24px;">
+      <a href="{{ manage_url }}" style="display: inline-block; background: #3c6939; color: #ffffff; text-decoration: none; padding: 12px 24px; border-radius: 6px; font-weight: 500;">manage my rsvp</a>
+    </p>
+    <p style="margin: 0 0 8px; font-size: 13px; color: #666;">or paste this into your browser:</p>
+    <p style="margin: 0 0 24px; font-size: 13px; word-break: break-all;"><a href="{{ manage_url }}" style="color: #3c6939;">{{ manage_url }}</a></p>
+    <p style="margin: 0; font-size: 13px; color: #666;">rsvping doesn't make you a pda member. want to join? reply to a host or visit the site to request to join.</p>
+  </div>
+  <p style="text-align: center; margin: 16px 0 0; font-size: 12px; color: #888;">— pda</p>
+</body>
+</html>

--- a/backend/templates/emails/rsvp_confirmation.txt
+++ b/backend/templates/emails/rsvp_confirmation.txt
@@ -1,0 +1,15 @@
+hi{% if display_name %} {{ display_name|lower }}{% endif %} —
+
+{% if waitlisted %}you're on the waitlist for {{ event_title|lower }}. we'll email you if a spot opens up.{% else %}you're in for {{ event_title|lower }} 🌱{% endif %}
+{% if event_when %}
+when: {{ event_when|lower }}{% endif %}{% if event_location %}
+where: {{ event_location|lower }}{% endif %}
+{% for link in event_links %}{{ link }}
+{% endfor %}
+manage or change your rsvp anytime:
+
+{{ manage_url }}
+
+rsvping doesn't make you a pda member. want to join? reply to a host or visit the site to request to join.
+
+— pda

--- a/backend/templates/emails/rsvp_waitlist_promoted.html
+++ b/backend/templates/emails/rsvp_waitlist_promoted.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+<body style="margin: 0; padding: 24px; background: #f5f5f3; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #222;">
+  <div style="max-width: 480px; margin: 0 auto; background: #ffffff; border-radius: 8px; padding: 32px;">
+    <p style="margin: 0 0 16px;">hi{% if display_name %} {{ display_name|lower }}{% endif %} —</p>
+    <p style="margin: 0 0 24px;">good news — a spot opened up and you're off the waitlist for <strong>{{ event_title|lower }}</strong> 🌱</p>
+    {% if event_when %}<p style="margin: 0 0 8px;">when: {{ event_when|lower }}</p>{% endif %}
+    {% if event_location %}<p style="margin: 0 0 8px;">where: {{ event_location|lower }}</p>{% endif %}
+    {% for link in event_links %}<p style="margin: 0 0 8px; font-size: 13px; word-break: break-all;"><a href="{{ link }}" style="color: #3c6939;">{{ link }}</a></p>{% endfor %}
+    <p style="margin: 24px 0 16px;">manage or change your rsvp anytime:</p>
+    <p style="margin: 0 0 24px;">
+      <a href="{{ manage_url }}" style="display: inline-block; background: #3c6939; color: #ffffff; text-decoration: none; padding: 12px 24px; border-radius: 6px; font-weight: 500;">manage my rsvp</a>
+    </p>
+    <p style="margin: 0 0 8px; font-size: 13px; color: #666;">or paste this into your browser:</p>
+    <p style="margin: 0 0 24px; font-size: 13px; word-break: break-all;"><a href="{{ manage_url }}" style="color: #3c6939;">{{ manage_url }}</a></p>
+    <p style="margin: 0; font-size: 13px; color: #666;">rsvping doesn't make you a pda member. want to join? reply to a host or visit the site to request to join.</p>
+  </div>
+  <p style="text-align: center; margin: 16px 0 0; font-size: 12px; color: #888;">— pda</p>
+</body>
+</html>

--- a/backend/templates/emails/rsvp_waitlist_promoted.txt
+++ b/backend/templates/emails/rsvp_waitlist_promoted.txt
@@ -1,0 +1,15 @@
+hi{% if display_name %} {{ display_name|lower }}{% endif %} —
+
+good news — a spot opened up and you're off the waitlist for {{ event_title|lower }} 🌱
+{% if event_when %}
+when: {{ event_when|lower }}{% endif %}{% if event_location %}
+where: {{ event_location|lower }}{% endif %}
+{% for link in event_links %}{{ link }}
+{% endfor %}
+manage or change your rsvp anytime:
+
+{{ manage_url }}
+
+rsvping doesn't make you a pda member. want to join? reply to a host or visit the site to request to join.
+
+— pda


### PR DESCRIPTION
**Stack 2/5 for splitting #562** (Issue 493). Targets `split-493-1-promote-ids` — review/merge after #567.

## Summary
Adds `RsvpEmailDetails` plus two send helpers (`send_rsvp_confirmation_email`, `send_rsvp_waitlist_promoted_email`) and their html/txt templates, for the upcoming public non-member RSVP flow.

Self-contained: dispatches through the existing injected `EmailSender`. No caller yet (the endpoint in stack 3/5 calls them).

## Test plan
- [ ] `make agent-ci` on GitHub (Postgres). Locally: typecheck + CI clean (same 16 pre-existing-on-`main` env failures, unrelated).