### PR TITLE
fix(nginx): raise client_max_body_size so photo uploads work (Issue 655)

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -5,6 +5,9 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # 10 MB app cap (_MAX_EVENT_PHOTO_SIZE) + multipart overhead; else nginx's 1 MB default 413s phone photos (Issue 655).
+    client_max_body_size 12m;
+
     gzip on;
     gzip_types text/plain text/css application/javascript application/json image/svg+xml;
     gzip_min_length 1024;


### PR DESCRIPTION
## Summary

Closes #655 (and the root cause behind the #613 / #610 photo-upload cluster).

Event photos were silently failing to upload on staging. A normal phone photo returned **413 Content Too Large** — but from **nginx**, not Django:

```
POST /api/community/events/<id>/photo/ → 413 (Content Too Large)
```

`nginx.conf.template` sets no `client_max_body_size`, so nginx applied its **1 MB default** and rejected any photo over 1 MB *before it reached Django/uvicorn*. Because the request never hit the app, `event.photo` was never persisted, and the photo silently vanished from the event detail and edit pages — looking exactly like an upload that "didn't work."

The app itself already permits **10 MB** (`_MAX_EVENT_PHOTO_SIZE`), so nginx was the real gate the whole time. The earlier #613 cache-bust fix addressed a *display* symptom for small photos but couldn't help larger ones that never uploaded.

## Change

- `nginx.conf.template`: add `client_max_body_size 12m;` at the `server` level (10 MB app cap + multipart overhead). Oversized uploads now reach Django and get its friendly 400 (`Code.Photo.TOO_LARGE`) instead of nginx's raw 413.

## Test plan

- [ ] Deploy to staging, upload a ~3–5 MB phone photo to an event → succeeds and renders on the detail page
- [ ] Upload a >10 MB photo → Django returns the friendly "too large" 400, not a raw 413
- [ ] Confirm existing small-photo uploads still work

Config-only change; no unit tests apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
