### PR TITLE
refactor(events): type RSVPIn/AttendanceIn with TextChoices enums (Issue 565)

### DIFF
--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -241,10 +241,6 @@ class EventOut(BaseModel):
 
 
 class RSVPIn(BaseModel):
-    # Typed by the enum so Pydantic rejects unknown values up front. Note this
-    # accepts ``waitlisted`` (a valid enum member) — the upsert endpoint's
-    # ``_validate_rsvp_status`` guard still rejects member-supplied waitlisting,
-    # which is system-assigned only.
     status: RSVPStatus
     has_plus_one: bool = False
 
@@ -269,8 +265,6 @@ class EventStatsOut(BaseModel):
 
 
 class AttendanceIn(BaseModel):
-    # The enum's three members are exactly the previously hand-validated set,
-    # so typing the field replaces the manual choice check entirely.
     attendance: AttendanceStatus
 
 

--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -15,6 +15,7 @@ from community.models import (
     EventType,
     InvitePermission,
     PageVisibility,
+    RSVPStatus,
 )
 
 # Loose RFC-5322-ish email check — Pydantic's full EmailStr validator is
@@ -240,7 +241,11 @@ class EventOut(BaseModel):
 
 
 class RSVPIn(BaseModel):
-    status: str = Field(max_length=FieldLimit.CHOICE)
+    # Typed by the enum so Pydantic rejects unknown values up front. Note this
+    # accepts ``waitlisted`` (a valid enum member) — the upsert endpoint's
+    # ``_validate_rsvp_status`` guard still rejects member-supplied waitlisting,
+    # which is system-assigned only.
+    status: RSVPStatus
     has_plus_one: bool = False
 
 
@@ -264,19 +269,9 @@ class EventStatsOut(BaseModel):
 
 
 class AttendanceIn(BaseModel):
-    attendance: str = Field(max_length=FieldLimit.CHOICE)
-
-    @field_validator("attendance")
-    @classmethod
-    def validate_attendance(cls, v: str) -> str:
-        valid = {AttendanceStatus.UNKNOWN, AttendanceStatus.ATTENDED, AttendanceStatus.NO_SHOW}
-        if v not in valid:
-            raise_validation(
-                Code.Event.ATTENDANCE_INVALID_CHOICE,
-                field="attendance",
-                allowed=sorted(valid),
-            )
-        return v
+    # The enum's three members are exactly the previously hand-validated set,
+    # so typing the field replaces the manual choice check entirely.
+    attendance: AttendanceStatus
 
 
 class EventIn(BaseModel):

--- a/backend/community/_validation.py
+++ b/backend/community/_validation.py
@@ -29,7 +29,6 @@ class Code:
         MAX_ATTENDEES_MUST_BE_AT_LEAST_ONE = "event.max_attendees_must_be_at_least_one"
         START_DATETIME_MUST_BE_FUTURE = "event.start_datetime_must_be_future"
         END_BEFORE_START = "event.end_before_start"
-        ATTENDANCE_INVALID_CHOICE = "event.attendance_invalid_choice"
         OFFICIAL_MUST_BE_PUBLIC = "event.official_must_be_public"
         INVALID_CREATE_STATUS = "event.invalid_create_status"
         DATE_LOCKED_BY_POLL = "event.date_locked_by_poll"

