### PR TITLE
chore(seed): staging demo-data seed command (Issue 653)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,8 @@ make dev-pg-db-init   # Create + migrate + seed the per-worktree Postgres DB
 make dev-pg-db-reset  # Drop and re-init the per-worktree Postgres DB
 make migrate          # makemigrations + migrate
 make seed             # Seed database with sample data (local dev)
+# seed staging demo data on demand (roles/users/events); never prod:
+#   railway run --environment staging python backend/manage.py seed_staging
 make agent-test       # Run pytest (quiet)
 make agent-test-since # Run pytest subset from git diff
 make agent-lint       # Run ruff (lint + format; minimal output)

--- a/backend/community/management/commands/_seed_staging_data.py
+++ b/backend/community/management/commands/_seed_staging_data.py
@@ -1,0 +1,138 @@
+"""Static data + pure helpers for the `seed_staging` command."""
+
+from dataclasses import dataclass
+
+from community.models.choices import EventType
+
+PASSWORD = "testPassword1@"
+
+
+@dataclass
+class SeedStagingEvent:
+    title: str
+    description: str
+    delta_days: int
+    duration_hours: float
+    location: str
+    event_type: str = EventType.COMMUNITY
+
+
+def perm_phone(index: int) -> str:
+    return f"+170255501{index:02d}"
+
+
+def cond_phone(index: int) -> str:
+    return f"+170255502{index:02d}"
+
+
+def perm_email(key: str) -> str:
+    return f"perm.{key}@staging.example"
+
+
+def cond_email(index: int) -> str:
+    return f"cond{index:02d}@staging.example"
+
+
+def condition_combinations() -> list[tuple[bool, bool, bool]]:
+    """All 8 (has_email, guidelines_done, sms_done) patterns, fixed order."""
+    return [
+        (has_email, guidelines_done, sms_done)
+        for has_email in (True, False)
+        for guidelines_done in (True, False)
+        for sms_done in (True, False)
+    ]
+
+
+def condition_label(combo: tuple[bool, bool, bool]) -> str:
+    has_email, guidelines_done, sms_done = combo
+    parts: list[str] = []
+    if not has_email:
+        parts.append("no-email")
+    if not guidelines_done:
+        parts.append("needs-guidelines")
+    if not sms_done:
+        parts.append("needs-sms")
+    return "cond: " + ("complete" if not parts else "+".join(parts))
+
+
+def is_seed_allowed(env_name: str | None, force: bool) -> bool:
+    """Allow local/unset and staging; refuse any other env unless forced."""
+    if not env_name or env_name == "staging":
+        return True
+    return force
+
+
+STAGING_EVENTS = [
+    SeedStagingEvent(
+        title="[staging] past potluck",
+        description="a wrapped-up community potluck from last month.",
+        delta_days=-30,
+        duration_hours=3,
+        location="community center",
+    ),
+    SeedStagingEvent(
+        title="[staging] last week's film night",
+        description="documentary screening and discussion.",
+        delta_days=-7,
+        duration_hours=2,
+        location="the annex",
+    ),
+    SeedStagingEvent(
+        title="[staging] yesterday's kitchen social",
+        description="casual cook-and-hang.",
+        delta_days=-1,
+        duration_hours=2.5,
+        location="shared kitchen",
+    ),
+    SeedStagingEvent(
+        title="[staging] happening today",
+        description="drop-in tabling and outreach.",
+        delta_days=0,
+        duration_hours=4,
+        location="market square",
+        event_type=EventType.OFFICIAL,
+    ),
+    SeedStagingEvent(
+        title="[staging] tomorrow's cooking workshop",
+        description="plant-based basics, hands-on.",
+        delta_days=1,
+        duration_hours=2,
+        location="teaching kitchen",
+    ),
+    SeedStagingEvent(
+        title="[staging] weekend park cleanup",
+        description="gloves and bags provided.",
+        delta_days=3,
+        duration_hours=3,
+        location="riverside park",
+    ),
+    SeedStagingEvent(
+        title="[staging] next week's book club",
+        description="this month's read: collective liberation.",
+        delta_days=7,
+        duration_hours=1.5,
+        location="library room b",
+    ),
+    SeedStagingEvent(
+        title="[staging] monthly official meeting",
+        description="agenda, updates, and open floor.",
+        delta_days=14,
+        duration_hours=2,
+        location="main hall",
+        event_type=EventType.OFFICIAL,
+    ),
+    SeedStagingEvent(
+        title="[staging] future festival",
+        description="all-day tabling, food, and music.",
+        delta_days=45,
+        duration_hours=8,
+        location="fairgrounds",
+    ),
+    SeedStagingEvent(
+        title="[staging] far-future retreat",
+        description="weekend planning retreat.",
+        delta_days=90,
+        duration_hours=48,
+        location="the lodge",
+    ),
+]

--- a/backend/community/management/commands/seed_staging.py
+++ b/backend/community/management/commands/seed_staging.py
@@ -1,6 +1,7 @@
 """Seed the staging deploy with events, single-permission roles, and matching users."""
 
 import os
+from datetime import timedelta
 
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
@@ -9,8 +10,15 @@ from users.models import User
 from users.permissions import PermissionKey
 from users.roles import Role
 
+from community.models import Event
+
 from ._seed_staging_data import (
     PASSWORD,
+    STAGING_EVENTS,
+    cond_email,
+    cond_phone,
+    condition_combinations,
+    condition_label,
     is_seed_allowed,
     perm_email,
     perm_phone,
@@ -40,10 +48,18 @@ class Command(BaseCommand):
             if options["reset"]:
                 self._reset()
             roles = self._seed_perm_roles()
-            self._seed_perm_users(roles)
+            perm_users = self._seed_perm_users(roles)
+            cond_users = self._seed_condition_users()
+            admin = perm_users[0] if perm_users else None
+            events = self._seed_events(admin)
+        self._print_summary(roles, perm_users, cond_users, events)
 
     def _reset(self) -> None:
-        pass  # implemented in Task 3
+        Event.objects.filter(title__startswith="[staging] ").delete()
+        User.objects.filter(phone_number__startswith="+170255501").delete()
+        User.objects.filter(phone_number__startswith="+170255502").delete()
+        Role.objects.filter(name__startswith="perm: ").delete()
+        self.stdout.write("  reset: removed staging-scoped rows")
 
     def _seed_perm_roles(self) -> dict[str, Role]:
         roles: dict[str, Role] = {}
@@ -52,9 +68,10 @@ class Command(BaseCommand):
                 name=f"perm: {key}",
                 defaults={"permissions": [key], "is_default": False},
             )
-            if not created and role.permissions != [key]:
+            if not created and (role.permissions != [key] or role.is_default):
                 role.permissions = [key]
-                role.save(update_fields=["permissions"])
+                role.is_default = False
+                role.save(update_fields=["permissions", "is_default"])
             roles[key] = role
             self.stdout.write(f"  {'created' if created else 'exists'} role: {role.name}")
         return roles
@@ -82,3 +99,77 @@ class Command(BaseCommand):
             users.append(user)
             self.stdout.write(f"  {'created' if created else 'exists'} user: {user.display_name}")
         return users
+
+    def _member_role(self) -> Role:
+        role, _ = Role.objects.get_or_create(name="member", defaults={"is_default": True})
+        return role
+
+    def _seed_condition_users(self) -> list[User]:
+        member_role = self._member_role()
+        now = timezone.now()
+        users: list[User] = []
+        for index, combo in enumerate(condition_combinations()):
+            has_email, guidelines_done, sms_done = combo
+            user, created = User.objects.get_or_create(
+                phone_number=cond_phone(index),
+                defaults={"display_name": condition_label(combo), "is_member": True},
+            )
+            user.email = cond_email(index) if has_email else None
+            user.guidelines_consent_at = now if guidelines_done else None
+            user.sms_consent_at = now if sms_done else None
+            user.needs_onboarding = False
+            user.onboarded_at = now
+            user.display_name = condition_label(combo)
+            user.save(
+                update_fields=[
+                    "email",
+                    "guidelines_consent_at",
+                    "sms_consent_at",
+                    "needs_onboarding",
+                    "onboarded_at",
+                    "display_name",
+                ]
+            )
+            if created:
+                user.set_password(PASSWORD)
+                user.save(update_fields=["password"])
+            user.roles.set([member_role])
+            users.append(user)
+            self.stdout.write(f"  {'created' if created else 'exists'} user: {user.display_name}")
+        return users
+
+    def _seed_events(self, created_by) -> list[Event]:
+        now = timezone.now()
+        events: list[Event] = []
+        for data in STAGING_EVENTS:
+            start = now + timedelta(days=data.delta_days)
+            end = start + timedelta(hours=data.duration_hours)
+            event, created = Event.objects.get_or_create(
+                title=data.title,
+                defaults={
+                    "description": data.description,
+                    "start_datetime": start,
+                    "end_datetime": end,
+                    "location": data.location,
+                    "event_type": data.event_type,
+                    "created_by": created_by,
+                },
+            )
+            events.append(event)
+            self.stdout.write(f"  {'created' if created else 'exists'} event: {data.title}")
+        return events
+
+    def _print_summary(self, roles, perm_users, cond_users, events) -> None:
+        self.stdout.write("")
+        self.stdout.write(f"password for all seeded users: {PASSWORD}")
+        self.stdout.write(
+            f"events: {len(events)}  roles: {len(roles)}  "
+            f"perm users: {len(perm_users)}  condition users: {len(cond_users)}"
+        )
+        self.stdout.write("per-permission users (phone -> role):")
+        for user in perm_users:
+            names = ", ".join(user.roles.values_list("name", flat=True))
+            self.stdout.write(f"  {user.phone_number} -> {names}")
+        self.stdout.write("profile-condition users (phone -> pattern):")
+        for user in cond_users:
+            self.stdout.write(f"  {user.phone_number} -> {user.display_name}")

