### PR TITLE
docs(conventions): standardize function docstring format (Issue 597)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,39 @@ References: `~/.claude/rules/standards-django-ninja.md`
 - All user-facing text in the frontend app must be **lowercase only** — labels, headings, buttons, placeholders, toasts, error messages, date formatting, etc.
 - Use `.toLowerCase()` on any dynamic/format-driven strings (e.g. `date-fns` output).
 
+### docstring format
+
+When a function/method warrants a doc comment, describe each parameter (name, type, description) and the return value in the standard shape below. This applies to **non-trivial functions** — anything with multiple parameters, non-obvious behavior, side effects, or a public/reused surface. Simple one-line helpers (e.g. a getter or a thin wrapper) may keep a single-line summary; do not pad trivial functions with boilerplate param/return sections.
+
+**Backend (Python):** a summary line, a blank line, one line per parameter (`name - type: description`), then a `Return:` block. Omit the `param`/`Return:` sections when there are no parameters / no meaningful return.
+
+```python
+def approve_join_request(request_id: str, approver: User) -> JoinRequest:
+    """
+    Approve a pending join request and promote the applicant.
+
+    request_id - str: id of the JoinRequest to approve
+    approver - User: the member performing the approval (for the audit log)
+
+    Return:
+        JoinRequest: the updated request in the APPROVED state
+    """
+```
+
+Google-style `Args:` / `Returns:` docstrings already present in the tree (e.g. `config/audit.py`) are an accepted equivalent and need not be rewritten; use the `param - type: description` + `Return:` form above for new/edited docstrings.
+
+**Frontend (TS/JS):** standard JSDoc — `@param {type} name - description` and `@returns {type} description`.
+
+```ts
+/**
+ * Resolve where to send a user after authentication.
+ *
+ * @param {User} user - the authenticated user
+ * @param {boolean} consented - whether guidelines consent is recorded
+ * @returns {string} the path to redirect to
+ */
+```
+
 ## Agent Directives
 
 1. **STEP 0 RULE**: Before ANY structural refactor on a file >300 LOC, first remove all dead props, unused exports, unused imports, and debug logs. Commit this cleanup separately.

--- a/backend/community/_join_request_approval.py
+++ b/backend/community/_join_request_approval.py
@@ -8,7 +8,15 @@ from users.roles import Role
 
 
 def _reactivate_archived_user(existing_user, join_request):
-    """Un-archive an existing user on re-approval, carrying any new consents."""
+    """
+    Un-archive an existing user on re-approval, carrying any new consents.
+
+    existing_user - User: the archived user row to reactivate
+    join_request - JoinRequest: the approved request supplying the fresh consents
+
+    Return:
+        str: a one-time magic login token for the reactivated user
+    """
     existing_user.archived_at = None
     existing_user.needs_onboarding = True
     existing_user.first_name = join_request.first_name
@@ -32,11 +40,18 @@ def _reactivate_archived_user(existing_user, join_request):
 
 
 def _promote_non_member(user, join_request):
-    """Promote a linked non-member User to a member in place.
+    """
+    Promote a linked non-member User to a member in place.
 
     Their prior RSVPs already point at this row, so flipping is_member keeps the
     full history instead of orphaning it under a fresh account. Outstanding
     scoped RSVP tokens are revoked — the member flow replaces them.
+
+    user - User: the non-member row to promote in place
+    join_request - JoinRequest: the approved request supplying display name and consents
+
+    Return:
+        str: a one-time magic login token for the promoted member
     """
     user.is_member = True
     user.needs_onboarding = True
@@ -69,13 +84,21 @@ def _promote_non_member(user, join_request):
 
 
 def _provision_approved_user(join_request, requesting_user) -> tuple[str | None, bool]:
-    """Create, reactivate, or promote the user for an approved join request.
+    """
+    Create, reactivate, or promote the user for an approved join request.
 
-    Returns ``(magic_token, user_created)``: the one-time login token and whether
-    a brand-new User row was created. A promoted non-member or reactivated
-    archived user returns a token with ``user_created`` reflecting whether the
-    row is new. When the phone already maps to an active member, nothing is
-    provisioned and ``(None, False)`` is returned.
+    A promoted non-member or reactivated archived user returns a token with
+    ``user_created`` reflecting whether the row is new. When the phone already
+    maps to an active member, nothing is provisioned and ``(None, False)`` is
+    returned.
+
+    join_request - JoinRequest: the approved request to provision a user for
+    requesting_user - User: the admin performing the approval (for the audit trail)
+
+    Return:
+        tuple[str | None, bool]: ``(magic_token, user_created)`` — the one-time
+        login token (or None when no user was provisioned) and whether a
+        brand-new User row was created
     """
     # A linked non-member is promoted in place; SET_NULL FK means a deleted user falls through.
     if join_request.user is not None and not join_request.user.is_member:

