### PR TITLE
refactor(events): switch invite-only 403 to event.perm_denied (Issue 387)

### DIFF
--- a/backend/community/_events.py
+++ b/backend/community/_events.py
@@ -249,7 +249,9 @@ def _enforce_event_read_visibility(event: Event, auth_user) -> None:
         co_host_ids = {str(c.id) for c in event.co_hosts.all()}
         invited_user_ids = {str(u.id) for u in event.invited_users.all()}
         if not _can_see_invite_only(auth_user, co_host_ids, invited_user_ids, event.created_by_id):
-            raise_validation(Code.Event.INVITE_ONLY, status_code=403)
+            raise_validation(
+                Code.Event.PERM_DENIED, status_code=403, action="view_invite_only_event"
+            )
 
 
 @router.get(

--- a/backend/community/_validation.py
+++ b/backend/community/_validation.py
@@ -33,7 +33,6 @@ class Code:
         OFFICIAL_MUST_BE_PUBLIC = "event.official_must_be_public"
         INVALID_CREATE_STATUS = "event.invalid_create_status"
         DATE_LOCKED_BY_POLL = "event.date_locked_by_poll"
-        INVITE_ONLY = "event.invite_only"
         AUTH_REQUIRED = "event.auth_required"
         CANCELLED_CANNOT_BE_EDITED = "event.cancelled_cannot_be_edited"
         PAST_CANNOT_BE_CANCELLED = "event.past_cannot_be_cancelled"

--- a/backend/community/validation_codes.json
+++ b/backend/community/validation_codes.json
@@ -47,11 +47,6 @@
         "params": []
       },
       {
-        "name": "INVITE_ONLY",
-        "value": "event.invite_only",
-        "params": []
-      },
-      {
         "name": "AUTH_REQUIRED",
         "value": "event.auth_required",
         "params": []

--- a/backend/tests/test_event_comments.py
+++ b/backend/tests/test_event_comments.py
@@ -402,7 +402,7 @@ class TestCommentVisibility:
             **stranger_headers,
         )
         # _can_see_invite_only returns False → _enforce_event_read_visibility
-        # raises Code.Event.INVITE_ONLY with status 403.
+        # raises Code.Event.PERM_DENIED with status 403.
         assert response.status_code == 403
 
     def test_invite_only_invitee_can_list(self, api_client, db, rsvp_user, rsvp_headers):

--- a/backend/tests/test_event_visibility.py
+++ b/backend/tests/test_event_visibility.py
@@ -172,14 +172,16 @@ class TestInviteOnlyVisibility:
             f"/api/community/events/{event.id}/", **self._auth_headers(test_user)
         )
         assert response.status_code == 403
-        assert_error_code(response, Code.Event.INVITE_ONLY)
+        err = assert_error_code(response, Code.Event.PERM_DENIED)
+        assert err["params"]["action"] == "view_invite_only_event"
 
     def test_get_event_403_for_anonymous(self, api_client, test_user):
         creator = self._make_user("+12025550207", "Creator7")
         event = self._make_invite_only_event(creator)
         response = api_client.get(f"/api/community/events/{event.id}/")
         assert response.status_code == 403
-        assert_error_code(response, Code.Event.INVITE_ONLY)
+        err = assert_error_code(response, Code.Event.PERM_DENIED)
+        assert err["params"]["action"] == "view_invite_only_event"
 
     def test_get_event_200_for_invited_user(self, api_client, test_user):
         creator = self._make_user("+12025550208", "Creator8")

--- a/backend/tests/test_single_event_ics.py
+++ b/backend/tests/test_single_event_ics.py
@@ -82,7 +82,7 @@ class TestSingleEventIcs:
 
         resp = api_client.get(f"/api/community/events/{event.id}/ics/")
         # Matches the canonical get_event gate, which 403s invite-only for
-        # non-invited/anon callers (Code.Event.INVITE_ONLY).
+        # non-invited/anon callers (Code.Event.PERM_DENIED).
         assert resp.status_code == 403
 
     def test_members_only_non_official_event_hidden_from_anon(self, api_client, test_user):

--- a/frontend/src/api/validationCodes.gen.ts
+++ b/frontend/src/api/validationCodes.gen.ts
@@ -16,7 +16,6 @@ export const Code = {
     OfficialMustBePublic: 'event.official_must_be_public',
     InvalidCreateStatus: 'event.invalid_create_status',
     DateLockedByPoll: 'event.date_locked_by_poll',
-    InviteOnly: 'event.invite_only',
     AuthRequired: 'event.auth_required',
     CancelledCannotBeEdited: 'event.cancelled_cannot_be_edited',
     PastCannotBeCancelled: 'event.past_cannot_be_cancelled',
@@ -210,7 +209,6 @@ export type ValidationCode =
   | 'event.official_must_be_public'
   | 'event.invalid_create_status'
   | 'event.date_locked_by_poll'
-  | 'event.invite_only'
   | 'event.auth_required'
   | 'event.cancelled_cannot_be_edited'
   | 'event.past_cannot_be_cancelled'
@@ -354,7 +352,6 @@ export const CODE_PARAMS: Record<ValidationCode, readonly string[]> = {
   'event.official_must_be_public': [],
   'event.invalid_create_status': [],
   'event.date_locked_by_poll': [],
-  'event.invite_only': [],
   'event.auth_required': [],
   'event.cancelled_cannot_be_edited': [],
   'event.past_cannot_be_cancelled': [],

--- a/frontend/src/api/validationCodes.ts
+++ b/frontend/src/api/validationCodes.ts
@@ -83,8 +83,6 @@ function messageForKnownCode(code: KnownCode, err: FieldError): string {
       return 'new events can only be saved as active or draft';
     case Code.Event.DateLockedByPoll:
       return "can't edit the date while a poll is active — finalize the poll first";
-    case Code.Event.InviteOnly:
-      return 'this event is invite only';
     case Code.Event.PermDenied:
       return "you don't have permission to see this event";
     case Code.Event.AuthRequired:


### PR DESCRIPTION
## Summary

Follow-up to #363. Invite-only event read denials now return `Code.Event.PERM_DENIED` (with `action="view_invite_only_event"`) instead of the bespoke `Code.Event.INVITE_ONLY`, so an authed member who clicks into an event they aren't invited to gets the accurate "you don't have permission to see this event" copy rather than the stranger-facing "invite only" notice.

- **Backend:** `_enforce_event_read_visibility` raises `Code.Event.PERM_DENIED` with `action="view_invite_only_event"`.
- `Code.Event.INVITE_ONLY` had no remaining callsites, so it's removed from `_validation.py` and regenerated into `validation_codes.json` / `validationCodes.gen.ts`.
- **Frontend:** dropped the `Code.Event.InviteOnly` message case; `EventDetailScreen` already routes `PermDenied` through the generic forbidden notice (the per-code `InviteOnlyNotice` branch was removed on main by prior work).
- Existing tests asserting `Event.INVITE_ONLY` updated to assert `PERM_DENIED` + the `action` param.

Closes #387

## Test plan

- [ ] `make agent-ci` — full backend suite (1080) + frontend (595) green, lint/typecheck/complexity clean
- [ ] As an authed non-invited member, GET an invite-only event → `403` with `code=event.perm_denied`, `params.action="view_invite_only_event"`
- [ ] As anon, GET an invite-only event → same `403 event.perm_denied`
- [ ] As an invited user / co-host / creator → `200`