### PR TITLE
feat(events): host email-blast to attendees — frontend (Issue 499)

### DIFF
--- a/frontend/src/api/eventBlast.ts
+++ b/frontend/src/api/eventBlast.ts
@@ -1,0 +1,26 @@
+import { useMutation } from '@tanstack/react-query';
+
+import { reportError } from '@/utils/errorReporter';
+
+import { apiClient } from './client';
+import type { components } from './types.gen';
+
+export type EmailBlastIn = components['schemas']['EmailBlastIn'];
+export type EmailBlastResult = components['schemas']['EmailBlastOut'];
+
+const ROUTE = '/events';
+
+export function useEmailBlast(eventId: string) {
+  return useMutation({
+    mutationFn: async (payload: EmailBlastIn): Promise<EmailBlastResult> => {
+      const { data } = await apiClient.post<EmailBlastResult>(
+        `/api/community/events/${eventId}/email-blast/`,
+        payload,
+      );
+      return data;
+    },
+    onError: (err) => {
+      void reportError(err, ROUTE, { action: 'email-blast', eventId });
+    },
+  });
+}

--- a/frontend/src/api/validationCodes.ts
+++ b/frontend/src/api/validationCodes.ts
@@ -119,6 +119,10 @@ function messageForKnownCode(code: KnownCode, err: FieldError): string {
       return 'check-in opens an hour before the event starts';
     case Code.Event.AttendanceOnlyForGoingRsvps:
       return 'attendance can only be marked on going rsvps';
+    case Code.Event.BlastInvalidAudience:
+      return 'that audience choice is not valid';
+    case Code.Event.BlastNoRecipients:
+      return 'no attendees in that audience have an email — nothing to send';
 
     // Poll
     case Code.Poll.NotFound:

--- a/frontend/src/screens/events/EmailBlastDialog.test.tsx
+++ b/frontend/src/screens/events/EmailBlastDialog.test.tsx
@@ -1,0 +1,242 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach,describe, expect, it, vi } from 'vitest';
+
+import type { Event, EventGuest } from '@/models/event';
+import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
+
+const mutateAsyncMock = vi.fn();
+const toastSuccessMock = vi.fn();
+const toastErrorMock = vi.fn();
+
+vi.mock('@/api/eventBlast', () => ({
+  useEmailBlast: () => ({ mutateAsync: mutateAsyncMock, isPending: false }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (m: string) => {
+      toastSuccessMock(m);
+    },
+    error: (m: string) => {
+      toastErrorMock(m);
+    },
+  },
+}));
+
+import { EmailBlastDialog } from './EmailBlastDialog';
+
+function guest(status: string, i: number): EventGuest {
+  return {
+    userId: `u${String(i)}`,
+    name: `Guest ${String(i)}`,
+    status,
+    phone: null,
+    photoUrl: '',
+    hasPlusOne: false,
+    attendance: 'unknown',
+  };
+}
+
+function makeEvent(guests: EventGuest[]): Event {
+  return {
+    id: 'ev1',
+    title: 'Potluck',
+    description: '',
+    startDatetime: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+    endDatetime: null,
+    location: '',
+    latitude: null,
+    longitude: null,
+    whatsappLink: '',
+    partifulLink: '',
+    otherLink: '',
+    venmoLink: '',
+    cashappLink: '',
+    zelleInfo: '',
+    price: '',
+    rsvpEnabled: true,
+    allowPlusOnes: false,
+    maxAttendees: null,
+    attendingCount: guests.filter((g) => g.status === 'attending').length,
+    waitlistedCount: 0,
+    invitedCount: 0,
+    datetimeTbd: false,
+    hasPoll: false,
+    datetimePollSlug: null,
+    createdById: 'creator',
+    createdByName: 'Creator',
+    createdByPhotoUrl: '',
+    coHostIds: [],
+    coHostNames: [],
+    coHostPhotoUrls: [],
+    coHostInviteIds: [],
+    guests,
+    myRsvp: null,
+    surveySlugs: [],
+    invitedUserIds: [],
+    invitedUserNames: [],
+    invitedUserPhotoUrls: [],
+    invitePermission: InvitePermission.CoHostsOnly,
+    pendingCohostInvites: [],
+    myPendingCohostInviteId: null,
+    eventType: EventType.Community,
+    visibility: EventVisibility.Public,
+    photoUrl: '',
+    isPast: false,
+    status: EventStatus.Active,
+    tags: [],
+  };
+}
+
+function renderDialog(event: Event) {
+  const onClose = vi.fn();
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const utils = render(
+    <QueryClientProvider client={qc}>
+      <EmailBlastDialog event={event} open onClose={onClose} />
+    </QueryClientProvider>,
+  );
+  return { ...utils, onClose };
+}
+
+const THREE_GUESTS = [guest('attending', 1), guest('maybe', 2), guest('cant_go', 3)];
+
+beforeEach(() => {
+  mutateAsyncMock.mockReset();
+  toastSuccessMock.mockReset();
+  toastErrorMock.mockReset();
+});
+
+describe('EmailBlastDialog', () => {
+  it('previews the recipient count for the default everyone audience', () => {
+    renderDialog(makeEvent(THREE_GUESTS));
+    expect(screen.getByText(/emailing 3 attendees/i)).toBeInTheDocument();
+  });
+
+  it('updates the recipient count when narrowing the audience to going only', async () => {
+    renderDialog(makeEvent(THREE_GUESTS));
+    await userEvent.selectOptions(screen.getByLabelText('send to'), 'going');
+    expect(screen.getByText(/emailing 1 attendee\b/i)).toBeInTheDocument();
+  });
+
+  it('requires a subject before moving to confirm', async () => {
+    renderDialog(makeEvent(THREE_GUESTS));
+    await userEvent.type(screen.getByLabelText('message'), 'hello');
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+    expect(screen.getByRole('alert')).toHaveTextContent(/add a subject/i);
+    expect(mutateAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it('requires a message before moving to confirm', async () => {
+    renderDialog(makeEvent(THREE_GUESTS));
+    await userEvent.type(screen.getByLabelText('subject'), 'hi');
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+    expect(screen.getByRole('alert')).toHaveTextContent(/add a message/i);
+    expect(mutateAsyncMock).not.toHaveBeenCalled();
+  });
+
+  it('requires a confirmation step before sending', async () => {
+    mutateAsyncMock.mockResolvedValue({
+      sent_count: 3,
+      skipped_no_email_count: 0,
+      failed_count: 0,
+    });
+    renderDialog(makeEvent(THREE_GUESTS));
+    await userEvent.type(screen.getByLabelText('subject'), 'schedule update');
+    await userEvent.type(screen.getByLabelText('message'), 'we moved to 6pm');
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+    expect(mutateAsyncMock).not.toHaveBeenCalled();
+    expect(screen.getByText(/can't be undone/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    await waitFor(() => {
+      expect(mutateAsyncMock).toHaveBeenCalledWith({
+        subject: 'schedule update',
+        message: 'we moved to 6pm',
+      });
+    });
+  });
+
+  it('sends the chosen audience statuses when narrowed', async () => {
+    mutateAsyncMock.mockResolvedValue({
+      sent_count: 1,
+      skipped_no_email_count: 0,
+      failed_count: 0,
+    });
+    renderDialog(makeEvent(THREE_GUESTS));
+    await userEvent.type(screen.getByLabelText('subject'), 'hi');
+    await userEvent.type(screen.getByLabelText('message'), 'going folks only');
+    await userEvent.selectOptions(screen.getByLabelText('send to'), 'going');
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+    await userEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    await waitFor(() => {
+      expect(mutateAsyncMock).toHaveBeenCalledWith({
+        subject: 'hi',
+        message: 'going folks only',
+        audience: ['attending'],
+      });
+    });
+  });
+
+  it('treats waitlisted as its own audience separate from going', async () => {
+    mutateAsyncMock.mockResolvedValue({
+      sent_count: 1,
+      skipped_no_email_count: 0,
+      failed_count: 0,
+    });
+    renderDialog(makeEvent([...THREE_GUESTS, guest('waitlisted', 4)]));
+    await userEvent.type(screen.getByLabelText('subject'), 'hi');
+    await userEvent.type(screen.getByLabelText('message'), 'waitlist only');
+    await userEvent.selectOptions(screen.getByLabelText('send to'), 'waitlisted');
+    expect(screen.getByText(/emailing 1 attendee\b/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+    await userEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    await waitFor(() => {
+      expect(mutateAsyncMock).toHaveBeenCalledWith({
+        subject: 'hi',
+        message: 'waitlist only',
+        audience: ['waitlisted'],
+      });
+    });
+  });
+
+  it("targets the can't-go audience", async () => {
+    mutateAsyncMock.mockResolvedValue({
+      sent_count: 1,
+      skipped_no_email_count: 0,
+      failed_count: 0,
+    });
+    renderDialog(makeEvent(THREE_GUESTS));
+    await userEvent.type(screen.getByLabelText('subject'), 'hi');
+    await userEvent.type(screen.getByLabelText('message'), 'sorry you missed it');
+    await userEvent.selectOptions(screen.getByLabelText('send to'), 'cant_go');
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+    await userEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    await waitFor(() => {
+      expect(mutateAsyncMock).toHaveBeenCalledWith({
+        subject: 'hi',
+        message: 'sorry you missed it',
+        audience: ['cant_go'],
+      });
+    });
+  });
+
+  it('shows a success toast with sent and skipped counts', async () => {
+    mutateAsyncMock.mockResolvedValue({
+      sent_count: 2,
+      skipped_no_email_count: 1,
+      failed_count: 0,
+    });
+    const { onClose } = renderDialog(makeEvent(THREE_GUESTS));
+    await userEvent.type(screen.getByLabelText('subject'), 'hi');
+    await userEvent.type(screen.getByLabelText('message'), 'body');
+    await userEvent.click(screen.getByRole('button', { name: /next/i }));
+    await userEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    await waitFor(() => {
+      expect(toastSuccessMock).toHaveBeenCalledWith(expect.stringContaining('sent to 2 attendees'));
+    });
+    expect(toastSuccessMock).toHaveBeenCalledWith(expect.stringContaining('1 skipped (no email)'));
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/frontend/src/screens/events/EmailBlastDialog.tsx
+++ b/frontend/src/screens/events/EmailBlastDialog.tsx
@@ -1,0 +1,197 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+import { extractApiErrorOr } from '@/api/apiErrors';
+import { useEmailBlast } from '@/api/eventBlast';
+import { Button } from '@/components/ui/Button';
+import { Dialog } from '@/components/ui/Dialog';
+import { Select } from '@/components/ui/Select';
+import { TextField } from '@/components/ui/TextField';
+import { type Event,RsvpServerStatus } from '@/models/event';
+
+interface Props {
+  event: Event;
+  open: boolean;
+  onClose: () => void;
+}
+
+const SUBJECT_MAX = 150;
+const MESSAGE_MAX = 5000;
+
+const AUDIENCE_EVERYONE = 'everyone';
+const AUDIENCE_GOING = 'going';
+const AUDIENCE_WAITLISTED = 'waitlisted';
+const AUDIENCE_MAYBE = 'maybe';
+const AUDIENCE_CANT_GO = 'cant_go';
+
+const AUDIENCE_OPTIONS = [
+  { value: AUDIENCE_EVERYONE, label: "everyone who rsvp'd" },
+  { value: AUDIENCE_GOING, label: 'going' },
+  { value: AUDIENCE_WAITLISTED, label: 'waitlisted' },
+  { value: AUDIENCE_MAYBE, label: 'maybe' },
+  { value: AUDIENCE_CANT_GO, label: "can't go" },
+];
+
+function statusesForAudience(audience: string): string[] | null {
+  if (audience === AUDIENCE_GOING) return [RsvpServerStatus.Attending];
+  if (audience === AUDIENCE_WAITLISTED) return [RsvpServerStatus.Waitlisted];
+  if (audience === AUDIENCE_MAYBE) return [RsvpServerStatus.Maybe];
+  if (audience === AUDIENCE_CANT_GO) return [RsvpServerStatus.CantGo];
+  return null;
+}
+
+function recipientCount(event: Event, audience: string): number {
+  const statuses = statusesForAudience(audience);
+  if (statuses === null) return event.guests.length;
+  const allowed = new Set(statuses);
+  return event.guests.filter((g) => allowed.has(g.status)).length;
+}
+
+export function EmailBlastDialog({ event, open, onClose }: Props) {
+  const blast = useEmailBlast(event.id);
+  const [subject, setSubject] = useState('');
+  const [message, setMessage] = useState('');
+  const [audience, setAudience] = useState(AUDIENCE_EVERYONE);
+  const [confirming, setConfirming] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const count = recipientCount(event, audience);
+
+  function reset() {
+    setSubject('');
+    setMessage('');
+    setAudience(AUDIENCE_EVERYONE);
+    setConfirming(false);
+    setError(null);
+  }
+
+  function handleClose() {
+    if (blast.isPending) return;
+    reset();
+    onClose();
+  }
+
+  function goToConfirm() {
+    setError(null);
+    if (!subject.trim()) {
+      setError('add a subject');
+      return;
+    }
+    if (!message.trim()) {
+      setError('add a message');
+      return;
+    }
+    setConfirming(true);
+  }
+
+  async function send() {
+    setError(null);
+    const statuses = statusesForAudience(audience);
+    try {
+      const result = await blast.mutateAsync({
+        subject: subject.trim(),
+        message: message.trim(),
+        ...(statuses ? { audience: statuses } : {}),
+      });
+      const skipped =
+        result.skipped_no_email_count > 0
+          ? `, ${String(result.skipped_no_email_count)} skipped (no email)`
+          : '';
+      const noun = result.sent_count === 1 ? 'attendee' : 'attendees';
+      toast.success(`sent to ${String(result.sent_count)} ${noun}${skipped} 🌱`);
+      reset();
+      onClose();
+    } catch (err) {
+      setError(extractApiErrorOr(err, "couldn't send — try again"));
+    }
+  }
+
+  if (confirming) {
+    return (
+      <Dialog open={open} onClose={handleClose} title="send email blast?">
+        <p className="text-foreground-secondary text-sm">
+          email <strong>{count}</strong> {count === 1 ? 'attendee' : 'attendees'}? this can't be
+          undone — anyone without an email on file will be skipped.
+        </p>
+        {error ? (
+          <p role="alert" className="mt-3 text-sm text-red-600">
+            {error}
+          </p>
+        ) : null}
+        <div className="mt-4 flex justify-end gap-2">
+          <Button
+            variant="ghost"
+            onClick={() => {
+              setConfirming(false);
+            }}
+            disabled={blast.isPending}
+          >
+            back
+          </Button>
+          <Button
+            onClick={() => {
+              void send();
+            }}
+            disabled={blast.isPending}
+          >
+            {blast.isPending ? 'sending…' : 'send'}
+          </Button>
+        </div>
+      </Dialog>
+    );
+  }
+
+  return (
+    <Dialog open={open} onClose={handleClose} title="email attendees">
+      <div className="flex flex-col gap-3">
+        <TextField
+          label="subject"
+          value={subject}
+          maxLength={SUBJECT_MAX}
+          onChange={(e) => {
+            setSubject(e.target.value);
+          }}
+        />
+        <div className="flex flex-col gap-1">
+          <label htmlFor="blast-message" className="text-foreground text-sm font-medium">
+            message
+          </label>
+          <textarea
+            id="blast-message"
+            value={message}
+            maxLength={MESSAGE_MAX}
+            onChange={(e) => {
+              setMessage(e.target.value);
+            }}
+            className="border-border-strong bg-surface focus:ring-brand-200 focus:border-brand-500 h-32 w-full rounded-md border px-3 py-2 text-sm transition-colors outline-none focus:ring-2"
+          />
+        </div>
+        <Select
+          label="send to"
+          options={AUDIENCE_OPTIONS}
+          value={audience}
+          onChange={(e) => {
+            setAudience(e.target.value);
+          }}
+        />
+        <p className="text-muted text-xs">
+          emailing {count} {count === 1 ? 'attendee' : 'attendees'} — anyone without an email is
+          skipped
+        </p>
+      </div>
+      {error ? (
+        <p role="alert" className="mt-3 text-sm text-red-600">
+          {error}
+        </p>
+      ) : null}
+      <div className="mt-4 flex justify-end gap-2">
+        <Button variant="ghost" onClick={handleClose}>
+          cancel
+        </Button>
+        <Button onClick={goToConfirm} disabled={count === 0}>
+          next
+        </Button>
+      </div>
+    </Dialog>
+  );
+}

--- a/frontend/src/screens/events/EventAdminActions.test.tsx
+++ b/frontend/src/screens/events/EventAdminActions.test.tsx
@@ -15,6 +15,12 @@ vi.mock('@/api/eventWrites', () => ({
   useDeleteEvent: vi.fn().mockReturnValue({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
+vi.mock('@/api/eventBlast', () => ({
+  useEmailBlast: vi.fn().mockReturnValue({ mutateAsync: vi.fn(), isPending: false }),
+}));
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
 import { EventAdminActions } from './EventAdminActions';
 
 const CREATOR_ID = 'creator-user';
@@ -127,6 +133,61 @@ describe('EventAdminActions', () => {
   });
 
   // With no one RSVP'd, skip the cancel-then-delete two-step: show delete outright.
+  it('host sees email-attendees button when the event has rsvps', () => {
+    const creator = makeUser(CREATOR_ID);
+    useAuthStore.setState({ status: 'authed', user: creator, accessToken: 'tok' });
+
+    const withGuests: Event = {
+      ...BASE_EVENT,
+      guests: [
+        {
+          userId: 'g1',
+          name: 'Guest',
+          status: 'attending',
+          phone: null,
+          photoUrl: '',
+          hasPlusOne: false,
+          attendance: 'unknown',
+        },
+      ],
+    };
+    renderActions(withGuests);
+
+    expect(screen.getByRole('button', { name: /email attendees/i })).toBeInTheDocument();
+  });
+
+  it('hides email-attendees button when no one has rsvpd', () => {
+    const creator = makeUser(CREATOR_ID);
+    useAuthStore.setState({ status: 'authed', user: creator, accessToken: 'tok' });
+
+    renderActions(BASE_EVENT); // guests: []
+
+    expect(screen.queryByRole('button', { name: /email attendees/i })).not.toBeInTheDocument();
+  });
+
+  it('hides all admin actions (incl. email attendees) from a non-host member', () => {
+    const regular = makeUser(REGULAR_ID);
+    useAuthStore.setState({ status: 'authed', user: regular, accessToken: 'tok' });
+
+    const withGuests: Event = {
+      ...BASE_EVENT,
+      guests: [
+        {
+          userId: 'g1',
+          name: 'Guest',
+          status: 'attending',
+          phone: null,
+          photoUrl: '',
+          hasPlusOne: false,
+          attendance: 'unknown',
+        },
+      ],
+    };
+    renderActions(withGuests);
+
+    expect(screen.queryByRole('button', { name: /email attendees/i })).not.toBeInTheDocument();
+  });
+
   it('creator sees delete (no cancel) for active upcoming event with no attendees', () => {
     const creator = makeUser(CREATOR_ID);
     useAuthStore.setState({ status: 'authed', user: creator, accessToken: 'tok' });

--- a/frontend/src/screens/events/EventAdminActions.tsx
+++ b/frontend/src/screens/events/EventAdminActions.tsx
@@ -13,6 +13,8 @@ import type { Event } from '@/models/event';
 import { EventStatus } from '@/models/event';
 import { hasPermission, Permission } from '@/models/permissions';
 
+import { EmailBlastDialog } from './EmailBlastDialog';
+
 interface Props {
   event: Event;
 }
@@ -44,6 +46,7 @@ function AdminActionRow({
   const [cancelError, setCancelError] = useState<string | null>(null);
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [blastOpen, setBlastOpen] = useState(false);
 
   const update = useUpdateEvent(event.id);
   const cancelMut = useCancelEvent(event.id);
@@ -53,6 +56,7 @@ function AdminActionRow({
   const isCancelled = event.status === EventStatus.Cancelled;
   const isDraft = event.status === EventStatus.Draft;
   const hasNoAttendees = event.attendingCount === 0;
+  const canEmailAttendees = !isDraft && event.guests.length > 0;
   const canDelete = (isCreator || canManage) && (isDraft || isCancelled || hasNoAttendees);
   const showCancel = !isCancelled && !isDraft && !hasNoAttendees;
   // Drafts are always editable — the edit-window cutoff protects the
@@ -104,6 +108,16 @@ function AdminActionRow({
             disabled={update.isPending}
           >
             {update.isPending ? 'publishing…' : 'publish'}
+          </Button>
+        ) : null}
+        {canEmailAttendees ? (
+          <Button
+            variant="secondary"
+            onClick={() => {
+              setBlastOpen(true);
+            }}
+          >
+            email attendees
           </Button>
         ) : null}
         {showCancel ? (
@@ -171,6 +185,14 @@ function AdminActionRow({
           </Button>
         </div>
       </Dialog>
+
+      <EmailBlastDialog
+        event={event}
+        open={blastOpen}
+        onClose={() => {
+          setBlastOpen(false);
+        }}
+      />
 
       <Dialog
         open={deleteOpen}


### PR DESCRIPTION
Part 2 of 2 — frontend for the host email-blast feature (Issue 499). Splits #533.

## ⚠️ Stacked PR
This PR is **stacked on #622** (backend). Its base is `feat-499-email-blast-backend`, so the diff shows **frontend only**. **Merge #622 first**, then this PR's base auto-retargets to `main` (or retarget manually before review).

## Frontend
- `useEmailBlast` hook calling `POST /events/{id}/email-blast/`.
- Two-step `EmailBlastDialog` (compose → confirm) with audience selector and recipient-count preview ("emailing N, M have no email and will be skipped"). All copy lowercase.
- Wired into `EventAdminActions` as a host/co-host-only action.
- Regenerated `types.gen.ts` + validation codes for the new endpoint.

## Verification
- **622 passed**, lint + typecheck green (`make agent-frontend-*`).

## Notes
Rebased on latest `main` — added `Event.tags` to the dialog test's event mock (new required field from #491) and applied `simple-import-sort` autofix (rule added on `main` after this branch was cut).
