### PR TITLE
feat(events): show spots-left countdown and rsvp state on cards (Issue 566)

### DIFF
--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -188,6 +188,9 @@ class EventListOut(BaseModel):
     waitlisted_count: int = 0
     invited_count: int = 0
     comment_count: int = 0
+    # Viewer's own RSVP status (None for unauthed or no-response). Lets calendar
+    # / my-events cards show RSVP state without a detail fetch per card.
+    my_rsvp: str | None = None
     is_past: bool = False
     status: str = "active"
     tags: list[TagOut] = []

--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -188,8 +188,6 @@ class EventListOut(BaseModel):
     waitlisted_count: int = 0
     invited_count: int = 0
     comment_count: int = 0
-    # Viewer's own RSVP status (None for unauthed or no-response). Lets calendar
-    # / my-events cards show RSVP state without a detail fetch per card.
     my_rsvp: str | None = None
     is_past: bool = False
     status: str = "active"

--- a/backend/community/_events.py
+++ b/backend/community/_events.py
@@ -214,7 +214,6 @@ def list_events(request, status: str = EventStatus.ACTIVE):
                 waitlisted_count=_waitlisted_count(e),
                 invited_count=e.invited_users.count(),
                 comment_count=e.comment_count,
-                # Reuses the prefetched rsvps — no extra query per event.
                 my_rsvp=_find_my_rsvp(e.rsvps.all(), auth_user),
                 co_host_ids=[str(c.id) for c in e.co_hosts.all()],
                 co_host_names=[c.display_name or c.phone_number for c in e.co_hosts.all()],

--- a/backend/community/_events.py
+++ b/backend/community/_events.py
@@ -18,6 +18,7 @@ from community._event_helpers import (
     _attending_headcount,
     _can_see_invite_only,
     _event_out,
+    _find_my_rsvp,
     _get_creator_name,
     _set_event_tags,
     _tags_out,
@@ -213,6 +214,8 @@ def list_events(request, status: str = EventStatus.ACTIVE):
                 waitlisted_count=_waitlisted_count(e),
                 invited_count=e.invited_users.count(),
                 comment_count=e.comment_count,
+                # Reuses the prefetched rsvps — no extra query per event.
+                my_rsvp=_find_my_rsvp(e.rsvps.all(), auth_user),
                 co_host_ids=[str(c.id) for c in e.co_hosts.all()],
                 co_host_names=[c.display_name or c.phone_number for c in e.co_hosts.all()],
                 is_past=e.is_past,

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -1266,6 +1266,17 @@
             ],
             "title": "Max Attendees"
           },
+          "my_rsvp": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "My Rsvp"
+          },
           "other_link": {
             "default": "",
             "title": "Other Link",

--- a/backend/tests/test_event_capacity.py
+++ b/backend/tests/test_event_capacity.py
@@ -390,3 +390,38 @@ class TestMaxAttendeesValidation:
             **auth_headers,
         )
         assert resp.status_code == 200
