### PR TITLE
fix(photos): drop unsupported heic uploads and surface crop decode errors (Issue 505)

### DIFF
--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -404,11 +404,12 @@ class EventPatchIn(BaseModel):
 
 
 _MAX_EVENT_PHOTO_SIZE = 10 * 1024 * 1024  # 10 MB
+# heic/heif are intentionally excluded: the frontend crops via a browser canvas
+# that can't decode them, so such uploads can only arrive via a hand-crafted
+# request and would never round-trip through the real UI (issue 505).
 _ALLOWED_IMAGE_TYPES = {
     "image/jpeg",
     "image/png",
     "image/webp",
     "image/gif",
-    "image/heic",
-    "image/heif",
 }

--- a/backend/tests/test_photos.py
+++ b/backend/tests/test_photos.py
@@ -102,6 +102,12 @@ class TestProfilePhoto:
         response = api_client.post("/api/auth/me/photo/", {"photo": big}, **_auth(member))
         assert response.status_code == 400
 
+    def test_upload_rejects_heic(self, api_client, member):
+        # heic can't be cropped client-side, so we don't accept it (issue 505).
+        heic = SimpleUploadedFile("photo.heic", b"fake heic bytes", content_type="image/heic")
+        response = api_client.post("/api/auth/me/photo/", {"photo": heic}, **_auth(member))
+        assert response.status_code == 400
+
     def test_delete_photo(self, api_client, member):
         photo = _make_test_image()
         api_client.post("/api/auth/me/photo/", {"photo": photo}, **_auth(member))
@@ -175,6 +181,16 @@ class TestEventPhoto:
         response = api_client.post(
             f"/api/community/events/{event.id}/photo/",
             {"photo": big},
+            **_auth(member),
+        )
+        assert response.status_code == 400
+
+    def test_upload_rejects_heic(self, api_client, member, event):
+        # heic can't be cropped client-side, so we don't accept it (issue 505).
+        heic = SimpleUploadedFile("photo.heic", b"fake heic bytes", content_type="image/heic")
+        response = api_client.post(
+            f"/api/community/events/{event.id}/photo/",
+            {"photo": heic},
             **_auth(member),
         )
         assert response.status_code == 400

--- a/backend/users/_auth.py
+++ b/backend/users/_auth.py
@@ -44,13 +44,14 @@ logger = logging.getLogger("pda.auth")
 router = Router()
 
 _MAX_PHOTO_SIZE = 5 * 1024 * 1024  # 5 MB
+# heic/heif are intentionally excluded: the frontend crops via a browser canvas
+# that can't decode them, so such uploads can only arrive via a hand-crafted
+# request and would never round-trip through the real UI (issue 505).
 _ALLOWED_IMAGE_TYPES = {
     "image/jpeg",
     "image/png",
     "image/webp",
     "image/gif",
-    "image/heic",
-    "image/heif",
 }
 
 

