### PR TITLE
docs(claude-md): add comments rule to discourage verbose comments (Issue 588)

### DIFF
--- a/.claude/task.md
+++ b/.claude/task.md
@@ -5,7 +5,7 @@
 **Acceptance criteria:** see issue #588 body.
 
 ## Pipeline stage
-review
+done
 
 ## Restart count
 0
@@ -17,3 +17,4 @@ review
 - work: added comments rule (no verbose/redundant comments; comment only non-obvious why; no what-restating; no multi-line blocks)
 - review: code-reviewer subagent round 1 -> no high/medium findings; clean
 - ci: backend green (1032 passed, ty, complexity, schemas); frontend green in isolation (JoinScreen timeouts were machine-contention flakes, pass 10/10 alone); change is doc-only
+- pr: opened draft PR #591 (https://github.com/ProteinDeficientsAnonymous/pda/pull/591)

--- a/.claude/task.md
+++ b/.claude/task.md
@@ -1,18 +1,19 @@
-# Task — issue #525
-**Goal:** feat(public-rsvp): enforce non-members never hold a role + trustworthy role counts
+# Task — issue #588
+**Goal:** Add CLAUDE.md rule: avoid verbose comments, only comment when code doesn't explain itself
 **Source:** label
-**Labels:** backend,RSVP & Attendance,auto
-**Acceptance criteria:** see issue #525 body.
+**Labels:** auto,chore,p2
+**Acceptance criteria:** see issue #588 body.
 
 ## Pipeline stage
-done
+review
 
 ## Restart count
-1
+0
 
 ## Progress log
 - dispatched
-- work: added m2m_changed pre_add guard (reject_role_for_non_member) on User.roles.through; added is_member=True to list_roles/delete_role counts; added TestNonMemberCannotHoldRole
-- review: code-reviewer clean (no high); applied medium fixes (docstring note + member-swap/reverse-set tests). 23 tests pass.
-- ci: backend make agent-ci passed (1026 tests, typecheck, complexity, schema); frontend lint/format/typecheck/types-check clean after pnpm install
-- PR: https://github.com/ProteinDeficientsAnonymous/pda/pull/557 (draft)
+- pickup: read task + issue #588; no `explore` label -> implement pipeline
+- triage: actionable as scoped; add `### comments` rule under `## Standards` in CLAUDE.md
+- work: added comments rule (no verbose/redundant comments; comment only non-obvious why; no what-restating; no multi-line blocks)
+- review: code-reviewer subagent round 1 -> no high/medium findings; clean
+- ci: backend green (1032 passed, ty, complexity, schemas); frontend green in isolation (JoinScreen timeouts were machine-contention flakes, pass 10/10 alone); change is doc-only

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,12 @@ Routes: see `.claude/docs/routes.md`
 
 References: `~/.claude/rules/standards-django-ninja.md`
 
+### comments
+- Avoid verbose or redundant comments. Code should be self-explanatory; comments are the exception, not the default.
+- Only add a comment when the code does **not** explain itself — i.e. the *why* is non-obvious: a hidden constraint, a subtle invariant, a workaround for a specific bug, or surprising behavior.
+- Never write comments that restate what the code does (the "what"). `# increment counter` above `counter += 1` is noise.
+- No multi-line comment blocks or multi-paragraph docstrings. Keep any comment to a single short line.
+
 ### frontend text casing
 - All user-facing text in the frontend app must be **lowercase only** — labels, headings, buttons, placeholders, toasts, error messages, date formatting, etc.
 - Use `.toLowerCase()` on any dynamic/format-driven strings (e.g. `date-fns` output).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ References: `~/.claude/rules/standards-django-ninja.md`
 - Avoid verbose or redundant comments. Code should be self-explanatory; comments are the exception, not the default.
 - Only add a comment when the code does **not** explain itself — i.e. the *why* is non-obvious: a hidden constraint, a subtle invariant, a workaround for a specific bug, or surprising behavior.
 - Never write comments that restate what the code does (the "what"). `# increment counter` above `counter += 1` is noise.
-- No multi-line comment blocks or multi-paragraph docstrings. Keep any comment to a single short line.
+- No multi-line comment blocks or multi-paragraph docstrings. Keep any comment to a single short line. The exception is a structured function docstring that documents params and return in a fixed format (e.g. `param(type): description` / `return(type): description`).
 
 ### frontend text casing
 - All user-facing text in the frontend app must be **lowercase only** — labels, headings, buttons, placeholders, toasts, error messages, date formatting, etc.


### PR DESCRIPTION
## Summary

Closes #588

- Add a `### comments` rule under `## Standards` in `CLAUDE.md` so agents stop producing verbose, redundant comments.
- The rule: avoid verbose/redundant comments (code should be self-explanatory); comment only when the *why* is non-obvious — a hidden constraint, subtle invariant, bug workaround, or surprising behavior; never restate the "what"; no multi-line comment blocks or multi-paragraph docstrings.
- Placed alongside the existing `### frontend text casing` rule and matched to its tone/formatting.

## Test plan

- [x] `make agent-ci` — backend fully green (1032 passed, ty typecheck, complexity, schema checks); frontend green when run without machine contention. Change is documentation-only and touches no code.
- [x] `pr-review-toolkit:code-reviewer` subagent — no high/medium findings; all four acceptance criteria satisfied.