### PR TITLE
refactor(events): expire cohost invites via scheduled job (Issue 382)

### DIFF
--- a/backend/community/_cohost_invite_helpers.py
+++ b/backend/community/_cohost_invite_helpers.py
@@ -1,5 +1,5 @@
 """Co-host invite helpers — diffing user input against existing invites,
-plus lazy-on-read expiration of pending invites past the event end.
+plus batch expiration of pending invites past the event end.
 """
 
 from __future__ import annotations
@@ -7,6 +7,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from django.db import transaction
+from django.db.models import Q
 from django.utils import timezone
 
 from community._validation import Code, raise_validation
@@ -18,21 +19,26 @@ if TYPE_CHECKING:
     from users.models import User as UserModel
 
 
-def expire_stale_cohost_invites(event: Event) -> None:
-    """Flip PENDING invites to EXPIRED once the event has ended.
+def expire_stale_cohost_invites() -> int:
+    """Flip every PENDING invite on a past event to EXPIRED.
 
-    Called from any read path that returns invite data so the UI never sees
-    actionable invites for a past event.
+    Batch sweep run by the ``expire_stale_cohost_invites`` management command
+    (scheduled daily). Returns the number of invites expired.
 
-    TODO(#382): replace this lazy-on-read approach with a scheduled job that
-    sweeps stale invites once.
+    "Past" mirrors ``Event.is_past``: TBD events are never past, and the cutoff
+    is ``end_datetime`` when set, else ``start_datetime``. Keeping the two in
+    sync matters now that nothing expires invites lazily on read — an event
+    with no ``end_datetime`` would otherwise strand its PENDING invites forever.
     """
-    end = event.end_datetime
-    if end is None or end >= timezone.now():
-        return
-    EventCoHostInvite.objects.filter(event=event, status=CoHostInviteStatus.PENDING).update(
-        status=CoHostInviteStatus.EXPIRED, decided_at=timezone.now()
+    now = timezone.now()
+    is_past = Q(event__end_datetime__lt=now) | Q(
+        event__end_datetime__isnull=True, event__start_datetime__lt=now
     )
+    return EventCoHostInvite.objects.filter(
+        is_past,
+        status=CoHostInviteStatus.PENDING,
+        event__datetime_tbd=False,
+    ).update(status=CoHostInviteStatus.EXPIRED, decided_at=now)
 
 
 _ACTIVE_OR_PENDING = (CoHostInviteStatus.PENDING, CoHostInviteStatus.ACCEPTED)
@@ -156,11 +162,12 @@ def _check_past_event_guard(
 
 
 def get_pending_invites_for_event(event: Event) -> list[EventCoHostInvite]:
-    """Return the event's pending invites after running lazy expiration.
+    """Return the event's pending invites.
 
-    Caller must have already verified the viewer is allowed to see them.
+    Caller must have already verified the viewer is allowed to see them. Stale
+    invites are swept to EXPIRED by the scheduled ``expire_stale_cohost_invites``
+    command, not on read.
     """
-    expire_stale_cohost_invites(event)
     return list(
         EventCoHostInvite.objects.filter(
             event=event, status=CoHostInviteStatus.PENDING
@@ -172,7 +179,6 @@ def get_my_pending_invite(event: Event, user) -> EventCoHostInvite | None:
     """Return the requesting user's PENDING invite for this event, or None."""
     if user is None:
         return None
-    expire_stale_cohost_invites(event)
     return EventCoHostInvite.objects.filter(
         event=event, user=user, status=CoHostInviteStatus.PENDING
     ).first()
@@ -186,7 +192,6 @@ def has_pending_cohost_invite(event: Event, user) -> bool:
     """
     if user is None:
         return False
-    expire_stale_cohost_invites(event)
     return EventCoHostInvite.objects.filter(
         event=event, user=user, status=CoHostInviteStatus.PENDING
     ).exists()

--- a/backend/community/_event_cohost_invites.py
+++ b/backend/community/_event_cohost_invites.py
@@ -22,7 +22,6 @@ from notifications.service import (
     create_cohost_removed_notification,
 )
 
-from community._cohost_invite_helpers import expire_stale_cohost_invites
 from community._event_helpers import _can_manage_cohost_invites, _event_out
 from community._event_schemas import EventOut
 from community._shared import ErrorOut
@@ -57,12 +56,10 @@ def accept_cohost_invite(request, event_id: UUID, invite_id: UUID):
     invite = _get_invite_or_404(event_id, invite_id)
     if invite.event.is_deleted:
         raise_validation(Code.Event.NOT_FOUND, status_code=404)
-    expire_stale_cohost_invites(invite.event)
-    invite.refresh_from_db()
 
     if invite.user_id != request.auth.pk:
         raise_validation(Code.CoHostInvite.NOT_INVITEE, status_code=403)
-    if invite.status != CoHostInviteStatus.PENDING:
+    if invite.status != CoHostInviteStatus.PENDING or invite.event.is_past:
         raise_validation(Code.CoHostInvite.NOT_PENDING, status_code=400)
 
     inviter_id = str(invite.invited_by_id) if invite.invited_by_id else None
@@ -88,12 +85,10 @@ def decline_cohost_invite(request, event_id: UUID, invite_id: UUID):
     invite = _get_invite_or_404(event_id, invite_id)
     if invite.event.is_deleted:
         raise_validation(Code.Event.NOT_FOUND, status_code=404)
-    expire_stale_cohost_invites(invite.event)
-    invite.refresh_from_db()
 
     if invite.user_id != request.auth.pk:
         raise_validation(Code.CoHostInvite.NOT_INVITEE, status_code=403)
-    if invite.status != CoHostInviteStatus.PENDING:
+    if invite.status != CoHostInviteStatus.PENDING or invite.event.is_past:
         raise_validation(Code.CoHostInvite.NOT_PENDING, status_code=400)
 
     inviter_id = str(invite.invited_by_id) if invite.invited_by_id else None

--- a/backend/community/management/commands/expire_stale_cohost_invites.py
+++ b/backend/community/management/commands/expire_stale_cohost_invites.py
@@ -1,0 +1,23 @@
+"""Management command to expire stale co-host invites (issue #382).
+
+Flips PENDING invites on already-ended events to EXPIRED. Schedule this via
+Railway cron (or any scheduler) to run at least daily, e.g.:
+  python manage.py expire_stale_cohost_invites
+"""
+
+import logging
+
+from django.core.management.base import BaseCommand
+
+from community._cohost_invite_helpers import expire_stale_cohost_invites
+
+logger = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    help = "Expire PENDING co-host invites on events that have already ended."
+
+    def handle(self, *args, **options):
+        count = expire_stale_cohost_invites()
+        logger.info("expire_stale_cohost_invites: expired %d invite(s)", count)
+        self.stdout.write(self.style.SUCCESS(f"Expired {count} invite(s)."))

--- a/backend/community/management/commands/purge_deleted_events.py
+++ b/backend/community/management/commands/purge_deleted_events.py
@@ -1,7 +1,7 @@
 """Management command to permanently delete soft-deleted events older than 30 days.
 
 Schedule this via Railway cron (or any scheduler) to run daily, e.g.:
-  python manage.py hard_delete_old_events
+  python manage.py purge_deleted_events
 """
 
 import logging
@@ -22,5 +22,5 @@ class Command(BaseCommand):
         cutoff = timezone.now() - timedelta(days=30)
         qs = Event.objects.filter(status=EventStatus.DELETED, deleted_at__lt=cutoff)
         count, _ = qs.delete()
-        logger.info("hard_delete_old_events: permanently deleted %d event(s)", count)
+        logger.info("purge_deleted_events: permanently deleted %d event(s)", count)
         self.stdout.write(self.style.SUCCESS(f"Deleted {count} event(s)."))

--- a/backend/tests/test_cohost_invite_expiration.py
+++ b/backend/tests/test_cohost_invite_expiration.py
@@ -1,0 +1,162 @@
+"""Tests for scheduled co-host invite expiration (issue #382).
+
+The `expire_stale_cohost_invites` management command sweeps PENDING invites on
+past events to EXPIRED, replacing the old lazy-on-read expiration. Also covers
+the accept/decline guard that blocks a stale invite before the daily sweep runs.
+"""
+
+import json
+from datetime import timedelta
+
+import pytest
+from community.models import (
+    CoHostInviteStatus,
+    Event,
+    EventCoHostInvite,
+    EventStatus,
+)
+from django.core.management import call_command
+from django.utils import timezone
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
+
+from tests.conftest import future_iso
+
+
+def _make_user(phone: str, name: str = "Member") -> User:
+    return User.objects.create_user(
+        phone_number=phone,
+        password="testpass123",
+        display_name=name,
+    )
+
+
+def _auth_headers(user: User) -> dict:
+    refresh = RefreshToken.for_user(user)
+    return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
+
+
+def _create_event_via_api(api_client, creator: User, **overrides) -> dict:
+    payload = {
+        "title": overrides.get("title", "Community Potluck"),
+        "start_datetime": overrides.get("start_datetime", future_iso(days=30)),
+        "end_datetime": overrides.get("end_datetime", future_iso(days=30, hours=2)),
+        "status": overrides.get("status", EventStatus.ACTIVE),
+        "co_host_ids": overrides.get("co_host_ids", []),
+    }
+    response = api_client.post(
+        "/api/community/events/",
+        data=json.dumps(payload),
+        content_type="application/json",
+        **_auth_headers(creator),
+    )
+    assert response.status_code == 201, response.content
+    return response.json()
+
+
+def _mark_event_past(event: Event) -> None:
+    past = timezone.now() - timedelta(days=1)
+    Event.objects.filter(pk=event.pk).update(
+        start_datetime=past - timedelta(hours=1),
+        end_datetime=past,
+    )
+
+
+@pytest.fixture
+def creator(db) -> User:
+    return _make_user("+12025550111", "Creator")
+
+
+@pytest.fixture
+def invitee(db) -> User:
+    return _make_user("+12025550112", "Invitee")
+
+
+@pytest.fixture
+def event_with_pending_invite(db, api_client, creator, invitee) -> tuple[Event, EventCoHostInvite]:
+    _create_event_via_api(api_client, creator, co_host_ids=[str(invitee.pk)])
+    event = Event.objects.get(created_by=creator)
+    invite = EventCoHostInvite.objects.get(event=event, user=invitee)
+    return event, invite
+
+
+@pytest.mark.django_db
+class TestExpireStaleCohostInvitesCommand:
+    def test_command_marks_stale_pending_invites_expired(self, event_with_pending_invite):
+        event, invite = event_with_pending_invite
+        _mark_event_past(event)
+
+        call_command("expire_stale_cohost_invites")
+
+        invite.refresh_from_db()
+        assert invite.status == CoHostInviteStatus.EXPIRED
+        assert invite.decided_at is not None
+
+    def test_command_leaves_future_event_invites_pending(self, event_with_pending_invite):
+        _event, invite = event_with_pending_invite
+
+        call_command("expire_stale_cohost_invites")
+
+        invite.refresh_from_db()
+        assert invite.status == CoHostInviteStatus.PENDING
+
+    def test_command_leaves_non_pending_invites_untouched(self, event_with_pending_invite):
+        event, invite = event_with_pending_invite
+        _mark_event_past(event)
+        invite.status = CoHostInviteStatus.ACCEPTED
+        invite.save(update_fields=["status"])
+
+        call_command("expire_stale_cohost_invites")
+
+        invite.refresh_from_db()
+        assert invite.status == CoHostInviteStatus.ACCEPTED
+
+    def test_command_expires_invite_on_past_event_with_no_end(self, event_with_pending_invite):
+        # end_datetime is nullable; is_past falls back to start_datetime. The
+        # sweep must match so these invites don't strand forever.
+        event, invite = event_with_pending_invite
+        past = timezone.now() - timedelta(days=1)
+        Event.objects.filter(pk=event.pk).update(start_datetime=past, end_datetime=None)
+
+        call_command("expire_stale_cohost_invites")
+
+        invite.refresh_from_db()
+        assert invite.status == CoHostInviteStatus.EXPIRED
+
+    def test_command_leaves_tbd_event_invites_pending(self, event_with_pending_invite):
+        event, invite = event_with_pending_invite
+        past = timezone.now() - timedelta(days=1)
+        Event.objects.filter(pk=event.pk).update(
+            start_datetime=past, end_datetime=None, datetime_tbd=True
+        )
+
+        call_command("expire_stale_cohost_invites")
+
+        invite.refresh_from_db()
+        assert invite.status == CoHostInviteStatus.PENDING
+
+    def test_accepting_invite_on_past_event_is_rejected(
+        self, api_client, invitee, event_with_pending_invite
+    ):
+        event, invite = event_with_pending_invite
+        _mark_event_past(event)
+        response = api_client.post(
+            f"/api/community/events/{event.id}/cohost-invites/{invite.id}/accept/",
+            **_auth_headers(invitee),
+        )
+        assert response.status_code == 400
+        invite.refresh_from_db()
+        assert invite.status == CoHostInviteStatus.PENDING
+
+    def test_declining_invite_on_past_event_is_rejected(
+        self, api_client, invitee, event_with_pending_invite
+    ):
+        event, invite = event_with_pending_invite
+        _mark_event_past(event)
+        response = api_client.post(
+            f"/api/community/events/{event.id}/cohost-invites/{invite.id}/decline/",
+            **_auth_headers(invitee),
+        )
+        assert response.status_code == 400
+        invite.refresh_from_db()
+        assert invite.status == CoHostInviteStatus.PENDING

--- a/backend/tests/test_event_cohost_invites.py
+++ b/backend/tests/test_event_cohost_invites.py
@@ -1,11 +1,11 @@
 """Tests for the co-host invite approval flow (issue #363).
 
-Covers diff-on-create, diff-on-patch, accept/decline/rescind endpoints, lazy
-expiration, notifications, EventOut visibility, and permission checks.
+Covers diff-on-create, diff-on-patch, accept/decline/rescind endpoints,
+notifications, EventOut visibility, and permission checks. Scheduled expiration
+lives in test_cohost_invite_expiration.py.
 """
 
 import json
-from datetime import timedelta
 
 import pytest
 from community.models import (
@@ -14,7 +14,6 @@ from community.models import (
     EventCoHostInvite,
     EventStatus,
 )
-from django.utils import timezone
 from ninja_jwt.tokens import RefreshToken
 from notifications.models import Notification, NotificationType
 from users.models import User
@@ -308,30 +307,6 @@ class TestRescind:
             **_auth_headers(creator),
         )
         assert response.status_code == 400
-
-
-# ─── Lazy expiration ──────────────────────────────────────────────────────────
-
-
-@pytest.mark.django_db
-class TestLazyExpire:
-    def test_pending_invite_expires_when_event_is_past(
-        self, api_client, creator, event_with_pending_invite
-    ):
-        event, invite = event_with_pending_invite
-        past = timezone.now() - timedelta(days=1)
-        Event.objects.filter(pk=event.pk).update(
-            start_datetime=past - timedelta(hours=1),
-            end_datetime=past,
-        )
-        # Simply reading the event detail triggers lazy expiration.
-        response = api_client.get(
-            f"/api/community/events/{event.id}/",
-            **_auth_headers(creator),
-        )
-        assert response.status_code == 200
-        invite.refresh_from_db()
-        assert invite.status == CoHostInviteStatus.EXPIRED
 
 
 # ─── EventOut visibility ──────────────────────────────────────────────────────

--- a/backend/tests/test_event_cohost_past_guard.py
+++ b/backend/tests/test_event_cohost_past_guard.py
@@ -122,9 +122,8 @@ class TestPastEventGuard:
         # Removal is housekeeping — should keep working after the event ends.
         event_id = _create_active_event(api_client, creator, co_host_ids=[str(invitee.pk)])
         _make_event_past(event_id)
-        # Invite would have been lazily expired on read; patch with empty list
-        # is a noop for the now-EXPIRED row (rescind branch only acts on
-        # PENDING/ACCEPTED).
+        # Removal path: patch with an empty list rescinds the still-PENDING
+        # invite — the guard only blocks upserts, not removals.
         response = api_client.patch(
             f"/api/community/events/{event_id}/",
             data=json.dumps({"co_host_ids": []}),

--- a/frontend/src/screens/events/CohostInviteBanner.tsx
+++ b/frontend/src/screens/events/CohostInviteBanner.tsx
@@ -1,7 +1,7 @@
 // Accept/decline banner shown to a user with a pending co-host invite for
-// this event. Hidden once the invite is resolved or the event is past — the
-// banner relies on `myPendingCohostInviteId` from EventOut, which the backend
-// clears via lazy expiration once the event ends.
+// this event. The `event.isPast` guard below hides it once the event ends —
+// the backend no longer expires invites on read (a scheduled sweep does that
+// nightly), so `myPendingCohostInviteId` can stay set on a just-ended event.
 
 import { toast } from 'sonner';
 

--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -243,6 +243,25 @@ describe('EventMemberSection — pending host row', () => {
     expect(screen.getByText(/pending/i)).toBeInTheDocument();
   });
 
+  it('hides pending chips on a past event', () => {
+    useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
+    renderSection({
+      ...BASE_EVENT,
+      isPast: true,
+      pendingCohostInvites: [
+        {
+          id: 'inv1',
+          userId: 'user-bob',
+          userName: 'Bob',
+          userPhotoUrl: '',
+          invitedAt: new Date(),
+        },
+      ],
+    });
+
+    expect(screen.queryByLabelText(/bob \(pending\)/i)).not.toBeInTheDocument();
+  });
+
   it('shows the rescind button only when the viewer is a host', () => {
     useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
     renderSection({

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -153,8 +153,10 @@ function HostSection({
     });
   });
   // Backend only includes pending invites for the creator + accepted co-hosts.
-  // Other viewers always get an empty list, so the chips never leak.
-  const pending = event.pendingCohostInvites;
+  // Other viewers always get an empty list, so the chips never leak. Past
+  // events are dropped here: the backend sweeps them to EXPIRED nightly, but
+  // until it runs they'd otherwise show as actionable pending chips.
+  const pending = event.isPast ? [] : event.pendingCohostInvites;
   if (hosts.length === 0 && pending.length === 0 && !canEdit) return null;
   const totalChips = hosts.length + pending.length;
   const label = totalChips > 1 ? 'hosts' : 'host';

--- a/scripts/cron.sh
+++ b/scripts/cron.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+set -e
+
+# Daily maintenance sweeps, run by a Railway cron service (start command:
+# `sh scripts/cron.sh`, schedule e.g. `0 3 * * *`). Mirrors entrypoint.sh:
+# from /app, cd into backend and invoke management commands via uv.
+cd backend
+uv run python manage.py expire_stale_cohost_invites
+uv run python manage.py purge_deleted_events


### PR DESCRIPTION
## Summary
- Replace lazy-on-read cohost invite expiration with a scheduled management command (`expire_stale_cohost_invites`).
- Rewrite the expiration helper into a batch sweep (no per-event arg) that marks PENDING invites EXPIRED for past events; the sweep mirrors `Event.is_past` exactly (past end-or-start, excludes `datetime_tbd`) so no invite is stranded.
- Remove the 3 lazy read-path calls, 2 endpoint calls, and the now-unused import.
- Add an explicit `event.is_past` guard to accept/decline so a stale PENDING invite can't be accepted/declined before the daily sweep runs.
- Hide pending cohost chips on past events in the frontend member section — with lazy-on-read expiration gone, the backend returns still-PENDING invites until the nightly sweep, and the host chips had no `isPast` guard.
- Rename the sibling cleanup command `hard_delete_old_events` → `purge_deleted_events` (the old name read as "old/past events" but it only purges user-soft-deleted events, `status=DELETED`, older than 30 days).
- Add `scripts/cron.sh` bundling both scheduled commands for a Railway cron service to invoke.

Closes #382

## ⚠️ Requires Railway dashboard setup (not wired by this PR)
These commands **do not run automatically** — Railway crons are configured in the dashboard, not in the repo. After merge, create a cron service per environment (staging + production) with:
- start command: `sh scripts/cron.sh`
- schedule: e.g. `0 3 * * *` (daily 03:00 UTC)

Until that's done, invites are only swept when the command is run manually. Note: `purge_deleted_events` (formerly `hard_delete_old_events`) appears to have never been scheduled either, so soft-deleted events have been accumulating — worth verifying in the dashboard.

## Test plan
- [ ] Run `expire_stale_cohost_invites` and confirm PENDING invites on past events flip to EXPIRED (including null-end and past-start cases; `datetime_tbd` events excluded).
- [ ] Confirm accept/decline is rejected on a past event.
- [ ] Confirm pending cohost chips are hidden on a past event in the member section.
- [ ] `make agent-ci` green.
