### PR TITLE
feat(public-rsvp): extend existing non-member rsvp token on return (Issue 555)

### DIFF
--- a/.claude/task.md
+++ b/.claude/task.md
@@ -1,17 +1,19 @@
-# Task — issue #491
-**Goal:** feat(public-rsvp): User.is_member flag, members() manager, email partial-unique index [stage 1/8]
+# Task — issue #555
+**Goal:** public-rsvp: recognize returning non-members and extend existing token on new RSVP
 **Source:** label
-**Labels:** backend,RSVP & Attendance,auto
-**Acceptance criteria:** see issue #491 body.
+**Labels:** backend,feature,auto,database,p1
+**Acceptance criteria:** see issue #555 body.
 
 ## Pipeline stage
-done
+pickup
+triage
+work
+review
+ci
 
 ## Restart count
 0
 
 ## Progress log
 - dispatched
-- review: clean after 2 rounds (no high/medium)
-- ci: backend make agent-ci passed (1017 tests); frontend lint/type/format clean
-- PR: https://github.com/ProteinDeficientsAnonymous/pda/pull/521 (draft)
+- triage: model-layer change only; public RSVP submission endpoints (stages 3/4) not built yet. Implementing issue_or_extend() on NonMemberRsvpToken to handle extend-vs-create. User get-or-create-by-phone (AC#1) belongs to the unbuilt endpoint; noted as out of scope here.

--- a/backend/tests/test_nonmember_rsvp_token.py
+++ b/backend/tests/test_nonmember_rsvp_token.py
@@ -58,6 +58,75 @@ class TestIssue:
 
 
 @pytest.mark.django_db
+class TestIssueOrExtend:
+    def test_first_call_issues_a_fresh_token(self, non_member):
+        from users.models import NonMemberRsvpToken
+
+        token = NonMemberRsvpToken.issue_or_extend(non_member)
+        assert token.user_id == non_member.id
+        assert token.is_valid
+        assert NonMemberRsvpToken.objects.filter(user=non_member).count() == 1
+
+    def test_extends_existing_valid_token_without_replacing_it(self, non_member):
+        from users.models import NON_MEMBER_RSVP_TOKEN_TTL_DAYS, NonMemberRsvpToken
+
+        first = NonMemberRsvpToken.issue(non_member)
+        # Pull expiry back so the extension is observable.
+        first.expires_at = timezone.now() + timedelta(days=1)
+        first.save(update_fields=["expires_at"])
+
+        before = timezone.now()
+        extended = NonMemberRsvpToken.issue_or_extend(non_member)
+
+        # Same row, same token string — a previously emailed link still resolves.
+        assert extended.pk == first.pk
+        assert extended.token == first.token
+        assert NonMemberRsvpToken.objects.filter(user=non_member).count() == 1
+
+        expected = before + timedelta(days=NON_MEMBER_RSVP_TOKEN_TTL_DAYS)
+        assert abs((extended.expires_at - expected).total_seconds()) < 60
+        # The old URL still resolves after extension.
+        assert NonMemberRsvpToken.resolve_user(first.token) == non_member
+
+    def test_issues_fresh_token_when_existing_is_expired(self, non_member):
+        from users.models import NonMemberRsvpToken
+
+        stale = NonMemberRsvpToken.issue(non_member)
+        stale.expires_at = timezone.now() - timedelta(seconds=1)
+        stale.save(update_fields=["expires_at"])
+
+        fresh = NonMemberRsvpToken.issue_or_extend(non_member)
+        assert fresh.pk != stale.pk
+        assert fresh.token != stale.token
+        assert fresh.is_valid
+        assert NonMemberRsvpToken.objects.filter(user=non_member).count() == 2
+
+    def test_issues_fresh_token_when_existing_is_revoked(self, non_member):
+        from users.models import NonMemberRsvpToken
+
+        revoked = NonMemberRsvpToken.issue(non_member)
+        revoked.revoke()
+
+        fresh = NonMemberRsvpToken.issue_or_extend(non_member)
+        assert fresh.pk != revoked.pk
+        assert fresh.is_valid
+        # The revoked token stays revoked.
+        revoked.refresh_from_db()
+        assert revoked.is_revoked
+
+    def test_rejects_member(self, db):
+        from users.models import NonMemberRsvpToken, User
+
+        member = User.objects.create_user(
+            phone_number="+12025559003",
+            display_name="Member",
+            is_member=True,
+        )
+        with pytest.raises(ValidationError):
+            NonMemberRsvpToken.issue_or_extend(member)
+
+
+@pytest.mark.django_db
 class TestResolveUser:
     def test_valid_token_resolves_to_user(self, non_member):
         from users.models import NonMemberRsvpToken

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -175,9 +175,11 @@ class NonMemberRsvpToken(models.Model):
 
     This token NEVER logs the user in — it is entirely separate from
     MagicLoginToken (different table, different validation path, narrower scope).
-    It grants scoped read/write to one non-member's RSVPs only. Issued (fresh)
-    on every successful non-member RSVP and delivered by email; old tokens stay
-    valid until they expire. Revoked when the user converts to a member.
+    It grants scoped read/write to one non-member's RSVPs only. On a non-member's
+    RSVP we EXTEND their existing valid token (see issue_or_extend) rather than
+    minting a new one, so a link saved from a previous email keeps working; a
+    fresh token is only issued when there is no valid one. Revoked when the user
+    converts to a member.
     """
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
@@ -227,6 +229,27 @@ class NonMemberRsvpToken(models.Model):
             token=secrets.token_urlsafe(32),
             expires_at=timezone.now() + timedelta(days=NON_MEMBER_RSVP_TOKEN_TTL_DAYS),
         )
+
+    @classmethod
+    def issue_or_extend(cls, user: "User") -> "NonMemberRsvpToken":
+        """Return a usable non-member RSVP token, reusing one when possible.
+
+        Called on each non-member RSVP. If the user already has a valid (not
+        expired, not revoked) token, its expiry is pushed out to 90 days from
+        now and the SAME token string is kept — so a link saved from a previous
+        email keeps resolving. Otherwise a fresh token is issued. Newest token
+        wins when several exist (Meta.ordering is -created_at).
+
+        Rejects members, like issue(): a member must use the member flow.
+        """
+        if user.is_member:
+            raise ValidationError("Cannot issue a non-member RSVP token for a member.")
+        existing = user.rsvp_tokens.first()
+        if existing is not None and existing.is_valid:
+            existing.expires_at = timezone.now() + timedelta(days=NON_MEMBER_RSVP_TOKEN_TTL_DAYS)
+            existing.save(update_fields=["expires_at"])
+            return existing
+        return cls.issue(user)
 
     @classmethod
     def resolve_user(cls, token: str) -> "User | None":


### PR DESCRIPTION
## Summary
- Add `NonMemberRsvpToken.issue_or_extend()`: a returning non-member with a valid token gets its `expires_at` bumped to now + 90 days while keeping the **same token string**, so a `/my-rsvps` link saved from a previous email keeps resolving. A fresh token is only minted when no valid one exists (expired or revoked). Members are rejected, matching `issue()`.
- Update the model docstring to reflect extend-vs-create (tokens are no longer always issued fresh on every RSVP).
- The public RSVP submission endpoints (stages 3/4) that will call this — and the `User` get-or-create-by-phone for recognizing returning non-members (AC #1) — are not built yet. This lands the model-layer extend-vs-create logic (AC #2/#3) and its tests ahead of them. No schema change, so no migration.

Part of the public-RSVP epic (#490).

## Test plan
- [ ] `cd backend && uv run pytest tests/test_nonmember_rsvp_token.py` — `TestIssueOrExtend` covers: first call issues fresh, valid token extended in place (same pk + token, old URL still resolves), expired → fresh, revoked → fresh (revoked stays revoked), member rejected.
- [ ] `make agent-ci` — backend + frontend green.
