### PR TITLE
chore(imports): hoist function-local imports in backend/ (Issue 586)

### DIFF
--- a/backend/community/_calendar.py
+++ b/backend/community/_calendar.py
@@ -3,6 +3,7 @@
 import secrets
 from datetime import timedelta
 
+import icalendar
 from config.auth import gated_jwt
 from django.db.models import Q
 from django.http import HttpRequest, HttpResponse
@@ -77,8 +78,6 @@ def calendar_feed(request, token: str = ""):
     if not user.calendar_token:
         return HttpResponse("Invalid token.", status=403, content_type="text/plain")
 
-    import icalendar
-
     cal = icalendar.Calendar()
     cal.add("prodid", "-//PDA//PDA Calendar//EN")
     cal.add("version", "2.0")
@@ -148,8 +147,6 @@ def single_event_ics(request, event_id: str):
     except ValidationException as exc:
         return HttpResponse("Event not found.", status=exc.status_code, content_type="text/plain")
 
-    import icalendar
-
     cal = icalendar.Calendar()
     cal.add("prodid", "-//PDA//PDA Calendar//EN")
     cal.add("version", "2.0")
@@ -170,8 +167,6 @@ def _ics_filename(event) -> str:
 
 
 def _build_vevent(event, request: HttpRequest, is_authed: bool):
-    import icalendar
-
     vevent = icalendar.Event()
     vevent.add("uid", f"{event.id}@pda")
     vevent.add("dtstamp", timezone.now())

--- a/backend/community/_event_comments.py
+++ b/backend/community/_event_comments.py
@@ -9,6 +9,7 @@ from django.db import transaction
 from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