--- a/backend/community/validation_codes.json
+++ b/backend/community/validation_codes.json
@@ -27,11 +27,6 @@
         "params": []
       },
       {
-        "name": "ATTENDANCE_INVALID_CHOICE",
-        "value": "event.attendance_invalid_choice",
-        "params": []
-      },
-      {
         "name": "OFFICIAL_MUST_BE_PUBLIC",
         "value": "event.official_must_be_public",
         "params": []

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -67,9 +67,7 @@
       "AttendanceIn": {
         "properties": {
           "attendance": {
-            "maxLength": 20,
-            "title": "Attendance",
-            "type": "string"
+            "$ref": "#/components/schemas/AttendanceStatus"
           }
         },
         "required": [
@@ -77,6 +75,15 @@
         ],
         "title": "AttendanceIn",
         "type": "object"
+      },
+      "AttendanceStatus": {
+        "enum": [
+          "unknown",
+          "attended",
+          "no_show"
+        ],
+        "title": "AttendanceStatus",
+        "type": "string"
       },
       "BulkUserCreateIn": {
         "properties": {
@@ -3297,9 +3304,7 @@
             "type": "boolean"
           },
           "status": {
-            "maxLength": 20,
-            "title": "Status",
-            "type": "string"
+            "$ref": "#/components/schemas/RSVPStatus"
           }
         },
         "required": [
@@ -3307,6 +3312,16 @@
         ],
         "title": "RSVPIn",
         "type": "object"
+      },
+      "RSVPStatus": {
+        "enum": [
+          "attending",
+          "maybe",
+          "cant_go",
+          "waitlisted"
+        ],
+        "title": "RSVPStatus",
+        "type": "string"
       },
       "ReactionToggleIn": {
         "properties": {

--- a/backend/tests/test_rsvp.py
+++ b/backend/tests/test_rsvp.py
@@ -123,13 +123,17 @@ class TestRSVP:
         assert response.json()["my_rsvp"] == RSVPStatus.CANT_GO
 
     def test_rsvp_invalid_status(self, api_client, auth_headers, rsvp_event):
+        # "going" is not a member of the RSVPStatus enum, so Pydantic rejects it
+        # at request-parse time (422) before the endpoint's status guard runs.
+        # A *valid-but-forbidden* value (waitlisted) is what the 400 guard
+        # covers — see test_cannot_set_waitlisted_directly.
         response = api_client.post(
             f"/api/community/events/{rsvp_event.id}/rsvp/",
             {"status": "going"},
             content_type="application/json",
             **auth_headers,
         )
-        assert response.status_code == 400
+        assert response.status_code == 422
 
     def test_rsvp_disabled_event(self, api_client, auth_headers, no_rsvp_event):
         response = api_client.post(

--- a/backend/tests/test_rsvp.py
+++ b/backend/tests/test_rsvp.py
@@ -123,10 +123,7 @@ class TestRSVP:
         assert response.json()["my_rsvp"] == RSVPStatus.CANT_GO
 
     def test_rsvp_invalid_status(self, api_client, auth_headers, rsvp_event):
-        # "going" is not a member of the RSVPStatus enum, so Pydantic rejects it
-        # at request-parse time (422) before the endpoint's status guard runs.
-        # A *valid-but-forbidden* value (waitlisted) is what the 400 guard
-        # covers — see test_cannot_set_waitlisted_directly.
+        # "going" is not an RSVPStatus member, so Pydantic rejects it at parse time (422).
         response = api_client.post(
             f"/api/community/events/{rsvp_event.id}/rsvp/",
             {"status": "going"},

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -1573,9 +1573,13 @@ export interface components {
         };
         /** AttendanceIn */
         AttendanceIn: {
-            /** Attendance */
-            attendance: string;
+            attendance: components["schemas"]["AttendanceStatus"];
         };
+        /**
+         * AttendanceStatus
+         * @enum {string}
+         */
+        AttendanceStatus: "unknown" | "attended" | "no_show";
         /** BulkUserCreateIn */
         BulkUserCreateIn: {
             /** Phone Numbers */
@@ -2985,9 +2989,13 @@ export interface components {
              * @default false
              */
             has_plus_one: boolean;
-            /** Status */
-            status: string;
+            status: components["schemas"]["RSVPStatus"];
         };
+        /**
+         * RSVPStatus
+         * @enum {string}
+         */
+        RSVPStatus: "attending" | "maybe" | "cant_go" | "waitlisted";
         /** ReactionToggleIn */
         ReactionToggleIn: {
             /** Emoji */

--- a/frontend/src/api/validationCodes.gen.ts
+++ b/frontend/src/api/validationCodes.gen.ts
@@ -12,7 +12,6 @@ export const Code = {
     MaxAttendeesMustBeAtLeastOne: 'event.max_attendees_must_be_at_least_one',
     StartDatetimeMustBeFuture: 'event.start_datetime_must_be_future',
     EndBeforeStart: 'event.end_before_start',
-    AttendanceInvalidChoice: 'event.attendance_invalid_choice',
     OfficialMustBePublic: 'event.official_must_be_public',
     InvalidCreateStatus: 'event.invalid_create_status',
     DateLockedByPoll: 'event.date_locked_by_poll',
@@ -204,7 +203,6 @@ export type ValidationCode =
   | 'event.max_attendees_must_be_at_least_one'
   | 'event.start_datetime_must_be_future'
   | 'event.end_before_start'
-  | 'event.attendance_invalid_choice'
   | 'event.official_must_be_public'
   | 'event.invalid_create_status'
   | 'event.date_locked_by_poll'
@@ -346,7 +344,6 @@ export const CODE_PARAMS: Record<ValidationCode, readonly string[]> = {
   'event.max_attendees_must_be_at_least_one': [],
   'event.start_datetime_must_be_future': [],
   'event.end_before_start': [],
-  'event.attendance_invalid_choice': [],
   'event.official_must_be_public': [],
   'event.invalid_create_status': [],
   'event.date_locked_by_poll': [],

--- a/frontend/src/api/validationCodes.ts
+++ b/frontend/src/api/validationCodes.ts
@@ -75,8 +75,6 @@ function messageForKnownCode(code: KnownCode, err: FieldError): string {
       return 'start date must be in the future';
     case Code.Event.EndBeforeStart:
       return 'end time must be after the start time';
-    case Code.Event.AttendanceInvalidChoice:
-      return 'pick a valid attendance option';
     case Code.Event.OfficialMustBePublic:
       return 'official events must be public';
     case Code.Event.InvalidCreateStatus:


### PR DESCRIPTION
## Summary

Closes #565

- Type the RSVP/attendance input schemas with their `TextChoices` enums instead of raw `str` (the repo's "prefer types over strings" rule):
  - `RSVPIn.status`: `str` → `RSVPStatus`
  - `AttendanceIn.attendance`: `str` → `AttendanceStatus`, dropping the manual `field_validator` (the enum's three members are exactly the previously hand-validated set).
- Remove the now-orphaned `ATTENDANCE_INVALID_CHOICE` validation code and its unreachable frontend message case; regenerate `validation_codes.json`, `validationCodes.gen.ts`, `openapi_schema.json`, and `types.gen.ts` (the API surface now exposes `RSVPStatus`/`AttendanceStatus` enums).

**Preserved invariant:** `waitlisted` is system-assigned only. It is a valid enum member, so it passes Pydantic — then the upsert endpoint's `_validate_rsvp_status` guard still rejects member-supplied `waitlisted` with a 400.

**Behavior note:** an invalid *non-enum* RSVP status (e.g. `"going"`) now returns 422 (Pydantic parse-time) instead of 400; `test_rsvp_invalid_status` was updated to assert 422. Invalid attendance already returned 422 on main — only the response body's error `code` changes (now a generic Pydantic error rather than `event.attendance_invalid_choice`).

## Test plan

- [x] `make agent-ci` passes (backend 1016 passed; ty / complexity / file-size / codes-sync / openapi-sync clean; frontend lint / prettier / 546 tests / typecheck / types-check clean)
- [x] `test_cannot_set_waitlisted_directly` still returns 400 (member-supplied waitlisted rejected)
- [x] `test_rsvp_invalid_status` returns 422 for a non-enum value
- [x] `test_rejects_invalid_attendance_value` returns 422