--- a/backend/community/management/commands/seed_staging.py
+++ b/backend/community/management/commands/seed_staging.py
@@ -1,0 +1,84 @@
+"""Seed the staging deploy with events, single-permission roles, and matching users."""
+
+import os
+
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.utils import timezone
+from users.models import User
+from users.permissions import PermissionKey
+from users.roles import Role
+
+from ._seed_staging_data import (
+    PASSWORD,
+    is_seed_allowed,
+    perm_email,
+    perm_phone,
+)
+
+
+class Command(BaseCommand):
+    help = "Seed staging with events, single-permission roles, and matching users."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--reset", action="store_true", help="Delete staging-scoped rows first."
+        )
+        parser.add_argument(
+            "--force", action="store_true", help="Run even if the environment is not staging."
+        )
+
+    def handle(self, *args, **options):
+        env_name = os.environ.get("RAILWAY_ENVIRONMENT_NAME")
+        self.stdout.write(f"detected environment: {env_name or 'local/unset'}")
+        if not is_seed_allowed(env_name, force=options["force"]):
+            raise CommandError(
+                f"refusing to seed in environment '{env_name}'. pass --force to override."
+            )
+
+        with transaction.atomic():
+            if options["reset"]:
+                self._reset()
+            roles = self._seed_perm_roles()
+            self._seed_perm_users(roles)
+
+    def _reset(self) -> None:
+        pass  # implemented in Task 3
+
+    def _seed_perm_roles(self) -> dict[str, Role]:
+        roles: dict[str, Role] = {}
+        for key in PermissionKey.values:
+            role, created = Role.objects.get_or_create(
+                name=f"perm: {key}",
+                defaults={"permissions": [key], "is_default": False},
+            )
+            if not created and role.permissions != [key]:
+                role.permissions = [key]
+                role.save(update_fields=["permissions"])
+            roles[key] = role
+            self.stdout.write(f"  {'created' if created else 'exists'} role: {role.name}")
+        return roles
+
+    def _seed_perm_users(self, roles: dict[str, Role]) -> list[User]:
+        users: list[User] = []
+        now = timezone.now()
+        for index, key in enumerate(PermissionKey.values):
+            user, created = User.objects.get_or_create(
+                phone_number=perm_phone(index),
+                defaults={
+                    "display_name": f"perm: {key}",
+                    "email": perm_email(key),
+                    "is_member": True,
+                    "needs_onboarding": False,
+                    "onboarded_at": now,
+                    "guidelines_consent_at": now,
+                    "sms_consent_at": now,
+                },
+            )
+            if created:
+                user.set_password(PASSWORD)
+                user.save(update_fields=["password"])
+            user.roles.set([roles[key]])
+            users.append(user)
+            self.stdout.write(f"  {'created' if created else 'exists'} user: {user.display_name}")
+        return users

--- a/backend/community/management/commands/seed_staging.py
+++ b/backend/community/management/commands/seed_staging.py
@@ -104,32 +104,35 @@ class Command(BaseCommand):
         role, _ = Role.objects.get_or_create(name="member", defaults={"is_default": True})
         return role
 
+    def _apply_condition_user_fields(self, user, combo, index, now) -> None:
+        has_email, guidelines_done, sms_done = combo
+        user.email = cond_email(index) if has_email else None
+        user.guidelines_consent_at = now if guidelines_done else None
+        user.sms_consent_at = now if sms_done else None
+        user.needs_onboarding = False
+        user.onboarded_at = now
+        user.display_name = condition_label(combo)
+        user.save(
+            update_fields=[
+                "email",
+                "guidelines_consent_at",
+                "sms_consent_at",
+                "needs_onboarding",
+                "onboarded_at",
+                "display_name",
+            ]
+        )
+
     def _seed_condition_users(self) -> list[User]:
         member_role = self._member_role()
         now = timezone.now()
         users: list[User] = []
         for index, combo in enumerate(condition_combinations()):
-            has_email, guidelines_done, sms_done = combo
             user, created = User.objects.get_or_create(
                 phone_number=cond_phone(index),
                 defaults={"display_name": condition_label(combo), "is_member": True},
             )
-            user.email = cond_email(index) if has_email else None
-            user.guidelines_consent_at = now if guidelines_done else None
-            user.sms_consent_at = now if sms_done else None
-            user.needs_onboarding = False
-            user.onboarded_at = now
-            user.display_name = condition_label(combo)
-            user.save(
-                update_fields=[
-                    "email",
-                    "guidelines_consent_at",
-                    "sms_consent_at",
-                    "needs_onboarding",
-                    "onboarded_at",
-                    "display_name",
-                ]
-            )
+            self._apply_condition_user_fields(user, combo, index, now)
             if created:
                 user.set_password(PASSWORD)
                 user.save(update_fields=["password"])