+from notifications.service import notify_comment_reply, notify_event_comment
 from users.permissions import PermissionKey
 
 from community._event_comment_schemas import (
@@ -212,8 +213,6 @@ def post_comment(request, event_id: UUID, payload: CommentBodyIn):
     user = request.auth
     _enforce_event_read_visibility(event, user)
     _require_rsvp_for_post(event, user)
-    from notifications.service import notify_event_comment
-
     with transaction.atomic():
         comment = EventComment.objects.create(event=event, author=user, body=payload.body)
         notify_event_comment(comment)
@@ -252,8 +251,6 @@ def post_reply(request, event_id: UUID, comment_id: UUID, payload: CommentBodyIn
         raise_validation(Code.Comment.NOT_FOUND, status_code=404)
     if parent.parent_id is not None:
         raise_validation(Code.Comment.REPLY_DEPTH_EXCEEDED, status_code=422)
-    from notifications.service import notify_comment_reply
-
     with transaction.atomic():
         reply = EventComment.objects.create(
             event=event, author=user, body=payload.body, parent=parent

--- a/backend/community/_event_flags.py
+++ b/backend/community/_event_flags.py
@@ -9,6 +9,7 @@ from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
+from notifications.service import create_event_flag_notifications
 from pydantic import BaseModel, Field
 from users.permissions import PermissionKey
 
@@ -87,8 +88,6 @@ def flag_event(request, event_id: UUID, data: EventFlagIn):
         flagged_by=request.auth,
         reason=data.reason,
     )
-
-    from notifications.service import create_event_flag_notifications
 
     create_event_flag_notifications(event, request.auth)
 

--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -5,10 +5,18 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from config.media_proxy import media_path
+from django.db.models import Case, IntegerField, Sum, Value, When
+from notifications.service import (
+    broadcast_cohost_change,
+    create_cohost_invite_notifications,
+    create_event_invite_notifications,
+    create_waitlist_promoted_notifications,
+)
 from users.models import User as UserModel
 from users.permissions import PermissionKey
 
 from community._cohost_invite_helpers import (
+    diff_cohost_invites,
     get_my_pending_invite,
     get_pending_invites_for_event,
 )
@@ -19,7 +27,15 @@ from community._event_schemas import (
     RSVPGuestOut,
 )
 from community._shared import _authenticated_user, _members_only
-from community.models import AttendanceStatus, Event, EventRSVP, RSVPStatus, SurveyQuestionType
+from community.models import (
+    AttendanceStatus,
+    CoHostInviteStatus,
+    Event,
+    EventCoHostInvite,
+    EventRSVP,
+    RSVPStatus,
+    SurveyQuestionType,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -71,8 +87,6 @@ def _attending_headcount(event: Event) -> int:
 
 def _attending_headcount_db(event: Event, exclude_user=None) -> int:
     """Count attending spots via DB query (use inside select_for_update transactions)."""
-    from django.db.models import Case, IntegerField, Sum, Value, When
-
     qs = EventRSVP.objects.filter(event=event, status=RSVPStatus.ATTENDING)
     if exclude_user is not None:
         qs = qs.exclude(user=exclude_user)
@@ -160,8 +174,6 @@ def promote_from_waitlist(event: Event) -> list[str]:
     Returns the list of promoted user ids so callers that need to follow up per
     promoted user (e.g. emailing promoted non-members) can do so after commit.
     """
-    from notifications.service import create_waitlist_promoted_notifications
-
     if event.max_attendees is None:
         return []
     promoted_user_ids: list[str] = []
@@ -284,8 +296,6 @@ def _accepted_invite_ids_for_co_hosts(event: Event, co_hosts: list) -> list[str 
     happen post-#363 data migration; kept to preserve the parallel-array
     invariant if a future migration ever leaves the data in an odd shape).
     """
-    from community.models import CoHostInviteStatus, EventCoHostInvite
-
     invite_id_by_user = dict(
         EventCoHostInvite.objects.filter(
             event=event, status=CoHostInviteStatus.ACCEPTED
@@ -381,10 +391,6 @@ def _update_co_hosts(
     take effect immediately (the rescind helper drops them from
     ``event.co_hosts`` if they had been accepted).
     """
-    from notifications.service import broadcast_cohost_change, create_cohost_invite_notifications
-
-    from community._cohost_invite_helpers import diff_cohost_invites
-
     next_ids = {str(uid) for uid in co_host_ids}
     newly_invited, removed_accepted_ids = diff_cohost_invites(event, next_ids, updater)
     if newly_invited:
@@ -404,8 +410,6 @@ def _update_invited_users(
     inviter: UserModel,
 ) -> None:
     """Update event.invited_users and notify newly added users."""
-    from notifications.service import create_event_invite_notifications
-
     id_list = list(invited_user_ids)
     old_ids = set(event.invited_users.values_list("pk", flat=True))
     invited = UserModel.objects.filter(pk__in=id_list)

--- a/backend/community/_event_transitions.py
+++ b/backend/community/_event_transitions.py
@@ -7,12 +7,13 @@ from django.utils import timezone
 from ninja.responses import Status
 from notifications.service import (
     create_cohost_invite_notifications,
+    create_event_cancellation_notifications,
     create_event_invite_notifications,
 )
 from users.permissions import PermissionKey
 
 from community._cohost_invite_helpers import diff_cohost_invites
-from community._event_helpers import _has_attendees
+from community._event_helpers import _event_out, _has_attendees
 from community._validation import Code, raise_validation
 from community.models import Event, EventStatus
 
@@ -26,8 +27,6 @@ def _cancel_event(request, event: Event, notify: bool) -> None:
     event.status = EventStatus.CANCELLED
     event.save(update_fields=["status"])
     if notify:
-        from notifications.service import create_event_cancellation_notifications
-
         create_event_cancellation_notifications(event, request.auth)
     audit_log(
         logging.INFO,
@@ -161,8 +160,6 @@ def _handle_status_update(request, event: Event, new_status: str, notify: bool):
 
     # After a delete transition the event is gone — stop further processing
     if new_status == EventStatus.DELETED:
-        from community._event_helpers import _event_out
-
         return Status(200, _event_out(event, request.auth))
 
     return None

--- a/backend/community/_feedback.py
+++ b/backend/community/_feedback.py
@@ -6,6 +6,7 @@ import re
 import time
 from urllib.request import Request, urlopen
 
+import jwt as pyjwt
 from config.auth import gated_jwt
 from config.ratelimit import auth_or_ip_key, rate_limit
 from django.conf import settings
@@ -14,7 +15,7 @@ from ninja import Router
 from ninja.responses import Status
 from pydantic import BaseModel, Field
 
-from community._shared import ErrorOut, _optional_jwt, flatten_to_single_line
+from community._shared import ErrorOut, _optional_jwt, flatten_to_single_line, logger
 from community._validation import Code, raise_validation
 from community.models import FeedbackType
 
@@ -102,8 +103,6 @@ def _build_feedback_metadata(meta: FeedbackMetadataIn) -> str:
 
 
 def _get_github_app_token(app_id: str, private_key_pem: str, installation_id: str) -> str:
-    import jwt as pyjwt
-
     now = int(time.time())
     app_jwt: str = pyjwt.encode(
         {"iat": now - 60, "exp": now + 540, "iss": app_id},
@@ -176,8 +175,6 @@ def _issue_labels(feedback_types: list[FeedbackType]) -> list[str]:
 )
 @rate_limit(key_func=auth_or_ip_key, rate="5/h")
 def submit_feedback(request, payload: FeedbackIn):
-    from community._shared import logger
-
     app_id = settings.GITHUB_APP_ID
     private_key = settings.GITHUB_APP_PRIVATE_KEY
     installation_id = settings.GITHUB_APP_INSTALLATION_ID

--- a/backend/community/_join_request_approval.py
+++ b/backend/community/_join_request_approval.py
@@ -1,10 +1,12 @@
 """User provisioning for approved join requests (create / reactivate + consent carry)."""
 
+from users._helpers import ConsentTimestamps, _create_magic_token
+from users.api import _create_user_with_role
+from users.models import User
+
 
 def _reactivate_archived_user(existing_user, join_request):
     """Un-archive an existing user on re-approval, carrying any new consents."""
-    from users._helpers import _create_magic_token
-
     existing_user.archived_at = None
     existing_user.needs_onboarding = True
     existing_user.display_name = join_request.display_name
@@ -30,13 +32,8 @@ def _provision_approved_user(join_request, requesting_user):
     Returns (magic_token, user_created). When the phone number already maps to an
     active user, nothing is provisioned and (None, False) is returned.
     """
-    from users.api import _create_user_with_role
-    from users.models import User
-
     existing_user = User.objects.filter(phone_number=join_request.phone_number).first()
     if existing_user is None:
-        from users._helpers import ConsentTimestamps
-
         _, magic_token = _create_user_with_role(
             join_request.phone_number,
             join_request.display_name,

--- a/backend/community/_join_request_resend.py
+++ b/backend/community/_join_request_resend.py
@@ -13,6 +13,8 @@ from django.db import transaction
 from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
+from users._helpers import _create_magic_token
+from users.models import MagicLoginToken, User
 from users.permissions import PermissionKey
 
 from community._join_requests import ApproveJoinRequestOut
@@ -35,9 +37,6 @@ def resend_magic_link(request, id: UUID):
     user so the welcome message in the wild can't be claimed twice. Refuses
     on already-logged-in users (use the members screen's password reset
     flow for that)."""
-    from users._helpers import _create_magic_token
-    from users.models import MagicLoginToken, User
-
     if not request.auth.has_permission(PermissionKey.APPROVE_JOIN_REQUESTS):
         audit_log(
             logging.WARNING,

--- a/backend/community/_join_requests.py
+++ b/backend/community/_join_requests.py
@@ -14,6 +14,7 @@ from ninja import Router
 from ninja.responses import Status
 from notifications.service import create_join_request_notifications
 from pydantic import BaseModel, EmailStr, Field, field_validator
+from users.models import User
 from users.permissions import PermissionKey
 
 from community._field_limits import FieldLimit
@@ -116,8 +117,6 @@ class CheckPhoneIn(BaseModel):
 
 
 def _join_request_out(jr: JoinRequest) -> JoinRequestOut:
-    from users.models import User
-
     answers = [
         JoinRequestAnswerOut(question_id=qid, label=data["label"], answer=data["answer"])
         for qid, data in (jr.custom_answers or {}).items()
@@ -221,8 +220,6 @@ def _check_submission_conflicts(validated_phone: str, normalized_email: str) -> 
     phone check) means an applicant sees the error on the form rather than
     the admin hitting it at approval time.
     """
-    from users.models import User
-
     if User.objects.filter(phone_number=validated_phone, archived_at__isnull=True).exists():
         raise_validation(Code.JoinRequest.PHONE_ALREADY_INVITED, status_code=409)
     if (
@@ -312,8 +309,6 @@ def list_join_requests(request):
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="list_join_requests")
 
-    from users.models import User
-
     cutoff = timezone.now() - timedelta(days=APPROVED_GRACE_DAYS)
     expired_phones = User.objects.filter(
         needs_onboarding=False, onboarded_at__lt=cutoff
@@ -354,8 +349,6 @@ def _stamp_decision(join_request: JoinRequest, status: str, actor) -> None:
     auth=gated_jwt,
 )
 def update_join_request_status(request, id: UUID, payload: JoinRequestStatusIn):
-    from users.models import User
-
     if not request.auth.has_permission(PermissionKey.APPROVE_JOIN_REQUESTS):
         audit_log(
             logging.WARNING,
@@ -468,13 +461,11 @@ def unreject_join_request(request, id: UUID):
 @router.post("/check-phone/", response={200: CheckPhoneOut, 429: ErrorOut}, auth=None)
 @rate_limit(key_func=client_ip, rate="20/h")
 def check_phone(request, payload: CheckPhoneIn):
-    from users.models import User as UserModel
-
     try:
         normalized = _validate_phone(payload.phone_number)
     except ValidationException:
         return Status(200, CheckPhoneOut(status="unknown"))
-    if UserModel.objects.filter(phone_number=normalized, archived_at__isnull=True).exists():
+    if User.objects.filter(phone_number=normalized, archived_at__isnull=True).exists():
         return Status(200, CheckPhoneOut(status="member"))
     if JoinRequest.objects.filter(
         phone_number=normalized, status=JoinRequestStatus.PENDING

--- a/backend/community/_login_link.py
+++ b/backend/community/_login_link.py
@@ -11,7 +11,10 @@ from ninja import Router
 from ninja.responses import Status
 from notifications._email_helpers import send_magic_login_email
 from notifications.email_sender import get_email_sender
+from notifications.service import create_magic_link_request_notifications
 from pydantic import BaseModel, Field
+from users._helpers import _create_magic_token
+from users.models import MagicLoginToken, User
 
 from community._field_limits import FieldLimit
 from community._shared import ErrorOut, _validate_phone, logger  # noqa: F401
@@ -66,10 +69,6 @@ def request_login_link(request, payload: RequestLoginLinkIn):
     Always returns 200 to prevent phone number enumeration.
     If a User exists, generates a magic link token and notifies admins.
     """
-    from notifications.service import create_magic_link_request_notifications
-    from users._helpers import _create_magic_token
-    from users.models import MagicLoginToken, User
-
     try:
         normalized = _validate_phone(payload.phone_number)
     except ValidationException:

--- a/backend/community/_survey_helpers.py
+++ b/backend/community/_survey_helpers.py
@@ -11,6 +11,7 @@ from community._survey_schemas import (
     SurveyResponseOut,
     VoterOut,
 )
+from community._validation import Code, raise_validation
 from community.models import (
     DatetimePollResult,
     Event,
@@ -85,8 +86,6 @@ def _apply_linked_event_update(updates: dict) -> dict:
 
     Raises ValidationException if the referenced event doesn't exist.
     """
-    from community._validation import Code, raise_validation
-
     eid = updates.pop("linked_event_id")
     if not eid:
         updates["linked_event"] = None

--- a/backend/community/management/commands/hard_delete_old_events.py
+++ b/backend/community/management/commands/hard_delete_old_events.py
@@ -10,6 +10,8 @@ from datetime import timedelta
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
+from community.models import Event, EventStatus
+
 logger = logging.getLogger(__name__)
 
 
@@ -17,8 +19,6 @@ class Command(BaseCommand):
     help = "Hard-delete events that have been soft-deleted for more than 30 days."
 
     def handle(self, *args, **options):
-        from community.models import Event, EventStatus
-
         cutoff = timezone.now() - timedelta(days=30)
         qs = Event.objects.filter(status=EventStatus.DELETED, deleted_at__lt=cutoff)
         count, _ = qs.delete()

--- a/backend/notifications/email_sender.py
+++ b/backend/notifications/email_sender.py
@@ -75,6 +75,7 @@ def get_email_sender() -> EmailSender:
             return _cached_sender
 
         if settings.RESEND_API_KEY:
+            # lazy import avoids circular dependency with email_sender
             from notifications._resend_sender import ResendSender
 
             _cached_sender = ResendSender()
@@ -82,6 +83,7 @@ def get_email_sender() -> EmailSender:
         else:
             if getattr(settings, "IS_PRODUCTION", False):
                 raise RuntimeError("RESEND_API_KEY is required in production but is not set")
+            # lazy import avoids circular dependency with email_sender
             from notifications._console_sender import ConsoleSender
 
             _cached_sender = ConsoleSender()

--- a/backend/notifications/service.py
+++ b/backend/notifications/service.py
@@ -2,17 +2,22 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from community.models import RSVPStatus
+from django.db import connection
+from django.db.models import Q
+from users.models import User
+from users.permissions import PermissionKey
+
+from notifications.models import Notification, NotificationType
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from community.models import Event
-    from users.models import User
 
 
 def _notify_users(user_ids: Iterable[str]) -> None:
     """Fire pg_notify on the notifications channel (for new notification rows)."""
-    from django.db import connection
-
     if connection.vendor != "postgresql":
         return
 
@@ -31,8 +36,6 @@ def _ping_event_update(user_ids: Iterable[str], event_id: str) -> None:
     `notification`) so the frontend only invalidates event caches — no bell,
     no unread-count refetch, no notification row.
     """
-    from django.db import connection
-
     if connection.vendor != "postgresql":
         return
 
@@ -76,8 +79,6 @@ def broadcast_event_update(
     co-hosts + invited + attending/maybe RSVPs. Pass `extra_user_ids` to
     include users who just lost their stake (e.g. a co-host who was removed).
     """
-    from community.models import RSVPStatus
-
     recipients: set[str] = set()
     if event.created_by_id:
         recipients.add(str(event.created_by_id))
@@ -95,12 +96,6 @@ def broadcast_event_update(
 
 
 def create_join_request_notifications(display_name: str) -> None:
-    from django.db.models import Q
-    from users.models import User
-    from users.permissions import PermissionKey
-
-    from notifications.models import Notification, NotificationType
-
     recipients = (
         User.objects.members()
         .filter(
@@ -124,15 +119,9 @@ def create_join_request_notifications(display_name: str) -> None:
 
 
 def create_event_flag_notifications(event: Event, flagger: User) -> None:
-    from django.db.models import Q
-    from users.models import User as UserModel
-    from users.permissions import PermissionKey
-
-    from notifications.models import Notification, NotificationType
-
     flagger_name = flagger.display_name or flagger.phone_number
     recipients = (
-        UserModel.objects.members()
+        User.objects.members()
         .filter(
             Q(roles__name="admin", roles__is_default=True)
             | Q(roles__permissions__contains=PermissionKey.MANAGE_EVENTS)
@@ -155,15 +144,9 @@ def create_event_flag_notifications(event: Event, flagger: User) -> None:
 
 
 def create_magic_link_request_notifications(user: User) -> None:
-    from django.db.models import Q
-    from users.models import User as UserModel
-    from users.permissions import PermissionKey
-
-    from notifications.models import Notification, NotificationType
-
     display = user.display_name or user.phone_number
     recipients = (
-        UserModel.objects.members()
+        User.objects.members()
         .filter(
             Q(roles__name="admin", roles__is_default=True)
             | Q(roles__permissions__contains=PermissionKey.APPROVE_JOIN_REQUESTS)
@@ -191,8 +174,6 @@ def create_cohost_invite_notifications(
     invited_by: User,
 ) -> None:
     """Notify users who just received a co-host invite for this event."""
-    from notifications.models import Notification, NotificationType
-
     invited_by_id = str(invited_by.pk)
     invited_by_name = invited_by.display_name or invited_by.phone_number
     notified_ids = [str(uid) for uid in new_user_ids if str(uid) != invited_by_id]
@@ -221,8 +202,6 @@ def create_cohost_invite_accepted_notification(
     inviter_id: str | None,
 ) -> None:
     """Notify the inviter that an invitee accepted their co-host invite."""
-    from notifications.models import Notification, NotificationType
-
     if inviter_id is None or str(inviter_id) == str(invitee.pk):
         return
     invitee_name = invitee.display_name or invitee.phone_number
@@ -242,8 +221,6 @@ def create_cohost_invite_declined_notification(
     inviter_id: str | None,
 ) -> None:
     """Notify the inviter that an invitee declined their co-host invite."""
-    from notifications.models import Notification, NotificationType
-
     if inviter_id is None or str(inviter_id) == str(invitee.pk):
         return
     invitee_name = invitee.display_name or invitee.phone_number
@@ -263,8 +240,6 @@ def create_cohost_removed_notification(event: Event, removed_user: User, remover
     Caller is responsible for skipping self-removal — no need to notify
     yourself that you stepped down.
     """
-    from notifications.models import Notification, NotificationType
-
     if str(remover.pk) == str(removed_user.pk):
         return
     remover_name = remover.display_name or remover.phone_number
@@ -279,10 +254,6 @@ def create_cohost_removed_notification(event: Event, removed_user: User, remover
 
 
 def create_event_cancellation_notifications(event: Event, canceller: User) -> None:
-    from community.models import RSVPStatus
-
-    from notifications.models import Notification, NotificationType
-
     canceller_id = str(canceller.pk)
     invited_ids = {str(u.pk) for u in event.invited_users.all()}
     rsvp_ids = {
@@ -312,8 +283,6 @@ def create_event_invite_notifications(
     new_user_ids: Iterable[str],
     inviter: User,
 ) -> None:
-    from notifications.models import Notification, NotificationType
-
     inviter_id = str(inviter.pk)
     inviter_name = inviter.display_name or inviter.phone_number
     notified_ids = [uid for uid in new_user_ids if str(uid) != inviter_id]
@@ -335,8 +304,6 @@ def create_waitlist_promoted_notifications(
     event: Event,
     promoted_user_ids: Iterable[str],
 ) -> None:
-    from notifications.models import Notification, NotificationType
-
     user_ids = list(promoted_user_ids)
     if not user_ids:
         return
@@ -360,8 +327,6 @@ def notify_comment_reply(reply) -> None:
     No-op if `reply` is a top-level comment or if the replier is the
     parent's author.
     """
-    from notifications.models import Notification, NotificationType
-
     if reply.parent_id is None:
         return
     parent_author_id = reply.parent.author_id
@@ -386,8 +351,6 @@ def notify_event_comment(comment) -> None:
     excluded from the recipient list — a host commenting on their own event
     doesn't notify themselves.
     """
-    from notifications.models import Notification, NotificationType
-
     if comment.parent_id is not None:
         return
     event = comment.event

--- a/backend/notifications/sse.py
+++ b/backend/notifications/sse.py
@@ -6,8 +6,10 @@ import logging
 
 from asgiref.sync import sync_to_async
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.contrib.auth.base_user import AbstractBaseUser
 from django.http import JsonResponse, StreamingHttpResponse
+from ninja_jwt.tokens import AccessToken
 
 logger = logging.getLogger("pda")
 
@@ -19,9 +21,6 @@ _HEARTBEAT_INTERVAL = 30  # seconds
 @sync_to_async
 def _get_user_from_token(token_str: str) -> AbstractBaseUser | None:
     """Validate a JWT access token and return the user, or None."""
-    from django.contrib.auth import get_user_model
-    from ninja_jwt.tokens import AccessToken
-
     try:
         validated = AccessToken(token_str)
         User = get_user_model()
@@ -55,6 +54,7 @@ def _format_notify_for_user(channel: str, payload: str, user_id: str) -> str | N
 
 async def _sse_generator(user_id: str):
     """Async generator that yields SSE events for a single user."""
+    # lazy import: psycopg only needed for the postgres LISTEN path
     import psycopg
 
     dsn = _build_async_dsn()

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,8 +1,17 @@
 from datetime import timedelta
+from unittest.mock import MagicMock
 
 import pytest
+from community.models import JoinFormQuestion, JoinRequest
+from django.core.cache import cache
 from django.test import Client
 from django.utils import timezone
+from ninja_jwt.tokens import RefreshToken
+from notifications import email_sender as email_sender_module
+from notifications.email_sender import SendResult
+from users.models import User, UserManager
+from users.permissions import PermissionKey
+from users.roles import Role
 
 
 def future_iso(days: int = 30, hours: int = 0, minutes: int = 0) -> str:
@@ -36,16 +45,12 @@ def api_client():
 
 @pytest.fixture
 def why_join_id(db):
-    from community.models import JoinFormQuestion
-
     q = JoinFormQuestion.objects.filter(required=True).first()
     return str(q.id) if q else ""
 
 
 @pytest.fixture(autouse=True)
 def _clear_rate_limit_cache():
-    from django.core.cache import cache
-
     cache.clear()
     yield
     cache.clear()
@@ -65,9 +70,6 @@ def _default_test_users_consented(monkeypatch):
     Tests that specifically exercise the consent gate explicitly set
     guidelines_consent_at = None on their user to opt back into the gated state.
     """
-    from django.utils import timezone
-    from users.models import UserManager
-
     original = UserManager.create_user
 
     def create_user(self, phone_number, password=None, **extra_fields):
@@ -80,8 +82,6 @@ def _default_test_users_consented(monkeypatch):
 
 @pytest.fixture
 def test_user(db):
-    from users.models import User
-
     user = User.objects.create_user(
         phone_number="+12025550101",
         password="testpass123",
@@ -92,18 +92,12 @@ def test_user(db):
 
 @pytest.fixture
 def auth_headers(test_user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(test_user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 
 
 @pytest.fixture
 def vettor_user(db):
-    from users.models import User
-    from users.permissions import PermissionKey
-    from users.roles import Role
-
     user = User.objects.create_user(
         phone_number="+12025550003",
         password="vettorpass123",
@@ -116,18 +110,12 @@ def vettor_user(db):
 
 @pytest.fixture
 def vettor_headers(vettor_user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(vettor_user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 
 
 @pytest.fixture
 def manage_users_user(db):
-    from users.models import User
-    from users.permissions import PermissionKey
-    from users.roles import Role
-
     user = User.objects.create_user(
         phone_number="+12025550010",
         password="adminpass123",
@@ -143,16 +131,12 @@ def manage_users_user(db):
 
 @pytest.fixture
 def manage_users_headers(manage_users_user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(manage_users_user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 
 
 @pytest.fixture
 def needs_onboarding_user(db):
-    from users.models import User
-
     return User.objects.create_user(
         phone_number="+12025550110",
         password="x",
@@ -163,16 +147,12 @@ def needs_onboarding_user(db):
 
 @pytest.fixture
 def needs_onboarding_auth_headers(needs_onboarding_user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(needs_onboarding_user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 
 
 @pytest.fixture
 def sample_join_request(db):
-    from community.models import JoinFormQuestion, JoinRequest
-
     q = JoinFormQuestion.objects.filter(required=True).first()
     answers = {}
     if q:
@@ -190,11 +170,6 @@ def fake_email_sender(monkeypatch):
 
     Yields the Mock so tests can inspect call args and tweak return values.
     """
-    from unittest.mock import MagicMock
-
-    from notifications import email_sender as email_sender_module
-    from notifications.email_sender import SendResult
-
     fake = MagicMock()
     fake.send.return_value = SendResult(success=True, provider_message_id="test_msg")
 

--- a/backend/tests/test_accept_guidelines.py
+++ b/backend/tests/test_accept_guidelines.py
@@ -6,6 +6,8 @@ enforced by config.auth.GatedJWTAuth.
 
 import pytest
 from ninja_jwt.tokens import RefreshToken
+from users.models import User
+from users.roles import Role
 
 
 def _headers(user):
@@ -15,8 +17,6 @@ def _headers(user):
 @pytest.mark.django_db
 class TestAcceptGuidelines:
     def test_stamps_consent_and_clears_flag(self, api_client):
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+12025550401", password="pass", display_name="Consenter"
         )
@@ -31,8 +31,6 @@ class TestAcceptGuidelines:
         assert user.guidelines_consent_at is not None
 
     def test_after_consent_protected_endpoints_unblock(self, api_client):
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+12025550402", password="pass", display_name="Consenter"
         )
@@ -48,8 +46,6 @@ class TestAcceptGuidelines:
         assert api_client.get("/api/notifications/", **headers).status_code == 200
 
     def test_idempotent_restamps(self, api_client):
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+12025550403", password="pass", display_name="Consenter"
         )
@@ -67,9 +63,6 @@ class TestAcceptGuidelines:
 
     def test_admin_is_not_grandfathered(self, api_client):
         """Admins are gated too — a fresh admin with null consent is blocked."""
-        from users.models import User
-        from users.roles import Role
-
         admin = User.objects.create_user(
             phone_number="+12025550404", password="pass", display_name="Admin"
         )

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -1,10 +1,12 @@
 import pytest
-from community._validation import Code
+from community._validation import Code, ValidationException
+from ninja_jwt.tokens import RefreshToken
 from users.api import (
     _create_user_with_role,
     _validate_admin_role_change,
     _validate_member_role_required,
 )
+from users.models import User
 from users.permissions import PermissionKey
 from users.roles import Role
 
@@ -17,8 +19,6 @@ from tests._asserts import assert_error_code
 
 @pytest.fixture
 def admin_user(db):
-    from users.models import User
-
     user = User.objects.create_superuser(
         phone_number="+12025550001",
         password="adminpass123",
@@ -29,8 +29,6 @@ def admin_user(db):
 
 @pytest.fixture
 def admin_headers(admin_user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(admin_user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 
@@ -38,8 +36,6 @@ def admin_headers(admin_user):
 @pytest.fixture
 def manage_users_user(db):
     """A non-superuser with only manage_users permission."""
-    from users.models import User
-
     user = User.objects.create_user(
         phone_number="+12025550002",
         password="managerpass123",
@@ -54,8 +50,6 @@ def manage_users_user(db):
 
 @pytest.fixture
 def manage_users_headers(manage_users_user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(manage_users_user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 
@@ -135,16 +129,12 @@ class TestRolesAndPermissions:
         assert not test_user.has_permission(PermissionKey.MANAGE_EVENTS)
 
     def test_superuser_gets_admin_role_on_create(self, db):
-        from users.models import User
-
         superuser = User.objects.create_superuser(
             phone_number="+12025559999", password="superpass123"
         )
         assert superuser.roles.filter(name="admin").exists()
 
     def test_has_permission_uses_prefetch_cache(self, test_user):
-        from users.models import User
-
         member_role = Role.objects.get(name="member")
         test_user.roles.add(member_role)
         user = User.objects.prefetch_related("roles").get(pk=test_user.pk)
@@ -198,8 +188,6 @@ class TestUserManagementAPI:
             **admin_headers,
         )
         assert response.status_code == 201
-        from users.models import User
-
         user = User.objects.get(phone_number="+12125551234")
         assert user.roles.filter(name="member").exists()
 
@@ -241,8 +229,6 @@ class TestUserManagementAPI:
         assert_error_code(response, Code.User.CANNOT_DELETE_LAST_ADMIN)
 
     def test_delete_user_success(self, api_client, admin_headers):
-        from users.models import User
-
         other = User.objects.create_user(phone_number="+12025550888", password="pass123")
         response = api_client.delete(f"/api/auth/users/{other.id}/", **admin_headers)
         assert response.status_code == 204
@@ -281,8 +267,6 @@ class TestUserManagementAPI:
 @pytest.mark.django_db
 class TestCreateUserWithRole:
     def _requester(self):
-        from users.models import User
-
         return User.objects.create_user(phone_number="+12025550000", password="p")
 
     def test_creates_user_with_default_member_role(self):
@@ -306,9 +290,6 @@ class TestCreateUserWithRole:
         assert user.roles.filter(pk=role.pk).exists()
 
     def test_raises_on_duplicate_phone(self):
-        from community._validation import ValidationException
-        from users.models import User
-
         User.objects.create_user(phone_number="+12025557777", password="pass123")
         with pytest.raises(ValidationException) as exc_info:
             _create_user_with_role(
@@ -317,8 +298,6 @@ class TestCreateUserWithRole:
         assert exc_info.value.code == Code.Phone.ALREADY_EXISTS
 
     def test_raises_on_invalid_phone(self):
-        from community._validation import ValidationException
-
         with pytest.raises(ValidationException) as exc_info:
             _create_user_with_role(
                 "not-a-phone", "Bad Phone", None, None, requesting_user=self._requester()
@@ -326,9 +305,6 @@ class TestCreateUserWithRole:
         assert exc_info.value.code == Code.Phone.INVALID
 
     def test_raises_on_bad_role_and_deletes_user(self):
-        from community._validation import ValidationException
-        from users.models import User
-
         with pytest.raises(ValidationException) as exc_info:
             _create_user_with_role(
                 "+12025556666",
@@ -341,9 +317,6 @@ class TestCreateUserWithRole:
         assert not User.objects.filter(phone_number="+12025556666").exists()
 
     def test_raises_when_non_admin_grants_admin_role(self):
-        from community._validation import ValidationException
-        from users.models import User
-
         admin_role = Role.objects.get_or_create(name="admin", defaults={"is_default": True})[0]
         non_admin = self._requester()
         with pytest.raises(ValidationException) as exc_info:
@@ -376,25 +349,18 @@ class TestCreateUserWithRole:
 @pytest.mark.django_db
 class TestValidateAdminRoleChange:
     def _admin_requester(self):
-        from users.models import User
-
         admin_role = Role.objects.get_or_create(name="admin", defaults={"is_default": True})[0]
         requester = User.objects.create_user(phone_number="+12025559000", password="p")
         requester.roles.add(admin_role)
         return requester
 
     def test_returns_none_when_no_admin_role_exists(self):
-        from users.models import User
-
         user = User.objects.create_user(phone_number="+12025550101", password="p", email="a@e.com")
         other = User.objects.create_user(phone_number="+12025550199", password="p")
         # No admin role exists — should be a no-op (not raise)
         _validate_admin_role_change(user, other, [])
 
     def test_returns_error_when_removing_own_admin(self):
-        from community._validation import ValidationException
-        from users.models import User
-
         admin_role = Role.objects.get_or_create(name="admin", defaults={"is_default": True})[0]
         member_role = Role.objects.get_or_create(name="member", defaults={"is_default": True})[0]
         user = User.objects.create_user(phone_number="+12025550102", password="p", email="b@e.com")
@@ -404,8 +370,6 @@ class TestValidateAdminRoleChange:
         assert exc_info.value.code == Code.Role.CANNOT_REMOVE_OWN_ADMIN
 
     def test_returns_none_when_keeping_own_admin(self):
-        from users.models import User
-
         admin_role = Role.objects.get_or_create(name="admin", defaults={"is_default": True})[0]
         user = User.objects.create_user(phone_number="+12025550103", password="p", email="c@e.com")
         user.roles.add(admin_role)
@@ -413,9 +377,6 @@ class TestValidateAdminRoleChange:
         _validate_admin_role_change(user, user, [admin_role])
 
     def test_returns_error_when_removing_last_admin(self):
-        from community._validation import ValidationException
-        from users.models import User
-
         admin_role = Role.objects.get_or_create(name="admin", defaults={"is_default": True})[0]
         member_role = Role.objects.get_or_create(name="member", defaults={"is_default": True})[0]
         user = User.objects.create_user(phone_number="+12025550104", password="p", email="d@e.com")
@@ -428,9 +389,6 @@ class TestValidateAdminRoleChange:
         assert exc_info.value.code == Code.Role.CANNOT_REMOVE_LAST_ADMIN
 
     def test_returns_error_when_non_admin_grants_admin(self):
-        from community._validation import ValidationException
-        from users.models import User
-
         admin_role = Role.objects.get_or_create(name="admin", defaults={"is_default": True})[0]
         target = User.objects.create_user(phone_number="+12025550105", password="p")
         non_admin = User.objects.create_user(phone_number="+12025550106", password="p")
@@ -440,8 +398,6 @@ class TestValidateAdminRoleChange:
         assert exc_info.value.status_code == 403
 
     def test_admin_may_grant_admin(self):
-        from users.models import User
-
         admin_role = Role.objects.get_or_create(name="admin", defaults={"is_default": True})[0]
         target = User.objects.create_user(phone_number="+12025550107", password="p")
         # Admin requester granting admin to target — no-op (no raise)
@@ -462,8 +418,6 @@ class TestValidateMemberRoleRequired:
         _validate_member_role_required([member_role, custom])
 
     def test_returns_error_when_member_role_missing(self):
-        from community._validation import ValidationException
-
         Role.objects.get_or_create(name="member", defaults={"is_default": True})
         custom = Role.objects.create(name="greeter")
         with pytest.raises(ValidationException) as exc_info:
@@ -471,8 +425,6 @@ class TestValidateMemberRoleRequired:
         assert exc_info.value.code == Code.Role.MEMBER_ROLE_REQUIRED
 
     def test_returns_error_when_new_roles_empty(self):
-        from community._validation import ValidationException
-
         Role.objects.get_or_create(name="member", defaults={"is_default": True})
         with pytest.raises(ValidationException) as exc_info:
             _validate_member_role_required([])

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -3,6 +3,7 @@
 import pytest
 from community._validation import Code
 from ninja_jwt.tokens import RefreshToken
+from users.models import User
 
 from tests._asserts import assert_error_code
 
@@ -13,8 +14,6 @@ from tests._asserts import assert_error_code
 
 @pytest.fixture
 def onboarding_user(db):
-    from users.models import User
-
     return User.objects.create_user(
         phone_number="+12025550901",
         password="temppass123",
@@ -179,8 +178,6 @@ class TestMe:
         assert response.json()["needs_onboarding"] is True
 
     def test_me_paused_user_returns_403(self, api_client, test_user):
-        from ninja_jwt.tokens import RefreshToken
-
         test_user.is_paused = True
         test_user.save(update_fields=["is_paused"])
         headers = {"HTTP_AUTHORIZATION": f"Bearer {RefreshToken.for_user(test_user).access_token}"}  # type: ignore
@@ -220,9 +217,6 @@ class TestChangePassword:
 
     def test_change_password_rejects_reuse(self, api_client, db):
         """New password must differ from the current one."""
-        from ninja_jwt.tokens import RefreshToken
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+12025550401", password="ReusedPass123!", display_name="Reuse"
         )
@@ -238,9 +232,6 @@ class TestChangePassword:
 
     def test_change_password_clears_needs_password_reset(self, api_client, db):
         """Setting a password via change-password satisfies a pending forced reset."""
-        from ninja_jwt.tokens import RefreshToken
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+12025550402", password="OldPass123!", display_name="Pending"
         )

--- a/backend/tests/test_auth_cookie.py
+++ b/backend/tests/test_auth_cookie.py
@@ -7,6 +7,7 @@ Covers: cookie set on login/magic-login, refresh via cookie, logout clears cooki
 import pytest
 from ninja_jwt.tokens import RefreshToken
 from users._refresh_cookie import REFRESH_COOKIE_NAME
+from users.models import MagicLoginToken
 
 
 @pytest.mark.django_db
@@ -39,8 +40,6 @@ class TestLoginSetsRefreshCookie:
 @pytest.mark.django_db
 class TestMagicLoginSetsRefreshCookie:
     def test_magic_login_sets_httponly_refresh_cookie(self, api_client, test_user):
-        from users.models import MagicLoginToken
-
         magic = MagicLoginToken.create_for_user(test_user)
         response = api_client.get(f"/api/auth/magic-login/{magic.token}/")
         assert response.status_code == 200

--- a/backend/tests/test_auth_gate.py
+++ b/backend/tests/test_auth_gate.py
@@ -6,7 +6,9 @@ password, pause, archive). GatedJWTAuth re-checks on every protected request and
 """
 
 import pytest
+from django.utils import timezone
 from ninja_jwt.tokens import RefreshToken
+from users.models import User
 
 
 def _headers(user):
@@ -16,8 +18,6 @@ def _headers(user):
 @pytest.mark.django_db
 class TestGatedJWTAuth:
     def test_needs_password_reset_blocks_protected_endpoint(self, api_client):
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+12025550301", password="pass", display_name="Reset Me"
         )
@@ -30,8 +30,6 @@ class TestGatedJWTAuth:
         assert resp.json()["detail"][0]["code"] == "auth.password_reset_required"
 
     def test_needs_password_reset_allows_me(self, api_client):
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+12025550302", password="pass", display_name="Reset Me"
         )
@@ -44,8 +42,6 @@ class TestGatedJWTAuth:
         assert resp.json()["needs_password_reset"] is True
 
     def test_needs_password_reset_allows_complete_onboarding(self, api_client):
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+12025550303",
             password="pass",
@@ -68,8 +64,6 @@ class TestGatedJWTAuth:
         assert user.needs_password_reset is False
 
     def test_needs_onboarding_blocks_protected_endpoint(self, api_client):
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+12025550304", password="pass", display_name="", needs_onboarding=True
         )
@@ -79,8 +73,6 @@ class TestGatedJWTAuth:
 
     def test_paused_user_blocked_on_protected_endpoint_after_token_issued(self, api_client):
         """is_paused set AFTER a token was issued must still revoke access per-request."""
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+12025550305", password="pass", display_name="Paused"
         )
@@ -93,9 +85,6 @@ class TestGatedJWTAuth:
         assert resp.json()["detail"][0]["code"] == "auth.account_paused"
 
     def test_archived_user_blocked_on_protected_endpoint_after_token_issued(self, api_client):
-        from django.utils import timezone
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+12025550306", password="pass", display_name="Archived"
         )
@@ -108,8 +97,6 @@ class TestGatedJWTAuth:
         assert resp.json()["detail"][0]["code"] == "auth.account_archived"
 
     def test_normal_user_unaffected(self, api_client):
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+12025550307", password="pass", display_name="Normal"
         )
@@ -117,8 +104,6 @@ class TestGatedJWTAuth:
         assert resp.status_code == 200
 
     def test_needs_guidelines_consent_blocks_protected_endpoint(self, api_client):
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+12025550308", password="pass", display_name="No Consent"
         )
@@ -131,8 +116,6 @@ class TestGatedJWTAuth:
         assert resp.json()["detail"][0]["code"] == "auth.guidelines_consent_required"
 
     def test_needs_guidelines_consent_allows_me(self, api_client):
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+12025550309", password="pass", display_name="No Consent"
         )
@@ -145,8 +128,6 @@ class TestGatedJWTAuth:
         assert resp.json()["needs_guidelines_consent"] is True
 
     def test_needs_guidelines_consent_allows_accept_endpoint(self, api_client):
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+12025550310", password="pass", display_name="No Consent"
         )
@@ -159,8 +140,6 @@ class TestGatedJWTAuth:
 
     def test_password_reset_takes_priority_over_consent(self, api_client):
         """A user owing both a password and consent is sent to the password gate first."""
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+12025550311", password="pass", display_name="Both"
         )

--- a/backend/tests/test_auth_update_me.py
+++ b/backend/tests/test_auth_update_me.py
@@ -1,6 +1,7 @@
 """Tests for PATCH /api/auth/me/ (update profile)."""
 
 import pytest
+from users.models import User
 
 
 @pytest.mark.django_db
@@ -67,8 +68,6 @@ class TestPatchMeEmail:
         assert test_user.email == "foo@example.com"
 
     def test_duplicate_email_rejected(self, api_client, auth_headers, db):
-        from users.models import User
-
         User.objects.create_user(
             phone_number="+12025550199", display_name="other", email="taken@example.com"
         )
@@ -83,8 +82,6 @@ class TestPatchMeEmail:
         assert body["detail"][0]["code"] == "email.already_exists"
 
     def test_duplicate_email_case_insensitive(self, api_client, auth_headers, db):
-        from users.models import User
-
         User.objects.create_user(
             phone_number="+12025550199", display_name="other", email="taken@example.com"
         )

--- a/backend/tests/test_calendar.py
+++ b/backend/tests/test_calendar.py
@@ -1,4 +1,16 @@
+import datetime as dt
+import json
+
 import pytest
+from community.models import (
+    Event,
+    EventRSVP,
+    EventStatus,
+    PageVisibility,
+    RSVPStatus,
+)
+from django.utils import timezone
+from users.models import CalendarFeedScope, User
 
 
 @pytest.mark.django_db
@@ -43,15 +55,11 @@ class TestCalendarToken:
 @pytest.mark.django_db
 class TestCalendarFeed:
     def test_feed_returns_ics(self, api_client, auth_headers, test_user):
-        from community.models import Event
-
         # Generate token
         resp = api_client.post("/api/community/calendar/token/", **auth_headers)
         token = resp.json()["token"]
 
         # Create an event
-        from django.utils import timezone
-
         Event.objects.create(
             title="Test Potluck",
             description="Bring snacks!",
@@ -70,10 +78,6 @@ class TestCalendarFeed:
         assert "The park" in content
 
     def test_feed_defaults_end_to_start_plus_2h(self, api_client, auth_headers, test_user):
-        import datetime as dt
-
-        from community.models import Event
-
         resp = api_client.post("/api/community/calendar/token/", **auth_headers)
         token = resp.json()["token"]
 
@@ -91,9 +95,6 @@ class TestCalendarFeed:
         assert "20260701T200000" in content
 
     def test_feed_includes_links_in_description(self, api_client, auth_headers, test_user):
-        from community.models import Event
-        from django.utils import timezone
-
         resp = api_client.post("/api/community/calendar/token/", **auth_headers)
         token = resp.json()["token"]
 
@@ -135,8 +136,6 @@ class TestCalendarFeedScope:
         return resp.json()["token"]
 
     def _make_other_user(self, suffix="0102"):
-        from users.models import User
-
         return User.objects.create_user(
             phone_number=f"+1202555{suffix}",
             password="testpass123",
@@ -144,9 +143,6 @@ class TestCalendarFeedScope:
         )
 
     def test_all_mode_excludes_drafts(self, api_client, auth_headers, test_user):
-        from community.models import Event, EventStatus
-        from django.utils import timezone
-
         token = self._token_for(api_client, auth_headers)
         other = self._make_other_user("0201")
 
@@ -169,9 +165,6 @@ class TestCalendarFeedScope:
         assert "Draft Event" not in content
 
     def test_all_mode_excludes_deleted_and_cancelled(self, api_client, auth_headers, test_user):
-        from community.models import Event, EventStatus
-        from django.utils import timezone
-
         token = self._token_for(api_client, auth_headers)
         other = self._make_other_user("0202")
 
@@ -196,10 +189,6 @@ class TestCalendarFeedScope:
     def test_mine_mode_includes_creator_cohost_invited_and_rsvps(
         self, api_client, auth_headers, test_user
     ):
-        from community.models import Event, EventRSVP, RSVPStatus
-        from django.utils import timezone
-        from users.models import CalendarFeedScope
-
         test_user.calendar_feed_scope = CalendarFeedScope.MINE
         test_user.save(update_fields=["calendar_feed_scope"])
         token = self._token_for(api_client, auth_headers)
@@ -251,10 +240,6 @@ class TestCalendarFeedScope:
     def test_mine_mode_excludes_cant_go_waitlisted_and_unrelated(
         self, api_client, auth_headers, test_user
     ):
-        from community.models import Event, EventRSVP, RSVPStatus
-        from django.utils import timezone
-        from users.models import CalendarFeedScope
-
         test_user.calendar_feed_scope = CalendarFeedScope.MINE
         test_user.save(update_fields=["calendar_feed_scope"])
         token = self._token_for(api_client, auth_headers)
@@ -289,10 +274,6 @@ class TestCalendarFeedScope:
     def test_mine_mode_still_hides_invite_only_when_not_participant(
         self, api_client, auth_headers, test_user
     ):
-        from community.models import Event, PageVisibility
-        from django.utils import timezone
-        from users.models import CalendarFeedScope
-
         test_user.calendar_feed_scope = CalendarFeedScope.MINE
         test_user.save(update_fields=["calendar_feed_scope"])
         token = self._token_for(api_client, auth_headers)
@@ -311,8 +292,6 @@ class TestCalendarFeedScope:
         assert "Secret Event" not in content
 
     def test_patch_me_persists_scope(self, api_client, auth_headers, test_user):
-        import json
-
         resp = api_client.patch(
             "/api/auth/me/",
             data=json.dumps({"calendar_feed_scope": "mine"}),

--- a/backend/tests/test_community.py
+++ b/backend/tests/test_community.py
@@ -3,6 +3,9 @@
 import json
 
 import pytest
+from community.models import EditablePage, PageVisibility
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
 from users.permissions import PermissionKey
 from users.roles import Role
 
@@ -28,8 +31,6 @@ def _pm(text: str) -> str:
 
 @pytest.fixture
 def manage_guidelines_user(db):
-    from users.models import User
-
     user = User.objects.create_user(
         phone_number="+12025550401",
         password="guidelinespass",
@@ -45,16 +46,12 @@ def manage_guidelines_user(db):
 
 @pytest.fixture
 def manage_guidelines_headers(manage_guidelines_user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(manage_guidelines_user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 
 
 @pytest.fixture
 def edit_homepage_user(db):
-    from users.models import User
-
     user = User.objects.create_user(
         phone_number="+12025550402",
         password="homepagepass",
@@ -70,16 +67,12 @@ def edit_homepage_user(db):
 
 @pytest.fixture
 def edit_homepage_headers(edit_homepage_user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(edit_homepage_user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 
 
 @pytest.fixture
 def edit_faq_user(db):
-    from users.models import User
-
     user = User.objects.create_user(
         phone_number="+12025550403",
         password="faqpass",
@@ -95,8 +88,6 @@ def edit_faq_user(db):
 
 @pytest.fixture
 def edit_faq_headers(edit_faq_user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(edit_faq_user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 
@@ -237,38 +228,28 @@ class TestCheckPhone:
 @pytest.mark.django_db
 class TestEditablePages:
     def _create_page(self, slug, visibility):
-        from community.models import EditablePage
-
         page = EditablePage.get_or_create_page(slug)
         page.visibility = visibility
         page.save(update_fields=["visibility"])
         return page
 
     def test_public_page_served_to_anon(self, api_client, db):
-        from community.models import PageVisibility
-
         self._create_page("about", PageVisibility.PUBLIC)
         response = api_client.get("/api/community/pages/about/")
         assert response.status_code == 200
 
     def test_members_only_page_blocked_for_anon(self, api_client, db):
-        from community.models import PageVisibility
-
         self._create_page("about", PageVisibility.MEMBERS_ONLY)
         response = api_client.get("/api/community/pages/about/")
         assert response.status_code == 403
 
     def test_invite_only_page_blocked_for_anon(self, api_client, db):
         # Previously only MEMBERS_ONLY was gated, so INVITE_ONLY leaked to anon.
-        from community.models import PageVisibility
-
         self._create_page("about", PageVisibility.INVITE_ONLY)
         response = api_client.get("/api/community/pages/about/")
         assert response.status_code == 403
 
     def test_invite_only_page_served_to_authed(self, api_client, auth_headers, db):
-        from community.models import PageVisibility
-
         self._create_page("about", PageVisibility.INVITE_ONLY)
         response = api_client.get("/api/community/pages/about/", **auth_headers)
         assert response.status_code == 200
@@ -285,8 +266,6 @@ class TestEditablePages:
         assert response.status_code == 400
 
     def test_update_page_accepts_valid_visibility(self, api_client, manage_guidelines_headers, db):
-        from community.models import PageVisibility
-
         response = api_client.patch(
             "/api/community/pages/about/",
             {"visibility": PageVisibility.MEMBERS_ONLY},

--- a/backend/tests/test_docs.py
+++ b/backend/tests/test_docs.py
@@ -1,13 +1,13 @@
 import pytest
 from community.models import DocFolder, Document
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
 from users.permissions import PermissionKey
 from users.roles import Role
 
 
 @pytest.fixture
 def manage_docs_user(db):
-    from users.models import User
-
     user = User.objects.create_user(
         phone_number="+15550003001",
         password="docspass123",
@@ -20,8 +20,6 @@ def manage_docs_user(db):
 
 @pytest.fixture
 def manage_docs_headers(manage_docs_user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(manage_docs_user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # ty: ignore[unresolved-attribute]
 

--- a/backend/tests/test_email_sender.py
+++ b/backend/tests/test_email_sender.py
@@ -4,7 +4,17 @@ import logging
 from unittest.mock import patch
 
 import pytest
-from notifications.email_sender import EmailSender, SendResult
+from django.conf import settings as django_settings
+from notifications import _resend_sender
+from notifications._console_sender import ConsoleSender
+from notifications._resend_sender import ResendSender
+from notifications.email_sender import (
+    EmailSender,
+    SendResult,
+    get_email_sender,
+    reset_email_sender_cache,
+)
+from resend.exceptions import RateLimitError, ResendError, ValidationError
 
 
 class TestSendResult:
@@ -37,8 +47,6 @@ class TestEmailSenderProtocol:
 
 class TestConsoleSender:
     def test_send_returns_success(self):
-        from notifications._console_sender import ConsoleSender
-
         sender = ConsoleSender()
         result = sender.send(
             to="user@example.com",
@@ -50,10 +58,6 @@ class TestConsoleSender:
         assert result.error is None
 
     def test_send_logs_email(self, caplog):
-        import logging
-
-        from notifications._console_sender import ConsoleSender
-
         with caplog.at_level(logging.INFO, logger="notifications.console_sender"):
             ConsoleSender().send(
                 to="user@example.com",
@@ -69,8 +73,6 @@ class TestConsoleSender:
 
 class TestResendSender:
     def test_send_success_returns_message_id(self):
-        from notifications._resend_sender import ResendSender
-
         with patch("resend.Emails.send") as mock_send:
             mock_send.return_value = {"id": "msg_abc123"}
             result = ResendSender().send(
@@ -84,8 +86,6 @@ class TestResendSender:
         assert result.error is None
 
     def test_send_exception_returns_failure(self):
-        from notifications._resend_sender import ResendSender
-
         with patch("resend.Emails.send", side_effect=RuntimeError("boom")):
             result = ResendSender().send(
                 to="user@example.com",
@@ -98,8 +98,6 @@ class TestResendSender:
         assert "boom" in (result.error or "")
 
     def test_send_does_not_log_raw_recipient(self, caplog):
-        from notifications._resend_sender import ResendSender
-
         with patch("resend.Emails.send") as mock_send:
             mock_send.return_value = {"id": "msg_abc123"}
             with caplog.at_level(logging.INFO, logger="notifications.resend_sender"):
@@ -117,9 +115,6 @@ class TestResendSender:
         assert "msg_abc123" in log_text
 
     def test_send_failure_does_not_log_raw_recipient(self, caplog):
-        from notifications._resend_sender import ResendSender
-        from resend.exceptions import ResendError
-
         err = ResendError(
             code="400",
             error_type="validation_error",
@@ -139,10 +134,6 @@ class TestResendSender:
         assert "secret.person@example.com" not in log_text
 
     def test_send_retries_transient_error_then_succeeds(self):
-        from notifications import _resend_sender
-        from notifications._resend_sender import ResendSender
-        from resend.exceptions import RateLimitError
-
         transient = RateLimitError(
             code="429", error_type="rate_limit_exceeded", message="slow down"
         )
@@ -159,9 +150,6 @@ class TestResendSender:
         assert mock_send.call_count == 2
 
     def test_send_does_not_retry_client_error(self):
-        from notifications._resend_sender import ResendSender
-        from resend.exceptions import ValidationError
-
         err = ValidationError(code="400", error_type="validation_error", message="bad")
         with patch("resend.Emails.send", side_effect=err) as mock_send:
             result = ResendSender().send(
@@ -173,9 +161,6 @@ class TestResendSender:
 
     def test_failure_log_reports_true_attempt_count(self, caplog):
         """A non-retryable error breaks after one try; the log must say attempts=1."""
-        from notifications._resend_sender import ResendSender
-        from resend.exceptions import ValidationError
-
         err = ValidationError(code="400", error_type="validation_error", message="bad")
         with patch("resend.Emails.send", side_effect=err):
             with caplog.at_level(logging.WARNING, logger="notifications.resend_sender"):
@@ -187,10 +172,6 @@ class TestResendSender:
         assert "attempts=1" in failure_logs[0]
 
     def test_send_gives_up_after_max_attempts(self):
-        from notifications import _resend_sender
-        from notifications._resend_sender import ResendSender
-        from resend.exceptions import RateLimitError
-
         transient = RateLimitError(
             code="429", error_type="rate_limit_exceeded", message="slow down"
         )
@@ -203,8 +184,6 @@ class TestResendSender:
         assert mock_send.call_count == _resend_sender._MAX_ATTEMPTS
 
     def test_send_uses_from_email_from_settings(self, settings):
-        from notifications._resend_sender import ResendSender
-
         settings.RESEND_FROM_EMAIL = "noreply@example.com"
         settings.RESEND_API_KEY = "test_key"
         with patch("resend.Emails.send") as mock_send:
@@ -229,9 +208,6 @@ class TestResendSender:
 
 class TestGetEmailSender:
     def test_returns_resend_sender_when_key_set(self, settings):
-        from notifications._resend_sender import ResendSender
-        from notifications.email_sender import get_email_sender, reset_email_sender_cache
-
         reset_email_sender_cache()
         settings.RESEND_API_KEY = "test_key"
         settings.RESEND_FROM_EMAIL = "noreply@example.com"
@@ -242,9 +218,6 @@ class TestGetEmailSender:
             reset_email_sender_cache()
 
     def test_returns_console_sender_when_no_key_in_dev(self, settings):
-        from notifications._console_sender import ConsoleSender
-        from notifications.email_sender import get_email_sender, reset_email_sender_cache
-
         reset_email_sender_cache()
         settings.RESEND_API_KEY = ""
         try:
@@ -254,8 +227,6 @@ class TestGetEmailSender:
             reset_email_sender_cache()
 
     def test_caches_sender_across_calls(self, settings):
-        from notifications.email_sender import get_email_sender, reset_email_sender_cache
-
         reset_email_sender_cache()
         settings.RESEND_API_KEY = ""
         try:
@@ -266,12 +237,9 @@ class TestGetEmailSender:
             reset_email_sender_cache()
 
     def test_raises_in_production_with_no_key(self, monkeypatch):
-        from django.conf import settings
-        from notifications.email_sender import get_email_sender, reset_email_sender_cache
-
         reset_email_sender_cache()
-        monkeypatch.setattr(settings, "RESEND_API_KEY", "")
-        monkeypatch.setattr(settings, "IS_PRODUCTION", True)
+        monkeypatch.setattr(django_settings, "RESEND_API_KEY", "")
+        monkeypatch.setattr(django_settings, "IS_PRODUCTION", True)
         try:
             with pytest.raises(RuntimeError, match="RESEND_API_KEY"):
                 get_email_sender()

--- a/backend/tests/test_event_cancel.py
+++ b/backend/tests/test_event_cancel.py
@@ -2,7 +2,10 @@
 
 import pytest
 from community._validation import Code
-from community.models import Event, EventStatus
+from community.models import Event, EventRSVP, EventStatus, RSVPStatus
+from ninja_jwt.tokens import RefreshToken
+from notifications.models import Notification, NotificationType
+from users.models import User
 from users.permissions import PermissionKey
 from users.roles import Role
 
@@ -12,8 +15,6 @@ from tests.conftest import future_iso, past_iso
 
 @pytest.fixture
 def manage_events_user(db):
-    from users.models import User
-
     user = User.objects.create_user(
         phone_number="+14155551235",
         password="eventmanagerpass123",
@@ -28,8 +29,6 @@ def manage_events_user(db):
 
 @pytest.fixture
 def manage_events_headers(manage_events_user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(manage_events_user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 
@@ -37,8 +36,6 @@ def manage_events_headers(manage_events_user):
 @pytest.fixture
 def upcoming_event_with_rsvp(db, manage_events_user, test_user):
     """An upcoming event with an attending RSVP — can be cancelled."""
-    from community.models import EventRSVP, RSVPStatus
-
     event = Event.objects.create(
         title="Cancellable Event",
         description="Has attendees",
@@ -126,8 +123,6 @@ class TestCancelEvent:
     def test_cancel_with_notify_creates_notifications(
         self, api_client, manage_events_headers, upcoming_event_with_rsvp, test_user
     ):
-        from notifications.models import Notification, NotificationType
-
         response = _patch_status(
             api_client,
             manage_events_headers,
@@ -148,10 +143,6 @@ class TestCancelEvent:
         Every attending RSVPer and every invited user should receive a cancellation
         notification. The canceller themselves must be excluded even if they'd RSVP'd.
         """
-        from community.models import EventRSVP, RSVPStatus
-        from notifications.models import Notification, NotificationType
-        from users.models import User
-
         attendee_two = User.objects.create_user(
             phone_number="+12025550102", password="pass123", display_name="Attendee Two"
         )
@@ -205,8 +196,6 @@ class TestCancelEvent:
     def test_cancel_without_notify_no_notifications(
         self, api_client, manage_events_headers, upcoming_event_with_rsvp, test_user
     ):
-        from notifications.models import Notification, NotificationType
-
         _patch_status(
             api_client,
             manage_events_headers,
@@ -234,8 +223,6 @@ class TestCancelEvent:
     def test_cancel_preserves_rsvps(
         self, api_client, manage_events_headers, upcoming_event_with_rsvp
     ):
-        from community.models import EventRSVP
-
         _patch_status(api_client, manage_events_headers, upcoming_event_with_rsvp.id, "cancelled")
         assert EventRSVP.objects.filter(event=upcoming_event_with_rsvp).exists()
 

--- a/backend/tests/test_event_capacity.py
+++ b/backend/tests/test_event_capacity.py
@@ -1,8 +1,14 @@
 """Tests for RSVP capacity limits and waitlist behaviour."""
 
+import json
+from datetime import timedelta
+
 import pytest
 from community._validation import Code
 from community.models import Event, EventRSVP, RSVPStatus
+from django.utils import timezone
+from ninja_jwt.tokens import RefreshToken
+from notifications.models import Notification, NotificationType
 from users.models import User
 
 from tests.conftest import future_iso
@@ -21,8 +27,6 @@ def _make_user(phone, name):
 
 
 def _jwt_headers(user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 
@@ -259,8 +263,6 @@ class TestWaitlistPromotionNotification:
         headers3,
     ):
         """Promoted user receives a WAITLIST_PROMOTED notification."""
-        from notifications.models import Notification, NotificationType
-
         _rsvp(api_client, capped_event, headers1)
         _rsvp(api_client, capped_event, headers2)
         _rsvp(api_client, capped_event, headers3)  # waitlisted
@@ -276,8 +278,6 @@ class TestWaitlistPromotionNotification:
 
     def test_no_notification_when_no_waitlisted(self, api_client, capped_event, headers1, headers2):
         """No notification created when a spot frees but nobody is waitlisted."""
-        from notifications.models import Notification, NotificationType
-
         _rsvp(api_client, capped_event, headers1)
         _rsvp(api_client, capped_event, headers2)
 
@@ -331,15 +331,9 @@ class TestCapacityCounts:
 class TestMaxAttendeesValidation:
     @staticmethod
     def _future_iso(days: int = 30) -> str:
-        from datetime import timedelta
-
-        from django.utils import timezone
-
         return (timezone.now() + timedelta(days=days)).isoformat()
 
     def test_create_rejects_zero_max_attendees(self, api_client, auth_headers):
-        import json
-
         resp = api_client.post(
             "/api/community/events/",
             data=json.dumps(
@@ -360,8 +354,6 @@ class TestMaxAttendeesValidation:
         )
 
     def test_create_accepts_null_max_attendees(self, api_client, auth_headers):
-        import json
-
         resp = api_client.post(
             "/api/community/events/",
             data=json.dumps(
@@ -378,8 +370,6 @@ class TestMaxAttendeesValidation:
         assert resp.status_code == 201
 
     def test_patch_rejects_zero_max_attendees(self, api_client, capped_event, auth_headers):
-        import json
-
         resp = api_client.patch(
             f"/api/community/events/{capped_event.id}/",
             data=json.dumps({"max_attendees": 0}),
@@ -393,8 +383,6 @@ class TestMaxAttendeesValidation:
         )
 
     def test_patch_accepts_null_max_attendees(self, api_client, capped_event, auth_headers):
-        import json
-
         resp = api_client.patch(
             f"/api/community/events/{capped_event.id}/",
             data=json.dumps({"max_attendees": None}),

--- a/backend/tests/test_event_comments.py
+++ b/backend/tests/test_event_comments.py
@@ -11,7 +11,11 @@ from community.models import (
     PageVisibility,
     RSVPStatus,
 )
+from django.core.cache import cache
 from django.utils import timezone
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
+from users.roles import Role
 
 from tests.conftest import future_iso
 
@@ -38,8 +42,6 @@ class TestGetComments:
 
 @pytest.fixture
 def rsvp_user(db):
-    from users.models import User
-
     return User.objects.create_user(
         phone_number="+12025550303",
         password="rsvppass123",
@@ -49,8 +51,6 @@ def rsvp_user(db):
 
 @pytest.fixture
 def rsvp_headers(rsvp_user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(rsvp_user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 
@@ -74,9 +74,6 @@ class TestPostComment:
     def test_post_requires_rsvp(self, api_client, event):
         # A logged-in user who is NOT the creator, not a co-host, not an admin,
         # and has no RSVP. Hosts/admins bypass the RSVP gate; bystanders don't.
-        from ninja_jwt.tokens import RefreshToken
-        from users.models import User
-
         bystander = User.objects.create_user(
             phone_number="+12025550909",
             password="bystanderpass",
@@ -185,9 +182,6 @@ class TestPostReply:
 
 @pytest.fixture
 def admin_user(db):
-    from users.models import User
-    from users.roles import Role
-
     user = User.objects.create_user(
         phone_number="+12025550404",
         password="adminpass123",
@@ -203,8 +197,6 @@ def admin_user(db):
 
 @pytest.fixture
 def admin_headers(admin_user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(admin_user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 
@@ -222,9 +214,6 @@ class TestDeleteComment:
         assert comment.deleted_at is not None
 
     def test_other_rsvper_cannot_delete(self, api_client, event_with_rsvp):
-        from ninja_jwt.tokens import RefreshToken
-        from users.models import User
-
         # A plain RSVP'd member who is not the event creator or admin
         bystander = User.objects.create_user(
             phone_number="+12025550606",
@@ -350,9 +339,6 @@ class TestReactionToggle:
 
     def test_reaction_requires_rsvp(self, api_client, event):
         # A bystander (not creator, not co-host, not admin, no RSVP).
-        from ninja_jwt.tokens import RefreshToken
-        from users.models import User
-
         bystander = User.objects.create_user(
             phone_number="+12025551010",
             password="bystanderpass",
@@ -372,8 +358,6 @@ class TestReactionToggle:
     def test_rate_limit_kicks_in(self, api_client, rsvp_headers, event_with_rsvp, rsvp_user):
         """11th write in 60s should 429. Toggles back-and-forth to avoid the
         unique-constraint blocking the second create — toggle on, off, on, off..."""
-        from django.core.cache import cache
-
         cache.clear()
         comment = EventComment.objects.create(event=event_with_rsvp, author=rsvp_user, body="hi")
         url = f"/api/community/events/{event_with_rsvp.id}/comments/{comment.id}/reactions/"
@@ -400,9 +384,6 @@ class TestReactionToggle:
 class TestCommentVisibility:
     def test_invite_only_non_invitee_cannot_list(self, api_client, db, rsvp_user, rsvp_headers):
         creator = rsvp_user  # using rsvp_user as the event creator
-        from ninja_jwt.tokens import RefreshToken
-        from users.models import User
-
         stranger = User.objects.create_user(
             phone_number="+12025550606",
             password="strangerpass",

--- a/backend/tests/test_event_drafts.py
+++ b/backend/tests/test_event_drafts.py
@@ -5,6 +5,9 @@ import json
 import pytest
 from community._validation import Code
 from community.models import Event, EventStatus
+from ninja_jwt.tokens import RefreshToken
+from notifications.models import Notification
+from users.models import User
 
 from tests._asserts import assert_error_code
 from tests.conftest import future_iso, past_iso
@@ -12,8 +15,6 @@ from tests.conftest import future_iso, past_iso
 
 @pytest.fixture
 def creator(db):
-    from users.models import User
-
     return User.objects.create_user(
         phone_number="+14155550201",
         password="creatorpass123",
@@ -23,16 +24,12 @@ def creator(db):
 
 @pytest.fixture
 def creator_headers(creator):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(creator)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 
 
 @pytest.fixture
 def other_member(db):
-    from users.models import User
-
     return User.objects.create_user(
         phone_number="+14155550202",
         password="otherpass123",
@@ -42,16 +39,12 @@ def other_member(db):
 
 @pytest.fixture
 def other_headers(other_member):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(other_member)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 
 
 @pytest.fixture
 def cohost(db):
-    from users.models import User
-
     return User.objects.create_user(
         phone_number="+14155550203",
         password="cohostpass123",
@@ -61,16 +54,12 @@ def cohost(db):
 
 @pytest.fixture
 def cohost_headers(cohost):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(cohost)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 
 
 @pytest.fixture
 def invitee(db):
-    from users.models import User
-
     return User.objects.create_user(
         phone_number="+14155550204",
         password="inviteepass123",
@@ -159,8 +148,6 @@ class TestCreateDraft:
     def test_invite_to_draft_skips_invitee_notifications(
         self, api_client, creator_headers, invitee, sample_draft
     ):
-        from notifications.models import Notification
-
         response = api_client.post(
             f"/api/community/events/{sample_draft.id}/invitations/",
             data=json.dumps({"user_ids": [str(invitee.pk)]}),
@@ -172,8 +159,6 @@ class TestCreateDraft:
         assert not Notification.objects.filter(recipient=invitee).exists()
 
     def test_create_draft_fires_cohost_notifications(self, api_client, creator_headers, cohost):
-        from notifications.models import Notification
-
         response = api_client.post(
             "/api/community/events/",
             data=json.dumps(
@@ -325,8 +310,6 @@ class TestPatchDraft:
     def test_patch_draft_cohost_adds_fires_notification(
         self, api_client, sample_draft, creator_headers, cohost
     ):
-        from notifications.models import Notification
-
         response = api_client.patch(
             f"/api/community/events/{sample_draft.id}/",
             data=json.dumps({"co_host_ids": [str(cohost.pk)]}),
@@ -354,8 +337,6 @@ class TestPublishDraft:
     def test_publish_draft_fires_invitee_notifications(
         self, api_client, sample_draft, creator_headers, invitee
     ):
-        from notifications.models import Notification
-
         sample_draft.invited_users.add(invitee)
         response = api_client.patch(
             f"/api/community/events/{sample_draft.id}/",

--- a/backend/tests/test_event_flags.py
+++ b/backend/tests/test_event_flags.py
@@ -1,7 +1,15 @@
 """Tests for event flag submission and admin review endpoints."""
 
+import uuid
+
 import pytest
-from community.models import Event, EventFlag, EventFlagStatus
+from community.models import (
+    Event,
+    EventFlag,
+    EventFlagStatus,
+    EventStatus,
+    PageVisibility,
+)
 from ninja_jwt.tokens import RefreshToken
 from notifications.models import Notification, NotificationType
 from users.models import User
@@ -84,8 +92,6 @@ class TestFlagSubmission:
         assert response.status_code == 409
 
     def test_flag_event_not_found_returns_404(self, api_client, member):
-        import uuid
-
         fake_id = uuid.uuid4()
         response = api_client.post(
             f"/api/community/events/{fake_id}/flag/",
@@ -222,8 +228,6 @@ class TestFlagReview:
 @pytest.mark.django_db
 class TestFlagVisibilityGating:
     def test_cannot_flag_invite_only_event_not_invited(self, api_client, member, other_member):
-        from community.models import PageVisibility
-
         event = Event.objects.create(
             title="Private gathering",
             start_datetime=future_iso(days=30),
@@ -240,8 +244,6 @@ class TestFlagVisibilityGating:
         assert not EventFlag.objects.filter(event=event).exists()
 
     def test_cannot_flag_deleted_event(self, api_client, member):
-        from community.models import EventStatus
-
         event = Event.objects.create(
             title="Removed event",
             start_datetime=future_iso(days=30),

--- a/backend/tests/test_event_link_validation.py
+++ b/backend/tests/test_event_link_validation.py
@@ -8,6 +8,10 @@ Validates that:
 """
 
 import pytest
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
+from users.permissions import PermissionKey
+from users.roles import Role
 
 from tests.conftest import future_iso
 
@@ -21,11 +25,6 @@ def base_event() -> dict:
 
 @pytest.fixture
 def manage_events_headers(db):
-    from ninja_jwt.tokens import RefreshToken
-    from users.models import User
-    from users.permissions import PermissionKey
-    from users.roles import Role
-
     user = User.objects.create_user(
         phone_number="+14155559001",
         password="eventmanagerpass123",

--- a/backend/tests/test_event_management.py
+++ b/backend/tests/test_event_management.py
@@ -2,7 +2,11 @@
 
 import pytest
 from community._validation import Code
-from community.models import Event
+from community.api import EventPatchIn
+from community.models import Event, EventStatus
+from django.core.cache import cache
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
 from users.permissions import PermissionKey
 from users.roles import Role
 
@@ -13,8 +17,6 @@ from tests.conftest import future_iso, past_iso
 @pytest.fixture
 def manage_events_user(db):
     """A non-superuser with only manage_events permission."""
-    from users.models import User
-
     user = User.objects.create_user(
         phone_number="+14155551234",
         password="eventmanagerpass123",
@@ -27,8 +29,6 @@ def manage_events_user(db):
 
 @pytest.fixture
 def manage_events_headers(manage_events_user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(manage_events_user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 
@@ -84,9 +84,6 @@ class TestEventManagement:
 
     def test_create_event_any_member(self, api_client, db):
         """Any authenticated member can create events."""
-        from ninja_jwt.tokens import RefreshToken
-        from users.models import User
-
         member = User.objects.create_user(
             phone_number="+12025550199",
             password="memberpass",
@@ -384,8 +381,6 @@ class TestEventManagement:
 
     def test_event_patch_fields_match_model(self):
         """All EventPatchIn fields (except M2M and transient fields) must exist on Event model."""
-        from community.api import EventPatchIn
-
         non_model_fields = {"co_host_ids", "status", "notify_attendees"}
         schema_fields = set(EventPatchIn.model_fields.keys()) - non_model_fields
         model_fields = {f.name for f in Event._meta.get_fields()}
@@ -396,8 +391,6 @@ class TestEventManagement:
 
     def test_soft_delete_past_event(self, api_client, manage_events_headers):
         """A manager can soft-delete a past event."""
-        from community.models import EventStatus
-
         event = Event.objects.create(
             title="Past Deletable Event",
             start_datetime=past_iso(days=90),
@@ -418,8 +411,6 @@ class TestEventManagement:
 
     def test_member_can_delete_own_past_event(self, api_client, auth_headers, test_user):
         """A member can soft-delete a past event they created."""
-        from community.models import EventStatus
-
         event = Event.objects.create(
             title="My Past Event",
             start_datetime=past_iso(days=60),
@@ -476,8 +467,6 @@ class TestEventManagement:
 @pytest.mark.django_db
 class TestEventRateLimiting:
     def test_create_event_rate_limited(self, api_client, manage_events_headers):
-        from django.core.cache import cache
-
         cache.clear()
         for i in range(10):
             resp = api_client.post(

--- a/backend/tests/test_event_stats.py
+++ b/backend/tests/test_event_stats.py
@@ -12,6 +12,8 @@ from community._event_helpers import (
 from community.models import AttendanceStatus, Event, EventRSVP, RSVPStatus
 from django.utils import timezone
 from ninja_jwt.tokens import RefreshToken
+from users.models import Role, User
+from users.permissions import PermissionKey
 
 
 def _auth(user):
@@ -21,8 +23,6 @@ def _auth(user):
 
 @pytest.fixture
 def members(db):
-    from users.models import User
-
     return [
         User.objects.create_user(
             phone_number=f"+1202555090{i}",
@@ -35,8 +35,6 @@ def members(db):
 
 @pytest.fixture
 def host_user(db):
-    from users.models import User
-
     return User.objects.create_user(
         phone_number="+12025558000",
         password="x",
@@ -46,8 +44,6 @@ def host_user(db):
 
 @pytest.fixture
 def cohost_user(db):
-    from users.models import User
-
     return User.objects.create_user(
         phone_number="+12025558001",
         password="x",
@@ -57,9 +53,6 @@ def cohost_user(db):
 
 @pytest.fixture
 def admin_user(db):
-    from users.models import Role, User
-    from users.permissions import PermissionKey
-
     admin = User.objects.create_user(
         phone_number="+12025558002",
         password="x",

--- a/backend/tests/test_event_visibility.py
+++ b/backend/tests/test_event_visibility.py
@@ -1,8 +1,14 @@
 """Tests for event public/auth visibility and invite-only access control."""
 
+import secrets
+from datetime import timedelta
+
 import pytest
 from community._validation import Code
-from community.models import Event
+from community.models import Event, EventType, PageVisibility
+from django.utils import timezone
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
 from users.permissions import PermissionKey
 from users.roles import Role
 
@@ -12,8 +18,6 @@ from tests._asserts import assert_error_code
 @pytest.fixture
 def official_event_user(db):
     """A user with tag_official_event permission."""
-    from users.models import User
-
     user = User.objects.create_user(
         phone_number="+14155559999",
         password="officialpass123",
@@ -28,8 +32,6 @@ def official_event_user(db):
 
 @pytest.fixture
 def official_event_headers(official_event_user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(official_event_user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 
@@ -37,8 +39,6 @@ def official_event_headers(official_event_user):
 @pytest.fixture
 def manage_events_user(db):
     """A non-superuser with only manage_events permission."""
-    from users.models import User
-
     user = User.objects.create_user(
         phone_number="+14155551234",
         password="eventmanagerpass123",
@@ -51,8 +51,6 @@ def manage_events_user(db):
 
 @pytest.fixture
 def manage_events_headers(manage_events_user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(manage_events_user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 
@@ -70,9 +68,6 @@ class TestEventVisibility:
         assert isinstance(response.json(), list)
 
     def test_events_strips_private_fields_for_anonymous(self, api_client, auth_headers, test_user):
-        from community.models import Event
-        from django.utils import timezone
-
         event = Event.objects.create(
             title="Test",
             start_datetime=timezone.now(),
@@ -100,11 +95,6 @@ class TestInviteOnlyVisibility:
     """Tests for invite_only PageVisibility — events hidden from non-invited members."""
 
     def _make_invite_only_event(self, creator, co_host=None, invited_user=None):
-        from datetime import timedelta
-
-        from community.models import PageVisibility
-        from django.utils import timezone
-
         future = timezone.now() + timedelta(days=7)
         event = Event.objects.create(
             title="Secret Gathering",
@@ -120,13 +110,9 @@ class TestInviteOnlyVisibility:
         return event
 
     def _make_user(self, phone, name):
-        from users.models import User
-
         return User.objects.create_user(phone_number=phone, password="pass123", display_name=name)
 
     def _auth_headers(self, user):
-        from ninja_jwt.tokens import RefreshToken
-
         refresh = RefreshToken.for_user(user)
         return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # ty: ignore[unresolved-attribute]
 
@@ -231,9 +217,6 @@ class TestInviteOnlyVisibility:
         assert response.json()["invited_user_ids"] == []
 
     def test_invited_list_hidden_for_regular_public_event(self, api_client, test_user):
-        from community.models import PageVisibility
-        from django.utils import timezone
-
         creator = self._make_user("+12025550211", "Creator11")
         event = Event.objects.create(
             title="Public Event",
@@ -279,12 +262,6 @@ class TestInviteOnlyVisibility:
         assert response.status_code == 200
 
     def test_calendar_feed_excludes_invite_only_for_non_invited(self, api_client):
-        import secrets
-
-        from community.models import PageVisibility
-        from django.utils import timezone
-        from users.models import User
-
         owner = User.objects.create_user(
             phone_number="+12025550214", password="pass123", display_name="Feed Owner"
         )
@@ -305,12 +282,6 @@ class TestInviteOnlyVisibility:
         assert b"Private Party" not in response.content
 
     def test_calendar_feed_includes_invite_only_for_invited(self, api_client):
-        import secrets
-
-        from community.models import PageVisibility
-        from django.utils import timezone
-        from users.models import User
-
         owner = User.objects.create_user(
             phone_number="+12025550216", password="pass123", display_name="Invited Owner"
         )
@@ -337,9 +308,6 @@ class TestOfficialEventVisibility:
     """Official events are public — visible to anonymous users."""
 
     def _make_official_event(self, creator):
-        from community.models import EventType
-        from django.utils import timezone
-
         return Event.objects.create(
             title="Official Meetup",
             start_datetime=timezone.now(),
@@ -364,8 +332,6 @@ class TestOfficialEventVisibility:
     def test_create_official_event_rejects_non_public_visibility(
         self, api_client, official_event_headers
     ):
-        from django.utils import timezone
-
         payload = {
             "title": "Official Event",
             "description": "",
@@ -384,9 +350,6 @@ class TestOfficialEventVisibility:
     def test_update_to_official_rejects_non_public_visibility(
         self, api_client, official_event_user, official_event_headers
     ):
-        from community.models import PageVisibility
-        from django.utils import timezone
-
         event = Event.objects.create(
             title="Community Event",
             start_datetime=timezone.now(),

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -1,13 +1,16 @@
 """Tests for feedback (GitHub issue creation) endpoint."""
 
+import io
+import json
+from urllib.error import URLError
+
 import pytest
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
 
 
 def _mock_urlopen(monkeypatch, issue_url="https://github.com/leahpeker/pda/issues/1"):
     """Patch community.api.urlopen to return a fake GitHub issue creation response."""
-    import io
-    import json
-
     captured: dict = {"calls": []}
 
     def fake_urlopen(request):
@@ -145,8 +148,6 @@ class TestFeedback:
         self, api_client, settings, monkeypatch
     ):
         """Submitter identity in issue body should be the user's UUID, not name or phone."""
-        import json
-
         for k, v in _APP_SETTINGS.items():
             setattr(settings, k, v)
         monkeypatch.setattr(
@@ -154,15 +155,11 @@ class TestFeedback:
         )
         captured = _mock_urlopen(monkeypatch)
 
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+15551239999",
             password="pw12345678",
             display_name="alice smith",
         )
-        from ninja_jwt.tokens import RefreshToken
-
         refresh = RefreshToken.for_user(user)
         headers = {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 
@@ -212,8 +209,6 @@ class TestFeedback:
         assert response.status_code == 201
 
     def test_feedback_returns_503_on_github_api_failure(self, api_client, settings, monkeypatch):
-        from urllib.error import URLError
-
         for k, v in _APP_SETTINGS.items():
             setattr(settings, k, v)
         monkeypatch.setattr(
@@ -241,8 +236,6 @@ class TestFeedbackLabels:
     """feedback_types map to GitHub issue labels."""
 
     def _labels_for(self, api_client, settings, monkeypatch, feedback_types):
-        import json
-
         for k, v in _APP_SETTINGS.items():
             setattr(settings, k, v)
         monkeypatch.setattr(
@@ -314,8 +307,6 @@ class TestFeedbackSanitization:
         return captured["calls"][-1]
 
     def test_description_is_fenced_to_neutralize_mentions(self, api_client, settings, monkeypatch):
-        import json
-
         req = self._submit(
             api_client,
             monkeypatch,
@@ -333,8 +324,6 @@ class TestFeedbackSanitization:
         assert "@leahpeker" in fenced  # still present, but inside the fence
 
     def test_description_cannot_break_out_of_fence(self, api_client, settings, monkeypatch):
-        import json
-
         # User tries to close the fence and inject active markdown afterwards.
         malicious = "```\n@everyone escaped"
         req = self._submit(
@@ -350,8 +339,6 @@ class TestFeedbackSanitization:
         assert first_fence.count("`") >= 4
 
     def test_metadata_user_agent_is_inline_code_escaped(self, api_client, settings, monkeypatch):
-        import json
-
         req = self._submit(
             api_client,
             monkeypatch,

--- a/backend/tests/test_guidelines.py
+++ b/backend/tests/test_guidelines.py
@@ -2,6 +2,8 @@ import json
 
 import pytest
 from community.models import CommunityGuidelines
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
 from users.permissions import PermissionKey
 from users.roles import Role
 
@@ -22,8 +24,6 @@ def _pm(text: str) -> str:
 
 @pytest.fixture
 def manage_guidelines_user(db):
-    from users.models import User
-
     user = User.objects.create_user(
         phone_number="+15550002001",
         password="editorpass123",
@@ -38,8 +38,6 @@ def manage_guidelines_user(db):
 
 @pytest.fixture
 def manage_guidelines_headers(manage_guidelines_user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(manage_guidelines_user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 

--- a/backend/tests/test_join_form_admin.py
+++ b/backend/tests/test_join_form_admin.py
@@ -4,14 +4,14 @@ import json
 
 import pytest
 from community.models import JoinFormQuestion, JoinFormQuestionType
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
 from users.permissions import PermissionKey
 from users.roles import Role
 
 
 @pytest.fixture
 def form_admin_user(db):
-    from users.models import User
-
     user = User.objects.create_user(
         phone_number="+12025550555",
         password="adminpass123",
@@ -27,8 +27,6 @@ def form_admin_user(db):
 
 @pytest.fixture
 def form_admin_headers(form_admin_user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(form_admin_user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 

--- a/backend/tests/test_join_request_conflicts.py
+++ b/backend/tests/test_join_request_conflicts.py
@@ -7,13 +7,14 @@ cache reset come from conftest.
 """
 
 import pytest
+from community.models import JoinRequest
+from django.utils import timezone
+from users.models import User
 
 
 @pytest.mark.django_db
 class TestJoinRequestConflicts:
     def test_submit_existing_user_returns_409(self, api_client, why_join_id):
-        from users.models import User
-
         User.objects.create_user(phone_number="+12025551299", password="pass")
         response = api_client.post(
             "/api/community/join-request/",
@@ -31,9 +32,6 @@ class TestJoinRequestConflicts:
         assert response.json()["detail"][0]["code"] == "join_request.phone_already_invited"
 
     def test_submit_existing_user_creates_no_join_request(self, api_client, why_join_id):
-        from community.models import JoinRequest
-        from users.models import User
-
         User.objects.create_user(phone_number="+12025551298", password="pass")
         api_client.post(
             "/api/community/join-request/",
@@ -50,8 +48,6 @@ class TestJoinRequestConflicts:
         assert not JoinRequest.objects.filter(phone_number="+12025551298").exists()
 
     def test_submit_existing_email_returns_409(self, api_client, why_join_id):
-        from users.models import User
-
         User.objects.create_user(
             phone_number="+12025551300", password="pass", email="taken@example.com"
         )
@@ -71,9 +67,6 @@ class TestJoinRequestConflicts:
         assert response.json()["detail"][0]["code"] == "email.already_exists"
 
     def test_submit_existing_email_creates_no_join_request(self, api_client, why_join_id):
-        from community.models import JoinRequest
-        from users.models import User
-
         User.objects.create_user(
             phone_number="+12025551302", password="pass", email="dupe@example.com"
         )
@@ -92,10 +85,6 @@ class TestJoinRequestConflicts:
         assert not JoinRequest.objects.filter(phone_number="+12025551303").exists()
 
     def test_archived_user_email_can_be_reused(self, api_client, why_join_id):
-        from community.models import JoinRequest
-        from django.utils import timezone
-        from users.models import User
-
         archived = User.objects.create_user(
             phone_number="+12025551304", password="pass", email="returning@example.com"
         )
@@ -118,10 +107,6 @@ class TestJoinRequestConflicts:
         assert JoinRequest.objects.filter(phone_number="+12025551305").exists()
 
     def test_archived_user_can_resubmit_join_request(self, api_client, why_join_id):
-        from community.models import JoinRequest
-        from django.utils import timezone
-        from users.models import User
-
         archived = User.objects.create_user(phone_number="+12025551297", password="pass")
         archived.archived_at = timezone.now()
         archived.save(update_fields=["archived_at"])

--- a/backend/tests/test_join_request_email.py
+++ b/backend/tests/test_join_request_email.py
@@ -1,12 +1,14 @@
 """Tests for email validation on join request submission."""
 
 import pytest
+from community._join_requests import _send_join_request_email
+from community._shared import flatten_to_single_line
+from community.models import JoinFormQuestion, JoinRequest
+from django.core import mail
 
 
 @pytest.fixture
 def why_join_id(db):
-    from community.models import JoinFormQuestion
-
     q = JoinFormQuestion.objects.filter(required=True).first()
     return str(q.id) if q else ""
 
@@ -43,8 +45,6 @@ class TestJoinRequestEmail:
         assert resp.status_code == 422
 
     def test_valid_email_persisted_lowercased(self, api_client, why_join_id):
-        from community.models import JoinRequest
-
         resp = api_client.post(
             "/api/community/join-request/",
             data={
@@ -66,8 +66,6 @@ class TestVettingEmailHeaderInjection:
     """Issue 457 — CR/LF in interpolated values must not forge email headers."""
 
     def test_flatten_to_single_line_collapses_crlf(self):
-        from community._shared import flatten_to_single_line
-
         out = flatten_to_single_line("Eve\r\nBcc: victim@example.com")
         assert "\n" not in out
         assert "\r" not in out
@@ -75,9 +73,6 @@ class TestVettingEmailHeaderInjection:
 
     @pytest.mark.django_db
     def test_vetting_email_subject_is_single_line(self, settings):
-        from community._join_requests import _send_join_request_email
-        from django.core import mail
-
         settings.VETTING_EMAIL = "vetting@example.com"
         settings.EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
         mail.outbox = []

--- a/backend/tests/test_join_request_management.py
+++ b/backend/tests/test_join_request_management.py
@@ -1,8 +1,14 @@
 """Tests for join request management (list, approve, reject)."""
 
+import uuid
+from datetime import timedelta
+
 import pytest
 from community._validation import Code
-from community.models import JoinRequestStatus
+from community.models import JoinRequest, JoinRequestStatus
+from django.utils import timezone
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
 
 from tests._asserts import assert_error_code
 
@@ -27,15 +33,11 @@ class TestJoinRequestManagement:
         assert data[0]["status"] == JoinRequestStatus.PENDING
 
     def test_admin_can_access_list(self, api_client, db):
-        from users.models import User
-
         admin = User.objects.create_superuser(
             phone_number="+12025550001",
             password="adminpass123",
             display_name="Admin User",
         )
-        from ninja_jwt.tokens import RefreshToken
-
         admin_headers = {
             "HTTP_AUTHORIZATION": f"Bearer {RefreshToken.for_user(admin).access_token}"  # type: ignore
         }
@@ -55,8 +57,6 @@ class TestJoinRequestManagement:
         assert data["id"] == str(sample_join_request.id)
 
     def test_approve_creates_user(self, api_client, vettor_headers, sample_join_request):
-        from users.models import User
-
         response = api_client.patch(
             f"/api/community/join-requests/{sample_join_request.id}/",
             {"status": JoinRequestStatus.APPROVED},
@@ -119,8 +119,6 @@ class TestJoinRequestManagement:
         assert response.status_code == 401
 
     def test_not_found(self, api_client, vettor_headers):
-        import uuid
-
         response = api_client.patch(
             f"/api/community/join-requests/{uuid.uuid4()}/",
             {"status": JoinRequestStatus.APPROVED},
@@ -196,8 +194,6 @@ class TestJoinRequestManagement:
     def test_approve_creates_user_with_member_role(
         self, api_client, vettor_headers, sample_join_request, db
     ):
-        from users.models import User
-
         response = api_client.patch(
             f"/api/community/join-requests/{sample_join_request.id}/",
             {"status": "approved"},
@@ -226,11 +222,6 @@ class TestJoinRequestManagement:
     def test_list_excludes_approved_onboarded_user_after_grace(
         self, api_client, vettor_headers, sample_join_request
     ):
-        from datetime import timedelta
-
-        from django.utils import timezone
-        from users.models import User
-
         api_client.patch(
             f"/api/community/join-requests/{sample_join_request.id}/",
             {"status": JoinRequestStatus.APPROVED},
@@ -250,11 +241,6 @@ class TestJoinRequestManagement:
     def test_list_includes_approved_onboarded_within_grace(
         self, api_client, vettor_headers, sample_join_request
     ):
-        from datetime import timedelta
-
-        from django.utils import timezone
-        from users.models import User
-
         api_client.patch(
             f"/api/community/join-requests/{sample_join_request.id}/",
             {"status": JoinRequestStatus.APPROVED},
@@ -275,8 +261,6 @@ class TestJoinRequestManagement:
     def test_list_excludes_legacy_onboarded_user_with_null_timestamp(
         self, api_client, vettor_headers, sample_join_request
     ):
-        from users.models import User
-
         api_client.patch(
             f"/api/community/join-requests/{sample_join_request.id}/",
             {"status": JoinRequestStatus.APPROVED},
@@ -309,10 +293,6 @@ class TestJoinRequestManagement:
         assert items[str(sample_join_request.id)]["onboarded_at"] is None
 
     def test_list_flags_previously_archived(self, api_client, vettor_headers, db):
-        from community.models import JoinRequest
-        from django.utils import timezone
-        from users.models import User
-
         archived = User.objects.create_user(
             phone_number="+12025550150", display_name="Comeback Kid"
         )
@@ -332,10 +312,6 @@ class TestJoinRequestManagement:
     def test_approve_archived_user_unarchives_and_issues_magic_link(
         self, api_client, vettor_headers, db
     ):
-        from community.models import JoinRequest
-        from django.utils import timezone
-        from users.models import User
-
         archived = User.objects.create_user(phone_number="+12025550151", display_name="Phoenix")
         archived.archived_at = timezone.now()
         archived.needs_onboarding = False
@@ -359,9 +335,6 @@ class TestJoinRequestManagement:
         assert archived.needs_onboarding is True
 
     def test_list_keeps_pending_and_rejected_unaffected(self, api_client, vettor_headers, db):
-        from community.models import JoinRequest
-        from users.models import User
-
         pending = JoinRequest.objects.create(
             display_name="Pending Person",
             phone_number="+12025550101",
@@ -394,9 +367,6 @@ class TestJoinRequestManagement:
 @pytest.mark.django_db
 class TestApprovalEmail:
     def test_approval_copies_email_to_new_user(self, api_client, vettor_headers):
-        from community.models import JoinRequest, JoinRequestStatus
-        from users.models import User
-
         jr = JoinRequest.objects.create(
             display_name="Applicant",
             phone_number="+12025550101",
@@ -414,9 +384,6 @@ class TestApprovalEmail:
         assert user.email == "applicant@example.com"
 
     def test_approval_conflict_when_email_taken(self, api_client, vettor_headers):
-        from community.models import JoinRequest, JoinRequestStatus
-        from users.models import User
-
         User.objects.create_user(
             phone_number="+12025550199", display_name="other", email="taken@example.com"
         )
@@ -439,10 +406,6 @@ class TestApprovalEmail:
 @pytest.mark.django_db
 class TestApprovalCarriesConsent:
     def test_new_user_inherits_join_request_consent(self, api_client, vettor_headers):
-        from community.models import JoinRequest
-        from django.utils import timezone
-        from users.models import User
-
         jr = JoinRequest.objects.create(
             display_name="Consenter",
             phone_number="+12025550701",
@@ -462,10 +425,6 @@ class TestApprovalCarriesConsent:
         assert user.sms_consent_at is not None
 
     def test_unarchived_user_inherits_join_request_consent(self, api_client, vettor_headers):
-        from community.models import JoinRequest
-        from django.utils import timezone
-        from users.models import User
-
         archived = User.objects.create_user(
             phone_number="+12025550702",
             display_name="Old Member",

--- a/backend/tests/test_join_request_resend.py
+++ b/backend/tests/test_join_request_resend.py
@@ -1,8 +1,12 @@
 """Tests for the resend-magic-link endpoint on approved join requests."""
 
+import uuid
+
 import pytest
 from community._validation import Code
 from community.models import JoinRequestStatus
+from django.utils import timezone
+from users.models import MagicLoginToken, User
 
 from tests._asserts import assert_error_code
 
@@ -38,8 +42,6 @@ class TestResendMagicLink:
     def test_resend_invalidates_previous_unused_tokens(
         self, api_client, vettor_headers, sample_join_request
     ):
-        from users.models import MagicLoginToken, User
-
         approve_response = _approve(api_client, vettor_headers, sample_join_request)
         original_token = approve_response.json()["magic_link_token"]
 
@@ -69,8 +71,6 @@ class TestResendMagicLink:
         assert_error_code(response, Code.JoinRequest.NOT_APPROVED)
 
     def test_already_logged_in_user_rejected(self, api_client, vettor_headers, sample_join_request):
-        from users.models import User
-
         _approve(api_client, vettor_headers, sample_join_request)
         user = User.objects.get(phone_number=sample_join_request.phone_number)
         user.needs_onboarding = False
@@ -85,9 +85,6 @@ class TestResendMagicLink:
         assert_error_code(response, Code.JoinRequest.ALREADY_LOGGED_IN)
 
     def test_archived_user_rejected(self, api_client, vettor_headers, sample_join_request):
-        from django.utils import timezone
-        from users.models import User
-
         _approve(api_client, vettor_headers, sample_join_request)
         user = User.objects.get(phone_number=sample_join_request.phone_number)
         user.archived_at = timezone.now()
@@ -102,8 +99,6 @@ class TestResendMagicLink:
         assert_error_code(response, Code.Auth.ACCOUNT_ARCHIVED)
 
     def test_paused_user_rejected(self, api_client, vettor_headers, sample_join_request):
-        from users.models import User
-
         _approve(api_client, vettor_headers, sample_join_request)
         user = User.objects.get(phone_number=sample_join_request.phone_number)
         user.is_paused = True
@@ -118,8 +113,6 @@ class TestResendMagicLink:
         assert_error_code(response, Code.Auth.ACCOUNT_PAUSED)
 
     def test_not_found(self, api_client, vettor_headers):
-        import uuid
-
         response = api_client.post(
             f"/api/community/join-requests/{uuid.uuid4()}/resend-magic-link/",
             content_type="application/json",

--- a/backend/tests/test_join_request_submission.py
+++ b/backend/tests/test_join_request_submission.py
@@ -1,8 +1,10 @@
 """Tests for join request submission."""
 
 import pytest
-from community.models import JoinRequestStatus
+from community.models import JoinRequest, JoinRequestStatus
+from django.core import mail
 from notifications.models import Notification, NotificationType
+from users.models import User
 from users.permissions import PermissionKey
 from users.roles import Role
 
@@ -10,8 +12,6 @@ from users.roles import Role
 @pytest.mark.django_db
 class TestJoinRequestSubmission:
     def test_submit_join_request(self, api_client, why_join_id):
-        from community.models import JoinRequest
-
         response = api_client.post(
             "/api/community/join-request/",
             {
@@ -101,8 +101,6 @@ class TestJoinRequestSubmission:
         assert response.json()["detail"][0]["code"] == "join_request.guidelines_consent_required"
 
     def test_submit_honeypot_silently_drops_request(self, api_client, why_join_id):
-        from community.models import JoinRequest
-
         response = api_client.post(
             "/api/community/join-request/",
             {
@@ -120,8 +118,6 @@ class TestJoinRequestSubmission:
         assert not JoinRequest.objects.filter(phone_number="+12025557777").exists()
 
     def test_submit_honeypot_blank_does_not_drop(self, api_client, why_join_id):
-        from community.models import JoinRequest
-
         response = api_client.post(
             "/api/community/join-request/",
             {
@@ -200,8 +196,6 @@ class TestJoinRequestSubmission:
     ):
         settings.VETTING_EMAIL = "vetting@pda.org"
         settings.EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
-        from django.core import mail
-
         api_client.post(
             "/api/community/join-request/",
             {
@@ -222,8 +216,6 @@ class TestJoinRequestSubmission:
         self, api_client, settings, why_join_id
     ):
         settings.VETTING_EMAIL = ""
-        from django.core import mail
-
         api_client.post(
             "/api/community/join-request/",
             {
@@ -384,8 +376,6 @@ class TestJoinRequestSubmission:
         assert response.json()["status"] == JoinRequestStatus.PENDING
 
     def test_submit_creates_notifications_for_approvers(self, api_client, why_join_id, db):
-        from users.models import User
-
         approver = User.objects.create_user(
             phone_number="+12025559001", password="pass", display_name="Approver"
         )

--- a/backend/tests/test_join_request_unreject.py
+++ b/backend/tests/test_join_request_unreject.py
@@ -1,5 +1,7 @@
 """Tests for the un-reject join request flow."""
 
+import uuid
+
 import pytest
 from community.models import JoinRequestStatus
 
@@ -67,8 +69,6 @@ class TestUnrejectJoinRequest:
         assert response.status_code == 401
 
     def test_unreject_not_found(self, api_client, vettor_headers):
-        import uuid
-
         response = api_client.patch(
             f"/api/community/join-requests/{uuid.uuid4()}/unreject/",
             content_type="application/json",

--- a/backend/tests/test_logging.py
+++ b/backend/tests/test_logging.py
@@ -1,8 +1,11 @@
 import logging
 
 import pytest
+from community.models import JoinFormQuestion
 from config.middleware import RequestLoggingMiddleware
+from django.http import JsonResponse
 from django.test import Client, RequestFactory
+from users.models import User
 
 
 class TestRequestLoggingMiddleware:
@@ -20,8 +23,6 @@ class TestRequestLoggingMiddleware:
         request = factory.get("/api/test/")
 
         def get_response(request):
-            from django.http import JsonResponse
-
             return JsonResponse({"ok": True})
 
         middleware = RequestLoggingMiddleware(get_response)
@@ -47,8 +48,6 @@ class TestRequestLoggingMiddleware:
         request = factory.get("/api/auth/me/")
 
         def get_response(request):
-            from django.http import JsonResponse
-
             return JsonResponse({"ok": True})
 
         middleware = RequestLoggingMiddleware(get_response)
@@ -75,8 +74,6 @@ class TestApplicationEventLogging:
 
     @pytest.mark.django_db
     def test_join_request_submission_logs_at_info(self, caplog):
-        from community.models import JoinFormQuestion
-
         q = JoinFormQuestion.objects.filter(required=True).first()
         answers = {str(q.id): "I love veganism"} if q else {}
         client = Client()
@@ -104,8 +101,6 @@ class TestApplicationEventLogging:
 
     @pytest.mark.django_db
     def test_auth_failure_logs_at_warning(self, caplog):
-        from users.models import User
-
         User.objects.create_user(phone_number="+14155551234", password="testpass")
         client = Client()
         with caplog.at_level(logging.WARNING, logger="pda.auth"):
@@ -119,8 +114,6 @@ class TestApplicationEventLogging:
 
     @pytest.mark.django_db
     def test_email_failure_logs_at_error(self, caplog, settings):
-        from community.models import JoinFormQuestion
-
         settings.VETTING_EMAIL = "test@example.com"
         settings.EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"
         q = JoinFormQuestion.objects.filter(required=True).first()

--- a/backend/tests/test_logging_redaction.py
+++ b/backend/tests/test_logging_redaction.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import sys
 
 import pytest
 from config.logging_config import JsonFormatter, SensitiveDataFilter
@@ -47,8 +48,6 @@ class TestJsonFormatter:
         try:
             raise ValueError("test error")
         except ValueError:
-            import sys
-
             exc_info = sys.exc_info()
 
         record = logging.LogRecord(

--- a/backend/tests/test_magic_login.py
+++ b/backend/tests/test_magic_login.py
@@ -1,8 +1,12 @@
 """Tests for the magic-login consume endpoint (GET /api/auth/magic-login/{token}/)."""
 
+from datetime import timedelta
+
 import pytest
 from community._validation import Code
+from django.utils import timezone
 from ninja_jwt.tokens import RefreshToken
+from users.models import MagicLoginToken, User
 
 from tests._asserts import assert_error_code
 
@@ -10,8 +14,6 @@ from tests._asserts import assert_error_code
 @pytest.mark.django_db
 class TestMagicLogin:
     def test_magic_login_valid_returns_tokens(self, api_client, test_user):
-        from users.models import MagicLoginToken
-
         magic = MagicLoginToken.create_for_user(test_user)
         response = api_client.get(f"/api/auth/magic-login/{magic.token}/")
         assert response.status_code == 200
@@ -24,8 +26,6 @@ class TestMagicLogin:
         assert response.status_code == 400
 
     def test_magic_login_used_token(self, api_client, test_user):
-        from users.models import MagicLoginToken
-
         magic = MagicLoginToken.create_for_user(test_user)
         magic.used = True
         magic.save(update_fields=["used"])
@@ -33,11 +33,6 @@ class TestMagicLogin:
         assert response.status_code == 400
 
     def test_magic_login_expired_token(self, api_client, test_user):
-        from datetime import timedelta
-
-        from django.utils import timezone
-        from users.models import MagicLoginToken
-
         magic = MagicLoginToken.objects.create(
             user=test_user,
             expires_at=timezone.now() - timedelta(minutes=1),
@@ -46,8 +41,6 @@ class TestMagicLogin:
         assert response.status_code == 400
 
     def test_magic_login_paused_user_returns_403(self, api_client, test_user):
-        from users.models import MagicLoginToken
-
         test_user.is_paused = True
         test_user.save(update_fields=["is_paused"])
         magic = MagicLoginToken.create_for_user(test_user)
@@ -56,8 +49,6 @@ class TestMagicLogin:
         assert_error_code(response, Code.Auth.ACCOUNT_PAUSED)
 
     def test_magic_login_marks_token_used(self, api_client, test_user):
-        from users.models import MagicLoginToken
-
         magic = MagicLoginToken.create_for_user(test_user)
         api_client.get(f"/api/auth/magic-login/{magic.token}/")
         magic.refresh_from_db()
@@ -65,8 +56,6 @@ class TestMagicLogin:
 
     def test_magic_login_cross_user_blocked(self, api_client, test_user):
         """A logged-in user clicking another user's magic link must be rejected."""
-        from users.models import MagicLoginToken, User
-
         other = User.objects.create_user(
             phone_number="+12025550202", password="otherpass123", display_name="other"
         )
@@ -79,8 +68,6 @@ class TestMagicLogin:
 
     def test_magic_login_same_user_still_works_when_authed(self, api_client, test_user):
         """Clicking your own magic link while already logged in is allowed."""
-        from users.models import MagicLoginToken
-
         magic = MagicLoginToken.create_for_user(test_user)
         headers = {"HTTP_AUTHORIZATION": f"Bearer {RefreshToken.for_user(test_user).access_token}"}  # type: ignore
         response = api_client.get(f"/api/auth/magic-login/{magic.token}/", **headers)
@@ -88,8 +75,6 @@ class TestMagicLogin:
 
     def test_self_service_token_forces_password_reset_on_consume(self, api_client, test_user):
         """A requires_password_reset token flags the user and disables the old password."""
-        from users.models import MagicLoginToken
-
         test_user.login_link_requested = True
         test_user.save(update_fields=["login_link_requested"])
         magic = MagicLoginToken.create_for_user(test_user, requires_password_reset=True)
@@ -105,8 +90,6 @@ class TestMagicLogin:
 
     def test_admin_onboarding_token_does_not_force_password_reset(self, api_client, test_user):
         """Regression guard: the shared consume endpoint must not flag plain tokens."""
-        from users.models import MagicLoginToken
-
         magic = MagicLoginToken.create_for_user(test_user)  # requires_password_reset defaults False
         response = api_client.get(f"/api/auth/magic-login/{magic.token}/")
         assert response.status_code == 200

--- a/backend/tests/test_nonmember_rsvp_token.py
+++ b/backend/tests/test_nonmember_rsvp_token.py
@@ -3,12 +3,15 @@ from datetime import timedelta
 import pytest
 from django.core.exceptions import ValidationError
 from django.utils import timezone
+from users.models import (
+    NON_MEMBER_RSVP_TOKEN_TTL_DAYS,
+    NonMemberRsvpToken,
+    User,
+)
 
 
 @pytest.fixture
 def non_member(db):
-    from users.models import User
-
     user = User.objects.create_user(
         phone_number="+12025559001",
         display_name="Non Member",
@@ -23,8 +26,6 @@ def non_member(db):
 @pytest.mark.django_db
 class TestIssue:
     def test_issue_produces_unique_urlsafe_token_with_90_day_expiry(self, non_member):
-        from users.models import NON_MEMBER_RSVP_TOKEN_TTL_DAYS, NonMemberRsvpToken
-
         before = timezone.now()
         token = NonMemberRsvpToken.issue(non_member)
 
@@ -39,15 +40,11 @@ class TestIssue:
         assert abs((token.expires_at - expected).total_seconds()) < 60
 
     def test_issue_tokens_are_unique(self, non_member):
-        from users.models import NonMemberRsvpToken
-
         first = NonMemberRsvpToken.issue(non_member)
         second = NonMemberRsvpToken.issue(non_member)
         assert first.token != second.token
 
     def test_issue_rejects_member(self, db):
-        from users.models import NonMemberRsvpToken, User
-
         member = User.objects.create_user(
             phone_number="+12025559002",
             display_name="Member",
@@ -60,16 +57,12 @@ class TestIssue:
 @pytest.mark.django_db
 class TestIssueOrExtend:
     def test_first_call_issues_a_fresh_token(self, non_member):
-        from users.models import NonMemberRsvpToken
-
         token = NonMemberRsvpToken.issue_or_extend(non_member)
         assert token.user_id == non_member.id
         assert token.is_valid
         assert NonMemberRsvpToken.objects.filter(user=non_member).count() == 1
 
     def test_extends_existing_valid_token_without_replacing_it(self, non_member):
-        from users.models import NON_MEMBER_RSVP_TOKEN_TTL_DAYS, NonMemberRsvpToken
-
         first = NonMemberRsvpToken.issue(non_member)
         # Pull expiry back so the extension is observable.
         first.expires_at = timezone.now() + timedelta(days=1)
@@ -89,8 +82,6 @@ class TestIssueOrExtend:
         assert NonMemberRsvpToken.resolve_user(first.token) == non_member
 
     def test_issues_fresh_token_when_existing_is_expired(self, non_member):
-        from users.models import NonMemberRsvpToken
-
         stale = NonMemberRsvpToken.issue(non_member)
         stale.expires_at = timezone.now() - timedelta(seconds=1)
         stale.save(update_fields=["expires_at"])
@@ -102,8 +93,6 @@ class TestIssueOrExtend:
         assert NonMemberRsvpToken.objects.filter(user=non_member).count() == 2
 
     def test_issues_fresh_token_when_existing_is_revoked(self, non_member):
-        from users.models import NonMemberRsvpToken
-
         revoked = NonMemberRsvpToken.issue(non_member)
         revoked.revoke()
 
@@ -115,8 +104,6 @@ class TestIssueOrExtend:
         assert revoked.is_revoked
 
     def test_rejects_member(self, db):
-        from users.models import NonMemberRsvpToken, User
-
         member = User.objects.create_user(
             phone_number="+12025559003",
             display_name="Member",
@@ -129,32 +116,22 @@ class TestIssueOrExtend:
 @pytest.mark.django_db
 class TestResolveUser:
     def test_valid_token_resolves_to_user(self, non_member):
-        from users.models import NonMemberRsvpToken
-
         token = NonMemberRsvpToken.issue(non_member)
         assert NonMemberRsvpToken.resolve_user(token.token) == non_member
 
     def test_unknown_token_returns_none(self, db):
-        from users.models import NonMemberRsvpToken
-
         assert NonMemberRsvpToken.resolve_user("does-not-exist") is None
 
     def test_blank_token_returns_none(self, db):
-        from users.models import NonMemberRsvpToken
-
         assert NonMemberRsvpToken.resolve_user("") is None
 
     def test_expired_token_returns_none(self, non_member):
-        from users.models import NonMemberRsvpToken
-
         token = NonMemberRsvpToken.issue(non_member)
         token.expires_at = timezone.now() - timedelta(seconds=1)
         token.save(update_fields=["expires_at"])
         assert NonMemberRsvpToken.resolve_user(token.token) is None
 
     def test_revoked_token_returns_none(self, non_member):
-        from users.models import NonMemberRsvpToken
-
         token = NonMemberRsvpToken.issue(non_member)
         token.revoke()
         assert NonMemberRsvpToken.resolve_user(token.token) is None
@@ -163,8 +140,6 @@ class TestResolveUser:
 @pytest.mark.django_db
 class TestRevoke:
     def test_revoke_stamps_revoked_at(self, non_member):
-        from users.models import NonMemberRsvpToken
-
         token = NonMemberRsvpToken.issue(non_member)
         assert token.is_valid
         token.revoke()
@@ -173,8 +148,6 @@ class TestRevoke:
         assert not token.is_valid
 
     def test_revoke_is_idempotent(self, non_member):
-        from users.models import NonMemberRsvpToken
-
         token = NonMemberRsvpToken.issue(non_member)
         token.revoke()
         first = token.revoked_at

--- a/backend/tests/test_onboarding.py
+++ b/backend/tests/test_onboarding.py
@@ -1,6 +1,11 @@
 """Tests for complete-onboarding email requirement (Task 4.1)."""
 
+from datetime import timedelta
+
 import pytest
+from django.utils import timezone
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
 
 
 @pytest.mark.django_db
@@ -48,8 +53,6 @@ class TestOnboardingEmail:
     def test_duplicate_email_rejected(
         self, api_client, needs_onboarding_user, needs_onboarding_auth_headers
     ):
-        from users.models import User
-
         User.objects.create_user(
             phone_number="+12025550199", display_name="other", email="taken@example.com"
         )
@@ -67,9 +70,6 @@ class TestOnboardingEmail:
         assert resp.json()["detail"][0]["code"] == "email.already_exists"
 
     def test_existing_email_user_can_skip(self, api_client, db):
-        from ninja_jwt.tokens import RefreshToken
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+12025550111",
             password="x",
@@ -91,9 +91,6 @@ class TestOnboardingEmail:
 
     def test_complete_onboarding_clears_needs_password_reset(self, api_client, db):
         """A user forced into a reset (via self-service magic link) is cleared on submit."""
-        from ninja_jwt.tokens import RefreshToken
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+12025550112",
             password="x",
@@ -120,9 +117,6 @@ class TestOnboardingEmail:
 
     def test_complete_onboarding_rejects_reusing_usable_password(self, api_client, db):
         """A user who still has a usable password can't 'reset' to the same one."""
-        from ninja_jwt.tokens import RefreshToken
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+12025550113",
             password="SamePass123!",
@@ -144,9 +138,6 @@ class TestOnboardingEmail:
     def test_complete_onboarding_reset_user_can_set_any_password(self, api_client, db):
         """A forced-reset user has an unusable password, so the reuse check must NOT
         false-positive and block them from setting a password."""
-        from ninja_jwt.tokens import RefreshToken
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+12025550114",
             password="x",
@@ -169,8 +160,6 @@ class TestOnboardingEmail:
 @pytest.mark.django_db
 class TestSmsConsentSerialized:
     def test_me_reports_needs_sms_consent_when_null(self, api_client, needs_onboarding_user):
-        from ninja_jwt.tokens import RefreshToken
-
         needs_onboarding_user.sms_consent_at = None
         needs_onboarding_user.save(update_fields=["sms_consent_at"])
         token = RefreshToken.for_user(needs_onboarding_user).access_token
@@ -231,10 +220,6 @@ class TestOnboardingConsent:
     def test_accept_does_not_overwrite_existing_consent(
         self, api_client, needs_onboarding_user, needs_onboarding_auth_headers
     ):
-        from datetime import timedelta
-
-        from django.utils import timezone
-
         earlier = timezone.now() - timedelta(days=30)
         needs_onboarding_user.guidelines_consent_at = earlier
         needs_onboarding_user.save(update_fields=["guidelines_consent_at"])

--- a/backend/tests/test_photos.py
+++ b/backend/tests/test_photos.py
@@ -4,7 +4,11 @@ import io
 
 import pytest
 from community.models import Event
+from config.media_proxy import serve_media
+from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.http import Http404
+from ninja_jwt.tokens import RefreshToken
 from PIL import Image
 from users.models import User
 from users.permissions import PermissionKey
@@ -24,8 +28,6 @@ def _make_test_image(fmt="JPEG", size=(20, 20)):
 
 
 def _auth(user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # ty: ignore[unresolved-attribute]
 
@@ -247,17 +249,11 @@ class TestMediaProxy:
         assert response.status_code in (400, 404)
 
     def test_serve_media_rejects_dot_dot_traversal(self):
-        from config.media_proxy import serve_media
-        from django.http import Http404
-
         for bad in ["../config/settings.py", "a/../../secret.py", "..%2fsettings.py"]:
             with pytest.raises(Http404):
                 serve_media(None, bad)
 
     def test_serve_media_rejects_absolute_and_null_and_backslash(self):
-        from config.media_proxy import serve_media
-        from django.http import Http404
-
         for bad in ["/etc/passwd", "foo\\bar", "foo\x00.jpg"]:
             with pytest.raises(Http404):
                 serve_media(None, bad)
@@ -265,8 +261,6 @@ class TestMediaProxy:
     def test_non_inline_type_forced_to_attachment(self, api_client, member):
         # An uploaded .html/.svg must download (attachment) so it can't run JS
         # on the app origin, and must carry nosniff (#446).
-        from django.core.files.storage import default_storage
-
         name = default_storage.save("uploads/evil.html", io.BytesIO(b"<script>alert(1)</script>"))
         try:
             response = api_client.get(f"/media/{name}")

--- a/backend/tests/test_polls.py
+++ b/backend/tests/test_polls.py
@@ -1,9 +1,11 @@
 """Tests for EventPoll endpoints: create, get, vote, finalize, delete."""
 
 import json
+import uuid
 
 import pytest
 from community.models import Event, EventPoll, PollAvailability, PollOption, PollVote
+from ninja_jwt.tokens import RefreshToken
 from users.models import User  # noqa: F401 (imported for create_user side effect)
 
 from tests.conftest import future_iso
@@ -33,8 +35,6 @@ def other_user(db):
 
 @pytest.fixture
 def other_headers(other_user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(other_user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 
@@ -124,8 +124,6 @@ class TestCreatePoll:
         assert response.status_code == 401
 
     def test_create_poll_event_not_found(self, api_client, auth_headers):
-        import uuid
-
         payload = {"options": [future_iso(days=120), future_iso(days=121)]}
         response = api_client.post(
             f"/api/community/events/{uuid.uuid4()}/poll/",
@@ -243,8 +241,6 @@ class TestVoteOnPoll:
         assert response.status_code == 400
 
     def test_vote_invalid_option_id(self, api_client, auth_headers, poll_with_options, poll_event):
-        import uuid
-
         payload = {"votes": {str(uuid.uuid4()): PollAvailability.YES}}
         response = api_client.post(
             f"/api/community/events/{poll_event.id}/poll/vote/",
@@ -336,8 +332,6 @@ class TestFinalizePoll:
         assert response.status_code == 400
 
     def test_finalize_invalid_option(self, api_client, auth_headers, poll_with_options, poll_event):
-        import uuid
-
         payload = {"winning_option_id": str(uuid.uuid4())}
         response = api_client.post(
             f"/api/community/events/{poll_event.id}/poll/finalize/",

--- a/backend/tests/test_prosemirror_html.py
+++ b/backend/tests/test_prosemirror_html.py
@@ -2,14 +2,13 @@
 
 import pytest
 from community._prosemirror_html import prosemirror_to_html
+from ninja_jwt.tokens import RefreshToken
+from users.models import Role, User
+from users.permissions import PermissionKey
 
 
 @pytest.fixture
 def edit_homepage_headers(db):
-    from ninja_jwt.tokens import RefreshToken
-    from users.models import Role, User
-    from users.permissions import PermissionKey
-
     user = User.objects.create_user(
         phone_number="+12025550999",
         password="testpass",

--- a/backend/tests/test_request_login_link.py
+++ b/backend/tests/test_request_login_link.py
@@ -1,15 +1,19 @@
 """Tests for the unauthenticated request-login-link endpoint."""
 
+from datetime import timedelta
+
 import pytest
+from django.core.cache import cache
+from django.utils import timezone
+from notifications.email_sender import SendResult
 from notifications.models import Notification, NotificationType
+from users.models import MagicLoginToken, User
 from users.permissions import PermissionKey
 from users.roles import Role
 
 
 def _make_approver():
     """Create a user with APPROVE_JOIN_REQUESTS permission and return them."""
-    from users.models import User
-
     approver = User.objects.create_user(
         phone_number="+12025559001", password="pass", display_name="Approver"
     )
@@ -24,8 +28,6 @@ _PHONE = "+12025558800"
 
 @pytest.fixture(autouse=True)
 def _clear_rate_limit_cache():
-    from django.core.cache import cache
-
     cache.clear()
     yield
     cache.clear()
@@ -34,8 +36,6 @@ def _clear_rate_limit_cache():
 @pytest.mark.django_db
 class TestRequestLoginLink:
     def test_returns_200_for_existing_user(self, api_client):
-        from users.models import User
-
         User.objects.create_user(phone_number=_PHONE, password="pass", display_name="Invited")
         response = api_client.post(_URL, {"phone_number": _PHONE}, content_type="application/json")
         assert response.status_code == 200
@@ -59,30 +59,22 @@ class TestRequestLoginLink:
         assert response.status_code == 200
 
     def test_creates_magic_token_for_existing_user(self, api_client):
-        from users.models import MagicLoginToken, User
-
         user = User.objects.create_user(phone_number=_PHONE, password="pass")
         api_client.post(_URL, {"phone_number": _PHONE}, content_type="application/json")
         assert MagicLoginToken.objects.filter(user=user).exists()
 
     def test_self_service_token_requires_password_reset(self, api_client):
         """Self-service login-link tokens must be flagged so consuming forces a reset."""
-        from users.models import MagicLoginToken, User
-
         user = User.objects.create_user(phone_number=_PHONE, password="pass")
         api_client.post(_URL, {"phone_number": _PHONE}, content_type="application/json")
         token = MagicLoginToken.objects.filter(user=user).latest("created_at")
         assert token.requires_password_reset is True
 
     def test_does_not_create_token_for_unknown_phone(self, api_client):
-        from users.models import MagicLoginToken
-
         api_client.post(_URL, {"phone_number": "+12025559998"}, content_type="application/json")
         assert MagicLoginToken.objects.count() == 0
 
     def test_creates_notification_for_approvers(self, api_client):
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number=_PHONE, password="pass", display_name="Invited Person"
         )
@@ -101,8 +93,6 @@ class TestRequestLoginLink:
         assert "token" not in notif.message.lower()
 
     def test_does_not_create_notification_for_unknown_phone(self, api_client):
-        from users.models import User
-
         approver = User.objects.create_user(phone_number="+12025559001", password="pass")
         role = Role.objects.create(name="vetter", permissions=[PermissionKey.APPROVE_JOIN_REQUESTS])
         approver.roles.add(role)
@@ -112,8 +102,6 @@ class TestRequestLoginLink:
         assert not Notification.objects.filter(recipient=approver).exists()
 
     def test_rate_limit_prevents_duplicate_tokens_within_cooldown(self, api_client):
-        from users.models import MagicLoginToken, User
-
         user = User.objects.create_user(phone_number=_PHONE, password="pass")
         # First request
         api_client.post(_URL, {"phone_number": _PHONE}, content_type="application/json")
@@ -126,8 +114,6 @@ class TestRequestLoginLink:
 
     def test_login_link_requested_does_not_block_re_request(self, api_client):
         """A prior pending request must NOT block a fresh request (no recent token)."""
-        from users.models import MagicLoginToken, User
-
         user = User.objects.create_user(phone_number=_PHONE, password="pass")
         user.login_link_requested = True
         user.save(update_fields=["login_link_requested"])
@@ -139,8 +125,6 @@ class TestRequestLoginLink:
 
     def test_recent_token_returns_cooldown(self, api_client):
         """A second request within the cooldown window returns cooldown, mints no token."""
-        from users.models import MagicLoginToken, User
-
         user = User.objects.create_user(phone_number=_PHONE, password="pass")
         api_client.post(_URL, {"phone_number": _PHONE}, content_type="application/json")
         assert MagicLoginToken.objects.filter(user=user).count() == 1
@@ -153,11 +137,6 @@ class TestRequestLoginLink:
 
     def test_new_request_invalidates_prior_unused_token(self, api_client):
         """Outside the cooldown, a fresh request invalidates the previous unused link."""
-        from datetime import timedelta
-
-        from django.utils import timezone
-        from users.models import MagicLoginToken, User
-
         user = User.objects.create_user(phone_number=_PHONE, password="pass")
         api_client.post(_URL, {"phone_number": _PHONE}, content_type="application/json")
         old = MagicLoginToken.objects.get(user=user)
@@ -174,8 +153,6 @@ class TestRequestLoginLink:
         assert MagicLoginToken.objects.filter(user=user, used=False).count() == 1
 
     def test_sets_login_link_requested_flag(self, api_client):
-        from users.models import User
-
         user = User.objects.create_user(phone_number=_PHONE, password="pass")
         assert user.login_link_requested is False
 
@@ -185,8 +162,6 @@ class TestRequestLoginLink:
         assert user.login_link_requested is True
 
     def test_rate_limited_after_five_requests_per_minute(self, api_client):
-        from django.core.cache import cache
-
         cache.clear()
         for _ in range(5):
             resp = api_client.post(
@@ -208,8 +183,6 @@ class TestRequestLoginLink:
 @pytest.mark.django_db
 class TestRequestLoginLinkEmailDelivery:
     def test_user_with_email_send_succeeds(self, api_client, fake_email_sender):
-        from users.models import User
-
         User.objects.create_user(
             phone_number="+12025550101",
             display_name="Sam",
@@ -229,8 +202,6 @@ class TestRequestLoginLinkEmailDelivery:
 
     def test_email_path_does_not_set_login_link_requested(self, api_client, fake_email_sender):
         """Email success must leave login_link_requested False so re-requests stay open."""
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+12025550101",
             display_name="Sam",
@@ -246,8 +217,6 @@ class TestRequestLoginLinkEmailDelivery:
 
     def test_admin_fallback_sets_login_link_requested(self, api_client, fake_email_sender):
         """No-email fallback dedupes admin notifications via login_link_requested."""
-        from users.models import User
-
         _make_approver()
         user = User.objects.create_user(
             phone_number="+12025550102",
@@ -265,8 +234,6 @@ class TestRequestLoginLinkEmailDelivery:
     def test_user_with_email_send_succeeds_skips_admin_notification(
         self, api_client, fake_email_sender
     ):
-        from users.models import User
-
         approver = _make_approver()
         user = User.objects.create_user(
             phone_number="+12025550101",
@@ -287,9 +254,6 @@ class TestRequestLoginLinkEmailDelivery:
         ).exists()
 
     def test_user_with_email_send_fails_still_returns_200(self, api_client, fake_email_sender):
-        from notifications.email_sender import SendResult
-        from users.models import User
-
         fake_email_sender.send.return_value = SendResult(success=False, error="invalid recipient")
         approver = _make_approver()
         user = User.objects.create_user(
@@ -311,8 +275,6 @@ class TestRequestLoginLinkEmailDelivery:
         assert notif.related_user_id == user.pk  # ty: ignore[unresolved-attribute]
 
     def test_user_with_no_email_skips_send(self, api_client, fake_email_sender):
-        from users.models import User
-
         approver = _make_approver()
         user = User.objects.create_user(
             phone_number="+12025550101",
@@ -338,8 +300,6 @@ class TestRequestLoginLinkEmailDelivery:
         """If something unexpected raises inside the email branch (template missing,
         bug in helper, etc.), the endpoint still returns 200 and the admin
         notification fallback fires."""
-        from users.models import User
-
         fake_email_sender.send.side_effect = RuntimeError("unexpected boom")
         approver = _make_approver()
         user = User.objects.create_user(

--- a/backend/tests/test_role_management.py
+++ b/backend/tests/test_role_management.py
@@ -1,5 +1,7 @@
 import pytest
 from community._validation import Code
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
 from users.permissions import PermissionKey
 from users.roles import Role
 
@@ -9,8 +11,6 @@ from tests._asserts import assert_error_code
 @pytest.fixture
 def manage_users_user(db):
     """Non-superuser with manage_users + manage_roles permissions."""
-    from users.models import User
-
     user = User.objects.create_user(
         phone_number="+12025550002",
         password="managerpass123",
@@ -25,8 +25,6 @@ def manage_users_user(db):
 
 @pytest.fixture
 def manage_users_headers(manage_users_user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(manage_users_user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 

--- a/backend/tests/test_rsvp.py
+++ b/backend/tests/test_rsvp.py
@@ -2,7 +2,9 @@
 
 import pytest
 from community._validation import Code
-from community.models import Event, EventRSVP, EventStatus, RSVPStatus
+from community.models import Event, EventRSVP, EventStatus, PageVisibility, RSVPStatus
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
 
 from tests._asserts import assert_error_code
 from tests.conftest import future_iso
@@ -37,8 +39,6 @@ def no_rsvp_event(db):
 
 @pytest.fixture
 def other_user(db):
-    from users.models import User
-
     return User.objects.create_user(
         phone_number="+12025550302",
         password="otherpass",
@@ -48,8 +48,6 @@ def other_user(db):
 
 @pytest.fixture
 def other_headers(other_user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(other_user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 
@@ -174,8 +172,6 @@ class TestRSVP:
         assert response.status_code == 200
         assert response.json()["my_rsvp"] == RSVPStatus.CANT_GO
         # Still only one RSVP record
-        from users.models import User
-
         user = User.objects.get(phone_number="+12025550101")
         assert EventRSVP.objects.filter(event=rsvp_event, user=user).count() == 1
 
@@ -400,8 +396,6 @@ class TestDeleteRSVPWithdrawal:
     def test_excluded_member_can_still_delete_stale_rsvp(
         self, api_client, other_headers, other_user, test_user, rsvp_event
     ):
-        from community.models import PageVisibility
-
         # other_user RSVPs ATTENDING while the event is public and full, with
         # test_user waitlisted behind them. The host then flips it to invite-only
         # without inviting other_user — they must still be able to withdraw, AND
@@ -427,8 +421,6 @@ class TestDeleteRSVPWithdrawal:
     def test_non_rsvper_cannot_probe_invite_only_via_delete(
         self, api_client, other_headers, rsvp_event
     ):
-        from community.models import PageVisibility
-
         # A member with NO RSVP who can't see the invite-only event gets the
         # read-visibility 403 — they can't use delete to probe for existence.
         rsvp_event.visibility = PageVisibility.INVITE_ONLY

--- a/backend/tests/test_single_event_ics.py
+++ b/backend/tests/test_single_event_ics.py
@@ -1,12 +1,14 @@
+import uuid
+
 import pytest
+from community.models import Event, EventStatus, EventType, PageVisibility
+from django.utils import timezone
+from users.models import User
 
 
 @pytest.mark.django_db
 class TestSingleEventIcs:
     def test_returns_ics_for_existing_event(self, api_client, test_user):
-        from community.models import Event
-        from django.utils import timezone
-
         event = Event.objects.create(
             title="Picnic in the Park",
             description="Bring hummus!",
@@ -24,15 +26,10 @@ class TestSingleEventIcs:
         assert "Prospect Park" in content
 
     def test_returns_404_for_nonexistent_event(self, api_client):
-        import uuid
-
         resp = api_client.get(f"/api/community/events/{uuid.uuid4()}/ics/")
         assert resp.status_code == 404
 
     def test_anon_ics_omits_member_only_links(self, api_client, test_user):
-        from community.models import Event
-        from django.utils import timezone
-
         event = Event.objects.create(
             title="Linked Picnic",
             description="Bring hummus!",
@@ -53,9 +50,6 @@ class TestSingleEventIcs:
         assert "example.com/secret" not in content
 
     def test_authed_ics_includes_member_only_links(self, api_client, auth_headers, test_user):
-        from community.models import Event
-        from django.utils import timezone
-
         event = Event.objects.create(
             title="Linked Picnic",
             description="Bring hummus!",
@@ -74,10 +68,6 @@ class TestSingleEventIcs:
         assert "Link: https://example.com/secret" in content
 
     def test_invite_only_event_hidden_from_anon(self, api_client, test_user):
-        from community.models import Event, PageVisibility
-        from django.utils import timezone
-        from users.models import User
-
         creator = User.objects.create_user(
             phone_number="+12025559999",
             password="testpass123",
@@ -96,10 +86,6 @@ class TestSingleEventIcs:
         assert resp.status_code == 403
 
     def test_members_only_non_official_event_hidden_from_anon(self, api_client, test_user):
-        from community.models import Event, EventType, PageVisibility
-        from django.utils import timezone
-        from users.models import User
-
         creator = User.objects.create_user(
             phone_number="+12025558888",
             password="testpass123",
@@ -127,9 +113,6 @@ class TestSingleEventIcs:
     def test_members_only_non_official_event_visible_to_member(
         self, api_client, auth_headers, test_user
     ):
-        from community.models import Event, EventType, PageVisibility
-        from django.utils import timezone
-
         event = Event.objects.create(
             title="Members Only Potluck",
             start_datetime=timezone.now(),
@@ -143,10 +126,6 @@ class TestSingleEventIcs:
         assert "Members Only Potluck" in resp.content.decode()
 
     def test_draft_event_hidden_from_anon(self, api_client, test_user):
-        from community.models import Event, EventStatus
-        from django.utils import timezone
-        from users.models import User
-
         creator = User.objects.create_user(
             phone_number="+12025557777",
             password="testpass123",
@@ -165,9 +144,6 @@ class TestSingleEventIcs:
         assert "Unpublished Draft" not in resp.content.decode()
 
     def test_deleted_event_hidden(self, api_client, auth_headers, test_user):
-        from community.models import Event, EventStatus
-        from django.utils import timezone
-
         event = Event.objects.create(
             title="Deleted Event",
             start_datetime=timezone.now(),
@@ -181,9 +157,6 @@ class TestSingleEventIcs:
         assert "Deleted Event" not in resp.content.decode()
 
     def test_invite_only_event_visible_to_creator(self, api_client, auth_headers, test_user):
-        from community.models import Event, PageVisibility
-        from django.utils import timezone
-
         event = Event.objects.create(
             title="Secret Invite Only",
             start_datetime=timezone.now(),
@@ -196,9 +169,6 @@ class TestSingleEventIcs:
         assert "Secret Invite Only" in resp.content.decode()
 
     def test_filename_is_sanitized_against_header_injection(self, api_client, test_user):
-        from community.models import Event
-        from django.utils import timezone
-
         event = Event.objects.create(
             title='evil"\r\nSet-Cookie: x=1',
             start_datetime=timezone.now(),

--- a/backend/tests/test_surveys_public.py
+++ b/backend/tests/test_surveys_public.py
@@ -5,6 +5,10 @@ import json
 import pytest
 from community._validation import Code
 from community.models import Survey, SurveyQuestion, SurveyQuestionType, SurveyResponse
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
+from users.permissions import PermissionKey
+from users.roles import Role
 
 from tests._asserts import assert_error_code
 from tests.conftest import future_iso
@@ -16,8 +20,6 @@ from tests.conftest import future_iso
 
 @pytest.fixture
 def survey_owner(db):
-    from users.models import User
-
     return User.objects.create_user(
         phone_number="+12025557001",
         password="ownerpass",
@@ -27,8 +29,6 @@ def survey_owner(db):
 
 @pytest.fixture
 def survey_owner_headers(survey_owner):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(survey_owner)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 
@@ -70,11 +70,6 @@ class TestSurveyTalliesAuthz:
         assert isinstance(response.json(), list)
 
     def test_manage_surveys_can_read_tallies(self, api_client, db, poll_survey):
-        from ninja_jwt.tokens import RefreshToken
-        from users.models import User
-        from users.permissions import PermissionKey
-        from users.roles import Role
-
         admin = User.objects.create_user(
             phone_number="+12025557010", password="x", display_name="Surveys Admin"
         )

--- a/backend/tests/test_user_management.py
+++ b/backend/tests/test_user_management.py
@@ -1,11 +1,10 @@
 import pytest
+from users.models import User
 
 
 @pytest.mark.django_db
 class TestCreateUserDuplicateEmail:
     def test_create_user_duplicate_email_rejected(self, api_client, manage_users_headers, db):
-        from users.models import User
-
         User.objects.create_user(
             phone_number="+12025550199", display_name="a", email="taken@example.com"
         )
@@ -23,8 +22,6 @@ class TestCreateUserDuplicateEmail:
         assert resp.json()["detail"][0]["code"] == "email.already_exists"
 
     def test_create_user_lowercases_email(self, api_client, manage_users_headers, db):
-        from users.models import User
-
         resp = api_client.post(
             "/api/auth/create-user/",
             data={
@@ -43,8 +40,6 @@ class TestCreateUserDuplicateEmail:
 @pytest.mark.django_db
 class TestAdminPatchEmail:
     def test_admin_patch_email_rejects_duplicate(self, api_client, manage_users_headers, db):
-        from users.models import User
-
         User.objects.create_user(
             phone_number="+12025550199", display_name="other", email="taken@example.com"
         )
@@ -59,8 +54,6 @@ class TestAdminPatchEmail:
         assert resp.json()["detail"][0]["code"] == "email.already_exists"
 
     def test_admin_patch_email_lowercases(self, api_client, manage_users_headers, db):
-        from users.models import User
-
         target = User.objects.create_user(phone_number="+12025550101", display_name="b")
         resp = api_client.patch(
             f"/api/auth/users/{target.id}/",

--- a/backend/tests/test_user_model.py
+++ b/backend/tests/test_user_model.py
@@ -1,11 +1,13 @@
 import pytest
+from community._validation import ValidationException
+from django.db import IntegrityError
+from users._helpers import _check_and_set_email, _normalize_email
+from users.models import User
 
 
 @pytest.mark.django_db
 class TestUserModel:
     def test_create_user_with_phone_number(self):
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+15550001001",
             password="testpass123",
@@ -16,20 +18,14 @@ class TestUserModel:
         assert user.check_password("testpass123")
 
     def test_username_field_is_phone_number(self):
-        from users.models import User
-
         assert User.USERNAME_FIELD == "phone_number"
 
     def test_user_has_no_first_last_name_fields(self):
-        from users.models import User
-
         assert not hasattr(User, "first_name") or User.first_name is None
         assert not hasattr(User, "last_name") or User.last_name is None
         assert not hasattr(User, "username") or User.username is None
 
     def test_email_is_optional(self):
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+15550001002",
             password="testpass123",
@@ -39,8 +35,6 @@ class TestUserModel:
         assert user.email is None
 
     def test_str_returns_display_name_or_phone(self):
-        from users.models import User
-
         user = User.objects.create_user(
             phone_number="+15550001003",
             password="testpass123",
@@ -55,8 +49,6 @@ class TestUserModel:
         assert str(user_no_name) == "+15550001004"
 
     def test_create_superuser(self):
-        from users.models import User
-
         user = User.objects.create_superuser(
             phone_number="+15550001005",
             password="adminpass123",
@@ -67,8 +59,6 @@ class TestUserModel:
         assert user.phone_number == "+15550001005"
 
     def test_phone_number_is_required(self):
-        from users.models import User
-
         with pytest.raises(ValueError, match="Phone number is required"):
             User.objects.create_user(phone_number="", password="testpass123")
 
@@ -76,16 +66,11 @@ class TestUserModel:
 @pytest.mark.django_db
 class TestUserEmailField:
     def test_two_users_with_null_email_allowed(self):
-        from users.models import User
-
         User.objects.create_user(phone_number="+12025550101", display_name="a", email=None)
         # Should NOT raise IntegrityError — multiple NULLs allowed.
         User.objects.create_user(phone_number="+12025550102", display_name="b", email=None)
 
     def test_duplicate_non_null_email_rejected(self):
-        from django.db import IntegrityError
-        from users.models import User
-
         User.objects.create_user(
             phone_number="+12025550101", display_name="a", email="dup@example.com"
         )
@@ -98,26 +83,16 @@ class TestUserEmailField:
 @pytest.mark.django_db
 class TestCheckAndSetEmail:
     def test_assigns_normalized(self):
-        from users._helpers import _check_and_set_email
-        from users.models import User
-
         u = User(phone_number="+12025550101", display_name="a")
         _check_and_set_email(u, "Foo@Example.COM")
         assert u.email == "foo@example.com"
 
     def test_blank_assigns_none(self):
-        from users._helpers import _check_and_set_email
-        from users.models import User
-
         u = User(phone_number="+12025550101", display_name="a")
         _check_and_set_email(u, "  ")
         assert u.email is None
 
     def test_raises_on_collision(self):
-        from community._validation import ValidationException
-        from users._helpers import _check_and_set_email
-        from users.models import User
-
         User.objects.create_user(
             phone_number="+12025550199", display_name="other", email="taken@example.com"
         )
@@ -126,9 +101,6 @@ class TestCheckAndSetEmail:
             _check_and_set_email(target, "Taken@Example.com")
 
     def test_exclude_pk_allows_self_update(self):
-        from users._helpers import _check_and_set_email
-        from users.models import User
-
         existing = User.objects.create_user(
             phone_number="+12025550101", display_name="a", email="me@example.com"
         )
@@ -139,18 +111,12 @@ class TestCheckAndSetEmail:
 
 class TestNormalizeEmail:
     def test_lowercases(self):
-        from users._helpers import _normalize_email
-
         assert _normalize_email("Foo@Example.COM") == "foo@example.com"
 
     def test_strips_whitespace(self):
-        from users._helpers import _normalize_email
-
         assert _normalize_email("  foo@example.com  ") == "foo@example.com"
 
     def test_blank_returns_none(self):
-        from users._helpers import _normalize_email
-
         assert _normalize_email("") is None
         assert _normalize_email("   ") is None
         assert _normalize_email(None) is None

--- a/backend/tests/test_validation_codes.py
+++ b/backend/tests/test_validation_codes.py
@@ -8,6 +8,10 @@ so the frontend owns UI copy.
 
 import pytest
 from community._validation import Code
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
+from users.permissions import PermissionKey
+from users.roles import Role
 
 from tests.conftest import future_iso
 
@@ -21,11 +25,6 @@ def base_event() -> dict:
 
 @pytest.fixture
 def manage_events_headers(db):
-    from ninja_jwt.tokens import RefreshToken
-    from users.models import User
-    from users.permissions import PermissionKey
-    from users.roles import Role
-
     user = User.objects.create_user(
         phone_number="+14155559010",
         password="validationcodepass123",

--- a/backend/tests/test_welcome_template.py
+++ b/backend/tests/test_welcome_template.py
@@ -1,5 +1,7 @@
 import pytest
 from community.models import WelcomeMessageTemplate
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
 from users.permissions import PermissionKey
 from users.roles import Role
 
@@ -8,8 +10,6 @@ from tests._asserts import assert_error_code
 
 @pytest.fixture
 def edit_welcome_user(db):
-    from users.models import User
-
     user = User.objects.create_user(
         phone_number="+15550003001",
         password="vetterpass123",
@@ -24,8 +24,6 @@ def edit_welcome_user(db):
 
 @pytest.fixture
 def edit_welcome_headers(edit_welcome_user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(edit_welcome_user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 

--- a/backend/tests/users/conftest.py
+++ b/backend/tests/users/conftest.py
@@ -1,12 +1,12 @@
 import pytest
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
 from users.permissions import PermissionKey
 from users.roles import Role
 
 
 @pytest.fixture
 def manage_users_user(db):
-    from users.models import User
-
     user = User.objects.create_user(
         phone_number="+12025550201",
         password="managerpass123",
@@ -22,16 +22,12 @@ def manage_users_user(db):
 
 @pytest.fixture
 def manage_users_headers(manage_users_user):
-    from ninja_jwt.tokens import RefreshToken
-
     refresh = RefreshToken.for_user(manage_users_user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
 
 
 @pytest.fixture
 def other_user(db):
-    from users.models import User
-
     return User.objects.create_user(
         phone_number="+12025550301",
         password="otherpass123",
@@ -42,8 +38,6 @@ def other_user(db):
 @pytest.fixture
 def member(db):
     """A member User (is_member=True). Reusable across user test files."""
-    from users.models import User
-
     return User.objects.create_user(
         phone_number="+12025550401",
         password="memberpass123",
@@ -58,8 +52,6 @@ def non_member(db):
     Passes is_member=False explicitly to override the conftest create_user
     monkeypatch, which otherwise forces is_member=True for the test population.
     """
-    from users.models import User
-
     return User.objects.create_user(
         phone_number="+12025550402",
         display_name="Non-member User",

--- a/backend/tests/users/test_users_admin_extended.py
+++ b/backend/tests/users/test_users_admin_extended.py
@@ -2,7 +2,12 @@
 
 import pytest
 from community._validation import Code
+from django.utils import timezone
+from ninja_jwt.tokens import RefreshToken
+from notifications.models import Notification, NotificationType
 from tests._asserts import assert_error_code
+from users.models import MagicLoginToken, User
+from users.roles import Role
 
 
 @pytest.mark.django_db
@@ -77,8 +82,6 @@ class TestUpdateUser:
         assert response.status_code == 400
 
     def test_cannot_pause_admin(self, api_client, manage_users_headers, other_user):
-        from users.roles import Role
-
         admin_role = Role.objects.get(name="admin", is_default=True)
         other_user.roles.add(admin_role)
         response = api_client.patch(
@@ -159,8 +162,6 @@ class TestDeleteUser:
         assert response.status_code == 403
 
     def test_delete_user_soft_archives(self, api_client, manage_users_headers, other_user):
-        from users.models import User
-
         response = api_client.delete(
             f"/api/auth/users/{other_user.pk}/",
             **manage_users_headers,
@@ -172,8 +173,6 @@ class TestDeleteUser:
     def test_delete_user_already_archived_returns_400(
         self, api_client, manage_users_headers, other_user
     ):
-        from django.utils import timezone
-
         other_user.archived_at = timezone.now()
         other_user.save(update_fields=["archived_at"])
 
@@ -185,8 +184,6 @@ class TestDeleteUser:
         assert_error_code(response, Code.User.ALREADY_ARCHIVED)
 
     def test_archived_user_excluded_from_list(self, api_client, manage_users_headers, other_user):
-        from django.utils import timezone
-
         other_user.archived_at = timezone.now()
         other_user.save(update_fields=["archived_at"])
 
@@ -196,8 +193,6 @@ class TestDeleteUser:
         assert str(other_user.pk) not in ids
 
     def test_archived_user_excluded_from_search(self, api_client, manage_users_headers, other_user):
-        from django.utils import timezone
-
         other_user.archived_at = timezone.now()
         other_user.save(update_fields=["archived_at"])
 
@@ -207,8 +202,6 @@ class TestDeleteUser:
         assert str(other_user.pk) not in ids
 
     def test_archived_user_cannot_login(self, api_client, other_user):
-        from django.utils import timezone
-
         other_user.archived_at = timezone.now()
         other_user.save(update_fields=["archived_at"])
 
@@ -221,9 +214,6 @@ class TestDeleteUser:
         assert_error_code(response, Code.Auth.ACCOUNT_ARCHIVED)
 
     def test_archived_user_cannot_magic_login(self, api_client, other_user):
-        from django.utils import timezone
-        from users.models import MagicLoginToken
-
         magic = MagicLoginToken.create_for_user(other_user)
         other_user.archived_at = timezone.now()
         other_user.save(update_fields=["archived_at"])
@@ -295,9 +285,6 @@ class TestGenerateMagicLink:
         self, api_client, manage_users_headers, other_user
     ):
         """When admin generates the link, MAGIC_LINK_REQUEST notifications are marked read."""
-        from notifications.models import Notification, NotificationType
-        from users.models import User
-
         approver = User.objects.create_user(phone_number="+12025557788", password="pass")
         Notification.objects.create(
             recipient=approver,
@@ -362,8 +349,6 @@ class TestSearchUsersRespectsShowPhone:
 @pytest.mark.django_db
 class TestUpdateUserRoles:
     def test_non_admin_cannot_grant_admin_role(self, api_client, manage_users_headers, other_user):
-        from users.roles import Role
-
         admin_role = Role.objects.get(name="admin")
         member_role = Role.objects.get(name="member")
         response = api_client.patch(
@@ -377,10 +362,6 @@ class TestUpdateUserRoles:
         assert not other_user.roles.filter(name="admin").exists()
 
     def test_admin_can_grant_admin_role(self, api_client, other_user):
-        from ninja_jwt.tokens import RefreshToken
-        from users.models import User
-        from users.roles import Role
-
         admin_role = Role.objects.get(name="admin")
         member_role = Role.objects.get(name="member")
         admin_user = User.objects.create_user(phone_number="+12025550401", password="adminpass123")

--- a/backend/tests/users/test_users_crud.py
+++ b/backend/tests/users/test_users_crud.py
@@ -3,6 +3,7 @@
 import pytest
 from community._validation import Code
 from tests._asserts import assert_error_code
+from users.models import User
 from users.roles import Role
 
 
@@ -29,8 +30,6 @@ class TestCreateUser:
         assert response.status_code == 201
 
     def test_create_user_non_admin_cannot_assign_admin_role(self, api_client, manage_users_headers):
-        from users.models import User
-
         admin_role = Role.objects.get(name="admin")
         response = api_client.post(
             "/api/auth/create-user/",
@@ -56,8 +55,6 @@ class TestCreateUser:
         assert_error_code(response, Code.Role.NOT_FOUND, "role_id")
 
     def test_create_user_sets_needs_onboarding(self, api_client, manage_users_headers):
-        from users.models import User
-
         response = api_client.post(
             "/api/auth/create-user/",
             {"phone_number": "+12025550903"},
@@ -194,8 +191,6 @@ class TestSearchUsers:
         assert response.status_code == 401
 
     def test_search_limits_to_ten_results(self, api_client, auth_headers, db):
-        from users.models import User
-
         for i in range(15):
             User.objects.create_user(
                 phone_number=f"+1555001{i:04d}",

--- a/backend/users/_auth.py
+++ b/backend/users/_auth.py
@@ -8,12 +8,14 @@ from config.audit import audit_log
 from config.auth import gated_jwt
 from config.media_proxy import media_path
 from config.ratelimit import rate_limit
+from django.contrib.auth import authenticate
 from django.http import HttpResponse
 from django.utils import timezone
 from ninja import File, Router
 from ninja.files import UploadedFile
 from ninja.responses import Status
 from ninja_jwt.authentication import JWTAuth
+from ninja_jwt.exceptions import TokenError
 from ninja_jwt.tokens import RefreshToken
 
 from users._helpers import _check_and_set_email
@@ -56,8 +58,6 @@ _ALLOWED_IMAGE_TYPES = {
 
 @router.post("/login/", response={200: TokenOut, 401: ErrorOut, 403: ErrorOut}, auth=None)
 def login(request, payload: LoginIn, response: HttpResponse):
-    from django.contrib.auth import authenticate
-
     auth_user = authenticate(request, username=payload.phone_number, password=payload.password)
     if auth_user is None:
         logger.warning("Authentication failure: invalid credentials")
@@ -187,8 +187,6 @@ def magic_login(request, token: str, response: HttpResponse):
 
 @router.post("/refresh/", response={200: AccessOut, 401: ErrorOut}, auth=None)
 def refresh_token(request, response: HttpResponse):
-    from ninja_jwt.exceptions import TokenError
-
     token = read_refresh_cookie(request)
     if not token:
         raise_validation(Code.Auth.REFRESH_TOKEN_INVALID, status_code=401)

--- a/backend/users/roles.py
+++ b/backend/users/roles.py
@@ -3,6 +3,8 @@ from typing import TYPE_CHECKING
 
 from django.db import models
 
+from users.permissions import PermissionKey
+
 if TYPE_CHECKING:
     from django.db.models import Manager
 
@@ -32,7 +34,5 @@ class Role(models.Model):
         the DB row was seeded before newer keys were added.
         """
         if self.name == "admin" and self.is_default:
-            from users.permissions import PermissionKey
-
             return list(PermissionKey.values)
         return list(self.permissions)


### PR DESCRIPTION
## Summary

Part of #529. Triage and hoist the ~540 function-local (indented) `import` / `from ... import` statements in `backend/`.

- **528 hoisted** to module top-level across 66 files (source + tests). Duplicate per-function imports collapsed into single top-level imports following the existing isort grouping.
- **8 kept function-local**, each with a one-line justification:
  - `notifications/email_sender.py` (×2): `ResendSender` / `ConsoleSender` — both modules import `email_sender` back (genuine circular dependency).
  - `notifications/sse.py`: `psycopg` — only needed on the postgres `LISTEN` path (lazy/optional).
  - `tests/test_settings.py` (×2): `config.settings` reloaded under monkeypatched env (must run after the patch).
  - `manage.py`, `config/validation_handlers.py`, `community/management/commands/dump_openapi_schema.py`: pre-existing Django idioms (ImportError guard / app-registry timing) left untouched.
- **Pure refactor — no behavior change.** The only non-import edits are alias-only rewrites that preserve identical semantics: `UserModel` → `User` and `settings` → `django_settings` (renamed to avoid colliding with the pytest `settings` fixture after `django.conf.settings` was hoisted).
- **No import cycle introduced.** Every changed module imports cleanly under `django.setup()`; `TYPE_CHECKING` blocks were not touched (runtime-needed symbols promoted to runtime imports, annotation-only symbols left in `TYPE_CHECKING`).

## Test plan

- [x] `make agent-backend-ci` passes — 1032 tests, ruff (`I`/`F401`/`F811`), `ty` typecheck, cognitive-complexity, file-size, validation-codes and OpenAPI schema checks all green.
- [x] No new import-cycle errors.
- [x] Independent code review found no high/medium/low findings (semantics-preserving).
