### PR TITLE
fix(sse): back off longer on a rate-limited ticket mint (Issue 648)

### DIFF
--- a/frontend/src/hooks/sseBackoff.test.ts
+++ b/frontend/src/hooks/sseBackoff.test.ts
@@ -1,0 +1,54 @@
+import { AxiosError, AxiosHeaders } from 'axios';
+import { describe, expect, it } from 'vitest';
+
+import {
+  isRateLimitError,
+  MAX_BACKOFF_MS,
+  normalBackoffDelay,
+  RATE_LIMIT_BACKOFF_MIN_MS,
+  rateLimitBackoffDelay,
+} from './sseBackoff';
+
+function axiosErrorWithStatus(status: number): AxiosError {
+  const err = new AxiosError('err');
+  err.response = {
+    status,
+    data: {},
+    statusText: '',
+    headers: {},
+    config: { headers: new AxiosHeaders() },
+  };
+  return err;
+}
+
+describe('normalBackoffDelay', () => {
+  it('grows exponentially from 1s and caps at MAX_BACKOFF_MS', () => {
+    expect(normalBackoffDelay(1)).toBe(1000);
+    expect(normalBackoffDelay(2)).toBe(2000);
+    expect(normalBackoffDelay(3)).toBe(4000);
+    expect(normalBackoffDelay(10)).toBe(MAX_BACKOFF_MS);
+  });
+});
+
+describe('rateLimitBackoffDelay', () => {
+  it('always waits at least a full rate-limit window, far above the fast backoff', () => {
+    expect(rateLimitBackoffDelay(0)).toBe(RATE_LIMIT_BACKOFF_MIN_MS);
+    expect(rateLimitBackoffDelay(0)).toBeGreaterThan(normalBackoffDelay(1));
+    // Even the earliest fast-backoff cap stays at/under the rate-limit floor.
+    expect(rateLimitBackoffDelay(0)).toBeGreaterThanOrEqual(MAX_BACKOFF_MS);
+  });
+
+  it('jitters upward so multiple tabs do not wake in lockstep', () => {
+    expect(rateLimitBackoffDelay(0.999)).toBeGreaterThan(RATE_LIMIT_BACKOFF_MIN_MS);
+  });
+});
+
+describe('isRateLimitError', () => {
+  it('is true only for a 429 axios error', () => {
+    expect(isRateLimitError(axiosErrorWithStatus(429))).toBe(true);
+    expect(isRateLimitError(axiosErrorWithStatus(500))).toBe(false);
+    expect(isRateLimitError(axiosErrorWithStatus(401))).toBe(false);
+    expect(isRateLimitError(new Error('network down'))).toBe(false);
+    expect(isRateLimitError(null)).toBe(false);
+  });
+});

--- a/frontend/src/hooks/sseBackoff.ts
+++ b/frontend/src/hooks/sseBackoff.ts
@@ -1,25 +1,17 @@
-import { isAxiosError } from 'axios';
+import { getApiStatus } from '@/api/apiErrors';
 
 export const MAX_BACKOFF_MS = 30_000;
-// The sse-ticket endpoint is rate-limited per-user (30/m). With several tabs
-// open, a backend blip makes every tab re-mint on each backoff step and can
-// trip that shared limit — locking the user out of live notifications while
-// they keep retrying blindly. On a 429 the window is measured in minutes, so
-// retrying in 1s is pointless: wait out roughly a full window, jittered so
-// multiple tabs don't all wake and re-mint in lockstep.
 export const RATE_LIMIT_BACKOFF_MIN_MS = 30_000;
 export const RATE_LIMIT_BACKOFF_JITTER_MS = 30_000;
 
-/** Exponential backoff for the nth (1-based) reconnect attempt, capped. */
 export function normalBackoffDelay(retry: number): number {
   return Math.min(2 ** (retry - 1) * 1000, MAX_BACKOFF_MS);
 }
 
-/** Long, jittered backoff for a rate-limited (429) ticket mint. */
 export function rateLimitBackoffDelay(rand: number = Math.random()): number {
   return RATE_LIMIT_BACKOFF_MIN_MS + Math.floor(rand * RATE_LIMIT_BACKOFF_JITTER_MS);
 }
 
 export function isRateLimitError(err: unknown): boolean {
-  return isAxiosError(err) && err.response?.status === 429;
+  return getApiStatus(err) === 429;
 }

--- a/frontend/src/hooks/sseBackoff.ts
+++ b/frontend/src/hooks/sseBackoff.ts
@@ -1,0 +1,25 @@
+import { isAxiosError } from 'axios';
+
+export const MAX_BACKOFF_MS = 30_000;
+// The sse-ticket endpoint is rate-limited per-user (30/m). With several tabs
+// open, a backend blip makes every tab re-mint on each backoff step and can
+// trip that shared limit — locking the user out of live notifications while
+// they keep retrying blindly. On a 429 the window is measured in minutes, so
+// retrying in 1s is pointless: wait out roughly a full window, jittered so
+// multiple tabs don't all wake and re-mint in lockstep.
+export const RATE_LIMIT_BACKOFF_MIN_MS = 30_000;
+export const RATE_LIMIT_BACKOFF_JITTER_MS = 30_000;
+
+/** Exponential backoff for the nth (1-based) reconnect attempt, capped. */
+export function normalBackoffDelay(retry: number): number {
+  return Math.min(2 ** (retry - 1) * 1000, MAX_BACKOFF_MS);
+}
+
+/** Long, jittered backoff for a rate-limited (429) ticket mint. */
+export function rateLimitBackoffDelay(rand: number = Math.random()): number {
+  return RATE_LIMIT_BACKOFF_MIN_MS + Math.floor(rand * RATE_LIMIT_BACKOFF_JITTER_MS);
+}
+
+export function isRateLimitError(err: unknown): boolean {
+  return isAxiosError(err) && err.response?.status === 429;
+}