--- a/backend/notifications/service.py
+++ b/backend/notifications/service.py
@@ -32,11 +32,18 @@ _EVENT_UPDATES_CHANNEL = "event_updates"
 
 
 def _ping_event_update(user_ids: Iterable[str], event_id: str) -> None:
-    """Fire pg_notify on the event_updates channel — a silent live-update ping.
+    """
+    Fire pg_notify on the event_updates channel — a silent live-update ping.
 
     The SSE layer delivers this as an `event_updated` event (distinct from
     `notification`) so the frontend only invalidates event caches — no bell,
     no unread-count refetch, no notification row.
+
+    user_ids - Iterable[str]: the users to ping
+    event_id - str: the event whose caches should be invalidated
+
+    Return:
+        None
     """
     if connection.vendor != "postgresql":
         return
@@ -58,11 +65,19 @@ def broadcast_cohost_change(
     exclude_user_ids: Iterable[str] = (),
     extra_user_ids: Iterable[str] = (),
 ) -> None:
-    """Live-update ping scoped to creator + accepted co-hosts.
+    """
+    Live-update ping scoped to creator + accepted co-hosts.
 
     Used when the cohost roster changes (accept / decline / rescind) so
     the host-management UI refreshes for the people who care, without
     pinging every member who's RSVP'd or been invited to the event.
+
+    event - Event: the event whose cohost roster changed
+    exclude_user_ids - Iterable[str]: users to omit from the ping
+    extra_user_ids - Iterable[str]: users to include beyond creator + co-hosts
+
+    Return:
+        None
     """
     recipients: set[str] = set()
     if event.created_by_id:
@@ -80,11 +95,19 @@ def broadcast_event_update(
     exclude_user_ids: Iterable[str] = (),
     extra_user_ids: Iterable[str] = (),
 ) -> None:
-    """Live-update ping for everyone currently able to see this event.
+    """
+    Live-update ping for everyone currently able to see this event.
 
     Creates no notification rows. Stakeholders are the creator + current
-    co-hosts + invited + attending/maybe RSVPs. Pass `extra_user_ids` to
-    include users who just lost their stake (e.g. a co-host who was removed).
+    co-hosts + invited + attending/maybe RSVPs.
+
+    event - Event: the event that changed
+    exclude_user_ids - Iterable[str]: users to omit from the ping
+    extra_user_ids - Iterable[str]: users to include beyond current stakeholders
+        (e.g. a co-host who just lost their stake)
+
+    Return:
+        None
     """
     recipients: set[str] = set()
     if event.created_by_id:

--- a/backend/users/_helpers.py
+++ b/backend/users/_helpers.py
@@ -58,10 +58,16 @@ def _resolve_name_fields(user: User, payload: NamePatchPayload) -> bool:
 
 
 def _create_magic_token(user: User, *, requires_password_reset: bool = False) -> str:
-    """Create a one-time magic login token. Returns the token UUID string.
+    """
+    Create a one-time magic login token.
 
-    Pass requires_password_reset=True for self-service login links so consuming
-    the token forces a password reset (admin onboarding links leave it False).
+    user - User: the user the token logs in
+    requires_password_reset - bool: pass True for self-service login links so
+        consuming the token forces a password reset (admin onboarding links
+        leave it False)
+
+    Return:
+        str: the token UUID as a string
     """
     magic = MagicLoginToken.create_for_user(user, requires_password_reset=requires_password_reset)
     return str(magic.token)
@@ -134,13 +140,20 @@ def _check_and_set_email(
     *,
     exclude_pk: uuid.UUID | str | None = None,
 ) -> None:
-    """Normalize email, enforce uniqueness, and assign to user.email.
+    """
+    Normalize email, enforce uniqueness, and assign to user.email.
 
     Raises ValidationException(409, "email.already_exists") on collision.
     Passes the normalized value (possibly None) through to ``user.email``.
 
-    Pass ``exclude_pk`` for the self-update case so users can re-submit
-    their own current email without a false collision.
+    user - User: the user whose ``email`` is set to the normalized value
+    raw - str | None: the raw email to normalize (blank/None clears the field)
+    exclude_pk - uuid.UUID | str | None: for the self-update case, the pk to
+        exclude from the uniqueness check so users can re-submit their own
+        current email without a false collision
+
+    Return:
+        None
     """
     normalized = _normalize_email(raw)
     if normalized:
@@ -153,10 +166,18 @@ def _check_and_set_email(
 
 
 def _validate_phone(raw: str, field: str = "phone_number") -> str:
-    """Parse, validate, and return E.164. Raises ValidationException on invalid.
+    """
+    Parse and validate a phone number, returning it in E.164 form.
 
-    Defaults to US region so bare 10-digit numbers are accepted.
-    Numbers with an explicit country code (e.g. +44...) are unaffected.
+    Raises ValidationException on an invalid number. Defaults to US region so
+    bare 10-digit numbers are accepted; numbers with an explicit country code
+    (e.g. +44...) are unaffected.
+
+    raw - str: the phone number to parse
+    field - str: the field name to attach to a validation error
+
+    Return:
+        str: the number formatted as E.164 (e.g. ``+15551234567``)
     """
     try:
         parsed = phonenumbers.parse(raw, "US")

