### PR TITLE
fix(auth): land fresh logins on calendar, not the member directory (Issue 479)

### DIFF
--- a/frontend/src/screens/auth/redirect.test.ts
+++ b/frontend/src/screens/auth/redirect.test.ts
@@ -47,8 +47,6 @@ describe('safeRedirect', () => {
     expect(safeRedirect('%E0%A4%A')).toBe(DEFAULT);
   });
 
-  // Issue 479: /members is a low-value bounce target — a fresh login should
-  // land on the calendar rather than the member directory.
   it('does not preserve /members or its subpaths', () => {
     expect(safeRedirect('/members')).toBe(DEFAULT);
     expect(safeRedirect('/members/abc123')).toBe(DEFAULT);

--- a/frontend/src/screens/auth/redirect.test.ts
+++ b/frontend/src/screens/auth/redirect.test.ts
@@ -46,4 +46,17 @@ describe('safeRedirect', () => {
     expect(safeRedirect('%')).toBe(DEFAULT);
     expect(safeRedirect('%E0%A4%A')).toBe(DEFAULT);
   });
+
+  // Issue 479: /members is a low-value bounce target — a fresh login should
+  // land on the calendar rather than the member directory.
+  it('does not preserve /members or its subpaths', () => {
+    expect(safeRedirect('/members')).toBe(DEFAULT);
+    expect(safeRedirect('/members/abc123')).toBe(DEFAULT);
+    expect(safeRedirect('/members?tab=all')).toBe(DEFAULT);
+    expect(safeRedirect(encodeURIComponent('/members/abc123'))).toBe(DEFAULT);
+  });
+
+  it('still preserves /admin/members (a different route)', () => {
+    expect(safeRedirect('/admin/members')).toBe('/admin/members');
+  });
 });

--- a/frontend/src/screens/auth/redirect.ts
+++ b/frontend/src/screens/auth/redirect.ts
@@ -4,6 +4,16 @@
 
 export const DEFAULT_POST_LOGIN_ROUTE = '/calendar';
 
+// The member directory is a low-value landing spot after login — bouncing an
+// expired session back onto it (via RequireAuth's ?redirect=) surprised users
+// who expected the calendar. Treat /members (and its subpaths) as non-preserved
+// so those land on the default route instead. Note: /admin/members is a
+// different route and stays preservable. (Issue 479)
+function isNonPreservedTarget(path: string): boolean {
+  const pathname = path.split(/[?#]/, 1)[0] ?? path;
+  return pathname === '/members' || pathname.startsWith('/members/');
+}
+
 // Only allow relative in-app paths. Reject anything that could leave the app —
 // absolute URLs (`http://evil.com`), scheme-relative URLs (`//evil.com`),
 // backslash tricks (`/\evil.com`), or paths that don't start with a single
@@ -20,5 +30,6 @@ export function safeRedirect(raw: string | null): string {
     decoded.startsWith('/') && !decoded.startsWith('//') && !decoded.includes('://');
   // Normalize backslashes — some browsers treat `/\` like `//`.
   if (!isRelativePath || decoded.startsWith('/\\')) return DEFAULT_POST_LOGIN_ROUTE;
+  if (isNonPreservedTarget(decoded)) return DEFAULT_POST_LOGIN_ROUTE;
   return decoded;
 }

--- a/frontend/src/screens/auth/redirect.ts
+++ b/frontend/src/screens/auth/redirect.ts
@@ -4,11 +4,6 @@
 
 export const DEFAULT_POST_LOGIN_ROUTE = '/calendar';
 
-// The member directory is a low-value landing spot after login — bouncing an
-// expired session back onto it (via RequireAuth's ?redirect=) surprised users
-// who expected the calendar. Treat /members (and its subpaths) as non-preserved
-// so those land on the default route instead. Note: /admin/members is a
-// different route and stays preservable. (Issue 479)
 function isNonPreservedTarget(path: string): boolean {
   const pathname = path.split(/[?#]/, 1)[0] ?? path;
   return pathname === '/members' || pathname.startsWith('/members/');


### PR DESCRIPTION
## Overview

Closes #479.

The report was "login redirects to members, should redirect to calendar". The
default post-login route is already `/calendar` (and always has been in git
history). The user landed on `/members` via **deep-link preservation**: their
session expired while on `/members`, `RequireAuth` bounced them to
`/login?redirect=/members`, and after re-auth `safeRedirect` correctly returned
them there. To the user that read as "login sent me to members".

## Change

Per the chosen approach — land *fresh* logins on the calendar without breaking
genuine deep-links — `safeRedirect` now treats `/members` and its subpaths as a
non-preserved redirect target, falling back to `/calendar`. Deep-links to
events/RSVP still preserve, and `/admin/members` (a different route) stays
preservable.

- `frontend/src/screens/auth/redirect.ts` — add `isNonPreservedTarget()` check
- `frontend/src/screens/auth/redirect.test.ts` — cover `/members`, subpaths,
  query strings, and the `/admin/members` non-regression

## Verification

`make agent-frontend-{test,lint,typecheck}` all green (625 tests pass, 10 in
redirect.test.ts).
