### PR TITLE
refactor: remove legacy React namespace imports

### DIFF
--- a/frontend/src/api/calendar.test.ts
+++ b/frontend/src/api/calendar.test.ts
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
-import React from 'react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({
@@ -21,8 +22,8 @@ function makeQc() {
 }
 
 function makeWrapper(qc: QueryClient) {
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: qc }, children);
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children);
 }
 
 beforeEach(() => {

--- a/frontend/src/api/content.test.ts
+++ b/frontend/src/api/content.test.ts
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
-import React from 'react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({
@@ -23,8 +24,8 @@ const mockedPatch = vi.mocked(apiClient.patch);
 
 function wrapper() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: qc }, children);
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children);
 }
 
 beforeEach(() => {

--- a/frontend/src/api/docs.mutations.test.ts
+++ b/frontend/src/api/docs.mutations.test.ts
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
-import React from 'react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({
@@ -29,8 +30,8 @@ function makeQc() {
 }
 
 function makeWrapper(qc: QueryClient) {
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: qc }, children);
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children);
 }
 
 beforeEach(() => {

--- a/frontend/src/api/eventComments.test.ts
+++ b/frontend/src/api/eventComments.test.ts
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
-import React from 'react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({
@@ -42,8 +43,8 @@ function wireCommentList(overrides: Partial<WireCommentList> = {}): WireCommentL
 
 function buildWrapper() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  const Wrapper = ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: qc }, children);
+  const Wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children);
   return { qc, Wrapper };
 }
 

--- a/frontend/src/api/eventPolls.test.ts
+++ b/frontend/src/api/eventPolls.test.ts
@@ -1,7 +1,8 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
 import type { AxiosError } from 'axios';
-import React from 'react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({
@@ -75,8 +76,8 @@ function wirePoll(overrides: Partial<WireEventPoll> = {}): WireEventPoll {
 
 function buildWrapper() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  const Wrapper = ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: qc }, children);
+  const Wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children);
   return { qc, Wrapper };
 }
 

