### PR TITLE
fix(notifications): navigate before closing the menu on tap (Issue 436)

### DIFF
--- a/frontend/src/layout/NotificationRow.test.tsx
+++ b/frontend/src/layout/NotificationRow.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { NotificationType } from '@/models/notification';
+
+import { NotificationRow } from './NotificationRow';
+
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', () => ({ useNavigate: () => mockNavigate }));
+
+function magicLinkNotification() {
+  return {
+    id: 'n1',
+    notificationType: NotificationType.MagicLinkRequest,
+    eventId: null,
+    relatedUserId: 'u123',
+    message: 'someone requested a new login link',
+    isRead: false,
+    createdAt: '2026-07-10T00:00:00Z',
+  };
+}
+
+describe('NotificationRow', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('navigates before closing the menu so the tap is not dropped mid-unmount (Issue 436)', async () => {
+    const calls: string[] = [];
+    mockNavigate.mockImplementation(() => calls.push('navigate'));
+    const onActivate = vi.fn(() => calls.push('activate'));
+
+    render(
+      <NotificationRow n={magicLinkNotification()} onMarkRead={vi.fn()} onActivate={onActivate} />,
+    );
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/admin/members/u123');
+    expect(onActivate).toHaveBeenCalledTimes(1);
+    // Navigation must be queued before the menu-close unmounts this row.
+    expect(calls).toEqual(['navigate', 'activate']);
+  });
+
+  it('marks the notification read on click', async () => {
+    const onMarkRead = vi.fn();
+    render(
+      <NotificationRow n={magicLinkNotification()} onMarkRead={onMarkRead} onActivate={vi.fn()} />,
+    );
+    await userEvent.click(screen.getByRole('button'));
+    expect(onMarkRead).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/layout/NotificationRow.tsx
+++ b/frontend/src/layout/NotificationRow.tsx
@@ -17,9 +17,12 @@ export function NotificationRow({
   const navigate = useNavigate();
   function onClick() {
     onMarkRead();
-    onActivate?.();
+    // Navigate before onActivate closes the menu. Closing first unmounts this
+    // row mid-click, which on mobile Safari can drop the queued navigation so
+    // the tap appears to do nothing (Issue 436).
     const target = notificationTarget(n);
     if (target) void navigate(target);
+    onActivate?.();
   }
   return (
     <button


### PR DESCRIPTION
## Summary

Closes #436.

Tapping a notification in the bell menu on mobile "didn't do anything" — it never navigated. `NotificationRow.onClick` closed the menu (`onActivate` → `setOpen(false)`) **before** calling `navigate()`:

```ts
onMarkRead();
onActivate?.();               // closes menu → unmounts this row
const target = notificationTarget(n);
if (target) void navigate(target);   // queued while the row is unmounting
```

Closing the menu unmounts the dropdown (and this row) mid-click. On desktop the navigation usually still completes; on mobile Safari the queued navigation is dropped as the component tears down, so the tap appears to do nothing — e.g. a `MagicLinkRequest` notification that should open `/admin/members/<id>` (the "resend link" flow the reporter was trying to reach).

## Change

- Reorder `onClick` so `navigate()` runs **before** `onActivate()` closes the menu.
- Add `NotificationRow.test.tsx` asserting the call order (navigate before activate) and that the row marks itself read on click.

## Test plan

- [x] `NotificationRow.test.tsx` — navigate fires with `/admin/members/<id>` before `onActivate`, and `onMarkRead` fires on click
- [x] `NotificationBell.test.tsx` still green (14 tests pass together)
- [x] `tsc --noEmit`, eslint, prettier — green on changed files
- [ ] Manual: on mobile, tap a notification in the bell → navigates to its target

🤖 Generated with [Claude Code](https://claude.com/claude-code)
