### PR TITLE
fix(profile): show pronouns near contact info and refresh on save (Issue 669)

### DIFF
--- a/frontend/src/auth/store.ts
+++ b/frontend/src/auth/store.ts
@@ -115,6 +115,9 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   async updateProfile(patch) {
     const user = await authApi.updateProfile(patch);
     set({ user });
+    // The view-profile screen reads from its own ['member-profile', id] query,
+    // which won't see store-only edits — invalidate so it refetches on next view.
+    void queryClient.invalidateQueries({ queryKey: ['member-profile', user.id] });
   },
 
   async uploadProfilePhoto(file) {

--- a/frontend/src/screens/profile/ProfileScreen.tsx
+++ b/frontend/src/screens/profile/ProfileScreen.tsx
@@ -35,6 +35,7 @@ export default function ProfileScreen() {
         <AvatarUpload size="lg" />
         <div className="flex flex-col items-center gap-1">
           <h1 className="text-2xl font-medium tracking-tight">{user.displayName}</h1>
+          {user.pronouns ? <p className="text-muted text-sm">{user.pronouns}</p> : null}
           <ContactLine value={formatPhone(user.phoneNumber)} visible={user.showPhone} />
           {user.email ? <ContactLine value={user.email} visible={user.showEmail} /> : null}
         </div>


### PR DESCRIPTION
## Overview

Fixes two pronoun bugs on the private `/profile` screen introduced when preferred pronouns were added (Issue 656 / PR #663).

Closes #669

## What changed

**Fix 1 — pronouns not shown near contact info.** `ProfileScreen` renders `user.pronouns` under the display name, just above the phone/email contact lines. Previously pronouns only appeared on the public view-profile page. Matches the display style used on `MemberProfileScreen`.

**Fix 2 — stale until refresh.** The settings save flow goes through `useAuthStore.updateProfile`, which only updated the Zustand store. The view-profile screen reads from its own `['member-profile', id]` TanStack Query, so it never saw store-only edits until a hard refresh. `updateProfile` now invalidates `['member-profile', user.id]` after saving, so view-profile refetches and shows the new pronouns immediately. `/profile` already reads live from the store, so Fix 1 makes it update instantly too.

No regression for other profile fields — the same invalidation applies to every `updateProfile` patch (name, email, bio, visibility, etc.).

## Verification

- `make agent-frontend-typecheck` — pass
- `make agent-frontend-lint` — pass
- `pnpm vitest run` on store / SettingsScreen / MemberProfileScreen suites — 17 passed