### PR TITLE
fix(members): add "not now" dismiss to email modal (Issue 672)

### DIFF
--- a/frontend/src/auth/guards.test.tsx
+++ b/frontend/src/auth/guards.test.tsx
@@ -447,11 +447,11 @@ describe('EmailGate', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByText(/add your email/i)).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /add your email/i })).toBeInTheDocument();
     expect(screen.queryByText('calendar')).not.toBeInTheDocument();
   });
 
-  it('reveals the app after dismissing via "not now"', async () => {
+  it('logs out (drops the session) when "not now" is clicked', async () => {
     const user = makeUser({ email: '' });
     useAuthStore.setState({ status: 'authed', user, accessToken: 'tok-abc' });
 
@@ -466,8 +466,8 @@ describe('EmailGate', () => {
     );
 
     await userEvent.click(screen.getByRole('button', { name: /not now/i }));
-    expect(screen.getByText('calendar')).toBeInTheDocument();
-    expect(screen.queryByText(/add your email/i)).not.toBeInTheDocument();
+    expect(useAuthStore.getState().status).toBe('unauthed');
+    expect(useAuthStore.getState().user).toBeNull();
   });
 
   it('renders Outlet when authed user has email', () => {

--- a/frontend/src/auth/guards.test.tsx
+++ b/frontend/src/auth/guards.test.tsx
@@ -451,15 +451,19 @@ describe('EmailGate', () => {
     expect(screen.queryByText('calendar')).not.toBeInTheDocument();
   });
 
-  it('logs out (drops the session) when "not now" is clicked', async () => {
+  it('logs out and lands on public calendar (not /login) when "not now" is clicked', async () => {
     const user = makeUser({ email: '' });
     useAuthStore.setState({ status: 'authed', user, accessToken: 'tok-abc' });
 
     render(
-      <MemoryRouter initialEntries={['/calendar']}>
+      <MemoryRouter initialEntries={['/members']}>
         <Routes>
           <Route element={<EmailGate />}>
             <Route path="/calendar" element={<div>calendar</div>} />
+            <Route element={<RequireAuth />}>
+              <Route path="/members" element={<div>members</div>} />
+            </Route>
+            <Route path="/login" element={<div>login</div>} />
           </Route>
         </Routes>
       </MemoryRouter>,
@@ -468,6 +472,8 @@ describe('EmailGate', () => {
     await userEvent.click(screen.getByRole('button', { name: /not now/i }));
     expect(useAuthStore.getState().status).toBe('unauthed');
     expect(useAuthStore.getState().user).toBeNull();
+    expect(await screen.findByText('calendar')).toBeInTheDocument();
+    expect(screen.queryByText('login')).not.toBeInTheDocument();
   });
 
   it('renders Outlet when authed user has email', () => {

--- a/frontend/src/auth/guards.test.tsx
+++ b/frontend/src/auth/guards.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -448,6 +449,25 @@ describe('EmailGate', () => {
 
     expect(screen.getByText(/add your email/i)).toBeInTheDocument();
     expect(screen.queryByText('calendar')).not.toBeInTheDocument();
+  });
+
+  it('reveals the app after dismissing via "not now"', async () => {
+    const user = makeUser({ email: '' });
+    useAuthStore.setState({ status: 'authed', user, accessToken: 'tok-abc' });
+
+    render(
+      <MemoryRouter initialEntries={['/calendar']}>
+        <Routes>
+          <Route element={<EmailGate />}>
+            <Route path="/calendar" element={<div>calendar</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await userEvent.click(screen.getByRole('button', { name: /not now/i }));
+    expect(screen.getByText('calendar')).toBeInTheDocument();
+    expect(screen.queryByText(/add your email/i)).not.toBeInTheDocument();
   });
 
   it('renders Outlet when authed user has email', () => {

--- a/frontend/src/auth/guards.tsx
+++ b/frontend/src/auth/guards.tsx
@@ -10,7 +10,7 @@
 // The onboarding gate wraps the WHOLE app so it applies on every navigation,
 // matching the Flutter behavior.
 
-import { type ReactNode, useEffect, useState } from 'react';
+import { type ReactNode, useEffect } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 
 import { RequireEmail } from '@/components/RequireEmail';
@@ -140,17 +140,12 @@ export function RequirePermission({ perm }: { perm: PermissionKey }) {
 
 export function EmailGate() {
   const user = useAuthStore((s) => s.user);
-  // Session-scoped: dismissing lets the user keep browsing without an email.
-  // A fresh login remounts this gate, so the prompt returns next session.
-  const [dismissed, setDismissed] = useState(false);
-  if (!dismissed && user && !user.needsOnboarding && !user.email) {
-    return (
-      <RequireEmail
-        onDismiss={() => {
-          setDismissed(true);
-        }}
-      />
-    );
+  const logout = useAuthStore((s) => s.logout);
+  // Mirrors the consent gate: you can't stay logged in without an email.
+  // "not now" drops the session, so RequireAuth bounces to /login and the
+  // public routes render logged-out.
+  if (user && !user.needsOnboarding && !user.email) {
+    return <RequireEmail onSkip={() => void logout()} />;
   }
   return <Outlet />;
 }

--- a/frontend/src/auth/guards.tsx
+++ b/frontend/src/auth/guards.tsx
@@ -11,7 +11,7 @@
 // matching the Flutter behavior.
 
 import { type ReactNode, useEffect } from 'react';
-import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { Navigate, Outlet, useLocation, useNavigate } from 'react-router-dom';
 
 import { RequireEmail } from '@/components/RequireEmail';
 import { hasPermission, type PermissionKey } from '@/models/permissions';
@@ -141,11 +141,17 @@ export function RequirePermission({ perm }: { perm: PermissionKey }) {
 export function EmailGate() {
   const user = useAuthStore((s) => s.user);
   const logout = useAuthStore((s) => s.logout);
-  // Mirrors the consent gate: you can't stay logged in without an email.
-  // "not now" drops the session, so RequireAuth bounces to /login and the
-  // public routes render logged-out.
+  const navigate = useNavigate();
+  // You can't stay logged in without an email, but "not now" isn't a dead end:
+  // it drops the session and lands on the public calendar, so the app stays
+  // usable from a logged-out state (an authed-only route would otherwise
+  // bounce to /login).
+  async function onSkip() {
+    await logout();
+    void navigate('/calendar', { replace: true });
+  }
   if (user && !user.needsOnboarding && !user.email) {
-    return <RequireEmail onSkip={() => void logout()} />;
+    return <RequireEmail onSkip={() => void onSkip()} />;
   }
   return <Outlet />;
 }

--- a/frontend/src/auth/guards.tsx
+++ b/frontend/src/auth/guards.tsx
@@ -145,13 +145,18 @@ export function EmailGate() {
   // You can't stay logged in without an email, but "not now" isn't a dead end:
   // it drops the session and lands on the public calendar, so the app stays
   // usable from a logged-out state (an authed-only route would otherwise
-  // bounce to /login).
+  // bounce to /login). A failed logout is swallowed so RequireEmail can
+  // re-enable its button and let the user retry.
   async function onSkip() {
-    await logout();
-    void navigate('/calendar', { replace: true });
+    try {
+      await logout();
+      void navigate('/calendar', { replace: true });
+    } catch {
+      // network/server error — stay on the modal, user can retry
+    }
   }
   if (user && !user.needsOnboarding && !user.email) {
-    return <RequireEmail onSkip={() => void onSkip()} />;
+    return <RequireEmail onSkip={onSkip} />;
   }
   return <Outlet />;
 }

--- a/frontend/src/auth/guards.tsx
+++ b/frontend/src/auth/guards.tsx
@@ -10,7 +10,7 @@
 // The onboarding gate wraps the WHOLE app so it applies on every navigation,
 // matching the Flutter behavior.
 
-import { type ReactNode, useEffect } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 
 import { RequireEmail } from '@/components/RequireEmail';
@@ -140,8 +140,17 @@ export function RequirePermission({ perm }: { perm: PermissionKey }) {
 
 export function EmailGate() {
   const user = useAuthStore((s) => s.user);
-  if (user && !user.needsOnboarding && !user.email) {
-    return <RequireEmail />;
+  // Session-scoped: dismissing lets the user keep browsing without an email.
+  // A fresh login remounts this gate, so the prompt returns next session.
+  const [dismissed, setDismissed] = useState(false);
+  if (!dismissed && user && !user.needsOnboarding && !user.email) {
+    return (
+      <RequireEmail
+        onDismiss={() => {
+          setDismissed(true);
+        }}
+      />
+    );
   }
   return <Outlet />;
 }

--- a/frontend/src/components/RequireEmail.test.tsx
+++ b/frontend/src/components/RequireEmail.test.tsx
@@ -28,15 +28,15 @@ describe('RequireEmail', () => {
   });
 
   it('renders the blocking form', () => {
-    render(<RequireEmail onDismiss={() => {}} />);
-    expect(screen.getByText(/add your email/i)).toBeInTheDocument();
+    render(<RequireEmail onSkip={() => {}} />);
+    expect(screen.getByRole('heading', { name: /add your email/i })).toBeInTheDocument();
     expect(screen.getByLabelText('email')).toBeInTheDocument();
   });
 
   it('submits and clears modal on success', async () => {
     const returned = { email: 'foo@example.com' };
     vi.mocked(updateProfile).mockResolvedValue(returned as never);
-    render(<RequireEmail onDismiss={() => {}} />);
+    render(<RequireEmail onSkip={() => {}} />);
     await userEvent.type(screen.getByLabelText('email'), 'foo@example.com');
     await userEvent.click(screen.getByRole('button', { name: /save/i }));
     expect(updateProfile).toHaveBeenCalledWith({ email: 'foo@example.com' });
@@ -53,32 +53,32 @@ describe('RequireEmail', () => {
         data: { detail: [{ code: 'email.already_exists', field: 'email' }] },
       },
     });
-    render(<RequireEmail onDismiss={() => {}} />);
+    render(<RequireEmail onSkip={() => {}} />);
     await userEvent.type(screen.getByLabelText('email'), 'taken@example.com');
     await userEvent.click(screen.getByRole('button', { name: /save/i }));
     expect(await screen.findByText(/already on another account/i)).toBeInTheDocument();
   });
 
   it('shows malformed-email error inline', async () => {
-    render(<RequireEmail onDismiss={() => {}} />);
+    render(<RequireEmail onSkip={() => {}} />);
     await userEvent.type(screen.getByLabelText('email'), 'not-an-email');
     await userEvent.click(screen.getByRole('button', { name: /save/i }));
     expect(await screen.findByText(/not a valid email/i)).toBeInTheDocument();
     expect(updateProfile).not.toHaveBeenCalled();
   });
 
-  it('dismisses via the "not now" button', async () => {
-    const onDismiss = vi.fn();
-    render(<RequireEmail onDismiss={onDismiss} />);
+  it('skips via the "not now" button without saving', async () => {
+    const onSkip = vi.fn();
+    render(<RequireEmail onSkip={onSkip} />);
     await userEvent.click(screen.getByRole('button', { name: /not now/i }));
-    expect(onDismiss).toHaveBeenCalledOnce();
+    expect(onSkip).toHaveBeenCalledOnce();
     expect(updateProfile).not.toHaveBeenCalled();
   });
 
-  it('dismisses via escape', async () => {
-    const onDismiss = vi.fn();
-    render(<RequireEmail onDismiss={onDismiss} />);
+  it('does not skip on escape', async () => {
+    const onSkip = vi.fn();
+    render(<RequireEmail onSkip={onSkip} />);
     await userEvent.keyboard('{Escape}');
-    expect(onDismiss).toHaveBeenCalledOnce();
+    expect(onSkip).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/components/RequireEmail.test.tsx
+++ b/frontend/src/components/RequireEmail.test.tsx
@@ -28,16 +28,16 @@ describe('RequireEmail', () => {
   });
 
   it('renders the blocking form', () => {
-    render(<RequireEmail />);
+    render(<RequireEmail onDismiss={() => {}} />);
     expect(screen.getByText(/add your email/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText('email')).toBeInTheDocument();
   });
 
   it('submits and clears modal on success', async () => {
     const returned = { email: 'foo@example.com' };
     vi.mocked(updateProfile).mockResolvedValue(returned as never);
-    render(<RequireEmail />);
-    await userEvent.type(screen.getByLabelText(/email/i), 'foo@example.com');
+    render(<RequireEmail onDismiss={() => {}} />);
+    await userEvent.type(screen.getByLabelText('email'), 'foo@example.com');
     await userEvent.click(screen.getByRole('button', { name: /save/i }));
     expect(updateProfile).toHaveBeenCalledWith({ email: 'foo@example.com' });
     expect(
@@ -53,17 +53,32 @@ describe('RequireEmail', () => {
         data: { detail: [{ code: 'email.already_exists', field: 'email' }] },
       },
     });
-    render(<RequireEmail />);
-    await userEvent.type(screen.getByLabelText(/email/i), 'taken@example.com');
+    render(<RequireEmail onDismiss={() => {}} />);
+    await userEvent.type(screen.getByLabelText('email'), 'taken@example.com');
     await userEvent.click(screen.getByRole('button', { name: /save/i }));
     expect(await screen.findByText(/already on another account/i)).toBeInTheDocument();
   });
 
   it('shows malformed-email error inline', async () => {
-    render(<RequireEmail />);
-    await userEvent.type(screen.getByLabelText(/email/i), 'not-an-email');
+    render(<RequireEmail onDismiss={() => {}} />);
+    await userEvent.type(screen.getByLabelText('email'), 'not-an-email');
     await userEvent.click(screen.getByRole('button', { name: /save/i }));
     expect(await screen.findByText(/not a valid email/i)).toBeInTheDocument();
     expect(updateProfile).not.toHaveBeenCalled();
+  });
+
+  it('dismisses via the "not now" button', async () => {
+    const onDismiss = vi.fn();
+    render(<RequireEmail onDismiss={onDismiss} />);
+    await userEvent.click(screen.getByRole('button', { name: /not now/i }));
+    expect(onDismiss).toHaveBeenCalledOnce();
+    expect(updateProfile).not.toHaveBeenCalled();
+  });
+
+  it('dismisses via escape', async () => {
+    const onDismiss = vi.fn();
+    render(<RequireEmail onDismiss={onDismiss} />);
+    await userEvent.keyboard('{Escape}');
+    expect(onDismiss).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/components/RequireEmail.test.tsx
+++ b/frontend/src/components/RequireEmail.test.tsx
@@ -28,7 +28,7 @@ describe('RequireEmail', () => {
   });
 
   it('renders the blocking form', () => {
-    render(<RequireEmail onSkip={() => {}} />);
+    render(<RequireEmail onSkip={() => Promise.resolve()} />);
     expect(screen.getByRole('heading', { name: /add your email/i })).toBeInTheDocument();
     expect(screen.getByLabelText('email')).toBeInTheDocument();
   });
@@ -36,7 +36,7 @@ describe('RequireEmail', () => {
   it('submits and clears modal on success', async () => {
     const returned = { email: 'foo@example.com' };
     vi.mocked(updateProfile).mockResolvedValue(returned as never);
-    render(<RequireEmail onSkip={() => {}} />);
+    render(<RequireEmail onSkip={() => Promise.resolve()} />);
     await userEvent.type(screen.getByLabelText('email'), 'foo@example.com');
     await userEvent.click(screen.getByRole('button', { name: /save/i }));
     expect(updateProfile).toHaveBeenCalledWith({ email: 'foo@example.com' });
@@ -53,14 +53,14 @@ describe('RequireEmail', () => {
         data: { detail: [{ code: 'email.already_exists', field: 'email' }] },
       },
     });
-    render(<RequireEmail onSkip={() => {}} />);
+    render(<RequireEmail onSkip={() => Promise.resolve()} />);
     await userEvent.type(screen.getByLabelText('email'), 'taken@example.com');
     await userEvent.click(screen.getByRole('button', { name: /save/i }));
     expect(await screen.findByText(/already on another account/i)).toBeInTheDocument();
   });
 
   it('shows malformed-email error inline', async () => {
-    render(<RequireEmail onSkip={() => {}} />);
+    render(<RequireEmail onSkip={() => Promise.resolve()} />);
     await userEvent.type(screen.getByLabelText('email'), 'not-an-email');
     await userEvent.click(screen.getByRole('button', { name: /save/i }));
     expect(await screen.findByText(/not a valid email/i)).toBeInTheDocument();
@@ -68,15 +68,27 @@ describe('RequireEmail', () => {
   });
 
   it('skips via the "not now" button without saving', async () => {
-    const onSkip = vi.fn();
+    const onSkip = vi.fn(() => Promise.resolve());
     render(<RequireEmail onSkip={onSkip} />);
     await userEvent.click(screen.getByRole('button', { name: /not now/i }));
     expect(onSkip).toHaveBeenCalledOnce();
     expect(updateProfile).not.toHaveBeenCalled();
   });
 
+  it('disables "not now" while the skip is in flight (no double-fire)', async () => {
+    let resolve!: () => void;
+    const onSkip = vi.fn(() => new Promise<void>((r) => (resolve = r)));
+    render(<RequireEmail onSkip={onSkip} />);
+    const button = screen.getByRole('button', { name: /not now/i });
+    await userEvent.click(button);
+    expect(button).toBeDisabled();
+    await userEvent.click(button);
+    expect(onSkip).toHaveBeenCalledOnce();
+    resolve();
+  });
+
   it('does not skip on escape', async () => {
-    const onSkip = vi.fn();
+    const onSkip = vi.fn(() => Promise.resolve());
     render(<RequireEmail onSkip={onSkip} />);
     await userEvent.keyboard('{Escape}');
     expect(onSkip).not.toHaveBeenCalled();

--- a/frontend/src/components/RequireEmail.tsx
+++ b/frontend/src/components/RequireEmail.tsx
@@ -1,4 +1,4 @@
-import { type SyntheticEvent, useEffect, useState } from 'react';
+import { type SyntheticEvent, useState } from 'react';
 
 import { extractApiErrorOr } from '@/api/apiErrors';
 import { updateProfile } from '@/api/auth';
@@ -6,20 +6,10 @@ import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import { TextField } from '@/components/ui/TextField';
 
-export function RequireEmail({ onDismiss }: { onDismiss: () => void }) {
+export function RequireEmail({ onSkip }: { onSkip: () => void }) {
   const [email, setEmail] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
-
-  useEffect(() => {
-    function onKey(e: KeyboardEvent) {
-      if (e.key === 'Escape') onDismiss();
-    }
-    document.addEventListener('keydown', onKey);
-    return () => {
-      document.removeEventListener('keydown', onKey);
-    };
-  }, [onDismiss]);
 
   async function onSubmit(e: SyntheticEvent) {
     e.preventDefault();
@@ -48,18 +38,14 @@ export function RequireEmail({ onDismiss }: { onDismiss: () => void }) {
       aria-labelledby="require-email-title"
       className="fixed inset-0 z-50 flex items-center justify-center p-4"
     >
-      <button
-        type="button"
-        aria-label="dismiss"
-        onClick={onDismiss}
-        className="absolute inset-0 cursor-default bg-black/60"
-      />
+      <div aria-hidden="true" className="absolute inset-0 bg-black/60" />
       <div className="bg-surface relative w-full max-w-sm rounded-lg p-6">
         <h2 id="require-email-title" className="mb-2 text-lg font-medium">
           add your email
         </h2>
         <p className="text-muted mb-4 text-sm">
-          we use email for account recovery and event updates — add yours now, or skip for now
+          we use email for account recovery and event updates — add your email to login or come back
+          later
         </p>
         <form onSubmit={(e) => void onSubmit(e)} className="flex flex-col gap-3" noValidate>
           <TextField
@@ -76,7 +62,7 @@ export function RequireEmail({ onDismiss }: { onDismiss: () => void }) {
           <Button type="submit" fullWidth disabled={submitting}>
             {submitting ? 'saving…' : 'save'}
           </Button>
-          <Button type="button" variant="ghost" fullWidth onClick={onDismiss} disabled={submitting}>
+          <Button type="button" variant="ghost" fullWidth onClick={onSkip} disabled={submitting}>
             not now
           </Button>
         </form>

--- a/frontend/src/components/RequireEmail.tsx
+++ b/frontend/src/components/RequireEmail.tsx
@@ -44,8 +44,8 @@ export function RequireEmail({ onSkip }: { onSkip: () => void }) {
           add your email
         </h2>
         <p className="text-muted mb-4 text-sm">
-          we use email for account recovery and event updates — add your email to login or come back
-          later
+          we use email for account recovery and event updates — add yours to stay logged in, or
+          keep browsing logged out
         </p>
         <form onSubmit={(e) => void onSubmit(e)} className="flex flex-col gap-3" noValidate>
           <TextField

--- a/frontend/src/components/RequireEmail.tsx
+++ b/frontend/src/components/RequireEmail.tsx
@@ -1,8 +1,4 @@
-// Blocking modal shown when a logged-in user has no email on file.
-// There is intentionally no close button — the user must supply an email
-// before the guard layer allows them to proceed.
-
-import { type SyntheticEvent, useState } from 'react';
+import { type SyntheticEvent, useEffect, useState } from 'react';
 
 import { extractApiErrorOr } from '@/api/apiErrors';
 import { updateProfile } from '@/api/auth';
@@ -10,10 +6,20 @@ import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import { TextField } from '@/components/ui/TextField';
 
-export function RequireEmail() {
+export function RequireEmail({ onDismiss }: { onDismiss: () => void }) {
   const [email, setEmail] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') onDismiss();
+    }
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [onDismiss]);
 
   async function onSubmit(e: SyntheticEvent) {
     e.preventDefault();
@@ -36,11 +42,24 @@ export function RequireEmail() {
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
-      <div className="bg-surface w-full max-w-sm rounded-lg p-6">
-        <h2 className="mb-2 text-lg font-medium">add your email</h2>
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="require-email-title"
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+    >
+      <button
+        type="button"
+        aria-label="dismiss"
+        onClick={onDismiss}
+        className="absolute inset-0 cursor-default bg-black/60"
+      />
+      <div className="bg-surface relative w-full max-w-sm rounded-lg p-6">
+        <h2 id="require-email-title" className="mb-2 text-lg font-medium">
+          add your email
+        </h2>
         <p className="text-muted mb-4 text-sm">
-          we use email for account recovery and event updates — please add yours to continue
+          we use email for account recovery and event updates — add yours now, or skip for now
         </p>
         <form onSubmit={(e) => void onSubmit(e)} className="flex flex-col gap-3" noValidate>
           <TextField
@@ -56,6 +75,9 @@ export function RequireEmail() {
           />
           <Button type="submit" fullWidth disabled={submitting}>
             {submitting ? 'saving…' : 'save'}
+          </Button>
+          <Button type="button" variant="ghost" fullWidth onClick={onDismiss} disabled={submitting}>
+            not now
           </Button>
         </form>
       </div>

--- a/frontend/src/components/RequireEmail.tsx
+++ b/frontend/src/components/RequireEmail.tsx
@@ -55,8 +55,8 @@ export function RequireEmail({ onSkip }: { onSkip: () => Promise<void> }) {
           add your email
         </h2>
         <p className="text-muted mb-4 text-sm">
-          we use email for account recovery and event updates — add yours to stay logged in, or
-          keep browsing logged out
+          we use email for account recovery and event updates — add yours to stay logged in, or keep
+          browsing logged out
         </p>
         <form onSubmit={(e) => void onSubmit(e)} className="flex flex-col gap-3" noValidate>
           <TextField

--- a/frontend/src/components/RequireEmail.tsx
+++ b/frontend/src/components/RequireEmail.tsx
@@ -6,10 +6,21 @@ import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import { TextField } from '@/components/ui/TextField';
 
-export function RequireEmail({ onSkip }: { onSkip: () => void }) {
+export function RequireEmail({ onSkip }: { onSkip: () => Promise<void> }) {
   const [email, setEmail] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
+  const [skipping, setSkipping] = useState(false);
+  const busy = submitting || skipping;
+
+  async function onSkipClick() {
+    setSkipping(true);
+    try {
+      await onSkip();
+    } finally {
+      setSkipping(false);
+    }
+  }
 
   async function onSubmit(e: SyntheticEvent) {
     e.preventDefault();
@@ -59,10 +70,16 @@ export function RequireEmail({ onSkip }: { onSkip: () => void }) {
             error={error ?? undefined}
             required
           />
-          <Button type="submit" fullWidth disabled={submitting}>
+          <Button type="submit" fullWidth disabled={busy}>
             {submitting ? 'saving…' : 'save'}
           </Button>
-          <Button type="button" variant="ghost" fullWidth onClick={onSkip} disabled={submitting}>
+          <Button
+            type="button"
+            variant="ghost"
+            fullWidth
+            onClick={() => void onSkipClick()}
+            disabled={busy}
+          >
             not now
           </Button>
         </form>


### PR DESCRIPTION
## overview

On `/members` (and every other authed route) an email-required modal trapped the user with no way out — closing the browser tab was the only escape. This gives the modal a clean exit: add your email to stay logged in, or pick **"not now"** to keep using the app from a logged-out state.

You can't stay *logged in* without an email — but "not now" isn't a dead end. It drops the session and drops you on the public calendar, so the app stays usable logged-out (an authed-only route would otherwise bounce to `/login`).

Closes #672

## what changed

- `frontend/src/auth/guards.tsx`
  - `EmailGate`'s "not now" now `logout()`s and navigates to `/calendar`, so the user continues logged-out instead of being bounced to `/login`
- `frontend/src/components/RequireEmail.tsx`
  - `not now` ghost button triggers the skip path (renamed `onDismiss` → `onSkip`)
  - removed escape-key and backdrop-click dismissal — only `save` or `not now` act
  - reworded the body copy: add email to stay logged in, or keep browsing logged out
- tests: "not now" logs out and lands on the public calendar (not `/login`); escape does not dismiss; updated existing tests for the renamed prop

## how verified

- `make agent-frontend-typecheck` — clean
- `make agent-frontend-lint` — clean
- `pnpm exec vitest run` for `RequireEmail.test.tsx` + `guards.test.tsx` — 28 passed
