### PR TITLE
fix(events): upload event photo to the created id on new-event flow (Issue 668)

### DIFF
--- a/frontend/src/api/eventWrites.test.ts
+++ b/frontend/src/api/eventWrites.test.ts
@@ -28,7 +28,12 @@ vi.mock('@/auth/store', () => {
 
 import { apiClient } from '@/api/client';
 
-import { eventToFormValues, toPartialWireBody, useInviteToEvent } from './eventWrites';
+import {
+  eventToFormValues,
+  toPartialWireBody,
+  useInviteToEvent,
+  useUploadEventPhoto,
+} from './eventWrites';
 import { textRecipientsKeys } from './textRecipients';
 
 function makeEvent(overrides: Partial<Event> = {}): Event {
@@ -203,5 +208,40 @@ describe('useInviteToEvent', () => {
     expect(invalidateSpy).toHaveBeenCalledWith({
       queryKey: textRecipientsKeys.detail(EVENT_ID),
     });
+  });
+});
+
+describe('useUploadEventPhoto', () => {
+  const EVENT_ID = '22222222-2222-2222-2222-222222222222';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function buildWrapper() {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const Wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: qc }, children);
+    return { qc, Wrapper };
+  }
+
+  // Regression for issue 668: on create the id isn't known until create-event
+  // resolves, so the upload must use the id from the mutation variables — not
+  // an id captured at hook-call time (which was '' on create → 404).
+  it('posts to the event id passed at call-time', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({ data: makeEvent({ id: EVENT_ID }) });
+    const { Wrapper } = buildWrapper();
+
+    const { result } = renderHook(() => useUploadEventPhoto(), { wrapper: Wrapper });
+    result.current.mutate({ eventId: EVENT_ID, blob: new Blob(['x'], { type: 'image/png' }) });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(apiClient.post).toHaveBeenCalledWith(
+      `/api/community/events/${EVENT_ID}/photo/`,
+      expect.any(FormData),
+      expect.objectContaining({ headers: { 'Content-Type': 'multipart/form-data' } }),
+    );
   });
 });

--- a/frontend/src/api/eventWrites.ts
+++ b/frontend/src/api/eventWrites.ts
@@ -272,11 +272,15 @@ export function useDeleteEvent(eventId: string) {
   });
 }
 
-export function useUploadEventPhoto(eventId: string) {
+// The event id is a mutation variable, not a hook argument: on the create
+// flow the id doesn't exist until create-event resolves, so binding it at
+// hook-call time (when it's still '') POSTed to a route with no id → 404 and
+// the photo was silently dropped (Issue 668).
+export function useUploadEventPhoto() {
   const qc = useQueryClient();
   const isAuthed = useAuthStore((s) => s.status === 'authed');
   return useMutation({
-    mutationFn: async (blob: Blob) => {
+    mutationFn: async ({ eventId, blob }: { eventId: string; blob: Blob }) => {
       const formData = new FormData();
       formData.append('photo', blob, 'event.png');
       const { data } = await apiClient.post<WireEvent>(
@@ -290,7 +294,7 @@ export function useUploadEventPhoto(eventId: string) {
       qc.setQueryData(eventKeys.detail(event.id, isAuthed), event);
       void qc.invalidateQueries({ queryKey: eventKeys.list(isAuthed) });
     },
-    onError: (err) => {
+    onError: (err, { eventId }) => {
       void reportError(err, ROUTE, { action: 'upload-event-photo', eventId });
     },
   });

--- a/frontend/src/screens/events/form/EventForm.tsx
+++ b/frontend/src/screens/events/form/EventForm.tsx
@@ -123,7 +123,7 @@ export function EventForm({ existing }: Props) {
 
   const create = useCreateEvent();
   const update = useUpdateEvent(existing?.id ?? '');
-  const uploadPhoto = useUploadEventPhoto(existing?.id ?? '');
+  const uploadPhoto = useUploadEventPhoto();
   const deletePhoto = useDeleteEventPhoto(existing?.id ?? '');
 
   const saving = create.isPending || update.isPending || uploadPhoto.isPending;
@@ -178,9 +178,11 @@ export function EventForm({ existing }: Props) {
       const created = await create.mutateAsync(merged);
       if (pendingPhoto) {
         try {
-          await uploadPhoto.mutateAsync(pendingPhoto);
+          await uploadPhoto.mutateAsync({ eventId: created.id, blob: pendingPhoto });
         } catch {
-          // Event saved; only the photo failed. Let the user retry from edit.
+          // Event saved; only the photo failed. Surface it so the host knows
+          // to re-add it from edit instead of the photo silently vanishing.
+          toast.error("event saved, but the photo didn't upload — add it again from edit");
         }
       }
       if (bufferedPollOptions && bufferedPollOptions.length >= 2) {
@@ -201,7 +203,7 @@ export function EventForm({ existing }: Props) {
 
   async function onCropPhoto(blob: Blob) {
     if (existing) {
-      await uploadPhoto.mutateAsync(blob);
+      await uploadPhoto.mutateAsync({ eventId: existing.id, blob });
     } else {
       setPendingPhoto(blob);
     }


### PR DESCRIPTION
## overview

Closes #668.

When creating a **new** event, uploading a photo, and publishing, the published event had **no photo** — but re-adding the photo from edit worked. The reported client stack trace was a `404 AxiosError` on upload.

## root cause

`useUploadEventPhoto(eventId)` captured the event id at **hook-call time**. In `EventForm`, on the create path `existing` is `undefined`, so the hook was bound to `''`:

```ts
const uploadPhoto = useUploadEventPhoto(existing?.id ?? '');  // '' on create
```

On submit, the upload POSTed to `/api/community/events//photo/` (empty id) → no route match → **404**. The `catch {}` around it swallowed the error silently, so the photo the host picked during create just vanished. On edit, `existing.id` is a real UUID, so it worked.

## the fix

- `useUploadEventPhoto()` now takes the event id as a **mutation variable** (`{ eventId, blob }`) rather than a hook argument, so the create flow threads the freshly-`created.id` into the upload.
- A failed upload now surfaces a toast (`"event saved, but the photo didn't upload — add it again from edit"`) instead of silently dropping the photo.
- The edit flow passes `existing.id` the same way.

## changed

- `frontend/src/api/eventWrites.ts` — `useUploadEventPhoto` signature + error reporter
- `frontend/src/screens/events/form/EventForm.tsx` — hook call, create-flow upload with `created.id`, edit-flow upload, failure toast
- `frontend/src/api/eventWrites.test.ts` — regression test asserting the upload posts to the id passed at call-time

## verification

- `make agent-frontend-typecheck` — clean
- `make agent-frontend-lint` — clean
- `vitest run src/api/eventWrites.test.ts` — 12 passed (1 new regression test)

Backend `/events/{event_id}/photo/` route was confirmed correct — this was frontend-only. Not merged/pushed to main.