--- a/frontend/src/components/ImageCropDialog.test.tsx
+++ b/frontend/src/components/ImageCropDialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -93,6 +93,23 @@ describe('ImageCropDialog', () => {
     await user.click(screen.getByRole('button', { name: /^cancel$/i }));
 
     expect(onCancel).toHaveBeenCalledOnce();
+  });
+
+  it('surfaces an error when the image fails to decode (e.g. heic) instead of failing silently', () => {
+    // The crop preview img can't decode some formats the OS hands us (heic).
+    // Without an onError handler the "save" button stays disabled with no
+    // explanation — a silent failure (issue 505).
+    const { container } = renderDialog();
+
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+
+    const img = container.querySelector('img');
+    expect(img).not.toBeNull();
+    fireEvent.error(img!);
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/couldn't read that image/i);
+    // save stays disabled because the image never produced a crop area
+    expect(screen.getByRole('button', { name: /^save$/i })).toBeDisabled();
   });
 
   it('dialog container has role="dialog" and is accessible', () => {

--- a/frontend/src/components/ImageCropDialog.tsx
+++ b/frontend/src/components/ImageCropDialog.tsx
@@ -21,6 +21,13 @@ interface Props {
   onCrop: (blob: Blob) => Promise<void> | void;
 }
 
+// Some formats the OS hands us (notably heic/heif from apple photos) can't be
+// decoded by the browser's <img>/canvas pipeline, so the crop preview never
+// loads. Surface that as a clear error instead of leaving "save" silently
+// disabled forever (issue 505).
+const DECODE_ERROR =
+  "couldn't read that image — try a jpeg, png, webp, or gif (heic isn't supported here)";
+
 export function ImageCropDialog({
   file,
   shape = 'round',
@@ -33,11 +40,16 @@ export function ImageCropDialog({
   const [crop, setCrop] = useState<Crop | undefined>(undefined);
   const [completed, setCompleted] = useState<PixelCrop | null>(null);
   const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const imgRef = useRef<HTMLImageElement | null>(null);
 
   function onImageLoad(e: React.SyntheticEvent<HTMLImageElement>) {
     const { width, height } = e.currentTarget;
     setCrop(initialCrop(width, height, shape));
+  }
+
+  function onImageError() {
+    setError(DECODE_ERROR);
   }
 
   function handleCancel() {
@@ -94,9 +106,21 @@ export function ImageCropDialog({
               a tall image down — a wrapper cap would just clip it and let the crop be
               dragged into the off-screen remainder. See issue 428. */}
           <ReactCrop {...reactCropProps} style={{ maxHeight: MAX_PREVIEW_PX }}>
-            <img ref={imgRef} src={src} alt="" onLoad={onImageLoad} className="w-auto" />
+            <img
+              ref={imgRef}
+              src={src}
+              alt=""
+              onLoad={onImageLoad}
+              onError={onImageError}
+              className="w-auto"
+            />
           </ReactCrop>
         </div>
+        {error ? (
+          <p role="alert" className="text-destructive text-xs">
+            {error}
+          </p>
+        ) : null}
         <div className="flex justify-end gap-2">
           <Button variant="ghost" onClick={handleCancel} disabled={saving}>
             cancel

--- a/frontend/src/screens/events/form/EventFormPhoto.tsx
+++ b/frontend/src/screens/events/form/EventFormPhoto.tsx
@@ -11,17 +11,13 @@ import { extractApiErrorOr } from '@/api/apiErrors';
 import { ImageCropDialog } from '@/components/ImageCropDialog';
 import { cn } from '@/utils/cn';
 
-const ALLOWED_MIME = [
-  'image/jpeg',
-  'image/png',
-  'image/webp',
-  'image/gif',
-  'image/heic',
-  'image/heif',
-];
+// Only formats the browser can decode into a canvas for cropping. heic/heif
+// (apple photos default) can't be decoded client-side, so we don't offer them
+// — the crop step would silently fail otherwise (issue 505).
+const ALLOWED_MIME = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
 
 const MAX_PHOTO_BYTES = 10 * 1024 * 1024;
-const TYPE_ERROR = 'pick a jpeg, png, webp, gif, or heic image';
+const TYPE_ERROR = 'pick a jpeg, png, webp, or gif image';
 const SIZE_ERROR = 'photo must be under 10 MB';
 
 function validateFile(f: File): string | null {

--- a/frontend/src/screens/settings/AvatarUpload.tsx
+++ b/frontend/src/screens/settings/AvatarUpload.tsx
@@ -6,14 +6,10 @@ import { ImageCropDialog } from '@/components/ImageCropDialog';
 import { cn } from '@/utils/cn';
 
 const MAX_FILE_BYTES = 5 * 1024 * 1024;
-const ALLOWED_MIME = [
-  'image/jpeg',
-  'image/png',
-  'image/webp',
-  'image/gif',
-  'image/heic',
-  'image/heif',
-];
+// Only formats the browser can decode into a canvas for cropping. heic/heif
+// (apple photos default) can't be decoded client-side, so we don't offer them
+// — the crop step would silently fail otherwise (issue 505).
+const ALLOWED_MIME = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
 
 interface Props {
   size?: 'md' | 'lg';
@@ -45,7 +41,7 @@ export function AvatarUpload({ size = 'md' }: Props) {
     e.target.value = '';
     if (!f) return;
     if (!ALLOWED_MIME.includes(f.type)) {
-      setError('please pick a jpeg, png, webp, gif, or heic image');
+      setError('please pick a jpeg, png, webp, or gif image');
       return;
     }
     if (f.size > MAX_FILE_BYTES) {


### PR DESCRIPTION
## Summary

Closes #505

A user reported event photo upload "didn't work" (macOS Chrome). Root cause: the app advertised heic/heif support, but the client-side crop pipeline decodes images via a browser `<img>`/canvas, which **cannot decode heic/heif** (the Apple Photos default). A user could pick a `.heic`, pass validation, then land in a crop dialog whose `<img>` never loaded — leaving the "save" button permanently disabled with **no error**. A silent "photo upload didn't work."

- Remove `image/heic` / `image/heif` from the frontend accept/validation lists (`EventFormPhoto.tsx`, `AvatarUpload.tsx`) and the backend allowed-type sets (`_event_schemas.py`, `users/_auth.py`) so the contract matches what the crop pipeline can actually process.
- Add an `onError` handler + `role="alert"` message to `ImageCropDialog` so any undecodable image surfaces a clear error instead of a dead button.
- Tests: backend rejects heic on both photo endpoints; frontend surfaces the decode error and keeps save disabled.

## Test plan

- [ ] `make agent-ci` passes (verified locally: 1005 backend + 547 frontend tests green)
- [ ] upload a jpeg/png/webp/gif event photo → crops and persists
- [ ] pick a `.heic` → blocked at file selection with a clear "pick a jpeg, png, webp, or gif image" message
- [ ] if an undecodable image still reaches the crop dialog → "couldn't read that image…" alert shows and save stays disabled