### PR TITLE
feat(layout): add shared copyright footer

### DIFF
--- a/frontend/src/layout/AppShell.test.tsx
+++ b/frontend/src/layout/AppShell.test.tsx
@@ -86,4 +86,12 @@ describe('AppShell + BottomNav', () => {
     const nav = screen.getByRole('navigation', { name: /primary/i });
     expect(nav).toBeInTheDocument();
   });
+
+  it('renders a lowercase copyright footer in the shared app shell', () => {
+    renderShell('/');
+
+    expect(screen.getByRole('contentinfo')).toHaveTextContent(
+      `© ${new Date().getFullYear()} protein deficients anonymous`,
+    );
+  });
 });

--- a/frontend/src/layout/AppShell.tsx
+++ b/frontend/src/layout/AppShell.tsx
@@ -10,6 +10,7 @@ import { useAuthStore } from '@/auth/store';
 import { FeedbackButton } from '@/components/FeedbackButton';
 
 import { BottomNav } from './BottomNav';
+import { Footer } from './Footer';
 import { NotificationBell } from './NotificationBell';
 import { PdaMenuSheet } from './PdaMenuSheet';
 
@@ -40,7 +41,12 @@ export function AppShell() {
       {/* Pad the bottom so the fixed BottomNav (h-14 + iOS safe area) doesn't
           cover the end of the scroll. Header already eats its own space. */}
       <div className="flex-1 overflow-x-hidden pb-[calc(3.5rem+env(safe-area-inset-bottom))]">
-        <Outlet />
+        <div className="flex min-h-full flex-col">
+          <div className="flex-1">
+            <Outlet />
+          </div>
+          <Footer />
+        </div>
       </div>
 
       <div id="pda-menu-sheet">

--- a/frontend/src/layout/Footer.tsx
+++ b/frontend/src/layout/Footer.tsx
@@ -1,0 +1,11 @@
+export function Footer() {
+  const year = new Date().getFullYear();
+
+  return (
+    <footer className="border-border bg-surface border-t">
+      <div className="mx-auto flex max-w-6xl items-center justify-center px-4 py-4">
+        <p className="text-muted text-sm">© {year} protein deficients anonymous</p>
+      </div>
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary

This PR adds a shared footer to the application with a copyright notice.

### Changes

* Added a reusable `Footer` component in `frontend/src/layout/Footer.tsx`.
* Integrated the footer into `AppShell` so it is rendered across all routes that use the shared layout.
* Displayed the copyright year dynamically using the current date.
* Kept the footer text lowercase to follow the project's frontend text-casing convention.
* Added a test to verify that the shared app shell renders the footer with the expected content.

### Verification

* Verified the footer is visible on public pages.
* Verified the footer is visible on authenticated pages.
* Confirmed the year is computed dynamically.
* Confirmed the footer does not overlap the fixed `BottomNav`.
* Ran:

  * `pnpm lint`
  * `pnpm typecheck`
  * `pnpm test`

All checks passed successfully.
<img width="1918" height="908" alt="Screenshot 2026-07-10 181659" src="https://github.com/user-attachments/assets/5d6f5075-fd01-4254-85f8-5dc20d0181c8" />
<img width="1918" height="906" alt="Screenshot 2026-07-10 181711" src="https://github.com/user-attachments/assets/0dfb0a70-0ee4-49ec-af8b-817c3ebfc27a" />
<img width="1902" height="903" alt="Screenshot 2026-07-10 181752" src="https://github.com/user-attachments/assets/ac8b761b-2720-4f89-91be-2950c1341593" />