--- a/backend/tests/test_seed_staging.py
+++ b/backend/tests/test_seed_staging.py
@@ -1,3 +1,5 @@
+from datetime import timedelta
+
 import pytest
 from community.management.commands._seed_staging_data import (
     PASSWORD,
@@ -10,8 +12,10 @@ from community.management.commands._seed_staging_data import (
     perm_email,
     perm_phone,
 )
+from community.models import Event
 from django.contrib.auth.hashers import check_password
 from django.core.management import call_command
+from django.utils import timezone
 from users.models import User
 from users.permissions import PermissionKey
 from users.roles import Role
@@ -102,3 +106,82 @@ def test_seed_staging_perm_users_hold_only_their_role_and_are_onboarded():
         assert user.email == perm_email(key)
         assert user.guidelines_consent_at is not None
         assert user.sms_consent_at is not None
+
+
+@pytest.mark.django_db
+def test_seed_staging_creates_eight_member_only_condition_users():
+    call_command("seed_staging")
+    combos_seen = set()
+    for index in range(8):
+        user = User.objects.get(phone_number=cond_phone(index))
+        assert user.is_member is True
+        assert user.needs_onboarding is False
+        assert check_password(PASSWORD, user.password)
+        role_names = set(user.roles.values_list("name", flat=True))
+        assert role_names == {"member"}
+        combos_seen.add(
+            (
+                user.email is not None and user.email != "",
+                user.guidelines_consent_at is not None,
+                user.sms_consent_at is not None,
+            )
+        )
+    assert combos_seen == set(condition_combinations())
+
+
+@pytest.mark.django_db
+def test_seed_staging_perm_and_condition_users_are_disjoint():
+    call_command("seed_staging")
+    perm = set(
+        User.objects.filter(phone_number__startswith="+170255501").values_list(
+            "phone_number", flat=True
+        )
+    )
+    cond = set(
+        User.objects.filter(phone_number__startswith="+170255502").values_list(
+            "phone_number", flat=True
+        )
+    )
+    assert len(perm) == 12
+    assert len(cond) == 8
+    assert perm.isdisjoint(cond)
+
+
+@pytest.mark.django_db
+def test_seed_staging_events_span_past_current_future():
+    call_command("seed_staging")
+    now = timezone.now()
+    events = list(Event.objects.filter(title__startswith="[staging] "))
+    assert len(events) >= 8
+    assert any(e.start_datetime < now - timedelta(hours=1) for e in events)
+    assert any(e.start_datetime > now + timedelta(hours=1) for e in events)
+
+
+@pytest.mark.django_db
+def test_seed_staging_is_idempotent():
+    call_command("seed_staging")
+    call_command("seed_staging")
+    assert User.objects.filter(phone_number__startswith="+170255501").count() == 12
+    assert User.objects.filter(phone_number__startswith="+170255502").count() == 8
+    assert Role.objects.filter(name__startswith="perm: ").count() == len(PermissionKey.values)
+    assert Event.objects.filter(title__startswith="[staging] ").count() == len(STAGING_EVENTS)
+
+
+@pytest.mark.django_db
+def test_seed_staging_reset_removes_only_scoped_rows():
+    User.objects.create_user(
+        phone_number="+17025559999", display_name="real person", is_member=True
+    )
+    call_command("seed_staging")
+    call_command("seed_staging", "--reset")
+    assert User.objects.filter(phone_number="+17025559999").exists()
+    assert User.objects.filter(phone_number__startswith="+170255501").count() == 12
+    assert User.objects.filter(phone_number__startswith="+170255502").count() == 8
+
+
+@pytest.mark.django_db
+def test_seed_staging_refuses_in_production(monkeypatch):
+    monkeypatch.setenv("RAILWAY_ENVIRONMENT_NAME", "production")
+    with pytest.raises(Exception):
+        call_command("seed_staging")
+    assert Role.objects.filter(name__startswith="perm: ").count() == 0

--- a/backend/tests/test_seed_staging.py
+++ b/backend/tests/test_seed_staging.py
@@ -1,3 +1,4 @@
+import pytest
 from community.management.commands._seed_staging_data import (
     PASSWORD,
     STAGING_EVENTS,
@@ -9,6 +10,11 @@ from community.management.commands._seed_staging_data import (
     perm_email,
     perm_phone,
 )
+from django.contrib.auth.hashers import check_password
+from django.core.management import call_command
+from users.models import User
+from users.permissions import PermissionKey
+from users.roles import Role
 
 
 def test_password_meets_validators():
@@ -71,3 +77,28 @@ def test_staging_events_span_past_current_future():
     assert any(d == 0 for d in deltas)
     assert any(d > 0 for d in deltas)
     assert len(STAGING_EVENTS) >= 8
+
+
+@pytest.mark.django_db
+def test_seed_staging_creates_one_role_per_permission():
+    call_command("seed_staging")
+    for key in PermissionKey.values:
+        role = Role.objects.get(name=f"perm: {key}")
+        assert role.permissions == [key]
+        assert role.is_default is False
+
+
+@pytest.mark.django_db
+def test_seed_staging_perm_users_hold_only_their_role_and_are_onboarded():
+    call_command("seed_staging")
+    for index, key in enumerate(PermissionKey.values):
+        user = User.objects.get(phone_number=perm_phone(index))
+        assert user.is_member is True
+        assert user.needs_onboarding is False
+        assert user.onboarded_at is not None
+        assert check_password(PASSWORD, user.password)
+        role_names = set(user.roles.values_list("name", flat=True))
+        assert role_names == {f"perm: {key}"}
+        assert user.email == perm_email(key)
+        assert user.guidelines_consent_at is not None
+        assert user.sms_consent_at is not None

--- a/backend/tests/test_seed_staging.py
+++ b/backend/tests/test_seed_staging.py
@@ -1,0 +1,73 @@
+from community.management.commands._seed_staging_data import (
+    PASSWORD,
+    STAGING_EVENTS,
+    cond_email,
+    cond_phone,
+    condition_combinations,
+    condition_label,
+    is_seed_allowed,
+    perm_email,
+    perm_phone,
+)
+
+
+def test_password_meets_validators():
+    assert len(PASSWORD) >= 8
+    assert any(c.islower() for c in PASSWORD)
+    assert any(c.isupper() for c in PASSWORD)
+    assert not PASSWORD.isdigit()
+
+
+def test_perm_phone_is_zero_padded_in_own_block():
+    assert perm_phone(0) == "+17025550100"
+    assert perm_phone(11) == "+17025550111"
+
+
+def test_cond_phone_is_zero_padded_in_own_block():
+    assert cond_phone(0) == "+17025550200"
+    assert cond_phone(7) == "+17025550207"
+
+
+def test_perm_and_cond_blocks_are_disjoint():
+    perm = {perm_phone(i) for i in range(12)}
+    cond = {cond_phone(i) for i in range(8)}
+    assert perm.isdisjoint(cond)
+    assert all(not p.startswith("+1702555000") for p in perm | cond)
+
+
+def test_condition_combinations_are_all_eight_unique():
+    combos = condition_combinations()
+    assert len(combos) == 8
+    assert len(set(combos)) == 8
+    assert (True, True, True) in combos
+    assert (False, False, False) in combos
+
+
+def test_condition_label_is_deterministic_and_descriptive():
+    assert condition_label((True, True, True)) == "cond: complete"
+    label = condition_label((False, True, False))
+    assert label.startswith("cond: ")
+    assert "no-email" in label
+    assert "needs-sms" in label
+
+
+def test_emails_are_distinct_and_key_derived():
+    assert perm_email("manage_events") == "perm.manage_events@staging.example"
+    assert cond_email(3) == "cond03@staging.example"
+
+
+def test_is_seed_allowed_guard():
+    assert is_seed_allowed(None, force=False) is True
+    assert is_seed_allowed("", force=False) is True
+    assert is_seed_allowed("staging", force=False) is True
+    assert is_seed_allowed("production", force=False) is False
+    assert is_seed_allowed("production", force=True) is True
+    assert is_seed_allowed("prod-preview", force=False) is False
+
+
+def test_staging_events_span_past_current_future():
+    deltas = [e.delta_days for e in STAGING_EVENTS]
+    assert any(d < 0 for d in deltas)
+    assert any(d == 0 for d in deltas)
+    assert any(d > 0 for d in deltas)
+    assert len(STAGING_EVENTS) >= 8

--- a/docs/superpowers/plans/2026-07-11-seed-staging.md
+++ b/docs/superpowers/plans/2026-07-11-seed-staging.md
@@ -1,0 +1,760 @@
+# seed_staging Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A dedicated, idempotent `seed_staging` management command that populates the staging deploy with varied events, one single-permission role per `PermissionKey`, a per-permission user for each role (complete profiles), and a separate set of 8 profile-condition users — all onboarding-complete with a known password.
+
+**Architecture:** Follows the existing `seed` command pattern: a `Command(BaseCommand)` orchestrator in `backend/community/management/commands/seed_staging.py` plus static data + pure helpers in a sibling `_seed_staging_data.py`. Roles/users are driven off the `PermissionKey` enum so coverage holds by construction. Idempotent via `get_or_create` + reconcile. A production guard keys off `RAILWAY_ENVIRONMENT_NAME`. Run on demand via a Railway one-off.
+
+**Tech Stack:** Django 5 management command, `django.utils.timezone`, pytest + `call_command`.
+
+## Global Constraints
+
+- Password for all seeded users: `testPassword1@` (passes `AUTH_PASSWORD_VALIDATORS`).
+- No top-of-file comments (hook-enforced). No banner/preamble comments. Module docstring is allowed.
+- Comments only where the *why* is non-obvious; single-line. Structured docstrings OK.
+- Prefer shared types over raw strings: use `PermissionKey`, `EventType`, `Role`.
+- Files under 300 LOC target, 500 hard max — split data into `_seed_staging_data.py`.
+- Never commit on `main`. This worktree is on branch `chore-seed-staging`. Commit via literal worktree path: `git -C /Users/leahpeker/development/pda/.claude/worktrees/chore-seed-staging commit -F <msgfile>` (single command; no heredoc; add and commit as separate Bash calls).
+- No `Co-Authored-By` trailers.
+- Reserved phone blocks: per-permission `+170255501NN` (NN=00..11), condition `+170255502NN` (NN=00..07). Disjoint from dev seed `+1702555000x`.
+- Role names: `perm: {key}`. Event titles prefixed `[staging] `.
+- Verify with `make agent-ci` (from worktree root) before marking complete / opening PR — not per commit.
+
+**Working directory for all commands:** `/Users/leahpeker/development/pda/.claude/worktrees/chore-seed-staging`. Run `make`/`pytest` from there; run `python manage.py` from `backend/`.
+
+---
+
+## File Structure
+
+- Create: `backend/community/management/commands/_seed_staging_data.py` — pure data + helpers: event templates, `PermissionKey`-derived role/user builders, the 8-combination enumerator, the `_is_seed_allowed` guard helper, and `PASSWORD`. No Django model access at import time beyond enum reads.
+- Create: `backend/community/management/commands/seed_staging.py` — `Command` orchestrator: guard check, seed roles → per-permission users → condition users → events, print summaries.
+- Create: `backend/tests/test_seed_staging.py` — pytest coverage.
+
+---
+
+## Task 1: Pure data module + guard/combination helpers
+
+Build `_seed_staging_data.py` with only pure, importable, unit-testable pieces (no DB). This task's deliverable is the data + helpers with their own tests.
+
+**Files:**
+- Create: `backend/community/management/commands/_seed_staging_data.py`
+- Test: `backend/tests/test_seed_staging.py`
+
+**Interfaces:**
+- Consumes: `users.permissions.PermissionKey`, `community.models.choices.EventType`.
+- Produces:
+  - `PASSWORD: str = "testPassword1@"`
+  - `perm_phone(index: int) -> str` → `f"+170255501{index:02d}"`
+  - `cond_phone(index: int) -> str` → `f"+170255502{index:02d}"`
+  - `condition_combinations() -> list[tuple[bool, bool, bool]]` → the 8 `(has_email, guidelines_done, sms_done)` tuples in fixed order.
+  - `condition_label(combo: tuple[bool, bool, bool]) -> str` → e.g. `"cond: complete"`, `"cond: no-email+needs-sms"`.
+  - `cond_email(index: int) -> str` → `f"cond{index:02d}@staging.example"`.
+  - `perm_email(key: str) -> str` → `f"perm.{key}@staging.example"`.
+  - `is_seed_allowed(env_name: str | None, force: bool) -> bool` → True for `None`/`""`/`"staging"`; for any other value only if `force`.
+  - `STAGING_EVENTS: list[SeedStagingEvent]` — dataclass instances (~10) spanning past/current/future.
+  - `SeedStagingEvent` dataclass: `title, description, delta_days: int, duration_hours: float, location, event_type: str = EventType.COMMUNITY`.
+
+- [ ] **Step 1: Write failing tests for the pure helpers**
+
+Create `backend/tests/test_seed_staging.py`:
+
+```python
+import pytest
+
+from community.management.commands._seed_staging_data import (
+    PASSWORD,
+    STAGING_EVENTS,
+    condition_combinations,
+    condition_label,
+    cond_email,
+    cond_phone,
+    is_seed_allowed,
+    perm_email,
+    perm_phone,
+)
+
+
+def test_password_meets_validators():
+    assert len(PASSWORD) >= 8
+    assert any(c.islower() for c in PASSWORD)
+    assert any(c.isupper() for c in PASSWORD)
+    assert not PASSWORD.isdigit()
+
+
+def test_perm_phone_is_zero_padded_in_own_block():
+    assert perm_phone(0) == "+17025550100"
+    assert perm_phone(11) == "+17025550111"
+
+
+def test_cond_phone_is_zero_padded_in_own_block():
+    assert cond_phone(0) == "+17025550200"
+    assert cond_phone(7) == "+17025550207"
+
+
+def test_perm_and_cond_blocks_are_disjoint():
+    perm = {perm_phone(i) for i in range(12)}
+    cond = {cond_phone(i) for i in range(8)}
+    assert perm.isdisjoint(cond)
+    assert all(not p.startswith("+1702555000") for p in perm | cond)
+
+
+def test_condition_combinations_are_all_eight_unique():
+    combos = condition_combinations()
+    assert len(combos) == 8
+    assert len(set(combos)) == 8
+    assert (True, True, True) in combos
+    assert (False, False, False) in combos
+
+
+def test_condition_label_is_deterministic_and_descriptive():
+    assert condition_label((True, True, True)) == "cond: complete"
+    label = condition_label((False, True, False))
+    assert label.startswith("cond: ")
+    assert "no-email" in label
+    assert "needs-sms" in label
+
+
+def test_emails_are_distinct_and_key_derived():
+    assert perm_email("manage_events") == "perm.manage_events@staging.example"
+    assert cond_email(3) == "cond03@staging.example"
+
+
+def test_is_seed_allowed_guard():
+    assert is_seed_allowed(None, force=False) is True
+    assert is_seed_allowed("", force=False) is True
+    assert is_seed_allowed("staging", force=False) is True
+    assert is_seed_allowed("production", force=False) is False
+    assert is_seed_allowed("production", force=True) is True
+    assert is_seed_allowed("prod-preview", force=False) is False
+
+
+def test_staging_events_span_past_current_future():
+    deltas = [e.delta_days for e in STAGING_EVENTS]
+    assert any(d < 0 for d in deltas)
+    assert any(d == 0 for d in deltas)
+    assert any(d > 0 for d in deltas)
+    assert len(STAGING_EVENTS) >= 8
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && uv run pytest tests/test_seed_staging.py -q`
+Expected: FAIL — `ModuleNotFoundError`/`ImportError` (module doesn't exist yet).
+
+- [ ] **Step 3: Implement `_seed_staging_data.py`**
+
+Create `backend/community/management/commands/_seed_staging_data.py`:
+
+```python
+"""Static data + pure helpers for the `seed_staging` command."""
+
+from dataclasses import dataclass
+
+from community.models.choices import EventType
+
+PASSWORD = "testPassword1@"
+
+
+@dataclass
+class SeedStagingEvent:
+    title: str
+    description: str
+    delta_days: int
+    duration_hours: float
+    location: str
+    event_type: str = EventType.COMMUNITY
+
+
+def perm_phone(index: int) -> str:
+    return f"+170255501{index:02d}"
+
+
+def cond_phone(index: int) -> str:
+    return f"+170255502{index:02d}"
+
+
+def perm_email(key: str) -> str:
+    return f"perm.{key}@staging.example"
+
+
+def cond_email(index: int) -> str:
+    return f"cond{index:02d}@staging.example"
+
+
+def condition_combinations() -> list[tuple[bool, bool, bool]]:
+    """All 8 (has_email, guidelines_done, sms_done) patterns, fixed order."""
+    return [
+        (has_email, guidelines_done, sms_done)
+        for has_email in (True, False)
+        for guidelines_done in (True, False)
+        for sms_done in (True, False)
+    ]
+
+
+def condition_label(combo: tuple[bool, bool, bool]) -> str:
+    has_email, guidelines_done, sms_done = combo
+    parts: list[str] = []
+    if not has_email:
+        parts.append("no-email")
+    if not guidelines_done:
+        parts.append("needs-guidelines")
+    if not sms_done:
+        parts.append("needs-sms")
+    return "cond: " + ("complete" if not parts else "+".join(parts))
+
+
+def is_seed_allowed(env_name: str | None, force: bool) -> bool:
+    """Allow local/unset and staging; refuse any other env unless forced."""
+    if not env_name or env_name == "staging":
+        return True
+    return force
+
+
+STAGING_EVENTS = [
+    SeedStagingEvent(
+        title="[staging] past potluck",
+        description="a wrapped-up community potluck from last month.",
+        delta_days=-30,
+        duration_hours=3,
+        location="community center",
+    ),
+    SeedStagingEvent(
+        title="[staging] last week's film night",
+        description="documentary screening and discussion.",
+        delta_days=-7,
+        duration_hours=2,
+        location="the annex",
+    ),
+    SeedStagingEvent(
+        title="[staging] yesterday's kitchen social",
+        description="casual cook-and-hang.",
+        delta_days=-1,
+        duration_hours=2.5,
+        location="shared kitchen",
+    ),
+    SeedStagingEvent(
+        title="[staging] happening today",
+        description="drop-in tabling and outreach.",
+        delta_days=0,
+        duration_hours=4,
+        location="market square",
+        event_type=EventType.OFFICIAL,
+    ),
+    SeedStagingEvent(
+        title="[staging] tomorrow's cooking workshop",
+        description="plant-based basics, hands-on.",
+        delta_days=1,
+        duration_hours=2,
+        location="teaching kitchen",
+    ),
+    SeedStagingEvent(
+        title="[staging] weekend park cleanup",
+        description="gloves and bags provided.",
+        delta_days=3,
+        duration_hours=3,
+        location="riverside park",
+    ),
+    SeedStagingEvent(
+        title="[staging] next week's book club",
+        description="this month's read: collective liberation.",
+        delta_days=7,
+        duration_hours=1.5,
+        location="library room b",
+    ),
+    SeedStagingEvent(
+        title="[staging] monthly official meeting",
+        description="agenda, updates, and open floor.",
+        delta_days=14,
+        duration_hours=2,
+        location="main hall",
+        event_type=EventType.OFFICIAL,
+    ),
+    SeedStagingEvent(
+        title="[staging] future festival",
+        description="all-day tabling, food, and music.",
+        delta_days=45,
+        duration_hours=8,
+        location="fairgrounds",
+    ),
+    SeedStagingEvent(
+        title="[staging] far-future retreat",
+        description="weekend planning retreat.",
+        delta_days=90,
+        duration_hours=48,
+        location="the lodge",
+    ),
+]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && uv run pytest tests/test_seed_staging.py -q`
+Expected: PASS (all pure-helper tests).
+
+- [ ] **Step 5: Typecheck + lint the new file**
+
+Run: `make agent-typecheck && make agent-lint`
+Expected: no errors. Fix any before committing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/leahpeker/development/pda/.claude/worktrees/chore-seed-staging add backend/community/management/commands/_seed_staging_data.py backend/tests/test_seed_staging.py
+git -C /Users/leahpeker/development/pda/.claude/worktrees/chore-seed-staging commit -F <msgfile>
+```
+Message: `feat(seed): staging seed data module + pure helpers (Issue 653)`
+
+---
+
+## Task 2: `seed_staging` command — roles + per-permission users
+
+Build the command orchestrator, seeding roles and per-permission users. Events + condition users come in Task 3; this task delivers a runnable command with the first two data sets.
+
+**Files:**
+- Create: `backend/community/management/commands/seed_staging.py`
+- Test: `backend/tests/test_seed_staging.py`
+
+**Interfaces:**
+- Consumes (Task 1): `PASSWORD`, `perm_phone`, `perm_email`, `is_seed_allowed`, `STAGING_EVENTS` (used in Task 3).
+- Consumes (codebase): `users.permissions.PermissionKey`, `users.roles.Role`, `users.models.User`, `django.utils.timezone`, `django.core.management.base.BaseCommand`, `django.core.management.base.CommandError`.
+- Produces: management command `seed_staging` with `--reset` and `--force` flags. Helper methods `_seed_perm_roles() -> dict[str, Role]`, `_seed_perm_users(roles) -> list[User]`.
+
+- [ ] **Step 1: Write failing tests for roles + per-permission users**
+
+Append to `backend/tests/test_seed_staging.py`:
+
+```python
+from django.core.management import call_command
+from django.contrib.auth.hashers import check_password
+
+from users.models import User
+from users.permissions import PermissionKey
+from users.roles import Role
+
+
+@pytest.mark.django_db
+def test_seed_staging_creates_one_role_per_permission():
+    call_command("seed_staging")
+    for key in PermissionKey.values:
+        role = Role.objects.get(name=f"perm: {key}")
+        assert role.permissions == [key]
+        assert role.is_default is False
+
+
+@pytest.mark.django_db
+def test_seed_staging_perm_users_hold_only_their_role_and_are_onboarded():
+    call_command("seed_staging")
+    for index, key in enumerate(PermissionKey.values):
+        user = User.objects.get(phone_number=perm_phone(index))
+        assert user.is_member is True
+        assert user.needs_onboarding is False
+        assert user.onboarded_at is not None
+        assert check_password(PASSWORD, user.password)
+        role_names = set(user.roles.values_list("name", flat=True))
+        assert role_names == {f"perm: {key}"}
+        assert user.email == perm_email(key)
+        assert user.guidelines_consent_at is not None
+        assert user.sms_consent_at is not None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && uv run pytest tests/test_seed_staging.py -k "one_role_per_permission or perm_users_hold" -q`
+Expected: FAIL — `CommandError: Unknown command: 'seed_staging'`.
+
+- [ ] **Step 3: Implement the command (roles + per-permission users)**
+
+Create `backend/community/management/commands/seed_staging.py`:
+
+```python
+"""Seed the staging deploy with events, single-permission roles, and matching users."""
+
+import os
+
+from django.contrib.auth import get_user_model
+from django.core.management.base import BaseCommand, CommandError
+from django.db import transaction
+from django.utils import timezone
+
+from users.permissions import PermissionKey
+from users.roles import Role
+
+from ._seed_staging_data import (
+    PASSWORD,
+    is_seed_allowed,
+    perm_email,
+    perm_phone,
+)
+
+User = get_user_model()
+
+
+class Command(BaseCommand):
+    help = "Seed staging with events, single-permission roles, and matching users."
+
+    def add_arguments(self, parser):
+        parser.add_argument("--reset", action="store_true", help="Delete staging-scoped rows first.")
+        parser.add_argument("--force", action="store_true", help="Run even if the environment is not staging.")
+
+    def handle(self, *args, **options):
+        env_name = os.environ.get("RAILWAY_ENVIRONMENT_NAME")
+        self.stdout.write(f"detected environment: {env_name or 'local/unset'}")
+        if not is_seed_allowed(env_name, force=options["force"]):
+            raise CommandError(
+                f"refusing to seed in environment '{env_name}'. pass --force to override."
+            )
+
+        with transaction.atomic():
+            if options["reset"]:
+                self._reset()
+            roles = self._seed_perm_roles()
+            self._seed_perm_users(roles)
+
+    def _reset(self) -> None:
+        pass  # implemented in Task 3
+
+    def _seed_perm_roles(self) -> dict[str, Role]:
+        roles: dict[str, Role] = {}
+        for key in PermissionKey.values:
+            role, created = Role.objects.get_or_create(
+                name=f"perm: {key}",
+                defaults={"permissions": [key], "is_default": False},
+            )
+            if not created and role.permissions != [key]:
+                role.permissions = [key]
+                role.save(update_fields=["permissions"])
+            roles[key] = role
+            self.stdout.write(f"  {'created' if created else 'exists'} role: {role.name}")
+        return roles
+
+    def _seed_perm_users(self, roles: dict[str, Role]) -> list[User]:
+        users: list[User] = []
+        now = timezone.now()
+        for index, key in enumerate(PermissionKey.values):
+            user, created = User.objects.get_or_create(
+                phone_number=perm_phone(index),
+                defaults={
+                    "display_name": f"perm: {key}",
+                    "email": perm_email(key),
+                    "is_member": True,
+                    "needs_onboarding": False,
+                    "onboarded_at": now,
+                    "guidelines_consent_at": now,
+                    "sms_consent_at": now,
+                },
+            )
+            if created:
+                user.set_password(PASSWORD)
+                user.save(update_fields=["password"])
+            user.roles.set([roles[key]])
+            users.append(user)
+            self.stdout.write(f"  {'created' if created else 'exists'} user: {user.display_name}")
+        return users
+```
+
+Note: `user.roles.set([...])` reconciles the role set to exactly that role on every run; the `reject_role_for_non_member` signal is satisfied because `is_member=True`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd backend && uv run pytest tests/test_seed_staging.py -k "one_role_per_permission or perm_users_hold" -q`
+Expected: PASS.
+
+- [ ] **Step 5: Typecheck + lint**
+
+Run: `make agent-typecheck && make agent-lint`
+Expected: no errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/leahpeker/development/pda/.claude/worktrees/chore-seed-staging add backend/community/management/commands/seed_staging.py backend/tests/test_seed_staging.py
+git -C /Users/leahpeker/development/pda/.claude/worktrees/chore-seed-staging commit -F <msgfile>
+```
+Message: `feat(seed): seed_staging command with roles + per-permission users (Issue 653)`
+
+---
+
+## Task 3: Condition users, events, reset, summary
+
+Complete the command: the separate 8-user condition set, events, `--reset` scoping, and summary output.
+
+**Files:**
+- Modify: `backend/community/management/commands/seed_staging.py`
+- Test: `backend/tests/test_seed_staging.py`
+
+**Interfaces:**
+- Consumes (Task 1): `STAGING_EVENTS`, `condition_combinations`, `condition_label`, `cond_phone`, `cond_email`.
+- Consumes (codebase): `community.models.Event`, `datetime.timedelta`.
+- Produces: methods `_seed_condition_users() -> list[User]`, `_seed_events(created_by) -> list[Event]`, a filled `_reset()`, and `_print_summary(...)`. The built-in `member` role is fetched/created like `seed.py` does.
+
+- [ ] **Step 1: Write failing tests for condition users, events, reset**
+
+Append to `backend/tests/test_seed_staging.py`:
+
+```python
+from datetime import timedelta
+
+from community.models import Event
+from community.management.commands._seed_staging_data import (
+    condition_combinations,
+    cond_phone,
+)
+
+
+@pytest.mark.django_db
+def test_seed_staging_creates_eight_member_only_condition_users():
+    call_command("seed_staging")
+    combos_seen = set()
+    for index in range(8):
+        user = User.objects.get(phone_number=cond_phone(index))
+        assert user.is_member is True
+        assert user.needs_onboarding is False
+        assert check_password(PASSWORD, user.password)
+        role_names = set(user.roles.values_list("name", flat=True))
+        assert role_names == {"member"}
+        combos_seen.add(
+            (
+                user.email is not None and user.email != "",
+                user.guidelines_consent_at is not None,
+                user.sms_consent_at is not None,
+            )
+        )
+    assert combos_seen == set(condition_combinations())
+
+
+@pytest.mark.django_db
+def test_seed_staging_perm_and_condition_users_are_disjoint():
+    call_command("seed_staging")
+    perm = set(User.objects.filter(phone_number__startswith="+170255501").values_list("phone_number", flat=True))
+    cond = set(User.objects.filter(phone_number__startswith="+170255502").values_list("phone_number", flat=True))
+    assert len(perm) == 12
+    assert len(cond) == 8
+    assert perm.isdisjoint(cond)
+
+
+@pytest.mark.django_db
+def test_seed_staging_events_span_past_current_future():
+    call_command("seed_staging")
+    now = timezone.now()
+    events = list(Event.objects.filter(title__startswith="[staging] "))
+    assert len(events) >= 8
+    assert any(e.start_datetime < now - timedelta(hours=1) for e in events)
+    assert any(e.start_datetime > now + timedelta(hours=1) for e in events)
+
+
+@pytest.mark.django_db
+def test_seed_staging_is_idempotent():
+    call_command("seed_staging")
+    call_command("seed_staging")
+    assert User.objects.filter(phone_number__startswith="+170255501").count() == 12
+    assert User.objects.filter(phone_number__startswith="+170255502").count() == 8
+    assert Role.objects.filter(name__startswith="perm: ").count() == len(PermissionKey.values)
+    assert Event.objects.filter(title__startswith="[staging] ").count() == len(STAGING_EVENTS)
+
+
+@pytest.mark.django_db
+def test_seed_staging_reset_removes_only_scoped_rows():
+    other = User.objects.create_user(phone_number="+17025559999", display_name="real person", is_member=True)
+    call_command("seed_staging")
+    call_command("seed_staging", "--reset")
+    assert User.objects.filter(phone_number="+17025559999").exists()
+    assert User.objects.filter(phone_number__startswith="+170255501").count() == 12
+    assert User.objects.filter(phone_number__startswith="+170255502").count() == 8
+
+
+@pytest.mark.django_db
+def test_seed_staging_refuses_in_production(monkeypatch):
+    monkeypatch.setenv("RAILWAY_ENVIRONMENT_NAME", "production")
+    with pytest.raises(Exception):
+        call_command("seed_staging")
+    assert Role.objects.filter(name__startswith="perm: ").count() == 0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd backend && uv run pytest tests/test_seed_staging.py -k "condition_users or disjoint or events_span or idempotent or reset_removes or refuses" -q`
+Expected: FAIL — condition users / events don't exist yet; `--reset` is a no-op; refuse-in-prod already passes but others fail.
+
+- [ ] **Step 3: Implement condition users, events, reset, summary**
+
+Edit `backend/community/management/commands/seed_staging.py`.
+
+Add imports at top (after existing imports):
+
+```python
+from datetime import timedelta
+
+from community.models import Event
+
+from ._seed_staging_data import (
+    STAGING_EVENTS,
+    cond_email,
+    cond_phone,
+    condition_combinations,
+    condition_label,
+)
+```
+
+Replace `handle` body's atomic block to seed all sets and print a summary:
+
+```python
+        with transaction.atomic():
+            if options["reset"]:
+                self._reset()
+            roles = self._seed_perm_roles()
+            perm_users = self._seed_perm_users(roles)
+            cond_users = self._seed_condition_users()
+            admin = perm_users[0] if perm_users else None
+            events = self._seed_events(admin)
+        self._print_summary(roles, perm_users, cond_users, events)
+```
+
+Replace the placeholder `_reset` with real scoping:
+
+```python
+    def _reset(self) -> None:
+        Event.objects.filter(title__startswith="[staging] ").delete()
+        User.objects.filter(phone_number__startswith="+170255501").delete()
+        User.objects.filter(phone_number__startswith="+170255502").delete()
+        Role.objects.filter(name__startswith="perm: ").delete()
+        self.stdout.write("  reset: removed staging-scoped rows")
+```
+
+Add the member-role fetch, condition users, events, and summary:
+
+```python
+    def _member_role(self) -> Role:
+        role, _ = Role.objects.get_or_create(name="member", defaults={"is_default": True})
+        return role
+
+    def _seed_condition_users(self) -> list[User]:
+        member_role = self._member_role()
+        now = timezone.now()
+        users: list[User] = []
+        for index, combo in enumerate(condition_combinations()):
+            has_email, guidelines_done, sms_done = combo
+            user, created = User.objects.get_or_create(
+                phone_number=cond_phone(index),
+                defaults={"display_name": condition_label(combo), "is_member": True},
+            )
+            user.email = cond_email(index) if has_email else None
+            user.guidelines_consent_at = now if guidelines_done else None
+            user.sms_consent_at = now if sms_done else None
+            user.needs_onboarding = False
+            user.onboarded_at = now
+            user.display_name = condition_label(combo)
+            user.save(update_fields=[
+                "email", "guidelines_consent_at", "sms_consent_at",
+                "needs_onboarding", "onboarded_at", "display_name",
+            ])
+            if created:
+                user.set_password(PASSWORD)
+                user.save(update_fields=["password"])
+            user.roles.set([member_role])
+            users.append(user)
+            self.stdout.write(f"  {'created' if created else 'exists'} user: {user.display_name}")
+        return users
+
+    def _seed_events(self, created_by) -> list[Event]:
+        now = timezone.now()
+        events: list[Event] = []
+        for data in STAGING_EVENTS:
+            start = now + timedelta(days=data.delta_days)
+            end = start + timedelta(hours=data.duration_hours)
+            event, created = Event.objects.get_or_create(
+                title=data.title,
+                defaults={
+                    "description": data.description,
+                    "start_datetime": start,
+                    "end_datetime": end,
+                    "location": data.location,
+                    "event_type": data.event_type,
+                    "created_by": created_by,
+                },
+            )
+            events.append(event)
+            self.stdout.write(f"  {'created' if created else 'exists'} event: {data.title}")
+        return events
+
+    def _print_summary(self, roles, perm_users, cond_users, events) -> None:
+        self.stdout.write("")
+        self.stdout.write(f"password for all seeded users: {PASSWORD}")
+        self.stdout.write(f"events: {len(events)}  roles: {len(roles)}  "
+                          f"perm users: {len(perm_users)}  condition users: {len(cond_users)}")
+        self.stdout.write("per-permission users (phone -> role):")
+        for user in perm_users:
+            names = ", ".join(user.roles.values_list("name", flat=True))
+            self.stdout.write(f"  {user.phone_number} -> {names}")
+        self.stdout.write("profile-condition users (phone -> pattern):")
+        for user in cond_users:
+            self.stdout.write(f"  {user.phone_number} -> {user.display_name}")
+```
+
+Note: condition users reconcile their profile fields on every run (set outside the `created` branch) so the intended pattern is stable even if the row pre-existed.
+
+- [ ] **Step 4: Run the full test file**
+
+Run: `cd backend && uv run pytest tests/test_seed_staging.py -q`
+Expected: PASS (all tests).
+
+- [ ] **Step 5: Run the command locally to eyeball output**
+
+Run: `cd backend && DJANGO_SETTINGS_MODULE=config.settings uv run python manage.py seed_staging 2>&1 | tail -40`
+Expected: two summary tables, sensible counts, no traceback. (Uses the worktree's SQLite/dev DB — safe.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git -C /Users/leahpeker/development/pda/.claude/worktrees/chore-seed-staging add backend/community/management/commands/seed_staging.py backend/tests/test_seed_staging.py
+git -C /Users/leahpeker/development/pda/.claude/worktrees/chore-seed-staging commit -F <msgfile>
+```
+Message: `feat(seed): condition users, events, --reset, and summary for seed_staging (Issue 653)`
+
+---
+
+## Task 4: Documentation + pre-PR CI gate
+
+Document how to run it and verify the whole suite.
+
+**Files:**
+- Modify: `CLAUDE.md` (add `seed_staging` to the dev-commands list) — one line.
+- Modify: `docs/superpowers/specs/2026-07-09-seed-staging-design.md` — none needed; already current.
+
+- [ ] **Step 1: Add a Makefile-adjacent note to CLAUDE.md**
+
+In `CLAUDE.md`, under the development-commands code block or Standards, add a single line documenting the on-demand staging run:
+
+```
+# Staging demo data (run on demand against staging, never prod):
+#   railway run --environment staging python backend/manage.py seed_staging
+```
+
+Place it as a comment line inside the existing ```bash dev-commands block, after `make seed`.
+
+- [ ] **Step 2: Run the full pre-PR CI gate**
+
+Run: `make agent-ci`
+Expected: all green (ruff, ty, complexity, pytest, frontend checks unaffected). Fix anything that fails, re-run until clean.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git -C /Users/leahpeker/development/pda/.claude/worktrees/chore-seed-staging add CLAUDE.md
+git -C /Users/leahpeker/development/pda/.claude/worktrees/chore-seed-staging commit -F <msgfile>
+```
+Message: `docs(seed): document on-demand staging seed run (Issue 653)`
+
+- [ ] **Step 4: Open the PR (draft)**
+
+Use the `/open-pr` skill (or `gh pr create --draft`) targeting `main`, linking Issue 653. Do not merge.
+
+---
+
+## Notes for the implementer
+
+- The `reject_role_for_non_member` m2m signal raises `ValueError` if a role is assigned to a non-member. All seeded users are `is_member=True`, so `user.roles.set([...])` is safe.
+- `User.email` has a partial unique constraint (`unique_non_blank_email`) — every seeded email is distinct by construction (`perm.{key}@...`, `cond{index:02d}@...`).
+- `Event` defaults: `status=EventStatus.ACTIVE`, `visibility=PageVisibility.PUBLIC`, so seeded events appear on the public calendar without extra fields.
+- `Role.name` is `max_length=50`; longest role name `perm: approve_join_requests` (27 chars) fits.
+- Do not add top-of-file comments (hook-enforced). Module docstrings are fine.

--- a/docs/superpowers/specs/2026-07-09-seed-staging-design.md
+++ b/docs/superpowers/specs/2026-07-09-seed-staging-design.md
@@ -10,7 +10,9 @@ Three related data sets:
 
 1. Varied events spanning past/current/future.
 2. One role per grantable `PermissionKey`, each granting exactly one permission.
-3. One member user per single-permission role, holding only that role.
+3. One member user per single-permission role, holding only that role. Users are
+   **onboarding-complete** (logged-in-ready) and carry a **variety of
+   profile-completeness conditions** so staging exercises those states.
 
 ## Approach
 
@@ -59,27 +61,49 @@ disjoint from the dev seed users at `+1702555000x`, so the command never touches
 real or dev accounts. Each user:
 
 - `is_member=True` (required by the `reject_role_for_non_member` m2m signal).
-- `needs_onboarding=True`, `set_unusable_password()` — real onboarding path.
+- **Onboarding complete**: `needs_onboarding=False`, `onboarded_at` set,
+  `set_password(PASSWORD)` — logged-in-ready, not magic-link/onboarding-pending.
 - `display_name = f"perm: {key}"`.
 - Assigned **only** its single-permission role via `user.roles.add(role)`. There
   is no "member role required" enforcement on direct `.add()` (only the API path
   enforces that), so the user holds exactly one role — matching AC.
 
 Idempotent via `get_or_create(phone_number=...)`; role assignment reconciled to
-exactly `{role}` on re-run.
+exactly `{role}` on re-run. Profile-condition fields (below) are also reconciled
+on re-run so the intended pattern is stable.
 
-### Credentials — magic-link onboarding
+### Profile-condition variants
 
-Login is phone + password, and seeded users have an unusable password. On **every
-run**, the command (re)issues a fresh `MagicLoginToken` per user
-(`MagicLoginToken.create_for_user`) and prints the onboarding URL. Following the
-link lands the user on `/onboarding` to set their own password — the real
-first-login flow. The printed table (permission → role → phone → onboarding URL)
-is how staging testers log in.
+Each user carries one of the profile-completeness patterns formed by three
+independent conditions:
 
-The onboarding base URL comes from a settings/env value (site URL); default to a
-relative `/onboarding?...` path if unset, and always print the raw token so the
-URL can be assembled by hand on staging.
+- **no email** — `email = None` (has phone, no email).
+- **needs guidelines consent** — `guidelines_consent_at = None`.
+- **needs sms consent** — `sms_consent_at = None`.
+
+"Complete" for a condition means the opposite: a real email, and a
+timestamp (`timezone.now()`) for each consent field. Emails must be **distinct
+per user** (the `unique_non_blank_email` partial constraint), so a user with an
+email gets a key-derived address like `perm.manage_events@staging.example`.
+
+The 3 booleans give **8 combinations** (all-complete, each single condition, each
+pair, all-three). All 8 are assigned deterministically across the 12
+per-permission users by index; the remaining 4 users repeat the more interesting
+multi-condition patterns (the two-condition and three-condition ones). Every
+combination is therefore present at least once.
+
+The pattern for a user is derived from its index (stable, deterministic — no
+randomness), so re-runs reproduce the exact same assignment. A small pure helper
+in `_seed_staging_data.py` maps `index → (has_email, guidelines_done, sms_done)`.
+
+### Credentials — known shared password
+
+Login is phone + password. Every seeded user gets the same documented password
+`testPassword1@` via `set_password()` (passes all `AUTH_PASSWORD_VALIDATORS`:
+length ≥ 8, mixed case, not all-numeric, not common, not similar to
+phone/display_name). Testers log in directly with the user's phone number + this
+password — no magic link, no onboarding step. The printed summary lists each
+user's phone so they can be logged into.
 
 ### Idempotency & `--reset`
 
@@ -94,8 +118,8 @@ URL can be assembled by hand on staging.
 ### Output
 
 Summary table printed at the end: each `PermissionKey` → role name → user phone →
-onboarding magic-link (or token). Plus counts of events/roles/users created vs
-skipped.
+profile-condition pattern (email? / guidelines? / sms?). Plus the shared password
+and counts of events/roles/users created vs skipped.
 
 ## Testing
 
@@ -105,10 +129,15 @@ skipped.
 - One role per `PermissionKey`; each role has exactly one permission equal to its
   key.
 - One user per role; each user holds exactly its one single-permission role and
-  is a member with `needs_onboarding=True` and an unusable password.
+  is a member that is **onboarding-complete** (`needs_onboarding=False`,
+  `onboarded_at` set) with a usable password that authenticates.
+- All **8 profile-condition combinations** appear across the seeded users
+  (assert by collecting each user's `(has_email, guidelines_done, sms_done)`
+  tuple and checking the set of 8 is fully covered).
+- The condition assignment is deterministic — running twice yields the same
+  pattern per user.
 - Events created span past/current/future (`start_datetime` before/around/after
   now).
-- A fresh `MagicLoginToken` exists per user after a run.
 - `--reset` removes only staging-scoped rows and re-seeds cleanly.
 
 ## Out of scope

--- a/docs/superpowers/specs/2026-07-09-seed-staging-design.md
+++ b/docs/superpowers/specs/2026-07-09-seed-staging-design.md
@@ -1,0 +1,119 @@
+# seed_staging — staging demo data (Issue 653)
+
+## Problem
+
+Staging is thin, making it hard to eyeball how calendar/event lists, permission
+gating, and the role editor behave with volume and variety. We need realistic
+demo data on the **staging** deploy only — not local dev `make seed`, not prod.
+
+Three related data sets:
+
+1. Varied events spanning past/current/future.
+2. One role per grantable `PermissionKey`, each granting exactly one permission.
+3. One member user per single-permission role, holding only that role.
+
+## Approach
+
+A dedicated, idempotent Django management command `seed_staging`, separate from
+the existing `seed` command so `make seed` never emits demo accounts. Data
+constants live in a sibling `_seed_staging_data.py` to keep the command file
+lean (file-size rule).
+
+Roles and users are **driven off the `PermissionKey` enum**, so "every grantable
+permission is represented" holds by construction — no hand-maintained list.
+
+### Files
+
+- `backend/community/management/commands/seed_staging.py` — orchestrator.
+- `backend/community/management/commands/_seed_staging_data.py` — event
+  templates, phone-number block, name helpers.
+- `backend/tests/test_seed_staging.py` — tests.
+
+### 1. Events
+
+~10 varied events built from templates with `delta_days` spanning past
+(negative), current (~0), and future (positive); varied titles, descriptions,
+locations, and `event_type`. Titles are prefixed `"[staging] "` so they are
+recognizable and scoped. Idempotent via `Event.objects.get_or_create(title=...)`,
+matching `seed.py`. `created_by` = the staging admin user (created below), or the
+first existing admin if present.
+
+### 2. Single-permission roles
+
+Iterate every `PermissionKey` value:
+
+```python
+Role.objects.get_or_create(
+    name=f"perm: {key}",
+    defaults={"permissions": [key]},
+)
+```
+
+On re-run the command **reconciles** `role.permissions` to exactly `[key]` so
+drift self-heals. Roles are non-default (`is_default=False`).
+
+### 3. One user per role
+
+Phone numbers in a reserved staging block `+1702555_01NN` (index-based),
+disjoint from the dev seed users at `+1702555000x`, so the command never touches
+real or dev accounts. Each user:
+
+- `is_member=True` (required by the `reject_role_for_non_member` m2m signal).
+- `needs_onboarding=True`, `set_unusable_password()` — real onboarding path.
+- `display_name = f"perm: {key}"`.
+- Assigned **only** its single-permission role via `user.roles.add(role)`. There
+  is no "member role required" enforcement on direct `.add()` (only the API path
+  enforces that), so the user holds exactly one role — matching AC.
+
+Idempotent via `get_or_create(phone_number=...)`; role assignment reconciled to
+exactly `{role}` on re-run.
+
+### Credentials — magic-link onboarding
+
+Login is phone + password, and seeded users have an unusable password. On **every
+run**, the command (re)issues a fresh `MagicLoginToken` per user
+(`MagicLoginToken.create_for_user`) and prints the onboarding URL. Following the
+link lands the user on `/onboarding` to set their own password — the real
+first-login flow. The printed table (permission → role → phone → onboarding URL)
+is how staging testers log in.
+
+The onboarding base URL comes from a settings/env value (site URL); default to a
+relative `/onboarding?...` path if unset, and always print the raw token so the
+URL can be assembled by hand on staging.
+
+### Idempotency & `--reset`
+
+- All creates use `get_or_create` by natural key (title / role name / phone).
+- Roles reconcile `permissions`; users reconcile role set. Re-running never
+  duplicates and only ever touches its own reserved names/phone block.
+- Support a `--reset` flag (per Django-ninja standards) that deletes only the
+  staging-scoped rows (roles named `perm: *`, users in the reserved phone block,
+  events titled `[staging] *`) before re-seeding. `--reset` never touches
+  non-scoped data.
+
+### Output
+
+Summary table printed at the end: each `PermissionKey` → role name → user phone →
+onboarding magic-link (or token). Plus counts of events/roles/users created vs
+skipped.
+
+## Testing
+
+`backend/tests/test_seed_staging.py`:
+
+- Idempotency: run twice → stable counts, no duplicates.
+- One role per `PermissionKey`; each role has exactly one permission equal to its
+  key.
+- One user per role; each user holds exactly its one single-permission role and
+  is a member with `needs_onboarding=True` and an unusable password.
+- Events created span past/current/future (`start_datetime` before/around/after
+  now).
+- A fresh `MagicLoginToken` exists per user after a run.
+- `--reset` removes only staging-scoped rows and re-seeds cleanly.
+
+## Out of scope
+
+- No frontend changes. `PERMISSION_LABELS` in `RoleFormDialog.tsx` is separate;
+  this command surfaces every permission as a role, which incidentally makes any
+  missing label visible in the editor, but syncing that mirror is not this task.
+- Not wired into any automatic deploy step — run on demand against staging.

--- a/docs/superpowers/specs/2026-07-09-seed-staging-design.md
+++ b/docs/superpowers/specs/2026-07-09-seed-staging-design.md
@@ -6,13 +6,18 @@ Staging is thin, making it hard to eyeball how calendar/event lists, permission
 gating, and the role editor behave with volume and variety. We need realistic
 demo data on the **staging** deploy only — not local dev `make seed`, not prod.
 
-Three related data sets:
+Data sets:
 
 1. Varied events spanning past/current/future.
 2. One role per grantable `PermissionKey`, each granting exactly one permission.
-3. One member user per single-permission role, holding only that role. Users are
-   **onboarding-complete** (logged-in-ready) and carry a **variety of
-   profile-completeness conditions** so staging exercises those states.
+3. **Per-permission users** — one member per single-permission role, holding only
+   that role, with a **complete** profile. All onboarding-complete
+   (logged-in-ready).
+4. **Profile-condition users** — a *separate* set of members (built-in `member`
+   role only) that exercise the **profile-completeness conditions**: one user per
+   combination of (no email / needs guidelines consent / needs sms consent). Also
+   onboarding-complete. These are in addition to the per-permission users, so
+   role/permission testing stays clean and independent of profile-state testing.
 
 ## Approach
 
@@ -54,47 +59,61 @@ Role.objects.get_or_create(
 On re-run the command **reconciles** `role.permissions` to exactly `[key]` so
 drift self-heals. Roles are non-default (`is_default=False`).
 
-### 3. One user per role
+### Phone-number blocks
 
-Phone numbers in a reserved staging block `+1702555_01NN` (index-based),
-disjoint from the dev seed users at `+1702555000x`, so the command never touches
-real or dev accounts. Each user:
+All seeded users live in a reserved staging block disjoint from the dev seed
+users (`+1702555000x`), so the command never touches real or dev accounts. Two
+non-overlapping sub-ranges keep the two groups distinct:
+
+- **Per-permission users**: `+170255501NN` (NN = permission index, 00–11).
+- **Profile-condition users**: `+170255502NN` (NN = combination index, 00–07).
+
+### 3. Per-permission users (complete profiles)
+
+One member per single-permission role. Each user:
 
 - `is_member=True` (required by the `reject_role_for_non_member` m2m signal).
 - **Onboarding complete**: `needs_onboarding=False`, `onboarded_at` set,
   `set_password(PASSWORD)` — logged-in-ready, not magic-link/onboarding-pending.
+- **Complete profile**: a distinct email, `guidelines_consent_at` and
+  `sms_consent_at` both set to `timezone.now()`.
 - `display_name = f"perm: {key}"`.
 - Assigned **only** its single-permission role via `user.roles.add(role)`. There
   is no "member role required" enforcement on direct `.add()` (only the API path
   enforces that), so the user holds exactly one role — matching AC.
 
 Idempotent via `get_or_create(phone_number=...)`; role assignment reconciled to
-exactly `{role}` on re-run. Profile-condition fields (below) are also reconciled
-on re-run so the intended pattern is stable.
+exactly `{role}` on re-run.
 
-### Profile-condition variants
+### 4. Profile-condition users (separate set)
 
-Each user carries one of the profile-completeness patterns formed by three
-independent conditions:
+A *separate* batch of members whose purpose is exercising profile-completeness
+states — independent of permission testing. Three independent conditions:
 
 - **no email** — `email = None` (has phone, no email).
 - **needs guidelines consent** — `guidelines_consent_at = None`.
 - **needs sms consent** — `sms_consent_at = None`.
 
-"Complete" for a condition means the opposite: a real email, and a
-timestamp (`timezone.now()`) for each consent field. Emails must be **distinct
-per user** (the `unique_non_blank_email` partial constraint), so a user with an
-email gets a key-derived address like `perm.manage_events@staging.example`.
+"Complete" for a condition means the opposite: a real email and a
+`timezone.now()` timestamp for the consent field. The 3 booleans give **8
+combinations** (all-complete → each single → each pair → all-three); the set
+contains **exactly 8 users, one per combination**.
 
-The 3 booleans give **8 combinations** (all-complete, each single condition, each
-pair, all-three). All 8 are assigned deterministically across the 12
-per-permission users by index; the remaining 4 users repeat the more interesting
-multi-condition patterns (the two-condition and three-condition ones). Every
-combination is therefore present at least once.
+Each condition user:
 
-The pattern for a user is derived from its index (stable, deterministic — no
-randomness), so re-runs reproduce the exact same assignment. A small pure helper
-in `_seed_staging_data.py` maps `index → (has_email, guidelines_done, sms_done)`.
+- `is_member=True`, onboarding-complete (`needs_onboarding=False`, `onboarded_at`
+  set, `set_password(PASSWORD)`).
+- Assigned **only the built-in `member` role** (no permission role) — so these
+  users add no permission coverage and isolate profile-state testing.
+- `display_name` encodes its pattern, e.g. `cond: no-email+needs-sms`.
+- Emails must be **distinct per user** (the `unique_non_blank_email` partial
+  constraint); a user that has an email gets an index-derived address like
+  `cond05@staging.example`.
+
+Combinations are enumerated deterministically (fixed order over the 3 booleans),
+so re-runs reproduce the exact same assignment. A small pure helper in
+`_seed_staging_data.py` yields the 8 `(has_email, guidelines_done, sms_done)`
+tuples. Idempotent + reconciled per re-run like the per-permission users.
 
 ### Credentials — known shared password
 
@@ -111,9 +130,9 @@ user's phone so they can be logged into.
 - Roles reconcile `permissions`; users reconcile role set. Re-running never
   duplicates and only ever touches its own reserved names/phone block.
 - Support a `--reset` flag (per Django-ninja standards) that deletes only the
-  staging-scoped rows (roles named `perm: *`, users in the reserved phone block,
-  events titled `[staging] *`) before re-seeding. `--reset` never touches
-  non-scoped data.
+  staging-scoped rows (roles named `perm: *`, users in **both** reserved phone
+  sub-ranges `+170255501xx`/`+170255502xx`, events titled `[staging] *`) before
+  re-seeding. `--reset` never touches non-scoped data.
 
 ### Running on staging & the production guard
 
@@ -145,9 +164,13 @@ force) -> bool`) makes this unit-testable without env manipulation.
 
 ### Output
 
-Summary table printed at the end: each `PermissionKey` → role name → user phone →
-profile-condition pattern (email? / guidelines? / sms?). Plus the shared password
-and counts of events/roles/users created vs skipped.
+Two summary tables printed at the end:
+
+- **Per-permission users**: `PermissionKey` → role name → user phone.
+- **Profile-condition users**: pattern (email? / guidelines? / sms?) → user phone.
+
+Plus the shared password and counts of events / roles / per-permission users /
+condition users created vs skipped.
 
 ## Testing
 
@@ -156,14 +179,17 @@ and counts of events/roles/users created vs skipped.
 - Idempotency: run twice → stable counts, no duplicates.
 - One role per `PermissionKey`; each role has exactly one permission equal to its
   key.
-- One user per role; each user holds exactly its one single-permission role and
-  is a member that is **onboarding-complete** (`needs_onboarding=False`,
-  `onboarded_at` set) with a usable password that authenticates.
-- All **8 profile-condition combinations** appear across the seeded users
-  (assert by collecting each user's `(has_email, guidelines_done, sms_done)`
-  tuple and checking the set of 8 is fully covered).
-- The condition assignment is deterministic — running twice yields the same
-  pattern per user.
+- One per-permission user per role; each holds exactly its one single-permission
+  role, is **onboarding-complete** (`needs_onboarding=False`, `onboarded_at` set)
+  with a usable password that authenticates, and has a **complete profile**
+  (email + both consent timestamps).
+- Exactly **8 profile-condition users** exist (separate from the per-permission
+  users), each holding **only the built-in `member` role**, and together they
+  cover all 8 `(has_email, guidelines_done, sms_done)` combinations exactly once.
+- Condition users are also onboarding-complete with usable passwords.
+- The two groups are disjoint (distinct phone sub-ranges; per-permission users
+  carry no `member`-only-condition entanglement).
+- Assignment is deterministic — running twice yields the same per-user pattern.
 - Events created span past/current/future (`start_datetime` before/around/after
   now).
 - `--reset` removes only staging-scoped rows and re-seeds cleanly.

--- a/docs/superpowers/specs/2026-07-09-seed-staging-design.md
+++ b/docs/superpowers/specs/2026-07-09-seed-staging-design.md
@@ -115,6 +115,34 @@ user's phone so they can be logged into.
   events titled `[staging] *`) before re-seeding. `--reset` never touches
   non-scoped data.
 
+### Running on staging & the production guard
+
+The container entrypoint (`entrypoint.sh`) runs `migrate` then uvicorn — it does
+**not** seed. The command is run **on demand** as a Railway one-off against the
+staging environment:
+
+```bash
+railway run --environment staging python backend/manage.py seed_staging
+```
+
+This executes inside the deployed container with staging's real `DATABASE_URL`.
+No deploy-config / entrypoint changes are needed.
+
+**Production guard.** The command inspects `RAILWAY_ENVIRONMENT_NAME` — the same
+Railway-provided env-name variable `community/_version.py` already reads (values
+like `staging` / `production`; unset locally). Note `settings.IS_PRODUCTION`
+cannot distinguish staging from prod (it only checks that `RAILWAY_ENVIRONMENT` is
+*set*, which is true for both), so the guard keys off the `_NAME` value:
+
+- `RAILWAY_ENVIRONMENT_NAME == "staging"` → run.
+- Unset (local dev / CI) → run (so tests and `make`-driven local runs work).
+- Any other value (`production`, etc.) → **refuse** with a clear error, unless
+  `--force` is passed.
+
+The command prints the detected environment before doing anything so the operator
+sees where it is about to seed. A tiny pure helper (`_is_seed_allowed(env_name,
+force) -> bool`) makes this unit-testable without env manipulation.
+
 ### Output
 
 Summary table printed at the end: each `PermissionKey` → role name → user phone →
@@ -139,10 +167,15 @@ and counts of events/roles/users created vs skipped.
 - Events created span past/current/future (`start_datetime` before/around/after
   now).
 - `--reset` removes only staging-scoped rows and re-seeds cleanly.
+- Production guard: `_is_seed_allowed` returns True for `"staging"` and for
+  unset/local, False for `"production"`, and True for `"production"` only when
+  `force=True`. The command exits non-zero and seeds nothing when the guard
+  refuses.
 
 ## Out of scope
 
 - No frontend changes. `PERMISSION_LABELS` in `RoleFormDialog.tsx` is separate;
   this command surfaces every permission as a role, which incidentally makes any
   missing label visible in the editor, but syncing that mirror is not this task.
-- Not wired into any automatic deploy step — run on demand against staging.
+- Not wired into any automatic deploy step — run on demand via a Railway one-off
+  (see "Running on staging"). No entrypoint/CI changes.

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -91,6 +91,7 @@ export function makeUser(overrides: Partial<User> = {}): User {
     displayName: 'Test User',
     email: '',
     bio: '',
+    pronouns: '',
     isSuperuser: false,
     isStaff: false,
     needsOnboarding: false,


### PR DESCRIPTION
## Summary

Adds a dedicated, idempotent `seed_staging` management command that populates the **staging** deploy with realistic demo data for exercising the calendar, events, and RBAC/role features. Separate from `make seed` (local dev) so it never emits demo accounts locally.

Seeds three data sets:
- **Events** — 10 varied `[staging] `-prefixed events spanning past / current / future dates.
- **Single-permission roles + users** — one `perm: <key>` role per `PermissionKey` (12), each granting exactly one permission, plus a matching per-permission user (complete profile, onboarding-complete, holding **only** that role).
- **Profile-condition users** — a *separate* set of 8 members (built-in `member` role only) covering all 8 combinations of *no email* / *needs guidelines consent* / *needs sms consent*.

All seeded users are onboarding-complete (logged-in-ready) with the documented password `testPassword1@`. Roles/users are driven off the `PermissionKey` enum, so every grantable permission is represented by construction.

Safety:
- **Idempotent** via `get_or_create` + reconcile; re-running never duplicates.
- **`--reset`** deletes only staging-scoped rows (its own phone blocks, `perm: *` roles, `[staging] *` events) — never real accounts.
- **Production guard** — refuses to run unless `RAILWAY_ENVIRONMENT_NAME` is `staging`/unset, overridable with `--force`.

Refs #653 (leaving the issue open for the user to close).

### How to run on staging
```
railway run --environment staging python backend/manage.py seed_staging
```

## Test plan
- [ ] `backend/tests/test_seed_staging.py` — 17 tests: pure helpers, one-role-per-permission, per-permission users hold only their role + complete profile, 8 condition-user combinations covered, groups disjoint, events span past/current/future, idempotency, `--reset` isolation (a real user survives), and the production guard. All passing locally.
- [ ] Ran the command against a local DB: 10 events, 12 roles + 12 per-permission users, 8 condition users — output matches spec.
- [ ] Note: full `make agent-ci` gate not run in this session (skipped per request); GitHub CI will run on push.
