### PR TITLE
fix(join-requests): clarify approved-tab subheading (Issue 437)

### DIFF
--- a/frontend/src/screens/admin/JoinRequestsScreen.tsx
+++ b/frontend/src/screens/admin/JoinRequestsScreen.tsx
@@ -143,8 +143,8 @@ export default function JoinRequestsScreen() {
 
       {filter === Filter.APPROVED ? (
         <p className="text-muted mb-3 text-xs">
-          approved members stay here for 3 days after their first login — then they drop off the
-          list automatically
+          approved members show here until 3 days after their first login — this tab clears them out
+          automatically once they're settled in
         </p>
       ) : null}
 


### PR DESCRIPTION
## Overview

Closes #437.

The join-requests approved-tab subheading read like a caption for the whole
list, so the reporter thought it was inaccurate ("I think it's just a list of
everyone who filled out the join form"). In fact it only renders under the
**approved** filter, and the behavior it describes is correct — approved members
stay visible for `APPROVED_GRACE_DAYS` (3) after onboarding, then the backend
hides them.

## Change

Reworded the subheading to make clear it's scoped to *this tab*, not the whole
screen. Copy-only; no behavior change.

- before: `approved members stay here for 3 days after their first login — then they drop off the list automatically`
- after: `approved members show here until 3 days after their first login — this tab clears them out automatically once they're settled in`

## Verification

`make agent-frontend-{test,lint,typecheck}` all green (623 tests pass). No test
asserted on the old string.
