### PR TITLE
docs: relax full-CI gate from per-commit to pre-PR

### DIFF
--- a/.claude/skills/commit/SKILL.md
+++ b/.claude/skills/commit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: commit
-description: Stage and commit changes using conventional commits. Run `make agent-ci` first, then create a properly formatted commit. Use when the user asks to commit, save, or check in changes.
+description: Stage and commit changes using conventional commits. Run cheap local checks first (full CI is a pre-PR gate, not per-commit — GitHub re-runs it on every push), then create a properly formatted commit. Use when the user asks to commit, save, or check in changes.
 ---
 
 # commit
@@ -9,7 +9,7 @@ Stage and create a commit using **conventional commits** format.
 
 ## Steps
 
-1. **Run CI first**: `make agent-ci`. If it fails, surface the errors and stop — do not commit.
+1. **Run cheap checks first**: typecheck + the tests you touched (e.g. `make agent-typecheck`, `make agent-frontend-typecheck`, `make agent-test-since`). If they fail, surface the errors and stop — do not commit. The full `make agent-ci` suite is a **pre-PR gate**, not a per-commit one: GitHub re-runs CI on every push, so run the umbrella once before the PR is review-ready (see `.claude/skills/open-pr`), not on every commit.
 2. **Inspect state** in parallel:
    - `git status` (no `-uall`)
    - `git diff` (staged + unstaged)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,7 @@ Routes: see `.claude/docs/routes.md`
 
 ## Standards
 
-**Agents:** Run **`make agent-ci`** (or matching `make agent-*` step) before claiming work complete or committing.
+**Agents:** Run the full **`make agent-ci`** suite once as a **pre-PR gate** — before opening/updating a PR or claiming work complete — not on every commit (GitHub re-runs CI on every push). While iterating, run the cheap `make agent-*` steps for what you touched (typecheck + relevant tests).
 
 References: `~/.claude/rules/standards-django-ninja.md`
 


### PR DESCRIPTION
## Overview

GitHub re-runs CI on every push, so running the full `make agent-ci` suite on every commit is redundant. This reframes it as a pre-PR gate (already enforced by the `open-pr` skill) and has the `commit` skill run only cheap local checks (typecheck + touched tests) while iterating.

- `.claude/skills/commit/SKILL.md` — step 1 now runs cheap checks; full CI reframed as a pre-PR gate
- `CLAUDE.md` — "Standards → Agents" line updated to match

## Test plan

- [ ] N/A — documentation/config only
