### PR TITLE
feat(public-rsvp): public RSVP submit endpoint + dedup + confirmation email (Issue 493)

### DIFF
--- a/backend/community/_public_rsvp.py
+++ b/backend/community/_public_rsvp.py
@@ -1,11 +1,4 @@
-"""Public (no-auth) non-member RSVP submission.
-
-Anonymous visitors RSVP to OFFICIAL, PUBLIC, active, rsvp-enabled events without
-an account. A non-member ``User`` row backs each RSVP so the entire existing
-RSVP machinery (capacity, plus-ones, waitlist, promotion) is reused unchanged.
-A scoped ``NonMemberRsvpToken`` is emailed (never returned in the response) so
-the visitor can manage their RSVP at ``/my-rsvps?token=...``.
-"""
+"""Public (no-auth) non-member RSVP submission."""
 
 import logging
 
@@ -57,11 +50,7 @@ class PublicRsvpOut(BaseModel):
 
 
 def _public_rsvp_decoy(event: Event, status: str, has_plus_one: bool) -> PublicRsvpOut:
-    """Mimic a real submission's shape so bots register success and stop retrying.
-
-    No User/RSVP/token row is created and no email is sent. The event payload is
-    the anonymous (un-RSVP'd) view, so gated details stay hidden.
-    """
+    """Mimic a real submission's shape (no rows created, no email) so bots register success."""
     return PublicRsvpOut(
         event=_event_out(event, None),
         rsvp=PublicRsvpStateOut(status=status, has_plus_one=has_plus_one),
@@ -69,11 +58,7 @@ def _public_rsvp_decoy(event: Event, status: str, has_plus_one: bool) -> PublicR
 
 
 def _load_public_rsvp_event(event_id) -> Event:
-    """Fetch an event eligible for public RSVP, else 404.
-
-    Every ineligible state collapses to Code.Event.NOT_FOUND so the endpoint
-    never leaks the existence of non-public events.
-    """
+    """Fetch a public-RSVP-eligible event, else 404 (every ineligible state hides as NOT_FOUND)."""
     event = Event.objects.prefetch_related("co_hosts", "invited_users").filter(id=event_id).first()
     if (
         event is None
@@ -88,8 +73,7 @@ def _load_public_rsvp_event(event_id) -> Event:
 
 
 def _reuse_phone_match(phone_match: User, email: str) -> User:
-    # Save the submitted email only if blank — never overwrite an existing email
-    # (avoids identity churn for a returning non-member).
+    # Backfill the email only if blank — never overwrite an existing one.
     if email and not phone_match.email:
         phone_match.email = email
         phone_match.save(update_fields=["email"])
@@ -105,11 +89,11 @@ def _reuse_email_match(email_match: User, phone: str) -> User:
 
 
 def _create_non_member(name: str, email: str, phone: str) -> User:
-    # Relies on the unique phone constraint for race safety — a concurrent
-    # IntegrityError loser is re-fetched by get_or_create's own SELECT. The
-    # email is dropped on a unique-email collision (e.g. an archived row holds
-    # it) inside a savepoint so the outer transaction survives; the RSVP still
-    # succeeds, just without an email saved on the new row.
+    """Get-or-create the non-member User keyed on the unique phone number.
+
+    On a unique-email collision the email is dropped inside a savepoint so the
+    outer transaction and the RSVP survive; the row is just saved without it.
+    """
     defaults = {"display_name": name, "is_member": False}
     try:
         with transaction.atomic():
@@ -126,9 +110,9 @@ def _create_non_member(name: str, email: str, phone: str) -> User:
 
 def _resolve_both_match(request, phone_match: User, email_match: User) -> User:
     if phone_match.pk == email_match.pk:
-        return phone_match  # Same non-member row — reuse, no change.
-    # Phone and email point at different non-member rows. Phone is the canonical
-    # identifier in this app — reuse it, leave its email as-is, flag for admins.
+        return phone_match
+    # Phone and email point at different rows. Phone is canonical here — reuse it
+    # and flag the ambiguity for admins.
     audit_log(
         logging.WARNING,
         "public_rsvp_contact_ambiguous",
@@ -141,22 +125,18 @@ def _resolve_both_match(request, phone_match: User, email_match: User) -> User:
 
 
 def _resolve_non_member(*, request, name: str, email: str, phone: str) -> User:
-    """Resolve (or create) the non-member User backing this RSVP.
+    """Resolve (or create) the non-member User backing this RSVP; member contact → 409.
 
-    Implements the spec's phone/email collision table. Members → 409. Returns a
-    non-member User. Must run inside the surrounding transaction.
+    Must run inside the surrounding transaction.
     """
     phone_match = User.objects.filter(phone_number=phone, archived_at__isnull=True).first()
-    # iexact, not exact: stored emails aren't guaranteed lowercased (the admin
-    # members screen stores them verbatim), so an exact match on the normalized
-    # input could miss a member and bypass the MEMBER_CONTACT_MUST_SIGN_IN gate.
+    # iexact: stored emails aren't guaranteed lowercased, so exact could miss a member.
     email_match = (
         User.objects.filter(email__iexact=email, archived_at__isnull=True).first()
         if email
         else None
     )
 
-    # Either contact belongs to a member → redirect to the authenticated flow.
     if (phone_match and phone_match.is_member) or (email_match and email_match.is_member):
         raise_validation(Code.Event.MEMBER_CONTACT_MUST_SIGN_IN, status_code=409)
 
@@ -189,6 +169,7 @@ def _email_details(event: Event, user: User, token_str: str) -> RsvpEmailDetails
         event_location=event.location,
         event_links=_event_links(event),
         manage_url=f"{settings.FRONTEND_BASE_URL}/my-rsvps?token={token_str}",
+        join_url=f"{settings.FRONTEND_BASE_URL}/join",
     )
 
 
@@ -251,8 +232,7 @@ def _email_promoted_non_members(request, event: Event, promoted_user_ids: list[s
 def submit_public_rsvp(request, event_id, payload: PublicRsvpIn):
     event = _load_public_rsvp_event(event_id)
 
-    # Honeypot trip — decoy 200 without persisting. Checked before field
-    # validation so a bot gets no validation feedback to iterate against.
+    # Honeypot trip — decoy 200 before validation, so bots get no feedback.
     if payload.website.strip():
         audit_log(
             logging.WARNING,

--- a/backend/community/_public_rsvp.py
+++ b/backend/community/_public_rsvp.py
@@ -1,0 +1,306 @@
+"""Public (no-auth) non-member RSVP submission.
+
+Anonymous visitors RSVP to OFFICIAL, PUBLIC, active, rsvp-enabled events without
+an account. A non-member ``User`` row backs each RSVP so the entire existing
+RSVP machinery (capacity, plus-ones, waitlist, promotion) is reused unchanged.
+A scoped ``NonMemberRsvpToken`` is emailed (never returned in the response) so
+the visitor can manage their RSVP at ``/my-rsvps?token=...``.
+"""
+
+import logging
+
+from config.audit import audit_log
+from config.ratelimit import client_ip, rate_limit
+from django.conf import settings
+from django.db import IntegrityError, transaction
+from django.utils import timezone
+from ninja import Router
+from ninja.responses import Status
+from notifications._email_helpers import (
+    RsvpEmailDetails,
+    send_rsvp_confirmation_email,
+    send_rsvp_waitlist_promoted_email,
+)
+from notifications.email_sender import get_email_sender
+from pydantic import BaseModel, EmailStr, Field
+from users.models import NonMemberRsvpToken, User
+
+from community._event_helpers import _event_out
+from community._event_rsvps import _apply_rsvp_in_transaction, _validate_rsvp_status
+from community._event_schemas import EventOut
+from community._field_limits import FieldLimit
+from community._shared import ErrorOut, _validate_phone, logger, validate_display_name
+from community._validation import Code, raise_validation
+from community.models import Event, EventStatus, EventType, PageVisibility, RSVPStatus
+
+router = Router()
+
+
+class PublicRsvpIn(BaseModel):
+    name: str = Field(max_length=FieldLimit.DISPLAY_NAME)
+    email: EmailStr
+    phone_number: str = Field(max_length=FieldLimit.PHONE)
+    status: str = Field(max_length=FieldLimit.CHOICE)
+    has_plus_one: bool = False
+    # Honeypot: hidden field humans never fill in. A non-empty value is spam.
+    website: str = Field(default="", max_length=FieldLimit.DISPLAY_NAME)
+
+
+class PublicRsvpStateOut(BaseModel):
+    status: str
+    has_plus_one: bool
+
+
+class PublicRsvpOut(BaseModel):
+    event: EventOut
+    rsvp: PublicRsvpStateOut
+
+
+def _public_rsvp_decoy(event: Event, status: str, has_plus_one: bool) -> PublicRsvpOut:
+    """Mimic a real submission's shape so bots register success and stop retrying.
+
+    No User/RSVP/token row is created and no email is sent. The event payload is
+    the anonymous (un-RSVP'd) view, so gated details stay hidden.
+    """
+    return PublicRsvpOut(
+        event=_event_out(event, None),
+        rsvp=PublicRsvpStateOut(status=status, has_plus_one=has_plus_one),
+    )
+
+
+def _load_public_rsvp_event(event_id) -> Event:
+    """Fetch an event eligible for public RSVP, else 404.
+
+    Every ineligible state collapses to Code.Event.NOT_FOUND so the endpoint
+    never leaks the existence of non-public events.
+    """
+    event = Event.objects.prefetch_related("co_hosts", "invited_users").filter(id=event_id).first()
+    if (
+        event is None
+        or event.event_type != EventType.OFFICIAL
+        or event.status != EventStatus.ACTIVE
+        or event.visibility != PageVisibility.PUBLIC
+        or not event.rsvp_enabled
+        or event.is_past
+    ):
+        raise_validation(Code.Event.NOT_FOUND, status_code=404)
+    return event
+
+
+def _reuse_phone_match(phone_match: User, email: str) -> User:
+    # Save the submitted email only if blank — never overwrite an existing email
+    # (avoids identity churn for a returning non-member).
+    if email and not phone_match.email:
+        phone_match.email = email
+        phone_match.save(update_fields=["email"])
+    return phone_match
+
+
+def _reuse_email_match(email_match: User, phone: str) -> User:
+    # Phone is required for non-members; backfill it only if somehow blank.
+    if not email_match.phone_number:
+        email_match.phone_number = phone
+        email_match.save(update_fields=["phone_number"])
+    return email_match
+
+
+def _create_non_member(name: str, email: str, phone: str) -> User:
+    # Relies on the unique phone constraint for race safety — a concurrent
+    # IntegrityError loser is re-fetched by get_or_create's own SELECT. The
+    # email is dropped on a unique-email collision (e.g. an archived row holds
+    # it) inside a savepoint so the outer transaction survives; the RSVP still
+    # succeeds, just without an email saved on the new row.
+    defaults = {"display_name": name, "is_member": False}
+    try:
+        with transaction.atomic():
+            user, created = User.objects.get_or_create(
+                phone_number=phone, defaults={**defaults, "email": email or None}
+            )
+    except IntegrityError:
+        user, created = User.objects.get_or_create(phone_number=phone, defaults=defaults)
+    if created:
+        user.set_unusable_password()
+        user.save(update_fields=["password"])
+    return user
+
+
+def _resolve_both_match(request, phone_match: User, email_match: User) -> User:
+    if phone_match.pk == email_match.pk:
+        return phone_match  # Same non-member row — reuse, no change.
+    # Phone and email point at different non-member rows. Phone is the canonical
+    # identifier in this app — reuse it, leave its email as-is, flag for admins.
+    audit_log(
+        logging.WARNING,
+        "public_rsvp_contact_ambiguous",
+        request,
+        target_type="user",
+        target_id=str(phone_match.pk),
+        details={"email_user_id": str(email_match.pk)},
+    )
+    return phone_match
+
+
+def _resolve_non_member(*, request, name: str, email: str, phone: str) -> User:
+    """Resolve (or create) the non-member User backing this RSVP.
+
+    Implements the spec's phone/email collision table. Members → 409. Returns a
+    non-member User. Must run inside the surrounding transaction.
+    """
+    phone_match = User.objects.filter(phone_number=phone, archived_at__isnull=True).first()
+    # iexact, not exact: stored emails aren't guaranteed lowercased (the admin
+    # members screen stores them verbatim), so an exact match on the normalized
+    # input could miss a member and bypass the MEMBER_CONTACT_MUST_SIGN_IN gate.
+    email_match = (
+        User.objects.filter(email__iexact=email, archived_at__isnull=True).first()
+        if email
+        else None
+    )
+
+    # Either contact belongs to a member → redirect to the authenticated flow.
+    if (phone_match and phone_match.is_member) or (email_match and email_match.is_member):
+        raise_validation(Code.Event.MEMBER_CONTACT_MUST_SIGN_IN, status_code=409)
+
+    if phone_match and email_match:
+        return _resolve_both_match(request, phone_match, email_match)
+    if phone_match:
+        return _reuse_phone_match(phone_match, email)
+    if email_match:
+        return _reuse_email_match(email_match, phone)
+    return _create_non_member(name, email, phone)
+
+
+def _format_event_when(event: Event) -> str:
+    if event.datetime_tbd or event.start_datetime is None:
+        return "to be decided"
+    local = timezone.localtime(event.start_datetime)
+    return local.strftime("%A, %B %d at %I:%M %p").replace(" 0", " ")
+
+
+def _event_links(event: Event) -> list[str]:
+    return [link for link in (event.whatsapp_link, event.partiful_link, event.other_link) if link]
+
+
+def _email_details(event: Event, user: User, token_str: str) -> RsvpEmailDetails:
+    return RsvpEmailDetails(
+        to=user.email,
+        display_name=user.display_name,
+        event_title=event.title,
+        event_when=_format_event_when(event),
+        event_location=event.location,
+        event_links=_event_links(event),
+        manage_url=f"{settings.FRONTEND_BASE_URL}/my-rsvps?token={token_str}",
+    )
+
+
+def _log_email_failure(request, event: Event, user: User, exc: Exception) -> None:
+    logger.warning("public rsvp email failed", exc_info=True)
+    audit_log(
+        logging.WARNING,
+        "public_rsvp_email_failed",
+        request,
+        target_type="event",
+        target_id=str(event.id),
+        details={"user_id": str(user.pk), "error": str(exc)},
+    )
+
+
+def _send_confirmation_email(
+    request, event: Event, user: User, token_str: str, waitlisted: bool
+) -> None:
+    """Best-effort confirmation email. A send failure must NOT roll back the RSVP."""
+    if not user.email:
+        return
+    try:
+        result = send_rsvp_confirmation_email(
+            sender=get_email_sender(),
+            details=_email_details(event, user, token_str),
+            waitlisted=waitlisted,
+        )
+        if not result.success:
+            raise RuntimeError(result.error or "send returned failure")
+    except Exception as exc:
+        _log_email_failure(request, event, user, exc)
+
+
+def _email_promoted_non_members(request, event: Event, promoted_user_ids: list[str]) -> None:
+    """Email any promoted non-members a fresh manage link. Best-effort per user."""
+    if not promoted_user_ids:
+        return
+    promoted = User.objects.filter(id__in=promoted_user_ids, is_member=False, email__isnull=False)
+    for user in promoted:
+        if not user.email:
+            continue
+        try:
+            token = NonMemberRsvpToken.issue(user)
+            result = send_rsvp_waitlist_promoted_email(
+                sender=get_email_sender(),
+                details=_email_details(event, user, token.token),
+            )
+            if not result.success:
+                raise RuntimeError(result.error or "send returned failure")
+        except Exception as exc:
+            _log_email_failure(request, event, user, exc)
+
+
+@router.post(
+    "/public/events/{event_id}/rsvp/",
+    response={200: PublicRsvpOut, 400: ErrorOut, 404: ErrorOut, 409: ErrorOut, 429: ErrorOut},
+    auth=None,
+)
+@rate_limit(key_func=client_ip, rate="5/h")
+def submit_public_rsvp(request, event_id, payload: PublicRsvpIn):
+    event = _load_public_rsvp_event(event_id)
+
+    # Honeypot trip — decoy 200 without persisting. Checked before field
+    # validation so a bot gets no validation feedback to iterate against.
+    if payload.website.strip():
+        audit_log(
+            logging.WARNING,
+            "public_rsvp_honeypot_tripped",
+            request,
+            target_type="event",
+            target_id=str(event_id),
+        )
+        return Status(200, _public_rsvp_decoy(event, payload.status, payload.has_plus_one))
+
+    name = payload.name.strip()
+    validate_display_name(name, field="name")
+    validated_phone = _validate_phone(payload.phone_number)
+    normalized_email = payload.email.strip().lower()
+    _validate_rsvp_status(payload.status)
+
+    with transaction.atomic():
+        user = _resolve_non_member(
+            request=request, name=name, email=normalized_email, phone=validated_phone
+        )
+        final_status, promoted_user_ids = _apply_rsvp_in_transaction(
+            event.id, user, payload.status, payload.has_plus_one
+        )
+        token = NonMemberRsvpToken.issue(user)
+
+    audit_log(
+        logging.INFO,
+        "public_rsvp_created",
+        request,
+        target_type="event",
+        target_id=str(event.id),
+        details={"user_id": str(user.pk), "status": final_status},
+    )
+
+    waitlisted = final_status == RSVPStatus.WAITLISTED
+    _send_confirmation_email(request, event, user, token.token, waitlisted)
+    _email_promoted_non_members(request, event, promoted_user_ids)
+
+    fresh_event = (
+        Event.objects.select_related("created_by")
+        .prefetch_related("co_hosts", "invited_users", "rsvps__user")
+        .get(id=event.id)
+    )
+    final_rsvp = user.event_rsvps.get(event=fresh_event)
+    return Status(
+        200,
+        PublicRsvpOut(
+            event=_event_out(fresh_event, user),
+            rsvp=PublicRsvpStateOut(status=final_rsvp.status, has_plus_one=final_rsvp.has_plus_one),
+        ),
+    )

--- a/backend/community/_public_rsvp.py
+++ b/backend/community/_public_rsvp.py
@@ -1,5 +1,3 @@
-"""Public (no-auth) non-member RSVP submission."""
-
 import logging
 
 from config.audit import audit_log
@@ -60,6 +58,8 @@ def _public_rsvp_decoy(event: Event, status: str, has_plus_one: bool) -> PublicR
 def _load_public_rsvp_event(event_id) -> Event:
     """Fetch a public-RSVP-eligible event, else 404 (every ineligible state hides as NOT_FOUND)."""
     event = Event.objects.prefetch_related("co_hosts", "invited_users").filter(id=event_id).first()
+    # OFFICIAL + PUBLIC are redundant today (official implies public); the type/visibility
+    # taxonomy needs untangling — see issue #604.
     if (
         event is None
         or event.event_type != EventType.OFFICIAL
@@ -72,20 +72,12 @@ def _load_public_rsvp_event(event_id) -> Event:
     return event
 
 
-def _reuse_phone_match(phone_match: User, email: str) -> User:
+def _backfill_email(phone_match: User, email: str) -> User:
     # Backfill the email only if blank — never overwrite an existing one.
     if email and not phone_match.email:
         phone_match.email = email
         phone_match.save(update_fields=["email"])
     return phone_match
-
-
-def _reuse_email_match(email_match: User, phone: str) -> User:
-    # Phone is required for non-members; backfill it only if somehow blank.
-    if not email_match.phone_number:
-        email_match.phone_number = phone
-        email_match.save(update_fields=["phone_number"])
-    return email_match
 
 
 def _create_non_member(name: str, email: str, phone: str) -> User:
@@ -109,10 +101,10 @@ def _create_non_member(name: str, email: str, phone: str) -> User:
 
 
 def _resolve_both_match(request, phone_match: User, email_match: User) -> User:
+    # Same row → the phone and email belong to one user; reuse it.
     if phone_match.pk == email_match.pk:
         return phone_match
-    # Phone and email point at different rows. Phone is canonical here — reuse it
-    # and flag the ambiguity for admins.
+    # Different rows: phone is canonical — reuse it and flag the ambiguity for admins.
     audit_log(
         logging.WARNING,
         "public_rsvp_contact_ambiguous",
@@ -130,11 +122,8 @@ def _resolve_non_member(*, request, name: str, email: str, phone: str) -> User:
     Must run inside the surrounding transaction.
     """
     phone_match = User.objects.filter(phone_number=phone, archived_at__isnull=True).first()
-    # iexact: stored emails aren't guaranteed lowercased, so exact could miss a member.
     email_match = (
-        User.objects.filter(email__iexact=email, archived_at__isnull=True).first()
-        if email
-        else None
+        User.objects.filter(email=email, archived_at__isnull=True).first() if email else None
     )
 
     if (phone_match and phone_match.is_member) or (email_match and email_match.is_member):
@@ -143,9 +132,9 @@ def _resolve_non_member(*, request, name: str, email: str, phone: str) -> User:
     if phone_match and email_match:
         return _resolve_both_match(request, phone_match, email_match)
     if phone_match:
-        return _reuse_phone_match(phone_match, email)
+        return _backfill_email(phone_match, email)
     if email_match:
-        return _reuse_email_match(email_match, phone)
+        return email_match
     return _create_non_member(name, email, phone)
 
 

--- a/backend/community/_validation.py
+++ b/backend/community/_validation.py
@@ -48,9 +48,6 @@ class Code:
         RSVP_INVALID_STATUS = "event.rsvp_invalid_status"
         NO_PLUS_ONE_SPOTS = "event.no_plus_one_spots"
         RSVP_NOT_FOUND = "event.rsvp_not_found"
-        # Raised by the public (non-member) RSVP endpoint when the submitted
-        # phone or email already belongs to a member — they must use the
-        # authenticated flow rather than the scoped non-member path.
         MEMBER_CONTACT_MUST_SIGN_IN = "event.member_contact_must_sign_in"
         ATTENDANCE_OPENS_LATER = "event.attendance_opens_later"
         ATTENDANCE_ONLY_FOR_GOING_RSVPS = "event.attendance_only_for_going_rsvps"

--- a/backend/community/_validation.py
+++ b/backend/community/_validation.py
@@ -48,6 +48,10 @@ class Code:
         RSVP_INVALID_STATUS = "event.rsvp_invalid_status"
         NO_PLUS_ONE_SPOTS = "event.no_plus_one_spots"
         RSVP_NOT_FOUND = "event.rsvp_not_found"
+        # Raised by the public (non-member) RSVP endpoint when the submitted
+        # phone or email already belongs to a member — they must use the
+        # authenticated flow rather than the scoped non-member path.
+        MEMBER_CONTACT_MUST_SIGN_IN = "event.member_contact_must_sign_in"
         ATTENDANCE_OPENS_LATER = "event.attendance_opens_later"
         ATTENDANCE_ONLY_FOR_GOING_RSVPS = "event.attendance_only_for_going_rsvps"
         PERM_DENIED = "event.perm_denied"  # params: { action?: str }

--- a/backend/community/api.py
+++ b/backend/community/api.py
@@ -32,6 +32,7 @@ from community._join_requests import router as join_requests_router
 from community._login_link import router as login_link_router
 from community._pages import router as pages_router
 from community._polls import router as polls_router
+from community._public_rsvp import router as public_rsvp_router
 from community._surveys import router as surveys_router
 from community._surveys_public import router as surveys_public_router
 from community._version import router as version_router
@@ -50,6 +51,7 @@ router.add_router("", feedback_router)
 router.add_router("", events_router)
 router.add_router("", event_tags_router)
 router.add_router("", event_rsvps_router)
+router.add_router("", public_rsvp_router)
 router.add_router("", event_actions_router)
 router.add_router("", event_cohost_invites_router)
 router.add_router("", event_invitations_router)

--- a/backend/community/validation_codes.json
+++ b/backend/community/validation_codes.json
@@ -122,6 +122,11 @@
         "params": []
       },
       {
+        "name": "MEMBER_CONTACT_MUST_SIGN_IN",
+        "value": "event.member_contact_must_sign_in",
+        "params": []
+      },
+      {
         "name": "ATTENDANCE_OPENS_LATER",
         "value": "event.attendance_opens_later",
         "params": []

--- a/backend/notifications/_email_helpers.py
+++ b/backend/notifications/_email_helpers.py
@@ -1,5 +1,3 @@
-"""Helpers for sending specific transactional emails."""
-
 from dataclasses import dataclass
 
 from django.template.loader import render_to_string

--- a/backend/notifications/_email_helpers.py
+++ b/backend/notifications/_email_helpers.py
@@ -1,9 +1,4 @@
-"""Helpers for sending specific transactional emails.
-
-Each helper renders its templates and dispatches via the injected
-`EmailSender`. The helpers exist so callers don't have to know template
-paths or context shapes — they just say "send a magic-login email."
-"""
+"""Helpers for sending specific transactional emails."""
 
 from dataclasses import dataclass
 
@@ -14,11 +9,7 @@ from notifications.email_sender import EmailSender, SendResult
 
 @dataclass(frozen=True)
 class RsvpEmailDetails:
-    """Event + recipient details shared by the non-member RSVP emails.
-
-    Bundling these keeps the send helpers to a handful of arguments and gives
-    callers one place to assemble the per-event context.
-    """
+    """Event + recipient details shared by the non-member RSVP emails."""
 
     to: str
     display_name: str
@@ -27,6 +18,7 @@ class RsvpEmailDetails:
     event_location: str
     event_links: list[str]
     manage_url: str
+    join_url: str
 
     def template_context(self) -> dict:
         return {
@@ -36,6 +28,7 @@ class RsvpEmailDetails:
             "event_location": self.event_location,
             "event_links": self.event_links,
             "manage_url": self.manage_url,
+            "join_url": self.join_url,
         }
 
 
@@ -45,11 +38,7 @@ def send_rsvp_confirmation_email(
     details: RsvpEmailDetails,
     waitlisted: bool,
 ) -> SendResult:
-    """Render and send the non-member RSVP confirmation email (Email 1).
-
-    `details.manage_url` is the scoped /my-rsvps?token=... magic link. When
-    `waitlisted` the subject and body reflect that the RSVP landed on the waitlist.
-    """
+    """Render and send the non-member RSVP confirmation email."""
     context = {**details.template_context(), "waitlisted": waitlisted}
     html = render_to_string("emails/rsvp_confirmation.html", context)
     text = render_to_string("emails/rsvp_confirmation.txt", context)
@@ -63,8 +52,7 @@ def send_rsvp_waitlist_promoted_email(
     sender: EmailSender,
     details: RsvpEmailDetails,
 ) -> SendResult:
-    """Render and send the "you're off the waitlist" email (Email 3) to a
-    non-member promoted off an event's waitlist."""
+    """Render and send the non-member "you're off the waitlist" email."""
     context = details.template_context()
     html = render_to_string("emails/rsvp_waitlist_promoted.html", context)
     text = render_to_string("emails/rsvp_waitlist_promoted.txt", context)

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -3291,6 +3291,83 @@
         "title": "PollResultsOut",
         "type": "object"
       },
+      "PublicRsvpIn": {
+        "properties": {
+          "email": {
+            "format": "email",
+            "title": "Email",
+            "type": "string"
+          },
+          "has_plus_one": {
+            "default": false,
+            "title": "Has Plus One",
+            "type": "boolean"
+          },
+          "name": {
+            "maxLength": 64,
+            "title": "Name",
+            "type": "string"
+          },
+          "phone_number": {
+            "maxLength": 20,
+            "title": "Phone Number",
+            "type": "string"
+          },
+          "status": {
+            "maxLength": 20,
+            "title": "Status",
+            "type": "string"
+          },
+          "website": {
+            "default": "",
+            "maxLength": 64,
+            "title": "Website",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "email",
+          "phone_number",
+          "status"
+        ],
+        "title": "PublicRsvpIn",
+        "type": "object"
+      },
+      "PublicRsvpOut": {
+        "properties": {
+          "event": {
+            "$ref": "#/components/schemas/EventOut"
+          },
+          "rsvp": {
+            "$ref": "#/components/schemas/PublicRsvpStateOut"
+          }
+        },
+        "required": [
+          "event",
+          "rsvp"
+        ],
+        "title": "PublicRsvpOut",
+        "type": "object"
+      },
+      "PublicRsvpStateOut": {
+        "properties": {
+          "has_plus_one": {
+            "title": "Has Plus One",
+            "type": "boolean"
+          },
+          "status": {
+            "title": "Status",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status",
+          "has_plus_one"
+        ],
+        "title": "PublicRsvpStateOut",
+        "type": "object"
+      },
       "RSVPGuestOut": {
         "properties": {
           "attendance": {
@@ -9781,6 +9858,88 @@
           }
         ],
         "summary": "Update Page",
+        "tags": [
+          "community"
+        ]
+      }
+    },
+    "/api/community/public/events/{event_id}/rsvp/": {
+      "post": {
+        "operationId": "community__public_rsvp_submit_public_rsvp",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "event_id",
+            "required": true,
+            "schema": {
+              "title": "Event Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PublicRsvpIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicRsvpOut"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "409": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Conflict"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          }
+        },
+        "summary": "Submit Public Rsvp",
         "tags": [
           "community"
         ]

--- a/backend/templates/emails/rsvp_confirmation.html
+++ b/backend/templates/emails/rsvp_confirmation.html
@@ -17,7 +17,7 @@
     </p>
     <p style="margin: 0 0 8px; font-size: 13px; color: #666;">or paste this into your browser:</p>
     <p style="margin: 0 0 24px; font-size: 13px; word-break: break-all;"><a href="{{ manage_url }}" style="color: #3c6939;">{{ manage_url }}</a></p>
-    <p style="margin: 0; font-size: 13px; color: #666;">rsvping doesn't make you a pda member. want to join? reply to a host or visit the site to request to join.</p>
+    <p style="margin: 0; font-size: 13px; color: #666;">when you join pda you get access to club events and our whatsapp community. <a href="{{ join_url }}" style="color: #3c6939;">click here to join</a>.</p>
   </div>
   <p style="text-align: center; margin: 16px 0 0; font-size: 12px; color: #888;">— pda</p>
 </body>

--- a/backend/templates/emails/rsvp_confirmation.txt
+++ b/backend/templates/emails/rsvp_confirmation.txt
@@ -10,6 +10,6 @@ manage or change your rsvp anytime:
 
 {{ manage_url }}
 
-rsvping doesn't make you a pda member. want to join? reply to a host or visit the site to request to join.
+when you join pda you get access to club events and our whatsapp community. click here to join: {{ join_url }}
 
 — pda

--- a/backend/templates/emails/rsvp_waitlist_promoted.html
+++ b/backend/templates/emails/rsvp_waitlist_promoted.html
@@ -13,7 +13,7 @@
     </p>
     <p style="margin: 0 0 8px; font-size: 13px; color: #666;">or paste this into your browser:</p>
     <p style="margin: 0 0 24px; font-size: 13px; word-break: break-all;"><a href="{{ manage_url }}" style="color: #3c6939;">{{ manage_url }}</a></p>
-    <p style="margin: 0; font-size: 13px; color: #666;">rsvping doesn't make you a pda member. want to join? reply to a host or visit the site to request to join.</p>
+    <p style="margin: 0; font-size: 13px; color: #666;">when you join pda you get access to club events and our whatsapp community. <a href="{{ join_url }}" style="color: #3c6939;">click here to join</a>.</p>
   </div>
   <p style="text-align: center; margin: 16px 0 0; font-size: 12px; color: #888;">— pda</p>
 </body>

--- a/backend/templates/emails/rsvp_waitlist_promoted.txt
+++ b/backend/templates/emails/rsvp_waitlist_promoted.txt
@@ -10,6 +10,6 @@ manage or change your rsvp anytime:
 
 {{ manage_url }}
 
-rsvping doesn't make you a pda member. want to join? reply to a host or visit the site to request to join.
+when you join pda you get access to club events and our whatsapp community. click here to join: {{ join_url }}
 
 — pda

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -1232,6 +1232,23 @@ export interface paths {
         patch: operations["community__pages_update_page"];
         trace?: never;
     };
+    "/api/community/public/events/{event_id}/rsvp/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Submit Public Rsvp */
+        post: operations["community__public_rsvp_submit_public_rsvp"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/community/request-login-link/": {
         parameters: {
             query?: never;
@@ -2994,6 +3011,42 @@ export interface components {
             voters: {
                 [key: string]: components["schemas"]["VoterOut"][];
             };
+        };
+        /** PublicRsvpIn */
+        PublicRsvpIn: {
+            /**
+             * Email
+             * Format: email
+             */
+            email: string;
+            /**
+             * Has Plus One
+             * @default false
+             */
+            has_plus_one: boolean;
+            /** Name */
+            name: string;
+            /** Phone Number */
+            phone_number: string;
+            /** Status */
+            status: string;
+            /**
+             * Website
+             * @default
+             */
+            website: string;
+        };
+        /** PublicRsvpOut */
+        PublicRsvpOut: {
+            event: components["schemas"]["EventOut"];
+            rsvp: components["schemas"]["PublicRsvpStateOut"];
+        };
+        /** PublicRsvpStateOut */
+        PublicRsvpStateOut: {
+            /** Has Plus One */
+            has_plus_one: boolean;
+            /** Status */
+            status: string;
         };
         /** RSVPGuestOut */
         RSVPGuestOut: {
@@ -7252,6 +7305,68 @@ export interface operations {
             };
             /** @description Forbidden */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
+    community__public_rsvp_submit_public_rsvp: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                event_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PublicRsvpIn"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PublicRsvpOut"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Conflict */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/api/validationCodes.gen.ts
+++ b/frontend/src/api/validationCodes.gen.ts
@@ -31,6 +31,7 @@ export const Code = {
     RsvpInvalidStatus: 'event.rsvp_invalid_status',
     NoPlusOneSpots: 'event.no_plus_one_spots',
     RsvpNotFound: 'event.rsvp_not_found',
+    MemberContactMustSignIn: 'event.member_contact_must_sign_in',
     AttendanceOpensLater: 'event.attendance_opens_later',
     AttendanceOnlyForGoingRsvps: 'event.attendance_only_for_going_rsvps',
     PermDenied: 'event.perm_denied',
@@ -224,6 +225,7 @@ export type ValidationCode =
   | 'event.rsvp_invalid_status'
   | 'event.no_plus_one_spots'
   | 'event.rsvp_not_found'
+  | 'event.member_contact_must_sign_in'
   | 'event.attendance_opens_later'
   | 'event.attendance_only_for_going_rsvps'
   | 'event.perm_denied'
@@ -367,6 +369,7 @@ export const CODE_PARAMS: Record<ValidationCode, readonly string[]> = {
   'event.rsvp_invalid_status': [],
   'event.no_plus_one_spots': [],
   'event.rsvp_not_found': [],
+  'event.member_contact_must_sign_in': [],
   'event.attendance_opens_later': [],
   'event.attendance_only_for_going_rsvps': [],
   'event.perm_denied': ['action'],

--- a/frontend/src/api/validationCodes.ts
+++ b/frontend/src/api/validationCodes.ts
@@ -115,6 +115,8 @@ function messageForKnownCode(code: KnownCode, err: FieldError): string {
       return 'no spots available for a +1';
     case Code.Event.RsvpNotFound:
       return 'rsvp not found';
+    case Code.Event.MemberContactMustSignIn:
+      return 'looks like you already have an account — sign in to rsvp';
     case Code.Event.AttendanceOpensLater:
       return 'check-in opens an hour before the event starts';
     case Code.Event.AttendanceOnlyForGoingRsvps:


### PR DESCRIPTION
**Stack 1/3 for Issue 493** (supersedes the monolithic #562). This stack splits the public-RSVP work into reviewable slices:

1. **#569 (this PR)** `split-493-3-endpoint` → `main` — endpoint + email infra
2. **#570** `split-493-4-tests-dedup` → `#569` — submission, dedup, gating, validation tests
3. **#571** `split-493-5-tests-capacity` → `#570` — capacity, waitlist, promotion, robustness tests

The cumulative stack produces a byte-for-byte identical final tree to the closed #562.

## Summary
Adds `POST /api/community/public/events/{event_id}/rsvp/` — a no-auth endpoint letting anonymous visitors RSVP to official public events. Each RSVP is backed by a non-member `User` row so the existing RSVP machinery (capacity, plus-ones, waitlist, promotion) is reused unchanged.

- **Strict event gating** — OFFICIAL + ACTIVE + PUBLIC + `rsvp_enabled` + not past; every ineligible state returns `404 NOT_FOUND` so the endpoint never leaks non-public events.
- **Phone/email dedup** — member-contact collision → `409 MEMBER_CONTACT_MUST_SIGN_IN` (new code); phone wins on ambiguity; email lookup is case-insensitive; existing emails never overwritten.
- **Scoped token, email-only** — issues a `NonMemberRsvpToken` and emails a `/my-rsvps?token=...` magic link (token never returned in the response). Email-send failure does not roll back the RSVP. Honeypot returns a decoy; rate limit `5/h` per IP.
- `promote_from_waitlist` / `_apply_rsvp_in_transaction` now also return the promoted user ids (backward-compatible — the authenticated caller ignores them) so the public endpoint can email promoted non-members after commit.

Tests land in #570 and #571. Generated openapi/types artifacts ship with the endpoint they reflect (the bulk of the +line count is generated).

## Test plan
- [ ] `make agent-ci` on GitHub (Postgres). Locally: backend + frontend typecheck clean; full CI clean (lint/format/codes-sync/complexity/file-size all pass; same 16 pre-existing env test failures). Endpoint behavior verified by the tests in #570 + #571 (all green against this base).