--- a/frontend/src/api/feedback.test.ts
+++ b/frontend/src/api/feedback.test.ts
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
-import React from 'react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({
@@ -15,8 +16,8 @@ const mockedPost = vi.mocked(apiClient.post);
 
 function wrapper() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: qc }, children);
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children);
 }
 
 beforeEach(() => {

--- a/frontend/src/api/join.test.ts
+++ b/frontend/src/api/join.test.ts
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
-import React from 'react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({
@@ -24,8 +25,8 @@ function makeAxiosError(status: number, data: Record<string, unknown> = {}): Err
 
 function wrapper() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: qc }, children);
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children);
 }
 
 beforeEach(() => {

--- a/frontend/src/api/notifications.test.ts
+++ b/frontend/src/api/notifications.test.ts
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
-import React from 'react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({
@@ -30,8 +31,8 @@ const mockedPost = vi.mocked(apiClient.post);
 
 function wrapper() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: qc }, children);
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children);
 }
 
 beforeEach(() => {

--- a/frontend/src/api/roles.test.ts
+++ b/frontend/src/api/roles.test.ts
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
-import React from 'react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({
@@ -23,8 +24,8 @@ function makeQc() {
 }
 
 function makeWrapper(qc: QueryClient) {
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: qc }, children);
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children);
 }
 
 beforeEach(() => {

--- a/frontend/src/api/surveyAdmin.tallies.test.ts
+++ b/frontend/src/api/surveyAdmin.tallies.test.ts
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
-import React from 'react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({
@@ -21,8 +22,8 @@ function makeQc() {
 }
 
 function makeWrapper(qc: QueryClient) {
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: qc }, children);
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children);
 }
 
 beforeEach(() => {

--- a/frontend/src/api/users.test.ts
+++ b/frontend/src/api/users.test.ts
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { renderHook, waitFor } from '@testing-library/react';
-import React from 'react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({
@@ -32,8 +33,8 @@ function makeQc() {
 
 // Each hook gets a fresh QueryClient so invalidations are observable in isolation.
 function makeWrapper(qc: QueryClient) {
-  return ({ children }: { children: React.ReactNode }) =>
-    React.createElement(QueryClientProvider, { client: qc }, children);
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children);
 }
 
 beforeEach(() => {

--- a/frontend/src/components/FeedbackButton.a11y.test.tsx
+++ b/frontend/src/components/FeedbackButton.a11y.test.tsx
@@ -1,7 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';

--- a/frontend/src/components/FeedbackButton.tsx
+++ b/frontend/src/components/FeedbackButton.tsx
@@ -5,7 +5,7 @@
 // per .claude/rules/ui-copy-tone.md. maxLength caps match the frontend
 // input-validation guidance (title 150, description 2000) and stay under
 // the backend FieldLimit on FeedbackIn (200 / 10000).
-
+import type { SyntheticEvent } from 'react';
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { toast } from 'sonner';
@@ -55,7 +55,7 @@ export function FeedbackButton() {
     setDescriptionError(undefined);
   }
 
-  async function onSubmit(e: React.SyntheticEvent<HTMLFormElement>) {
+  async function onSubmit(e: SyntheticEvent<HTMLFormElement>) {
     e.preventDefault();
     const trimmedTitle = title.trim();
     const trimmedDescription = description.trim();

--- a/frontend/src/components/ImageCropDialog.a11y.test.tsx
+++ b/frontend/src/components/ImageCropDialog.a11y.test.tsx
@@ -1,10 +1,10 @@
 import { render } from '@testing-library/react';
-import React from 'react';
+import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
 
 vi.mock('react-image-crop', () => ({
-  default: ({ circularCrop, children }: { circularCrop?: boolean; children?: React.ReactNode }) => (
+  default: ({ circularCrop, children }: { circularCrop?: boolean; children?: ReactNode }) => (
     <div data-testid="cropper" data-circular={String(Boolean(circularCrop))}>
       {children}
     </div>

--- a/frontend/src/components/ImageCropDialog.test.tsx
+++ b/frontend/src/components/ImageCropDialog.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
+import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // react-image-crop uses pointer events + ResizeObserver that jsdom doesn't
@@ -14,7 +14,7 @@ vi.mock('react-image-crop', () => ({
   }: {
     circularCrop?: boolean;
     aspect?: number;
-    children?: React.ReactNode;
+    children?: ReactNode;
   }) => (
     <div
       data-testid="cropper"

--- a/frontend/src/components/ImageCropDialog.tsx
+++ b/frontend/src/components/ImageCropDialog.tsx
@@ -3,6 +3,7 @@
 
 import 'react-image-crop/dist/ReactCrop.css';
 
+import type { SyntheticEvent } from 'react';
 import { useRef, useState } from 'react';
 import ReactCrop, { type Crop, type PercentCrop, type PixelCrop } from 'react-image-crop';
 
@@ -48,7 +49,7 @@ export function ImageCropDialog({
   const [saving, setSaving] = useState(false);
   const imgRef = useRef<HTMLImageElement | null>(null);
 
-  function onImageLoad(e: React.SyntheticEvent<HTMLImageElement>) {
+  function onImageLoad(e: SyntheticEvent<HTMLImageElement>) {
     const { width, height } = e.currentTarget;
     setCrop(initialCrop(width, height, shape));
     if (shape === 'rect') setAspect(defaultCoverAspect(width, height));

--- a/frontend/src/components/RichEditor/RichEditorToolbar.tsx
+++ b/frontend/src/components/RichEditor/RichEditorToolbar.tsx
@@ -1,4 +1,5 @@
 import type { Editor } from '@tiptap/react';
+import type { ReactNode } from 'react';
 import { useEffect, useRef, useState } from 'react';
 
 import { cn } from '@/utils/cn';
@@ -204,9 +205,9 @@ function Menu({
   children,
 }: {
   label: string;
-  trigger: React.ReactNode;
+  trigger: ReactNode;
   active: boolean;
-  children: (close: () => void) => React.ReactNode;
+  children: (close: () => void) => ReactNode;
 }) {
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
@@ -277,7 +278,7 @@ function MenuItem({
 }: {
   active: boolean;
   onClick: () => void;
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   return (
     <button
@@ -310,7 +311,7 @@ function ToolButton({
   label: string;
   active: boolean;
   onClick: () => void;
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   return (
     <button
@@ -344,7 +345,7 @@ function promptLink(editor: Editor) {
 
 // --- icons ---
 
-function Icon({ children }: { children: React.ReactNode }) {
+function Icon({ children }: { children: ReactNode }) {
   return (
     <svg
       aria-hidden="true"

--- a/frontend/src/components/SortableList.tsx
+++ b/frontend/src/components/SortableList.tsx
@@ -23,7 +23,7 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
 
 interface Props<T extends { id: string }> {
   items: readonly T[];
@@ -71,7 +71,7 @@ function SortableRow({ id, children }: { id: string; children: ReactNode }) {
   const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
     id,
   });
-  const style: React.CSSProperties = {
+  const style: CSSProperties = {
     transform: CSS.Transform.toString(transform),
     transition,
     opacity: isDragging ? 0.6 : 1,

--- a/frontend/src/components/ui/PhoneField.tsx
+++ b/frontend/src/components/ui/PhoneField.tsx
@@ -1,5 +1,6 @@
 import 'react-phone-number-input/style.css';
 
+import type { CSSProperties } from 'react';
 import type { InputHTMLAttributes } from 'react';
 import PhoneInput, { type Country, type Value } from 'react-phone-number-input';
 import flags from 'react-phone-number-input/flags';
@@ -67,7 +68,7 @@ export function PhoneField({
         style={
           {
             '--PhoneInput-color--focus': 'var(--color-brand-600)',
-          } as React.CSSProperties
+          } as CSSProperties
         }
         className={cn(
           'PhoneInput flex items-center gap-2',

--- a/frontend/src/layout/AppShell.test.tsx
+++ b/frontend/src/layout/AppShell.test.tsx
@@ -1,7 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/frontend/src/layout/BottomNav.tsx
+++ b/frontend/src/layout/BottomNav.tsx
@@ -5,6 +5,7 @@
 // announce them. Active state uses a filled icon + dot so the distinction
 // survives the color-blind-friendly rule (not color-only).
 
+import type { ReactNode } from 'react';
 import { NavLink, useLocation, useNavigate } from 'react-router-dom';
 
 import { useAuthStore } from '@/auth/store';
@@ -72,7 +73,7 @@ export function BottomNav() {
 interface NavItemProps {
   to: string;
   label: string;
-  children: (state: { active: boolean }) => React.ReactNode;
+  children: (state: { active: boolean }) => ReactNode;
 }
 
 function NavItem({ to, label, children }: NavItemProps) {

--- a/frontend/src/layout/NotificationBell.test.tsx
+++ b/frontend/src/layout/NotificationBell.test.tsx
@@ -1,7 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/frontend/src/screens/admin/JoinQuestionDialog.tsx
+++ b/frontend/src/screens/admin/JoinQuestionDialog.tsx
@@ -1,6 +1,7 @@
 // Create / edit a single JoinFormQuestion. Kept in its own file so the
 // parent screen stays focused on list semantics + reorder.
 
+import type { SyntheticEvent } from 'react';
 import { useState } from 'react';
 
 import { extractApiErrorOr } from '@/api/apiErrors';
@@ -36,7 +37,7 @@ function JoinQuestionDialogBody({ open, onClose, existing }: Props) {
 
   const busy = create.isPending || update.isPending;
 
-  async function onSubmit(e: React.SyntheticEvent) {
+  async function onSubmit(e: SyntheticEvent) {
     e.preventDefault();
     setError(null);
     if (!label.trim()) {

--- a/frontend/src/screens/admin/MemberCreateDialog.test.tsx
+++ b/frontend/src/screens/admin/MemberCreateDialog.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useCreateUser } from '@/api/users';

--- a/frontend/src/screens/admin/MembersScreen.test.tsx
+++ b/frontend/src/screens/admin/MembersScreen.test.tsx
@@ -1,7 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/frontend/src/screens/admin/SurveyAdminListScreen.tsx
+++ b/frontend/src/screens/admin/SurveyAdminListScreen.tsx
@@ -1,4 +1,5 @@
 import { format } from 'date-fns';
+import type { SyntheticEvent } from 'react';
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 
@@ -146,7 +147,7 @@ function CreateSurveyDialog({ open, onClose }: { open: boolean; onClose: () => v
   });
   const [error, setError] = useState<string | null>(null);
 
-  async function submit(e: React.SyntheticEvent) {
+  async function submit(e: SyntheticEvent) {
     e.preventDefault();
     setError(null);
     if (!values.title.trim() || !values.slug.trim()) {

--- a/frontend/src/screens/admin/SurveyQuestionDialog.tsx
+++ b/frontend/src/screens/admin/SurveyQuestionDialog.tsx
@@ -1,6 +1,7 @@
 // Create / edit a single survey question. Covers all 9 field types; options
 // textarea appears only for types that use them.
 
+import type { SyntheticEvent } from 'react';
 import { useState } from 'react';
 
 import { extractApiErrorOr } from '@/api/apiErrors';
@@ -58,7 +59,7 @@ function SurveyQuestionDialogBody({ surveyId, open, onClose, existing }: Props) 
   const wantsOptions = TYPES.find((t) => t.value === fieldType)?.wantsOptions ?? false;
   const busy = create.isPending || update.isPending;
 
-  async function submit(e: React.SyntheticEvent) {
+  async function submit(e: SyntheticEvent) {
     e.preventDefault();
     setError(null);
     if (!label.trim()) {

--- a/frontend/src/screens/auth/LoginScreen.a11y.test.tsx
+++ b/frontend/src/screens/auth/LoginScreen.a11y.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
-import React from 'react';
+import type{ ReactElement } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
@@ -19,7 +19,7 @@ import { useAuthStore } from '@/auth/store';
 
 import LoginScreen from './LoginScreen';
 
-function renderWith(component: React.ReactElement) {
+function renderWith(component: ReactElement) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={qc}>

--- a/frontend/src/screens/auth/LoginScreen.tsx
+++ b/frontend/src/screens/auth/LoginScreen.tsx
@@ -1,4 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import type { SyntheticEvent } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { isValidPhoneNumber } from 'react-phone-number-input';
@@ -36,7 +37,7 @@ export default function LoginScreen() {
   const [phoneError, setPhoneError] = useState<string | null>(null);
   const [checking, setChecking] = useState(false);
 
-  async function onPhoneSubmit(e: React.SyntheticEvent) {
+  async function onPhoneSubmit(e: SyntheticEvent) {
     e.preventDefault();
     setPhoneError(null);
     if (!phone || !isValidPhoneNumber(phone)) {

--- a/frontend/src/screens/auth/RequestLoginLinkDialog.tsx
+++ b/frontend/src/screens/auth/RequestLoginLinkDialog.tsx
@@ -1,3 +1,4 @@
+import type { SyntheticEvent } from 'react';
 import { useState } from 'react';
 import { isValidPhoneNumber } from 'react-phone-number-input';
 
@@ -33,7 +34,7 @@ function RequestLoginLinkForm({
   const [delivery, setDelivery] = useState<RequestLoginLinkDelivery | null>(null);
   const requestLink = useRequestLoginLink();
 
-  async function onSubmit(e: React.SyntheticEvent) {
+  async function onSubmit(e: SyntheticEvent) {
     e.preventDefault();
     setError(null);
     if (!phone || !isValidPhoneNumber(phone)) {

--- a/frontend/src/screens/calendar/CalendarScreen.test.tsx
+++ b/frontend/src/screens/calendar/CalendarScreen.test.tsx
@@ -1,7 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/frontend/src/screens/calendar/CalendarToolbar.tsx
+++ b/frontend/src/screens/calendar/CalendarToolbar.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import type { ToolbarProps } from 'react-big-calendar';
 
 import { cn } from '@/utils/cn';
@@ -47,7 +48,7 @@ function ChevronButton({
 }: {
   label: string;
   onClick: () => void;
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   return (
     <button

--- a/frontend/src/screens/events/EventActions.tsx
+++ b/frontend/src/screens/events/EventActions.tsx
@@ -3,6 +3,7 @@
 // Add-to-calendar is a tiny popover with google / apple / download-ics.
 // Share uses the Web Share API when available; falls back to clipboard.
 
+import type { ReactNode } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -126,7 +127,7 @@ function CalendarMenu({ event }: { event: Event }) {
 
 interface IconChipProps {
   label: string;
-  children: React.ReactNode;
+  children: ReactNode;
   onClick: () => void;
   'aria-expanded'?: boolean;
 }

--- a/frontend/src/screens/events/EventAdminActions.test.tsx
+++ b/frontend/src/screens/events/EventAdminActions.test.tsx
@@ -1,6 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/frontend/src/screens/events/EventAttendancePanel.test.tsx
+++ b/frontend/src/screens/events/EventAttendancePanel.test.tsx
@@ -1,6 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen } from '@testing-library/react';
-import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Event, EventStats } from '@/models/event';

--- a/frontend/src/screens/events/EventDetailScreen.test.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.test.tsx
@@ -1,6 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
-import React from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { Link, useParams } from 'react-router-dom';
 
 import { extractApiError, getApiStatus } from '@/api/apiErrors';
@@ -98,7 +99,7 @@ function Badge({
   children,
 }: {
   tone: 'neutral' | 'blue' | 'amber' | 'lavender';
-  children: React.ReactNode;
+  children: ReactNode;
 }) {
   const tones = {
     neutral: 'bg-surface-dim text-foreground-secondary',

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -2,6 +2,7 @@
 // backend gates behind auth: hosts, location, links, cost, invite, rsvp,
 // plus the admin actions card for the event's creator / co-hosts / managers.
 
+import type { ReactNode } from 'react';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { toast } from 'sonner';
@@ -99,7 +100,7 @@ function ReportEventButton({ eventId }: { eventId: string }) {
   );
 }
 
-function Card({ label, children }: { label: string; children: React.ReactNode }) {
+function Card({ label, children }: { label: string; children: ReactNode }) {
   return (
     <section className="border-border bg-surface rounded-lg border p-4">
       <h2 className="text-muted mb-3 text-xs font-medium tracking-wide">{label}</h2>

--- a/frontend/src/screens/events/comments/CommentItem.test.tsx
+++ b/frontend/src/screens/events/comments/CommentItem.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
-import React from 'react';
+import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({
@@ -19,7 +19,7 @@ import type { EventComment } from '@/models/eventComment';
 
 import { CommentItem } from './CommentItem';
 
-function wrap(ui: React.ReactNode) {
+function wrap(ui: ReactNode) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(<QueryClientProvider client={qc}>{ui}</QueryClientProvider>);
 }

--- a/frontend/src/screens/events/comments/EventCommentsCard.test.tsx
+++ b/frontend/src/screens/events/comments/EventCommentsCard.test.tsx
@@ -1,6 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
-import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/client', () => ({

--- a/frontend/src/screens/events/form/EventFormPhoto.tsx
+++ b/frontend/src/screens/events/form/EventFormPhoto.tsx
@@ -3,6 +3,7 @@
 // On create the cropped blob is staged and uploaded after the event POST returns
 // an id; on edit it uploads immediately.
 
+import type { ChangeEvent, DragEvent,MouseEvent } from 'react';
 import { useRef, useState } from 'react';
 
 import { extractApiErrorOr } from '@/api/apiErrors';
@@ -66,7 +67,7 @@ export function EventFormPhoto({ photoUrl, photoUpdatedAt, onCrop, onDelete, dis
     setFile(f);
   }
 
-  function onPick(e: React.ChangeEvent<HTMLInputElement>) {
+  function onPick(e: ChangeEvent<HTMLInputElement>) {
     setError(null);
     const f = e.target.files?.[0];
     e.target.value = '';
@@ -75,30 +76,30 @@ export function EventFormPhoto({ photoUrl, photoUpdatedAt, onCrop, onDelete, dis
   }
 
   // Only treat drags carrying files as drop targets — ignore text/HTML drags.
-  function isFileDrag(e: React.DragEvent): boolean {
+  function isFileDrag(e: DragEvent): boolean {
     return Array.from(e.dataTransfer.types).includes('Files');
   }
 
-  function onDragEnter(e: React.DragEvent) {
+  function onDragEnter(e: DragEvent) {
     if (locked || !isFileDrag(e)) return;
     e.preventDefault();
     dragDepthRef.current += 1;
     setDragOver(true);
   }
 
-  function onDragOver(e: React.DragEvent) {
+  function onDragOver(e: DragEvent) {
     if (locked || !isFileDrag(e)) return;
     e.preventDefault();
     e.dataTransfer.dropEffect = 'copy';
   }
 
-  function onDragLeave(e: React.DragEvent) {
+  function onDragLeave(e: DragEvent) {
     if (locked || !isFileDrag(e)) return;
     dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
     if (dragDepthRef.current === 0) setDragOver(false);
   }
 
-  function onDrop(e: React.DragEvent) {
+  function onDrop(e: DragEvent) {
     if (locked || !isFileDrag(e)) return;
     e.preventDefault();
     dragDepthRef.current = 0;
@@ -122,7 +123,7 @@ export function EventFormPhoto({ photoUrl, photoUpdatedAt, onCrop, onDelete, dis
     }
   }
 
-  async function handleDelete(e: React.MouseEvent) {
+  async function handleDelete(e: MouseEvent) {
     e.stopPropagation();
     if (!onDelete || locked) return;
     setBusy(true);

--- a/frontend/src/screens/notifications/NotificationsScreen.test.tsx
+++ b/frontend/src/screens/notifications/NotificationsScreen.test.tsx
@@ -1,6 +1,5 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/frontend/src/screens/public/FaqScreen.test.tsx
+++ b/frontend/src/screens/public/FaqScreen.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
-import React from 'react';
+import type { ReactElement } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -50,7 +50,7 @@ const baseUser: User = {
   roles: [],
 };
 
-function renderWith(component: React.ReactElement) {
+function renderWith(component: ReactElement) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={qc}>

--- a/frontend/src/screens/public/GuidelinesScreen.test.tsx
+++ b/frontend/src/screens/public/GuidelinesScreen.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
-import React from 'react';
+import type { ReactElement } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -50,7 +50,7 @@ const baseUser: User = {
   roles: [],
 };
 
-function renderWith(component: React.ReactElement) {
+function renderWith(component: ReactElement) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={qc}>

--- a/frontend/src/screens/public/HomeScreen.test.tsx
+++ b/frontend/src/screens/public/HomeScreen.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
-import React from 'react';
+import type { ReactElement } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -52,7 +52,7 @@ const baseUser: User = {
   roles: [],
 };
 
-function renderWith(component: React.ReactElement) {
+function renderWith(component: ReactElement) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={qc}>

--- a/frontend/src/screens/public/InstallAppScreen.a11y.test.tsx
+++ b/frontend/src/screens/public/InstallAppScreen.a11y.test.tsx
@@ -1,13 +1,13 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render } from '@testing-library/react';
-import React from 'react';
+import type { ReactElement } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
 import { axe } from 'vitest-axe';
 
 import InstallAppScreen from './InstallAppScreen';
 
-function renderWith(component: React.ReactElement) {
+function renderWith(component: ReactElement) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={qc}>

--- a/frontend/src/screens/public/InstallAppScreen.test.tsx
+++ b/frontend/src/screens/public/InstallAppScreen.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
-import React from 'react';
+import type { ReactElement } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it } from 'vitest';
 
@@ -30,7 +30,7 @@ const baseUser: User = {
   roles: [],
 };
 
-function renderWith(component: React.ReactElement) {
+function renderWith(component: ReactElement) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={qc}>

--- a/frontend/src/screens/public/JoinScreen.a11y.test.tsx
+++ b/frontend/src/screens/public/JoinScreen.a11y.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
-import React from 'react';
+import type { ReactElement } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
@@ -23,7 +23,7 @@ import JoinScreen from './JoinScreen';
 const mockUseJoinQuestions = vi.mocked(useJoinQuestions);
 const mockUseSubmitJoinRequest = vi.mocked(useSubmitJoinRequest);
 
-function renderWith(component: React.ReactElement) {
+function renderWith(component: ReactElement) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={qc}>

--- a/frontend/src/screens/public/JoinScreen.test.tsx
+++ b/frontend/src/screens/public/JoinScreen.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
+import type { ReactElement } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -36,7 +36,7 @@ const defaultSubmitResult = {
   mutateAsync: vi.fn(),
 } as unknown as ReturnType<typeof useSubmitJoinRequest>;
 
-function renderWith(component: React.ReactElement, initialRoute = '/join') {
+function renderWith(component: ReactElement, initialRoute = '/join') {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={qc}>

--- a/frontend/src/screens/public/JoinScreen.tsx
+++ b/frontend/src/screens/public/JoinScreen.tsx
@@ -1,3 +1,4 @@
+import type { SyntheticEvent } from 'react';
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { toast } from 'sonner';
@@ -114,7 +115,7 @@ function JoinForm({ questions }: { questions: readonly JoinQuestion[] }) {
     return Object.keys(next).length === 0;
   }
 
-  async function onSubmit(e: React.SyntheticEvent) {
+  async function onSubmit(e: SyntheticEvent) {
     e.preventDefault();
     setServerError(null);
     if (!validate()) return;

--- a/frontend/src/screens/public/SmsPolicyScreen.tsx
+++ b/frontend/src/screens/public/SmsPolicyScreen.tsx
@@ -4,6 +4,8 @@
 // breaks Twilio's verification process. The automated SMS send path is deferred
 // (see #501), but this policy page stays to back manual group-text consent.
 
+import type { ReactNode } from 'react';
+
 import { ContentContainer } from './ContentContainer';
 
 export default function SmsPolicyScreen() {
@@ -82,7 +84,7 @@ export default function SmsPolicyScreen() {
   );
 }
 
-function Section({ heading, children }: { heading: string; children: React.ReactNode }) {
+function Section({ heading, children }: { heading: string; children: ReactNode }) {
   return (
     <section className="mb-6">
       <h2 className="text-foreground mb-2 text-sm font-medium tracking-wide">{heading}</h2>

--- a/frontend/src/screens/settings/AvatarUpload.tsx
+++ b/frontend/src/screens/settings/AvatarUpload.tsx
@@ -1,3 +1,4 @@
+import type { ChangeEvent } from 'react';
 import { useRef, useState } from 'react';
 
 import { extractApiErrorOr } from '@/api/apiErrors';
@@ -39,7 +40,7 @@ export function AvatarUpload({ size = 'md' }: Props) {
   const cameraSize = size === 'lg' ? 'h-9 w-9' : 'h-8 w-8';
   const cameraIconSize = size === 'lg' ? 'h-5 w-5' : 'h-4 w-4';
 
-  function onPick(e: React.ChangeEvent<HTMLInputElement>) {
+  function onPick(e: ChangeEvent<HTMLInputElement>) {
     setError(null);
     const f = e.target.files?.[0];
     e.target.value = '';

--- a/frontend/src/screens/settings/SettingsScreen.test.tsx
+++ b/frontend/src/screens/settings/SettingsScreen.test.tsx
@@ -25,7 +25,6 @@ const storageMock = vi.hoisted(() => {
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 

--- a/frontend/src/screens/settings/SettingsScreen.tsx
+++ b/frontend/src/screens/settings/SettingsScreen.tsx
@@ -1,3 +1,4 @@
+import type { ReactNode } from 'react';
 import { useState } from 'react';
 
 import { type TextScale, type ThemeMode, useAccessibilityStore } from '@/accessibility/store';
@@ -112,7 +113,7 @@ function BuildInfo() {
   );
 }
 
-function Section({ label, children }: { label: string; children: React.ReactNode }) {
+function Section({ label, children }: { label: string; children: ReactNode }) {
   return (
     <section className="border-border bg-surface mb-6 rounded-lg border p-4">
       <h2 className="text-muted mb-3 text-xs font-medium tracking-wide">{label}</h2>

--- a/frontend/src/screens/surveys/SurveyScreen.tsx
+++ b/frontend/src/screens/surveys/SurveyScreen.tsx
@@ -1,3 +1,4 @@
+import type { SyntheticEvent } from 'react';
 import { useState } from 'react';
 import { useParams } from 'react-router-dom';
 
@@ -54,7 +55,7 @@ function SurveyForm({ survey }: { survey: Survey }) {
     return Object.keys(next).length === 0;
   }
 
-  async function onSubmit(e: React.SyntheticEvent) {
+  async function onSubmit(e: SyntheticEvent) {
     e.preventDefault();
     setServerError(null);
     if (!validate()) return;

--- a/s -ExecutionPolicy RemoteSigned) ; (& cUsersHPDesktopOpen Sourcepda.venvScriptsActivate.ps1)
+++ b/s -ExecutionPolicy RemoteSigned) ; (& cUsersHPDesktopOpen Sourcepda.venvScriptsActivate.ps1)
@@ -1,0 +1,331 @@
+[1mdiff --git a/frontend/src/api/calendar.test.ts b/frontend/src/api/calendar.test.ts[m
+[1mindex 516268a..f1eafd6 100644[m
+[1m--- a/frontend/src/api/calendar.test.ts[m
+[1m+++ b/frontend/src/api/calendar.test.ts[m
+[36m@@ -1,6 +1,7 @@[m
+ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';[m
+ import { renderHook, waitFor } from '@testing-library/react';[m
+[31m-import React from 'react';[m
+[32m+[m[32mimport type { ReactNode } from 'react';[m
+[32m+[m[32mimport { createElement } from 'react';[m
+ import { beforeEach, describe, expect, it, vi } from 'vitest';[m
+ [m
+ vi.mock('@/api/client', () => ({[m
+[36m@@ -21,8 +22,8 @@[m [mfunction makeQc() {[m
+ }[m
+ [m
+ function makeWrapper(qc: QueryClient) {[m
+[31m-  return ({ children }: { children: React.ReactNode }) =>[m
+[31m-    React.createElement(QueryClientProvider, { client: qc }, children);[m
+[32m+[m[32m  return ({ children }: { children: ReactNode }) =>[m
+[32m+[m[32m    createElement(QueryClientProvider, { client: qc }, children);[m
+ }[m
+ [m
+ beforeEach(() => {[m
+[1mdiff --git a/frontend/src/api/content.test.ts b/frontend/src/api/content.test.ts[m
+[1mindex 913e213..62f0cb2 100644[m
+[1m--- a/frontend/src/api/content.test.ts[m
+[1m+++ b/frontend/src/api/content.test.ts[m
+[36m@@ -1,6 +1,7 @@[m
+ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';[m
+ import { renderHook, waitFor } from '@testing-library/react';[m
+[31m-import React from 'react';[m
+[32m+[m[32mimport type { ReactNode } from 'react';[m
+[32m+[m[32mimport { createElement } from 'react';[m
+ import { beforeEach, describe, expect, it, vi } from 'vitest';[m
+ [m
+ vi.mock('@/api/client', () => ({[m
+[36m@@ -23,8 +24,8 @@[m [mconst mockedPatch = vi.mocked(apiClient.patch);[m
+ [m
+ function wrapper() {[m
+   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });[m
+[31m-  return ({ children }: { children: React.ReactNode }) =>[m
+[31m-    React.createElement(QueryClientProvider, { client: qc }, children);[m
+[32m+[m[32m  return ({ children }: { children: ReactNode }) =>[m
+[32m+[m[32m    createElement(QueryClientProvider, { client: qc }, children);[m
+ }[m
+ [m
+ beforeEach(() => {[m
+[1mdiff --git a/frontend/src/api/docs.mutations.test.ts b/frontend/src/api/docs.mutations.test.ts[m
+[1mindex 73c6f82..fe77850 100644[m
+[1m--- a/frontend/src/api/docs.mutations.test.ts[m
+[1m+++ b/frontend/src/api/docs.mutations.test.ts[m
+[36m@@ -1,6 +1,7 @@[m
+ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';[m
+ import { renderHook, waitFor } from '@testing-library/react';[m
+[31m-import React from 'react';[m
+[32m+[m[32mimport type { ReactNode } from 'react';[m
+[32m+[m[32mimport { createElement } from 'react';[m
+ import { beforeEach, describe, expect, it, vi } from 'vitest';[m
+ [m
+ vi.mock('@/api/client', () => ({[m
+[36m@@ -29,8 +30,8 @@[m [mfunction makeQc() {[m
+ }[m
+ [m
+ function makeWrapper(qc: QueryClient) {[m
+[31m-  return ({ children }: { children: React.ReactNode }) =>[m
+[31m-    React.createElement(QueryClientProvider, { client: qc }, children);[m
+[32m+[m[32m  return ({ children }: { children: ReactNode }) =>[m
+[32m+[m[32m    createElement(QueryClientProvider, { client: qc }, children);[m
+ }[m
+ [m
+ beforeEach(() => {[m
+[1mdiff --git a/frontend/src/api/eventComments.test.ts b/frontend/src/api/eventComments.test.ts[m
+[1mindex 7edfc4a..7b47ab5 100644[m
+[1m--- a/frontend/src/api/eventComments.test.ts[m
+[1m+++ b/frontend/src/api/eventComments.test.ts[m
+[36m@@ -1,6 +1,7 @@[m
+ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';[m
+ import { renderHook, waitFor } from '@testing-library/react';[m
+[31m-import React from 'react';[m
+[32m+[m[32mimport type { ReactNode } from 'react';[m
+[32m+[m[32mimport { createElement } from 'react';[m
+ import { beforeEach, describe, expect, it, vi } from 'vitest';[m
+ [m
+ vi.mock('@/api/client', () => ({[m
+[36m@@ -42,8 +43,8 @@[m [mfunction wireCommentList(overrides: Partial<WireCommentList> = {}): WireCommentL[m
+ [m
+ function buildWrapper() {[m
+   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });[m
+[31m-  const Wrapper = ({ children }: { children: React.ReactNode }) =>[m
+[31m-    React.createElement(QueryClientProvider, { client: qc }, children);[m
+[32m+[m[32m  const Wrapper = ({ children }: { children: ReactNode }) =>[m
+[32m+[m[32m    createElement(QueryClientProvider, { client: qc }, children);[m
+   return { qc, Wrapper };[m
+ }[m
+ [m
+[1mdiff --git a/frontend/src/api/eventPolls.test.ts b/frontend/src/api/eventPolls.test.ts[m
+[1mindex e81cf22..b6f1317 100644[m
+[1m--- a/frontend/src/api/eventPolls.test.ts[m
+[1m+++ b/frontend/src/api/eventPolls.test.ts[m
+[36m@@ -1,7 +1,8 @@[m
+ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';[m
+ import { renderHook, waitFor } from '@testing-library/react';[m
+ import type { AxiosError } from 'axios';[m
+[31m-import React from 'react';[m
+[32m+[m[32mimport type { ReactNode } from 'react';[m
+[32m+[m[32mimport { createElement } from 'react';[m
+ import { beforeEach, describe, expect, it, vi } from 'vitest';[m
+ [m
+ vi.mock('@/api/client', () => ({[m
+[36m@@ -75,8 +76,8 @@[m [mfunction wirePoll(overrides: Partial<WireEventPoll> = {}): WireEventPoll {[m
+ [m
+ function buildWrapper() {[m
+   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });[m
+[31m-  const Wrapper = ({ children }: { children: React.ReactNode }) =>[m
+[31m-    React.createElement(QueryClientProvider, { client: qc }, children);[m
+[32m+[m[32m  const Wrapper = ({ children }: { children: ReactNode }) =>[m
+[32m+[m[32m    createElement(QueryClientProvider, { client: qc }, children);[m
+   return { qc, Wrapper };[m
+ }[m
+ [m
+[1mdiff --git a/frontend/src/api/feedback.test.ts b/frontend/src/api/feedback.test.ts[m
+[1mindex c0915dc..2230557 100644[m
+[1m--- a/frontend/src/api/feedback.test.ts[m
+[1m+++ b/frontend/src/api/feedback.test.ts[m
+[36m@@ -1,6 +1,7 @@[m
+ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';[m
+ import { renderHook, waitFor } from '@testing-library/react';[m
+[31m-import React from 'react';[m
+[32m+[m[32mimport type { ReactNode } from 'react';[m
+[32m+[m[32mimport { createElement } from 'react';[m
+ import { beforeEach, describe, expect, it, vi } from 'vitest';[m
+ [m
+ vi.mock('@/api/client', () => ({[m
+[36m@@ -15,8 +16,8 @@[m [mconst mockedPost = vi.mocked(apiClient.post);[m
+ [m
+ function wrapper() {[m
+   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });[m
+[31m-  return ({ children }: { children: React.ReactNode }) =>[m
+[31m-    React.createElement(QueryClientProvider, { client: qc }, children);[m
+[32m+[m[32m  return ({ children }: { children: ReactNode }) =>[m
+[32m+[m[32m    createElement(QueryClientProvider, { client: qc }, children);[m
+ }[m
+ [m
+ beforeEach(() => {[m
+[1mdiff --git a/frontend/src/api/join.test.ts b/frontend/src/api/join.test.ts[m
+[1mindex 8ec3225..e7b54a1 100644[m
+[1m--- a/frontend/src/api/join.test.ts[m
+[1m+++ b/frontend/src/api/join.test.ts[m
+[36m@@ -1,6 +1,7 @@[m
+ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';[m
+ import { renderHook, waitFor } from '@testing-library/react';[m
+[31m-import React from 'react';[m
+[32m+[m[32mimport type { ReactNode } from 'react';[m
+[32m+[m[32mimport { createElement } from 'react';[m
+ import { beforeEach, describe, expect, it, vi } from 'vitest';[m
+ [m
+ vi.mock('@/api/client', () => ({[m
+[36m@@ -24,8 +25,8 @@[m [mfunction makeAxiosError(status: number, data: Record<string, unknown> = {}): Err[m
+ [m
+ function wrapper() {[m
+   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });[m
+[31m-  return ({ children }: { children: React.ReactNode }) =>[m
+[31m-    React.createElement(QueryClientProvider, { client: qc }, children);[m
+[32m+[m[32m  return ({ children }: { children: ReactNode }) =>[m
+[32m+[m[32m    createElement(QueryClientProvider, { client: qc }, children);[m
+ }[m
+ [m
+ beforeEach(() => {[m
+[1mdiff --git a/frontend/src/api/notifications.test.ts b/frontend/src/api/notifications.test.ts[m
+[1mindex 9f5df0b..14b66c1 100644[m
+[1m--- a/frontend/src/api/notifications.test.ts[m
+[1m+++ b/frontend/src/api/notifications.test.ts[m
+[36m@@ -1,6 +1,7 @@[m
+ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';[m
+ import { renderHook, waitFor } from '@testing-library/react';[m
+[31m-import React from 'react';[m
+[32m+[m[32mimport type { ReactNode } from 'react';[m
+[32m+[m[32mimport { createElement } from 'react';[m
+ import { beforeEach, describe, expect, it, vi } from 'vitest';[m
+ [m
+ vi.mock('@/api/client', () => ({[m
+[36m@@ -30,8 +31,8 @@[m [mconst mockedPost = vi.mocked(apiClient.post);[m
+ [m
+ function wrapper() {[m
+   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });[m
+[31m-  return ({ children }: { children: React.ReactNode }) =>[m
+[31m-    React.createElement(QueryClientProvider, { client: qc }, children);[m
+[32m+[m[32m  return ({ children }: { children: ReactNode }) =>[m
+[32m+[m[32m    createElement(QueryClientProvider, { client: qc }, children);[m
+ }[m
+ [m
+ beforeEach(() => {[m
+[1mdiff --git a/frontend/src/api/roles.test.ts b/frontend/src/api/roles.test.ts[m
+[1mindex a3fef5c..e8c38df 100644[m
+[1m--- a/frontend/src/api/roles.test.ts[m
+[1m+++ b/frontend/src/api/roles.test.ts[m
+[36m@@ -1,6 +1,7 @@[m
+ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';[m
+ import { renderHook, waitFor } from '@testing-library/react';[m
+[31m-import React from 'react';[m
+[32m+[m[32mimport type { ReactNode } from 'react';[m
+[32m+[m[32mimport { createElement } from 'react';[m
+ import { beforeEach, describe, expect, it, vi } from 'vitest';[m
+ [m
+ vi.mock('@/api/client', () => ({[m
+[36m@@ -23,8 +24,8 @@[m [mfunction makeQc() {[m
+ }[m
+ [m
+ function makeWrapper(qc: QueryClient) {[m
+[31m-  return ({ children }: { children: React.ReactNode }) =>[m
+[31m-    React.createElement(QueryClientProvider, { client: qc }, children);[m
+[32m+[m[32m  return ({ children }: { children: ReactNode }) =>[m
+[32m+[m[32m    createElement(QueryClientProvider, { client: qc }, children);[m
+ }[m
+ [m
+ beforeEach(() => {[m
+[1mdiff --git a/frontend/src/api/surveyAdmin.tallies.test.ts b/frontend/src/api/surveyAdmin.tallies.test.ts[m
+[1mindex 98a5f91..8bcc305 100644[m
+[1m--- a/frontend/src/api/surveyAdmin.tallies.test.ts[m
+[1m+++ b/frontend/src/api/surveyAdmin.tallies.test.ts[m
+[36m@@ -1,6 +1,7 @@[m
+ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';[m
+ import { renderHook, waitFor } from '@testing-library/react';[m
+[31m-import React from 'react';[m
+[32m+[m[32mimport type { ReactNode } from 'react';[m
+[32m+[m[32mimport { createElement } from 'react';[m
+ import { beforeEach, describe, expect, it, vi } from 'vitest';[m
+ [m
+ vi.mock('@/api/client', () => ({[m
+[36m@@ -21,8 +22,8 @@[m [mfunction makeQc() {[m
+ }[m
+ [m
+ function makeWrapper(qc: QueryClient) {[m
+[31m-  return ({ children }: { children: React.ReactNode }) =>[m
+[31m-    React.createElement(QueryClientProvider, { client: qc }, children);[m
+[32m+[m[32m  return ({ children }: { children: ReactNode }) =>[m
+[32m+[m[32m    createElement(QueryClientProvider, { client: qc }, children);[m
+ }[m
+ [m
+ beforeEach(() => {[m
+[1mdiff --git a/frontend/src/api/users.test.ts b/frontend/src/api/users.test.ts[m
+[1mindex 04e4c7e..0e8db17 100644[m
+[1m--- a/frontend/src/api/users.test.ts[m
+[1m+++ b/frontend/src/api/users.test.ts[m
+[36m@@ -1,6 +1,7 @@[m
+ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';[m
+ import { renderHook, waitFor } from '@testing-library/react';[m
+[31m-import React from 'react';[m
+[32m+[m[32mimport type { ReactNode } from 'react';[m
+[32m+[m[32mimport { createElement } from 'react';[m
+ import { beforeEach, describe, expect, it, vi } from 'vitest';[m
+ [m
+ vi.mock('@/api/client', () => ({[m
+[36m@@ -32,8 +33,8 @@[m [mfunction makeQc() {[m
+ [m
+ // Each hook gets a fresh QueryClient so invalidations are observable in isolation.[m
+ function makeWrapper(qc: QueryClient) {[m
+[31m-  return ({ children }: { children: React.ReactNode }) =>[m
+[31m-    React.createElement(QueryClientProvider, { client: qc }, children);[m
+[32m+[m[32m  return ({ children }: { children: ReactNode }) =>[m
+[32m+[m[32m    createElement(QueryClientProvider, { client: qc }, children);[m
+ }[m
+ [m
+ beforeEach(() => {[m
+[1mdiff --git a/frontend/src/components/FeedbackButton.a11y.test.tsx b/frontend/src/components/FeedbackButton.a11y.test.tsx[m
+[1mindex 25a584f..814d45d 100644[m
+[1m--- a/frontend/src/components/FeedbackButton.a11y.test.tsx[m
+[1m+++ b/frontend/src/components/FeedbackButton.a11y.test.tsx[m
+[36m@@ -1,7 +1,6 @@[m
+ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';[m
+ import { render, screen } from '@testing-library/react';[m
+ import userEvent from '@testing-library/user-event';[m
+[31m-import React from 'react';[m
+ import { MemoryRouter } from 'react-router-dom';[m
+ import { beforeEach, describe, expect, it, vi } from 'vitest';[m
+ import { axe } from 'vitest-axe';[m
+[1mdiff --git a/frontend/src/components/FeedbackButton.tsx b/frontend/src/components/FeedbackButton.tsx[m
+[1mindex 88ddce4..9bb937b 100644[m
+[1m--- a/frontend/src/components/FeedbackButton.tsx[m
+[1m+++ b/frontend/src/components/FeedbackButton.tsx[m
+[36m@@ -5,7 +5,7 @@[m
+ // per .claude/rules/ui-copy-tone.md. maxLength caps match the frontend[m
+ // input-validation guidance (title 150, description 2000) and stay under[m
+ // the backend FieldLimit on FeedbackIn (200 / 10000).[m
+[31m-[m
+[32m+[m[32mimport type { SyntheticEvent } from 'react';[m
+ import { useEffect, useState } from 'react';[m
+ import { useLocation } from 'react-router-dom';[m
+ import { toast } from 'sonner';[m
+[36m@@ -55,7 +55,7 @@[m [mexport function FeedbackButton() {[m
+     setDescriptionError(undefined);[m
+   }[m
+ [m
+[31m-  async function onSubmit(e: React.SyntheticEvent<HTMLFormElement>) {[m
+[32m+[m[32m  async function onSubmit(e: SyntheticEvent<HTMLFormElement>) {[m
+     e.preventDefault();[m
+     const trimmedTitle = title.trim();[m
+     const trimmedDescription = description.trim();[m
+[1mdiff --git a/frontend/src/components/ImageCropDialog.a11y.test.tsx b/frontend/src/components/ImageCropDialog.a11y.test.tsx[m
+[1mindex e3279b3..8b18ba7 100644[m
+[1m--- a/frontend/src/components/ImageCropDialog.a11y.test.tsx[m
+[1m+++ b/frontend/src/components/ImageCropDialog.a11y.test.tsx[m
+[36m@@ -1,10 +1,10 @@[m
+ import { render } from '@testing-library/react';[m
+[31m-import React from 'react';[m
+[32m+[m[32mimport type { ReactNode } from 'react';[m
+ import { beforeEach, describe, expect, it, vi } from 'vitest';[m
+ import { axe } from 'vitest-axe';[m
+ [m
+ vi.mock('react-image-crop', () => ({[m
+[31m-  default: ({ circularCrop, children }: { circularCrop?: boolean; children?: React.ReactNode }) => ([m
+[32m+[m[32m  default: ({ circularCrop, children }: { circularCrop?: boolean; children?: ReactNode }) => ([m
+     <div data-testid="cropper" data-circular={String(Boolean(circularCrop))}>[m
+       {children}[m
+     </div>[m
+[1mdiff --git a/frontend/src/components/ImageCropDialog.test.tsx b/frontend/src/components/ImageCropDialog.test.tsx[m
+[1mindex 59140e0..f8176ef 100644[m
+[1m--- a/frontend/src/components/ImageCropDialog.test.tsx[m
+[1m+++ b/frontend/src/components/ImageCropDialog.test.tsx[m
+[36m@@ -1,6 +1,6 @@[m
+ import { render, screen } from '@testing-library/react';[m
+ import userEvent from '@testing-library/user-event';[m
+[31m-import React from 'react';[m
+[32m+[m[32mimport type { ReactNode } from 'react';[m
+ import { beforeEach, describe, expect, it, vi } from 'vitest';[m
+ [m
+ // react-image-crop uses pointer events + ResizeObserver that jsdom doesn't[m
+[36m@@ -14,7 +14,7 @@[m [mvi.mock('react-image-crop', () => ({[m
+   }: {[m
+     cir


### PR DESCRIPTION
## Summary

This PR modernizes React imports across the frontend by removing legacy `React` namespace usage now that the project uses the modern JSX runtime (`react-jsx`).

## Changes

- Removed unused `import React from 'react'` statements.
- Replaced `React.*` type references with `import type` where appropriate.
- Converted runtime namespace usages (e.g. `React.createElement`) to named imports.
- Left comments and documentation unchanged.

## Validation

- ✅ `pnpm typecheck`
- ✅ `pnpm lint`

This is a refactoring only and does not change application behavior.