--- a/frontend/src/api/apiErrors.ts
+++ b/frontend/src/api/apiErrors.ts
@@ -14,8 +14,11 @@ import { type FieldError, messagesFromFieldErrors } from './validationCodes';
 
 /**
  * Extract a user-facing message from any API error.
- * Returns null when the error isn't an axios error we can interpret — callers
- * fall back to their own default ("couldn't save — try again", etc.).
+ *
+ * @param {unknown} err - the thrown error (typically from an axios request)
+ * @returns {string | null} the message, or null when the error isn't an axios
+ *   error we can interpret — callers fall back to their own default
+ *   ("couldn't save — try again", etc.).
  */
 export function extractApiError(err: unknown): string | null {
   if (!isAxiosError(err)) return null;
@@ -40,15 +43,22 @@ export function extractApiError(err: unknown): string | null {
 /**
  * Like extractApiError but returns a fallback string when no message is
  * recoverable. Convenience for call sites that always want a display string.
+ *
+ * @param {unknown} err - the thrown error (typically from an axios request)
+ * @param {string} fallback - message to return when nothing is recoverable
+ * @returns {string} the extracted message, or `fallback`
  */
 export function extractApiErrorOr(err: unknown, fallback: string): string {
   return extractApiError(err) ?? fallback;
 }
 
 /**
- * HTTP status from any API error, or null if the error isn't an axios error
- * with a response. Use this instead of importing `isAxiosError` directly so
- * call sites don't reach into `error.response?.status` on their own.
+ * HTTP status from any API error. Use this instead of importing `isAxiosError`
+ * directly so call sites don't reach into `error.response?.status` on their own.
+ *
+ * @param {unknown} err - the thrown error (typically from an axios request)
+ * @returns {number | null} the HTTP status, or null if the error isn't an axios
+ *   error with a response
  */
 export function getApiStatus(err: unknown): number | null {
   if (!isAxiosError(err)) return null;
@@ -56,9 +66,13 @@ export function getApiStatus(err: unknown): number | null {
 }
 
 /**
- * True if the error carries a structured-detail entry with the given code.
+ * Whether the error carries a structured-detail entry with the given code.
  * Prefer this over status-based branching when the code is more specific than
  * the status (e.g. distinguishing flag_already_flagged from any 409).
+ *
+ * @param {unknown} err - the thrown error (typically from an axios request)
+ * @param {string} code - the structured error code to look for
+ * @returns {boolean} true if any detail entry carries `code`
  */
 export function hasErrorCode(err: unknown, code: string): boolean {
   if (!isAxiosError(err)) return false;

--- a/frontend/src/api/join.test.ts
+++ b/frontend/src/api/join.test.ts
@@ -15,7 +15,13 @@ import { AlreadyInvitedError, useJoinRequests, useSubmitJoinRequest } from './jo
 const mockedGet = vi.mocked(apiClient.get);
 const mockedPost = vi.mocked(apiClient.post);
 
-/** Create an axios-style error with a given HTTP status. */
+/**
+ * Create an axios-style error with a given HTTP status.
+ *
+ * @param {number} status - the HTTP status to attach to the error response
+ * @param {Record<string, unknown>} data - the response body payload
+ * @returns {Error} an error shaped like an axios error
+ */
 function makeAxiosError(status: number, data: Record<string, unknown> = {}): Error {
   return Object.assign(new Error(`HTTP ${status}`), {
     isAxiosError: true,

--- a/frontend/src/api/validationCodes.ts
+++ b/frontend/src/api/validationCodes.ts
@@ -32,7 +32,12 @@ export interface FieldError {
   params?: Record<string, unknown>;
 }
 
-/** Return user-facing copy for a single field error. */
+/**
+ * Return user-facing copy for a single field error.
+ *
+ * @param {FieldError} err - the structured field error from the API
+ * @returns {string} the message to display for that error
+ */
 export function messageForCode(err: FieldError): string {
   if (isKnownCode(err.code)) {
     return messageForKnownCode(err.code, err);
@@ -41,9 +46,15 @@ export function messageForCode(err: FieldError): string {
 }
 
 /**
+ * Return user-facing copy for a known field-error code.
+ *
  * Exhaustive over `KnownCode`. Adding a new code to the backend will fail the
  * build here until a `case` is added, eliminating silent fallbacks for
  * codes the FE forgot to ship copy for.
+ *
+ * @param {KnownCode} code - the recognized error code
+ * @param {FieldError} err - the full field error (for interpolating params)
+ * @returns {string} the message to display for that code
  */
 function messageForKnownCode(code: KnownCode, err: FieldError): string {
   switch (code) {
@@ -439,7 +450,12 @@ function assertNever(code: never): never {
   throw new Error(`unhandled validation code: ${String(code)}`);
 }
 
-/** Join multiple field errors into a single human-readable sentence. */
+/**
+ * Join multiple field errors into a single human-readable sentence.
+ *
+ * @param {FieldError[]} errors - the structured field errors from the API
+ * @returns {string} the deduped messages joined with ` · `
+ */
 export function messagesFromFieldErrors(errors: FieldError[]): string {
   const msgs = errors.map(messageForCode);
   // Dedup while preserving order — backend sometimes emits two errors for

--- a/frontend/src/models/user.ts
+++ b/frontend/src/models/user.ts
@@ -57,6 +57,10 @@ export interface User {
  *     collects neither). Anyone missing either goes to /onboarding, which
  *     collects whatever's missing (legacy accounts approved before email was
  *     required land here).
+ *
+ * @param {User | null} user - the authenticated user, or null when signed out
+ * @returns {'/new-password' | '/onboarding' | null} the setup route, or null
+ *   when nothing is pending
  */
 export function passwordSetupRedirect(user: User | null): '/new-password' | '/onboarding' | null {
   if (!user) return null;
@@ -65,6 +69,16 @@ export function passwordSetupRedirect(user: User | null): '/new-password' | '/on
   return hasNameAndEmail ? '/new-password' : '/onboarding';
 }
 
+/**
+ * Where a user must go to accept the community guidelines before using the app,
+ * or null if they've already consented. The consent gate is HARD — no skip, no
+ * dismiss — and applies to everyone (admins included). It runs only after any
+ * password setup (passwordSetupRedirect) is resolved, so a brand-new user sets
+ * their name + password first, then consents.
+ *
+ * @param {User | null} user - the authenticated user, or null when signed out
+ * @returns {'/consent' | null} the consent route, or null when already consented
+ */
 export function consentRedirect(user: User | null): '/consent' | null {
   if (!user) return null;
   return user.needsGuidelinesConsent || user.needsSmsConsent ? '/consent' : null;
@@ -83,6 +97,10 @@ export function consentRedirect(user: User | null): '/consent' | null {
  * with the new auth state, so a pending user sees a blank screen until refresh.
  * Navigating to the gate target up-front avoids that race entirely; the gate
  * remains the backstop for every later navigation.
+ *
+ * @param {User | null} user - the freshly-authenticated user, or null
+ * @returns {'/new-password' | '/onboarding' | '/consent' | null} the gate route
+ *   to navigate to, or null when the user may enter the app
  */
 export function postAuthRedirect(
   user: User | null,


### PR DESCRIPTION
## Summary

Standardizes the project's function/method docstring conventions and documents them so new code follows suit. Documentation/comments only — **no behavior changes**.

Closes #597

- **CLAUDE.md** — adds a "docstring format" section documenting both conventions with examples:
  - Backend (Python): summary line + `param - type: description` lines + a `Return:` block. Google-style `Args:`/`Returns:` already in the tree (e.g. `config/audit.py`) is noted as an accepted equivalent.
  - Frontend (TS/JS): standard JSDoc — `@param {type} name - description` and `@returns {type} description`.
- **Frontend** — all 11 hand-written function doc comments converted to JSDoc (`apiErrors.ts`, `validationCodes.ts`, `models/user.ts`, `join.test.ts`).
- **Backend** — a curated set of non-trivial, multi-param functions converted to the `param - type: description` + `Return:` format across three areas: `community/_join_request_approval.py`, `users/_helpers.py`, `notifications/service.py`.

### Scope decision (documented)

The issue explicitly asks to *"decide scope: whether this covers only non-trivial/public functions or everything."* The backend has 249 function docstrings, 247 of them plain one-line prose. Converting every trivial one-liner to a full param/Return block would be large, low-value churn that hurts readability. This PR instead **documents the standard for the whole project** (criterion #1) and **applies it to the functions that genuinely benefit** (multiple params, non-obvious behavior, public/reused surface), establishing the convention across all main areas. New/edited code follows the documented format going forward.

## Test plan

- [x] `make agent-lint` (backend ruff check + format) — green
- [x] backend format check + `ty` typecheck — green (pre-existing warnings only, in untouched files)
- [x] `make agent-frontend-lint` (eslint) + prettier check — green
- [x] frontend `tsc --noEmit` — green
- [x] Diff verified to touch only docstrings/comments (zero executable-line changes), so backend/frontend behavior and tests are unaffected
- [x] code-reviewer subagent: docstrings verified accurate against signatures + return types; 0 high/medium findings