### PR TITLE
fix(events): refresh group-text recipients after inviting a member (Issue 612)

### DIFF
--- a/frontend/src/api/eventWrites.test.ts
+++ b/frontend/src/api/eventWrites.test.ts
@@ -1,6 +1,10 @@
 // Pure-helper tests for the event write layer: enum-coercion on the inbound
 // side (eventToFormValues) and per-field PATCH body building (toPartialWireBody).
-import { describe, expect, it } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   type Event,
@@ -10,7 +14,22 @@ import {
   InvitePermission,
 } from '@/models/event';
 
-import { eventToFormValues, toPartialWireBody } from './eventWrites';
+vi.mock('@/api/client', () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+
+vi.mock('@/auth/store', () => {
+  const state = { status: 'authed', user: { id: 'u-me' } };
+  const useAuthStore = vi.fn((selector?: (s: typeof state) => unknown) =>
+    selector ? selector(state) : state,
+  );
+  return { useAuthStore };
+});
+
+import { apiClient } from '@/api/client';
+
+import { eventToFormValues, toPartialWireBody, useInviteToEvent } from './eventWrites';
+import { textRecipientsKeys } from './textRecipients';
 
 function makeEvent(overrides: Partial<Event> = {}): Event {
   return {
@@ -153,5 +172,36 @@ describe('toPartialWireBody', () => {
   it('maps tagIds to tag_ids, including an empty list (clears tags)', () => {
     expect(toPartialWireBody({ tagIds: ['t1', 't2'] })).toEqual({ tag_ids: ['t1', 't2'] });
     expect(toPartialWireBody({ tagIds: [] })).toEqual({ tag_ids: [] });
+  });
+});
+
+describe('useInviteToEvent', () => {
+  const EVENT_ID = '11111111-1111-1111-1111-111111111111';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function buildWrapper() {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const Wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: qc }, children);
+    return { qc, Wrapper };
+  }
+
+  it('invalidates the text-recipients query so the group-text count refreshes (issue 612)', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({ data: { id: EVENT_ID } });
+    const { qc, Wrapper } = buildWrapper();
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+
+    const { result } = renderHook(() => useInviteToEvent(EVENT_ID), { wrapper: Wrapper });
+    result.current.mutate(['user-a']);
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: textRecipientsKeys.detail(EVENT_ID),
+    });
   });
 });

--- a/frontend/src/api/eventWrites.ts
+++ b/frontend/src/api/eventWrites.ts
@@ -21,6 +21,7 @@ import { extractApiErrorOr, getApiStatus } from './apiErrors';
 import { apiClient } from './client';
 import { mapEvent, type WireEvent } from './eventMapper';
 import { eventKeys } from './events';
+import { textRecipientsKeys } from './textRecipients';
 
 const ROUTE = '/events';
 
@@ -197,6 +198,7 @@ export function useInviteToEvent(eventId: string) {
     onSuccess: (event) => {
       qc.setQueryData(eventKeys.detail(event.id, isAuthed), event);
       void qc.invalidateQueries({ queryKey: eventKeys.list(isAuthed) });
+      void qc.invalidateQueries({ queryKey: textRecipientsKeys.detail(event.id) });
     },
     onError: (err) => {
       void reportError(err, ROUTE, { action: 'invite-to-event', eventId });


### PR DESCRIPTION
## Overview

Fixes #612 — after inviting a member to an event, opening "group text" showed a stale invited count that didn't include the just-invited person.

## Root cause

`GroupTextDialog` reads its recipient buckets (`invited`, `attending`, `maybe`, `cantGo`, `waitlisted`) from the `text-recipients` query (`textRecipientsKeys.detail(eventId)`). But `useInviteToEvent`'s `onSuccess` only invalidated the event **detail** and **list** queries — never `text-recipients`. So React Query served the pre-invite cached recipients and the count stayed stale.

## Fix

Invalidate `textRecipientsKeys.detail(event.id)` on invite success so the dialog refetches:

```ts
onSuccess: (event) => {
  qc.setQueryData(eventKeys.detail(event.id, isAuthed), event);
  void qc.invalidateQueries({ queryKey: eventKeys.list(isAuthed) });
  void qc.invalidateQueries({ queryKey: textRecipientsKeys.detail(event.id) });
},
```

## Tests

- New hook test in `eventWrites.test.ts`: renders `useInviteToEvent`, runs the mutation, asserts `invalidateQueries` is called with the `text-recipients` key. Verified it **fails without the fix**.
- Full frontend suite green: `626 passed / 1 skipped`, typecheck + eslint + prettier clean.

## Note (out of scope, flagged separately)

`text-recipients` also contains RSVP-status buckets (`attending`/`maybe`/`cantGo`/`waitlisted`). RSVP-changing mutations (in the rsvp layer, not `eventWrites.ts`) don't invalidate this key either, so the group-text count can also go stale after an RSVP change. That's a related but distinct staleness class — worth a follow-up rather than expanding this PR's scope.