+
+
+@pytest.mark.django_db
+class TestListMyRsvp:
+    """The list endpoint surfaces the viewer's own RSVP so calendar / my-events
+    cards can show RSVP state without a per-card detail fetch (issue #566)."""
+
+    def _list(self, api_client, headers=None):
+        return api_client.get("/api/community/events/", **(headers or {}))
+
+    def _find(self, resp, event):
+        return next(e for e in resp.json() if e["id"] == str(event.id))
+
+    def test_list_includes_viewer_rsvp(self, api_client, unlimited_event, headers1):
+        _rsvp(api_client, unlimited_event, headers1, status=RSVPStatus.MAYBE)
+        resp = self._list(api_client, headers1)
+        assert resp.status_code == 200
+        assert self._find(resp, unlimited_event)["my_rsvp"] == RSVPStatus.MAYBE
+
+    def test_list_my_rsvp_null_without_response(self, api_client, unlimited_event, headers1):
+        resp = self._list(api_client, headers1)
+        assert resp.status_code == 200
+        assert self._find(resp, unlimited_event)["my_rsvp"] is None
+
+    def test_list_my_rsvp_is_per_viewer(self, api_client, unlimited_event, headers1, headers2):
+        _rsvp(api_client, unlimited_event, headers1, status=RSVPStatus.ATTENDING)
+        # user2 hasn't responded — their list view must not see user1's status.
+        resp = self._list(api_client, headers2)
+        assert self._find(resp, unlimited_event)["my_rsvp"] is None
+
+    def test_list_my_rsvp_null_for_unauthed(self, api_client, unlimited_event, headers1):
+        _rsvp(api_client, unlimited_event, headers1, status=RSVPStatus.ATTENDING)
+        resp = self._list(api_client)
+        assert resp.status_code == 200
+        assert self._find(resp, unlimited_event)["my_rsvp"] is None

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -2148,6 +2148,8 @@ export interface components {
             longitude?: number | null;
             /** Max Attendees */
             max_attendees?: number | null;
+            /** My Rsvp */
+            my_rsvp?: string | null;
             /**
              * Other Link
              * @default

--- a/frontend/src/models/event.test.ts
+++ b/frontend/src/models/event.test.ts
@@ -1,6 +1,15 @@
 import { describe, expect, it } from 'vitest';
 
-import { type Event, eventClass, EventStatus, EventType, EventVisibility } from './event';
+import {
+  type Event,
+  eventClass,
+  EventStatus,
+  EventType,
+  EventVisibility,
+  myRsvpLabel,
+  RsvpServerStatus,
+  spotsLeft,
+} from './event';
 
 function makeEvent(overrides: Partial<Event> = {}): Event {
   return {
@@ -108,5 +117,40 @@ describe('eventClass', () => {
     });
     expect(eventClass(event)).not.toBe('pda-evt pda-evt-members');
     expect(eventClass(event)).toBe('pda-evt pda-evt-invite');
+  });
+});
+
+describe('spotsLeft', () => {
+  it('returns null for unlimited-capacity events', () => {
+    expect(spotsLeft(makeEvent({ maxAttendees: null, attendingCount: 5 }))).toBeNull();
+  });
+
+  it('returns remaining spots for capacity-limited events', () => {
+    expect(spotsLeft(makeEvent({ maxAttendees: 10, attendingCount: 3 }))).toBe(7);
+  });
+
+  it('returns 0 when full', () => {
+    expect(spotsLeft(makeEvent({ maxAttendees: 10, attendingCount: 10 }))).toBe(0);
+  });
+
+  it('clamps to 0 when over capacity (waitlist overflow)', () => {
+    expect(spotsLeft(makeEvent({ maxAttendees: 10, attendingCount: 13 }))).toBe(0);
+  });
+});
+
+describe('myRsvpLabel', () => {
+  it('returns null when the viewer has not responded', () => {
+    expect(myRsvpLabel(makeEvent({ myRsvp: null }))).toBeNull();
+  });
+
+  it('maps each rsvp status to a lowercase label', () => {
+    expect(myRsvpLabel(makeEvent({ myRsvp: RsvpServerStatus.Attending }))).toBe('going');
+    expect(myRsvpLabel(makeEvent({ myRsvp: RsvpServerStatus.Maybe }))).toBe('maybe');
+    expect(myRsvpLabel(makeEvent({ myRsvp: RsvpServerStatus.CantGo }))).toBe("can't go");
+    expect(myRsvpLabel(makeEvent({ myRsvp: RsvpServerStatus.Waitlisted }))).toBe('waitlisted');
+  });
+
+  it('returns null for an unrecognized status', () => {
+    expect(myRsvpLabel(makeEvent({ myRsvp: 'bogus' }))).toBeNull();
   });
 });

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -1,7 +1,3 @@
-// Event domain model. The backend blanks out member-only fields for unauthed
-// users (empty strings, false bools, empty lists) — we render exactly what the
-// server gives us and don't attempt to gate again client-side.
-
 export const EventType = {
   Community: 'community',
   Official: 'official',
@@ -25,16 +21,12 @@ export const InvitePermission = {
   CoHostsOnly: 'co_hosts_only',
 } as const;
 
-// Accepted input statuses for POST /rsvp/.
-// `waitlisted` is server-assigned only (when an `attending` request comes in
-// over capacity). See backend _event_rsvps.py _coerce_status.
 export const RsvpStatus = {
   Attending: 'attending',
   Maybe: 'maybe',
   CantGo: 'cant_go',
 } as const;
 
-// Statuses the server may return on a guest's `status` field.
 export const RsvpServerStatus = {
   ...RsvpStatus,
   Waitlisted: 'waitlisted',
@@ -83,8 +75,6 @@ export interface EventStats {
   cancellations: EventCancellation[];
 }
 
-// List endpoint returns a subset; detail endpoint returns everything.
-// We model them as one interface with the detail-only fields optional.
 export interface Event {
   id: string;
   title: string;
@@ -96,7 +86,6 @@ export interface Event {
   latitude: number | null;
   longitude: number | null;
 
-  // Member-only (blanked '' for unauthed).
   whatsappLink: string;
   partifulLink: string;
   otherLink: string;
@@ -122,12 +111,8 @@ export interface Event {
   coHostIds: string[];
   coHostNames: string[];
   coHostPhotoUrls: string[];
-  // Parallel to coHostIds: accepted co-host's invite id, used by the × on
-  // host chips. null for legacy rows missing an invite (defensive — shouldn't
-  // happen post-#363 data migration). Detail-only.
   coHostInviteIds: (string | null)[];
 
-  // Detail-only.
   guests: EventGuest[];
   myRsvp: string | null;
   surveySlugs: string[];
@@ -136,9 +121,6 @@ export interface Event {
   invitedUserPhotoUrls: string[];
   invitePermission: string;
 
-  // Co-host invite approval flow (#363). Pending list visible to creator +
-  // accepted co-hosts only; myPendingCohostInviteId set when the requesting
-  // user has a pending invite for this event (drives the accept/decline banner).
   pendingCohostInvites: PendingCohostInvite[];
   myPendingCohostInviteId: string | null;
 
@@ -161,11 +143,6 @@ export interface PendingCohostInvite {
   invitedAt: Date;
 }
 
-// Maps an event to its chip/calendar css classes. Colocated with the model so
-// any list/detail/badge view can reuse the same color mapping. Returns two
-// classes: the shared .pda-evt base + one of the type/visibility variants.
-// Precedence matches the Flutter frontend: cancelled > official > invite-only
-// > members-only > community.
 export function eventClass(e: Event): string {
   if (e.status === EventStatus.Cancelled) return 'pda-evt pda-evt-cancelled';
   if (e.eventType === EventType.Official) return 'pda-evt pda-evt-official';
@@ -174,16 +151,11 @@ export function eventClass(e: Event): string {
   return 'pda-evt pda-evt-community';
 }
 
-// Remaining capacity for a capacity-limited event, or null when capacity is
-// unlimited (maxAttendees === null) so callers can render gracefully. Never
-// negative — an over-capacity event (waitlist overflow) reports 0 spots left.
 export function spotsLeft(e: Event): number | null {
   if (e.maxAttendees === null) return null;
   return Math.max(0, e.maxAttendees - e.attendingCount);
 }
 
-// Short lowercase label for the viewer's own RSVP state, or null when they
-// haven't responded. Drives the badge on calendar / my-events cards.
 export function myRsvpLabel(e: Event): string | null {
   switch (e.myRsvp) {
     case RsvpServerStatus.Attending:

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -173,3 +173,28 @@ export function eventClass(e: Event): string {
   if (e.visibility === EventVisibility.MembersOnly) return 'pda-evt pda-evt-members';
   return 'pda-evt pda-evt-community';
 }
+
+// Remaining capacity for a capacity-limited event, or null when capacity is
+// unlimited (maxAttendees === null) so callers can render gracefully. Never
+// negative — an over-capacity event (waitlist overflow) reports 0 spots left.
+export function spotsLeft(e: Event): number | null {
+  if (e.maxAttendees === null) return null;
+  return Math.max(0, e.maxAttendees - e.attendingCount);
+}
+
+// Short lowercase label for the viewer's own RSVP state, or null when they
+// haven't responded. Drives the badge on calendar / my-events cards.
+export function myRsvpLabel(e: Event): string | null {
+  switch (e.myRsvp) {
+    case RsvpServerStatus.Attending:
+      return 'going';
+    case RsvpServerStatus.Maybe:
+      return 'maybe';
+    case RsvpServerStatus.CantGo:
+      return "can't go";
+    case RsvpServerStatus.Waitlisted:
+      return 'waitlisted';
+    default:
+      return null;
+  }
+}

--- a/frontend/src/screens/calendar/AgendaList.tsx
+++ b/frontend/src/screens/calendar/AgendaList.tsx
@@ -7,6 +7,7 @@ import { useMemo, useState } from 'react';
 
 import { SegmentedControl } from '@/components/ui/SegmentedControl';
 import { type Event as PdaEvent, eventClass, EventType } from '@/models/event';
+import { EventCardBadges } from '@/screens/events/EventCardBadges';
 import { cn } from '@/utils/cn';
 
 type TypeFilter = 'all' | typeof EventType.Official | typeof EventType.Community;
@@ -139,6 +140,7 @@ function AgendaCard({ event, onSelect }: CardProps) {
           <span className="truncate">{event.location}</span>
         </div>
       ) : null}
+      <EventCardBadges event={event} variant="card" className="mt-1.5" />
     </button>
   );
 }

--- a/frontend/src/screens/calendar/DayEventList.tsx
+++ b/frontend/src/screens/calendar/DayEventList.tsx
@@ -6,6 +6,7 @@
 import { format, isSameDay } from 'date-fns';
 
 import { type Event as PdaEvent, eventClass } from '@/models/event';
+import { EventCardBadges } from '@/screens/events/EventCardBadges';
 import { cn } from '@/utils/cn';
 
 interface Props {
@@ -108,6 +109,7 @@ function DayEventCard({ event, onSelect }: CardProps) {
       {event.description ? (
         <p className="mt-1 line-clamp-2 text-xs opacity-90">{event.description}</p>
       ) : null}
+      <EventCardBadges event={event} variant="card" className="mt-1.5" />
     </button>
   );
 }

--- a/frontend/src/screens/events/EventCardBadges.test.tsx
+++ b/frontend/src/screens/events/EventCardBadges.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  type Event,
+  EventStatus,
+  EventType,
+  EventVisibility,
+  RsvpServerStatus,
+} from '@/models/event';
+
+import { EventCardBadges } from './EventCardBadges';
+
+function makeEvent(overrides: Partial<Event> = {}): Event {
+  return {
+    id: 'ev1',
+    title: 'potluck',
+    description: '',
+    startDatetime: new Date('2026-04-15T18:00:00Z'),
+    endDatetime: null,
+    location: '',
+    latitude: null,
+    longitude: null,
+    whatsappLink: '',
+    partifulLink: '',
+    otherLink: '',
+    venmoLink: '',
+    cashappLink: '',
+    zelleInfo: '',
+    price: '',
+    rsvpEnabled: false,
+    allowPlusOnes: false,
+    maxAttendees: null,
+    attendingCount: 0,
+    waitlistedCount: 0,
+    invitedCount: 0,
+    datetimeTbd: false,
+    hasPoll: false,
+    datetimePollSlug: null,
+    createdById: null,
+    createdByName: null,
+    createdByPhotoUrl: '',
+    coHostIds: [],
+    coHostNames: [],
+    coHostPhotoUrls: [],
+    coHostInviteIds: [],
+    guests: [],
+    myRsvp: null,
+    surveySlugs: [],
+    invitedUserIds: [],
+    invitedUserNames: [],
+    invitedUserPhotoUrls: [],
+    invitePermission: 'all_members',
+    pendingCohostInvites: [],
+    myPendingCohostInviteId: null,
+    eventType: EventType.Community,
+    visibility: EventVisibility.Public,
+    photoUrl: '',
+    isPast: false,
+    status: EventStatus.Active,
+    tags: [],
+    ...overrides,
+  };
+}
+
+describe('EventCardBadges', () => {
+  it('renders nothing when there is no rsvp and capacity is unlimited', () => {
+    const { container } = render(<EventCardBadges event={makeEvent()} variant="card" />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows the viewer rsvp state', () => {
+    render(
+      <EventCardBadges event={makeEvent({ myRsvp: RsvpServerStatus.Attending })} variant="card" />,
+    );
+    expect(screen.getByText('going')).toBeInTheDocument();
+  });
+
+  it('shows going/{max} headcount for capacity-limited events', () => {
+    render(
+      <EventCardBadges event={makeEvent({ maxAttendees: 20, attendingCount: 8 })} variant="row" />,
+    );
+    expect(screen.getByText('8 / 20 going')).toBeInTheDocument();
+  });
+
+  it('omits the headcount for unlimited-capacity events', () => {
+    render(
+      <EventCardBadges
+        event={makeEvent({ maxAttendees: null, myRsvp: RsvpServerStatus.Maybe })}
+        variant="row"
+      />,
+    );
+    expect(screen.getByText('maybe')).toBeInTheDocument();
+    expect(screen.queryByText(/going$/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/events/EventCardBadges.tsx
+++ b/frontend/src/screens/events/EventCardBadges.tsx
@@ -1,11 +1,3 @@
-// Compact badges for event cards / rows: the viewer's own rsvp state and a
-// going/{max} headcount. Used on calendar cards (colored backgrounds → the
-// "card" variant uses translucent currentColor pills) and on the my-events
-// list (neutral surface → the "row" variant uses muted surface pills).
-//
-// Renders nothing when there's nothing to show (no rsvp + unlimited capacity),
-// so callers can drop it in unconditionally.
-
 import { type Event, myRsvpLabel } from '@/models/event';
 import { cn } from '@/utils/cn';
 

--- a/frontend/src/screens/events/EventCardBadges.tsx
+++ b/frontend/src/screens/events/EventCardBadges.tsx
@@ -1,0 +1,45 @@
+// Compact badges for event cards / rows: the viewer's own rsvp state and a
+// going/{max} headcount. Used on calendar cards (colored backgrounds → the
+// "card" variant uses translucent currentColor pills) and on the my-events
+// list (neutral surface → the "row" variant uses muted surface pills).
+//
+// Renders nothing when there's nothing to show (no rsvp + unlimited capacity),
+// so callers can drop it in unconditionally.
+
+import { type Event, myRsvpLabel } from '@/models/event';
+import { cn } from '@/utils/cn';
+
+type Variant = 'card' | 'row';
+
+const PILL_CLASS: Record<Variant, string> = {
+  card: 'rounded-full bg-black/10 px-2 py-0.5 dark:bg-white/15',
+  row: 'rounded-full bg-surface-dim text-foreground-secondary px-2 py-0.5',
+};
+
+function headcountLabel(event: Event): string | null {
+  if (event.maxAttendees === null) return null;
+  // Matches the spacing of the detail-panel summary ("n / max going").
+  return `${String(event.attendingCount)} / ${String(event.maxAttendees)} going`;
+}
+
+export function EventCardBadges({
+  event,
+  variant,
+  className,
+}: {
+  event: Event;
+  variant: Variant;
+  className?: string;
+}) {
+  const rsvp = myRsvpLabel(event);
+  const headcount = headcountLabel(event);
+  if (!rsvp && !headcount) return null;
+
+  const pill = PILL_CLASS[variant];
+  return (
+    <div className={cn('flex flex-wrap items-center gap-1.5 text-xs', className)}>
+      {rsvp ? <span className={cn(pill, 'font-medium')}>{rsvp}</span> : null}
+      {headcount ? <span className={pill}>{headcount}</span> : null}
+    </div>
+  );
+}

--- a/frontend/src/screens/events/MyEventsScreen.tsx
+++ b/frontend/src/screens/events/MyEventsScreen.tsx
@@ -15,6 +15,8 @@ import type { Event } from '@/models/event';
 import { EventStatus, EventType, RsvpStatus } from '@/models/event';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 
+import { EventCardBadges } from './EventCardBadges';
+
 type Filter = 'upcoming' | 'past' | 'drafts' | 'cancelled';
 type Scope = 'all' | 'hosting';
 
@@ -159,6 +161,7 @@ function EventRow({ event }: { event: Event }) {
             : format(event.startDatetime, 'EEE MMM d, h:mm a').toLowerCase()}
           {event.location ? ` · ${event.location}` : ''}
         </p>
+        <EventCardBadges event={event} variant="row" className="mt-1.5" />
       </div>
       <div className="flex items-center gap-2 text-xs">
         {event.status === EventStatus.Cancelled ? (

--- a/frontend/src/screens/events/MyEventsScreen.tsx
+++ b/frontend/src/screens/events/MyEventsScreen.tsx
@@ -1,9 +1,3 @@
-// Member-facing "my events" list — events the current user created or
-// co-hosts. Active events come from the same flat `useEvents()` feed as the
-// calendar (client-split by start time into upcoming/past). Drafts and
-// cancelled events come from dedicated `?status=` queries; backend already
-// scopes those to events the user created or co-hosts.
-
 import { format } from 'date-fns';
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';

--- a/frontend/src/screens/events/RsvpSection.test.tsx
+++ b/frontend/src/screens/events/RsvpSection.test.tsx
@@ -250,3 +250,25 @@ describe('RsvpSection — waitlist label at capacity (issue #584)', () => {
     });
   });
 });
+
+describe('RsvpSection — spots left', () => {
+  it('shows "x spots left" for a capacity-limited event with room', () => {
+    renderSection(makeEvent({ maxAttendees: 10, attendingCount: 7, myRsvp: null }));
+    expect(screen.getByText('3 spots left')).toBeInTheDocument();
+  });
+
+  it('singularizes "1 spot left"', () => {
+    renderSection(makeEvent({ maxAttendees: 10, attendingCount: 9, myRsvp: null }));
+    expect(screen.getByText('1 spot left')).toBeInTheDocument();
+  });
+
+  it('shows no spots-left text for unlimited-capacity events', () => {
+    renderSection(makeEvent({ maxAttendees: null, attendingCount: 7, myRsvp: null }));
+    expect(screen.queryByText(/spots? left/)).not.toBeInTheDocument();
+  });
+
+  it('shows no spots-left text at capacity', () => {
+    renderSection(makeEvent({ maxAttendees: 10, attendingCount: 10, myRsvp: null }));
+    expect(screen.queryByText(/spots? left/)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/events/RsvpSection.tsx
+++ b/frontend/src/screens/events/RsvpSection.tsx
@@ -171,9 +171,6 @@ function WaitlistView({ onLeave, busy }: { onLeave: () => void; busy: boolean })
   );
 }
 
-// "x spots left" countdown for capacity-limited events. Renders nothing for
-// unlimited-capacity events (spotsLeft === null) or once full (0 left — the
-// "event is full" warning covers that case).
 function SpotsLeft({ event }: { event: Event }) {
   const left = spotsLeft(event);
   if (left === null || left === 0) return null;

--- a/frontend/src/screens/events/RsvpSection.tsx
+++ b/frontend/src/screens/events/RsvpSection.tsx
@@ -11,7 +11,7 @@ import { extractApiErrorOr } from '@/api/apiErrors';
 import { useRemoveRsvp, useSetRsvp } from '@/api/rsvp';
 import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
-import { type Event, RsvpServerStatus, RsvpStatus } from '@/models/event';
+import { type Event, RsvpServerStatus, RsvpStatus, spotsLeft } from '@/models/event';
 import { cn } from '@/utils/cn';
 
 import { RsvpGuestList } from './RsvpGuestList';
@@ -42,7 +42,9 @@ export function RsvpSection({ event, canSeeInvited }: Props) {
   // toggle reflects the wrong user (issue #368).
   const myGuest = event.guests.find((g) => g.userId === myUserId);
   const hasPlusOne = myGuest?.hasPlusOne ?? false;
-  const atCapacity = event.maxAttendees !== null && event.attendingCount >= event.maxAttendees;
+  // spotsLeft is null for unlimited capacity, 0 once full — so "no spots left"
+  // is exactly spotsLeft === 0 (single source of truth with the SpotsLeft pill).
+  const atCapacity = spotsLeft(event) === 0;
 
   async function apply(next: InputStatus) {
     setError(null);
@@ -104,6 +106,7 @@ export function RsvpSection({ event, canSeeInvited }: Props) {
               );
             })}
           </div>
+          <SpotsLeft event={event} />
           {event.allowPlusOnes &&
           (myRsvp === RsvpServerStatus.Attending || myRsvp === RsvpServerStatus.Maybe) ? (
             <div className="flex justify-center">
@@ -167,6 +170,19 @@ function WaitlistView({ onLeave, busy }: { onLeave: () => void; busy: boolean })
         leave waitlist
       </Button>
     </div>
+  );
+}
+
+// "x spots left" countdown for capacity-limited events. Renders nothing for
+// unlimited-capacity events (spotsLeft === null) or once full (0 left — the
+// "event is full" warning covers that case).
+function SpotsLeft({ event }: { event: Event }) {
+  const left = spotsLeft(event);
+  if (left === null || left === 0) return null;
+  return (
+    <p className="text-warning text-center text-xs">
+      {left === 1 ? '1 spot left' : `${String(left)} spots left`}
+    </p>
   );
 }
 

--- a/frontend/src/screens/events/RsvpSection.tsx
+++ b/frontend/src/screens/events/RsvpSection.tsx
@@ -42,8 +42,6 @@ export function RsvpSection({ event, canSeeInvited }: Props) {
   // toggle reflects the wrong user (issue #368).
   const myGuest = event.guests.find((g) => g.userId === myUserId);
   const hasPlusOne = myGuest?.hasPlusOne ?? false;
-  // spotsLeft is null for unlimited capacity, 0 once full — so "no spots left"
-  // is exactly spotsLeft === 0 (single source of truth with the SpotsLeft pill).
   const atCapacity = spotsLeft(event) === 0;
 
   async function apply(next: InputStatus) {


### PR DESCRIPTION
## Summary

Closes #566

- Add a lowercase **"x spots left"** countdown to `RsvpSection` for capacity-limited events. Renders nothing for unlimited-capacity events or once full (the existing "event is full" warning covers the full case). Singularizes to "1 spot left".
- Surface the viewer's **rsvp state** (going / maybe / can't go / waitlisted) and a **going/{max} headcount** on calendar agenda cards, calendar day cards, and my-events rows, via a shared `EventCardBadges` component (translucent pills on the colored calendar cards, muted pills on the neutral my-events surface).
- New pure helpers `spotsLeft()` and `myRsvpLabel()` in `models/event.ts` (handle unlimited / over-capacity / unknown-status edge cases).

### Scope note (deviation from the issue's "frontend-only" assumption)
The issue assumed this was presentation-only, but the **list** endpoint (`GET /api/community/events/`) did **not** return the viewer's rsvp — `my_rsvp` is a detail-only field, so `event.myRsvp` was always `null` on cards (and an existing my-events filter on `myRsvp` was a silent no-op). To meet the acceptance criterion "cards show the viewer's RSVP state", `my_rsvp` was added to `EventListOut` and populated from the **already-prefetched** rsvps using the same `_find_my_rsvp` helper the detail endpoint uses — **no extra query**, per-viewer, and null for unauthed callers.

## Test plan
- [ ] `make agent-ci` green (backend 1020 tests, frontend lint/format/test/typecheck/types-check) — ran locally, passing
- [ ] Open the calendar (agenda + day views) while logged in: events you've rsvp'd to show a "going"/"maybe"/etc. pill; capacity-limited events show "n / max going"
- [ ] My events rows show the same badges
- [ ] Open a capacity-limited event's detail: shows "x spots left" until full, then the "event is full" warning; unlimited-capacity events show neither
- [ ] Unauthed calendar view shows no rsvp pills