### PR TITLE
feat: 584 - "join the waitlist" pill when event is full

### DIFF
--- a/frontend/src/screens/events/RsvpSection.test.tsx
+++ b/frontend/src/screens/events/RsvpSection.test.tsx
@@ -213,3 +213,39 @@ describe('RsvpSection — +1 toggle', () => {
     expect(screen.queryByRole('button', { name: /\+1/ })).not.toBeInTheDocument();
   });
 });
+
+describe('RsvpSection — waitlist label at capacity (issue #584)', () => {
+  it('shows "join the waitlist" instead of "i\'m going" when the event is full and I am not attending', () => {
+    renderSection(makeEvent({ maxAttendees: 2, attendingCount: 2, myRsvp: null }));
+
+    expect(screen.getByRole('button', { name: 'join the waitlist' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: "i'm going" })).not.toBeInTheDocument();
+  });
+
+  it('keeps the "i\'m going" label when the event has spots left', () => {
+    renderSection(makeEvent({ maxAttendees: 4, attendingCount: 2, myRsvp: null }));
+
+    expect(screen.getByRole('button', { name: "i'm going" })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'join the waitlist' })).not.toBeInTheDocument();
+  });
+
+  it('keeps the "i\'m going" label when I am already attending, even at capacity', () => {
+    renderSection(
+      makeEvent({ maxAttendees: 2, attendingCount: 2, myRsvp: RsvpServerStatus.Attending }),
+    );
+
+    expect(screen.getByRole('button', { name: "i'm going" })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'join the waitlist' })).not.toBeInTheDocument();
+  });
+
+  it('tapping "join the waitlist" still sends status: attending (server auto-waitlists)', () => {
+    renderSection(makeEvent({ maxAttendees: 2, attendingCount: 2, myRsvp: null }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'join the waitlist' }));
+
+    expect(setRsvpMutate).toHaveBeenCalledWith({
+      eventId: 'ev1',
+      status: RsvpServerStatus.Attending,
+    });
+  });
+});

--- a/frontend/src/screens/events/RsvpSection.tsx
+++ b/frontend/src/screens/events/RsvpSection.tsx
@@ -88,21 +88,24 @@ export function RsvpSection({ event, canSeeInvited }: Props) {
       ) : (
         <>
           <div className="flex flex-wrap justify-center gap-2">
-            {PILLS.map((p) => (
-              <RsvpPill
-                key={p.status}
-                label={p.label}
-                active={myRsvp === p.status}
-                disabled={busy}
-                onClick={() => void apply(p.status)}
-              />
-            ))}
+            {PILLS.map((p) => {
+              // At capacity, tapping "i'm going" actually waitlists you — so
+              // the label should say what the action does (issue #584).
+              const waitlistAttending =
+                p.status === RsvpStatus.Attending &&
+                atCapacity &&
+                myRsvp !== RsvpServerStatus.Attending;
+              return (
+                <RsvpPill
+                  key={p.status}
+                  label={waitlistAttending ? 'join the waitlist' : p.label}
+                  active={myRsvp === p.status}
+                  disabled={busy}
+                  onClick={() => void apply(p.status)}
+                />
+              );
+            })}
           </div>
-          {atCapacity && myRsvp !== RsvpServerStatus.Attending ? (
-            <p className="text-warning text-center text-xs">
-              event is full — tapping "i'm going" adds you to the waitlist
-            </p>
-          ) : null}
           {event.allowPlusOnes &&
           (myRsvp === RsvpServerStatus.Attending || myRsvp === RsvpServerStatus.Maybe) ? (
             <div className="flex justify-center">

--- a/frontend/src/screens/events/RsvpSection.tsx
+++ b/frontend/src/screens/events/RsvpSection.tsx
@@ -89,8 +89,6 @@ export function RsvpSection({ event, canSeeInvited }: Props) {
         <>
           <div className="flex flex-wrap justify-center gap-2">
             {PILLS.map((p) => {
-              // At capacity, tapping "i'm going" actually waitlists you — so
-              // the label should say what the action does (issue #584).
               const waitlistAttending =
                 p.status === RsvpStatus.Attending &&
                 atCapacity &&


### PR DESCRIPTION
## Overview

In `RsvpSection.tsx`, the RSVP pills were static. When an event is at capacity, tapping "i'm going" actually adds the viewer to the waitlist (the server auto-waitlists). This makes the attending pill's label read **"join the waitlist"** instead of "i'm going" when the event is full (`atCapacity`) and the viewer is not already attending, so the button text matches what the action does. The now-redundant "event is full — tapping ..." warning line is removed.

Closes #584

## Test plan

- [x] `RsvpSection.test.tsx` — label swaps to "join the waitlist" when full + not attending
- [x] label stays "i'm going" when spots are left
- [x] label stays "i'm going" when already attending, even at capacity
- [x] tapping "join the waitlist" still sends `status: attending` (server auto-waitlists)
- [x] full frontend suite green (550 passed / 1 skipped), tsc + eslint clean