--- a/frontend/src/hooks/useEventSource.ts
+++ b/frontend/src/hooks/useEventSource.ts
@@ -49,9 +49,7 @@ export function useEventSource({ url, token, events, onStatusChange }: Options):
     }
 
     function scheduleRateLimitedReconnect() {
-      // Ticket minting was rate-limited (429). This is not an auth problem, so
-      // skip the token refresh and don't touch the normal backoff counter —
-      // just wait out the rate window (jittered) and try minting again.
+      // A 429 isn't auth, so skip the refresh and leave the backoff counter alone.
       reconnectTimer = window.setTimeout(() => void connect(), rateLimitBackoffDelay());
     }
 

--- a/frontend/src/hooks/useEventSource.ts
+++ b/frontend/src/hooks/useEventSource.ts
@@ -4,6 +4,8 @@ import { refreshAccessToken } from '@/api/client';
 import { fetchSseTicket } from '@/api/notifications';
 import { API_BASE_URL } from '@/config/env';
 
+import { isRateLimitError, normalBackoffDelay, rateLimitBackoffDelay } from './sseBackoff';
+
 type Handler = (event: MessageEvent<string>) => void;
 
 interface Options {
@@ -12,8 +14,6 @@ interface Options {
   events: Record<string, Handler>;
   onStatusChange?: (connected: boolean) => void;
 }
-
-const MAX_BACKOFF_MS = 30_000;
 
 export function useEventSource({ url, token, events, onStatusChange }: Options): void {
   // Keep the latest handlers in a ref so we don't tear down the connection
@@ -44,9 +44,15 @@ export function useEventSource({ url, token, events, onStatusChange }: Options):
         if (state.closed) return;
         if (next && next !== token) return; // outer effect reruns with new token
         retry += 1;
-        const delay = Math.min(2 ** (retry - 1) * 1000, MAX_BACKOFF_MS);
-        reconnectTimer = window.setTimeout(() => void connect(), delay);
+        reconnectTimer = window.setTimeout(() => void connect(), normalBackoffDelay(retry));
       });
+    }
+
+    function scheduleRateLimitedReconnect() {
+      // Ticket minting was rate-limited (429). This is not an auth problem, so
+      // skip the token refresh and don't touch the normal backoff counter —
+      // just wait out the rate window (jittered) and try minting again.
+      reconnectTimer = window.setTimeout(() => void connect(), rateLimitBackoffDelay());
     }
 
     function attachHandlers(source: EventSource) {
@@ -74,8 +80,13 @@ export function useEventSource({ url, token, events, onStatusChange }: Options):
         // Mint a fresh single-use ticket. If this fails the session may be gone
         // or the backend is down — back off and retry like any other error.
         ticket = await fetchSseTicket();
-      } catch {
-        if (!state.closed) scheduleReconnect();
+      } catch (err) {
+        if (state.closed) return;
+        if (isRateLimitError(err)) {
+          scheduleRateLimitedReconnect();
+        } else {
+          scheduleReconnect();
+        }
         return;
       }
       if (state.closed) return;


### PR DESCRIPTION
## Summary

Closes #648.

`useEventSource` mints a fresh single-use SSE ticket (`POST /api/notifications/sse-ticket/`) on **every** reconnect, and treats a `429` from that endpoint like any other error — same 1/2/4/8/16/30s backoff, re-minting on each step. The endpoint is rate-limited **30/m per user**.

A single tab is fine (~2 mints/min at steady state). But a user with several tabs open during a backend blip burns the early backoff steps across all tabs and can trip the shared per-user limit. Because a `429` is handled identically to a network error, the tabs keep retrying blindly and the user is **locked out of live notifications** until the window clears. Not a security issue — a UX cliff for multi-tab users on flaky networks.

## Change

- Detect a `429` on the ticket mint and back off **~30–60s (jittered)** instead of the fast ramp, and **skip the token refresh** (a 429 isn't an auth failure). Jitter prevents multiple tabs from waking and re-minting in lockstep.
- Tickets are **single-use with a 60s TTL**, so caching/reusing one across reconnects isn't viable (the issue's option 1) — waiting out the rate window (option 2) is the correct lever.
- Extracted the backoff + error-classification logic into `sseBackoff.ts` as **pure functions** (`normalBackoffDelay`, `rateLimitBackoffDelay`, `isRateLimitError`) so it's unit-testable without `EventSource` stubs or fake timers.

## Test plan

- [x] `sseBackoff.test.ts` — exponential backoff caps at 30s; rate-limit backoff always ≥30s and jitters up; `isRateLimitError` true only for a 429 axios error
- [x] `tsc --noEmit`, eslint, prettier — green on all changed files
- [x] Isolated vitest run of the hook + notification neighbors — green (full-suite timeouts observed were machine-load flakes, reproduced identically on a baseline run *without* this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
