### PR TITLE
feat(join-requests): open whatsapp send in a new tab (Issue 665)

### DIFF
--- a/frontend/src/screens/admin/ApprovalCredentialsDialog.test.tsx
+++ b/frontend/src/screens/admin/ApprovalCredentialsDialog.test.tsx
@@ -83,6 +83,13 @@ describe('ApprovalCredentialsDialog', () => {
     expect(wa?.getAttribute('href')).toContain(encodeURIComponent('hi Sam, from Vetter Vee: '));
   });
 
+  it('opens send links in a new tab with safe rel', () => {
+    renderDialog(makeUser());
+    const wa = screen.getByText('send via whatsapp').closest('a');
+    expect(wa?.getAttribute('target')).toBe('_blank');
+    expect(wa?.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+
   it('hides edit-template trigger without permission', () => {
     renderDialog(makeUser());
     expect(screen.queryByRole('button', { name: /edit shared welcome template/i })).toBeNull();

--- a/frontend/src/screens/admin/ApprovalCredentialsDialog.tsx
+++ b/frontend/src/screens/admin/ApprovalCredentialsDialog.tsx
@@ -121,7 +121,7 @@ function SendLink({ href, label, disabled }: { href: string; label: string; disa
     );
   }
   return (
-    <a href={href} className={className}>
+    <a href={href} target="_blank" rel="noopener noreferrer" className={className}>
       {label}
     </a>
   );


### PR DESCRIPTION
## overview

the "send via whatsapp" action in the approval-credentials dialog (reached from `/join-requests`) opened in the current tab, pulling the vetter away from the screen. this makes the send links open in a new tab so the user stays on `/join-requests`.

Closes #665

## what changed

- `ApprovalCredentialsDialog.tsx`: the `SendLink` anchor now sets `target="_blank"` with `rel="noopener noreferrer"`. this covers both the whatsapp and sms send links.
- added a test asserting the whatsapp link opens in a new tab with the safe `rel`.

the whatsapp paragraph-formatting note in the issue is whatsapp-side rendering and out of scope — no url-encoding change was warranted (newlines are already `encodeURIComponent`-encoded in the message body).

## verification

- `make agent-frontend-typecheck` — clean
- `make agent-frontend-lint` — clean
- `ApprovalCredentialsDialog.test.tsx` — 4 passed
