### PR TITLE
fix(events): hide comments and invite button when rsvp disabled (Issue 666, Issue 667)

### DIFF
--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -23,6 +23,9 @@ vi.mock('./EventAdminActions', () => ({ EventAdminActions: () => null }));
 vi.mock('./EventFlagDialog', () => ({ EventFlagDialog: () => null }));
 vi.mock('./InviteDialog', () => ({ InviteDialog: () => null }));
 vi.mock('./AddCoHostDialog', () => ({ AddCoHostDialog: () => null }));
+vi.mock('./comments/EventCommentsCard', () => ({
+  EventCommentsCard: () => <div data-testid="comments-card" />,
+}));
 
 import { EventMemberSection } from './EventMemberSection';
 
@@ -221,6 +224,34 @@ describe('EventMemberSection — past event gates (#385)', () => {
     useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
     renderSection({ ...ACCEPTED_COHOST_EVENT, isPast: true });
     expect(screen.getByRole('button', { name: /remove bob as co-host/i })).toBeInTheDocument();
+  });
+});
+
+describe('EventMemberSection — rsvp-disabled gates (#666, #667)', () => {
+  const RSVP_ENABLED_EVENT: Event = { ...BASE_EVENT, rsvpEnabled: true };
+
+  it('hides the comments section when rsvp is disabled (#666)', () => {
+    useAuthStore.setState({ status: 'authed', user: STRANGER, accessToken: 'tok' });
+    renderSection({ ...BASE_EVENT, rsvpEnabled: false });
+    expect(screen.queryByTestId('comments-card')).not.toBeInTheDocument();
+  });
+
+  it('shows the comments section when rsvp is enabled', () => {
+    useAuthStore.setState({ status: 'authed', user: STRANGER, accessToken: 'tok' });
+    renderSection(RSVP_ENABLED_EVENT);
+    expect(screen.getByTestId('comments-card')).toBeInTheDocument();
+  });
+
+  it('hides the invite members button when rsvp is disabled (#667)', () => {
+    useAuthStore.setState({ status: 'authed', user: STRANGER, accessToken: 'tok' });
+    renderSection({ ...BASE_EVENT, rsvpEnabled: false });
+    expect(screen.queryByRole('button', { name: /invite members/i })).not.toBeInTheDocument();
+  });
+
+  it('shows the invite members button when rsvp is enabled and the viewer may invite', () => {
+    useAuthStore.setState({ status: 'authed', user: STRANGER, accessToken: 'tok' });
+    renderSection(RSVP_ENABLED_EVENT);
+    expect(screen.getByRole('button', { name: /invite members/i })).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -36,9 +36,11 @@ export function EventMemberSection({ event }: Props) {
   const canManageEvents = hasPermission(user, Permission.ManageEvents);
   const canSeeInvited = isCoHost || canManageEvents;
   const isCancelled = event.status === EventStatus.Cancelled;
+  const rsvpDisabled = !event.rsvpEnabled;
   const canInvite =
     !isCancelled &&
     !event.isPast &&
+    !rsvpDisabled &&
     (isCoHost || event.invitePermission === InvitePermission.AllMembers);
   const showRsvp = !event.isPast && event.rsvpEnabled && event.status !== EventStatus.Cancelled;
   const showStandaloneInvited = !showRsvp && canSeeInvited && event.invitedCount > 0;
@@ -71,7 +73,7 @@ export function EventMemberSection({ event }: Props) {
         </Card>
       ) : null}
       {canInvite ? <InviteSection event={event} /> : null}
-      <EventCommentsCard eventId={event.id} />
+      {rsvpDisabled ? null : <EventCommentsCard eventId={event.id} />}
       <EventAdminActions event={event} />
       <ReportEventButton eventId={event.id} />
     </div>


### PR DESCRIPTION
## Overview

On an event where RSVP is **disabled**, two UI affordances were shown that make no sense when nobody can RSVP:

- The comments section still rendered, showing the "rsvp to join the conversation" prompt (Issue 666).
- The "invite members" button was still visible — but with RSVP disabled there's no confirmation an invite actually landed (Issue 667).

Closes #666
Closes #667

## What changed

In `frontend/src/screens/events/EventMemberSection.tsx`:

- Introduced a single source-of-truth `rsvpDisabled = !event.rsvpEnabled` so both gates stay consistent.
- **Comments (Issue 666):** the `EventCommentsCard` is no longer rendered at all when RSVP is disabled — the "rsvp to join the conversation" prompt never shows.
- **Invite button (Issue 667):** `canInvite` now requires RSVP to be enabled, so the "invite members" button is hidden on RSVP-disabled events (for all viewers). The top-level **share** button in `EventActions` is untouched and still covers public, RSVP-disabled events.

"RSVP disabled" is keyed off the existing `event.rsvpEnabled` field (API: `rsvp_enabled`) — the same field already used for the RSVP card and kebab-menu gating.

Added tests in `EventMemberSection.test.tsx` covering both fixes (comments + invite hidden when disabled, shown when enabled).

## Verification

- `make agent-frontend-typecheck` — passes
- `make agent-frontend-lint` — passes
- Vitest (`EventMemberSection`, `EventDetailScreen`, `EventCommentsCard`) — 31 passed, including 4 new tests
