### PR TITLE
fix(sms-policy): allow policy page to open from agreement gate (Issue 671)

### DIFF
--- a/frontend/src/auth/guards.test.tsx
+++ b/frontend/src/auth/guards.test.tsx
@@ -343,6 +343,25 @@ describe('OnboardingGate', () => {
     expect(screen.queryByText('consent page')).not.toBeInTheDocument();
   });
 
+  it('lets a needsSmsConsent user read /sms-policy (so consent is possible)', () => {
+    const user = makeUser({ needsGuidelinesConsent: true, needsSmsConsent: true });
+    useAuthStore.setState({ status: 'authed', user, accessToken: 'tok-abc' });
+
+    render(
+      <MemoryRouter initialEntries={['/sms-policy']}>
+        <Routes>
+          <Route element={<OnboardingGate />}>
+            <Route path="/sms-policy" element={<div>sms policy page</div>} />
+            <Route path="/consent" element={<div>consent page</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('sms policy page')).toBeInTheDocument();
+    expect(screen.queryByText('consent page')).not.toBeInTheDocument();
+  });
+
   it('sends a password setup to /onboarding before asking for consent', () => {
     // A brand-new user who owes both password setup and consent resolves the
     // password gate first — consent is only asked once setup is done.

--- a/frontend/src/auth/guards.tsx
+++ b/frontend/src/auth/guards.tsx
@@ -84,11 +84,8 @@ export function OnboardingGate() {
       return <Navigate to={setupTarget} replace />;
     }
   } else if (consentTarget) {
-    // Consent gate. The consent screen blocks login completion, but the user can
-    // either accept (clears the needs-consent flags on /me/) or pick "not now" on
-    // the screen itself to log out. We pin them to /consent EXCEPT for the policy
-    // pages it links to — they must be able to read what they're agreeing to, so
-    // trapping those pages would make honest consent impossible.
+    // Pin to /consent, but leave the policy pages it links to reachable — users
+    // must be able to read what they're agreeing to.
     if (path !== consentTarget && !CONSENT_POLICY_PATHS.has(path)) {
       return <Navigate to={consentTarget} replace />;
     }

--- a/frontend/src/auth/guards.tsx
+++ b/frontend/src/auth/guards.tsx
@@ -14,10 +14,15 @@ import { type ReactNode, useEffect } from 'react';
 import { Navigate, Outlet, useLocation } from 'react-router-dom';
 
 import { RequireEmail } from '@/components/RequireEmail';
+import { CONSENT_REGISTRY } from '@/models/consent';
 import { hasPermission, type PermissionKey } from '@/models/permissions';
 import { guidelinesConsentRedirect, passwordSetupRedirect } from '@/models/user';
 
 import { useAuthStore } from './store';
+
+// Policy pages the consent screen links to must stay reachable while the consent
+// gate is active, otherwise the user can't read what they're agreeing to.
+const CONSENT_POLICY_PATHS = new Set(CONSENT_REGISTRY.map((c) => c.linkTo.toLowerCase()));
 
 // ----------------------------------------------------------------------------
 // AuthBoot — kick off session restore exactly once on mount.
@@ -79,13 +84,12 @@ export function OnboardingGate() {
       return <Navigate to={setupTarget} replace />;
     }
   } else if (consentTarget) {
-    // Guidelines-consent gate. The consent screen blocks login completion, but
-    // the user can either accept (clears needsGuidelinesConsent on /me/) or pick
-    // "not now" on the screen itself to log out. We pin them to /consent EXCEPT
-    // for /guidelines — they must be able to read what they're agreeing to (the
-    // consent screen links there), so trapping that page would make honest
-    // consent impossible.
-    if (path !== consentTarget && path !== '/guidelines') {
+    // Consent gate. The consent screen blocks login completion, but the user can
+    // either accept (clears the needs-consent flags on /me/) or pick "not now" on
+    // the screen itself to log out. We pin them to /consent EXCEPT for the policy
+    // pages it links to — they must be able to read what they're agreeing to, so
+    // trapping those pages would make honest consent impossible.
+    if (path !== consentTarget && !CONSENT_POLICY_PATHS.has(path)) {
       return <Navigate to={consentTarget} replace />;
     }
   } else if (user) {


### PR DESCRIPTION
## overview

Closes #671

On a fresh login, a user who needs to agree to the sms policy sees the consent gate. The sms consent checkbox links to `/sms-policy`, but the user couldn't open that page to read it before agreeing — the consent gate bounced them straight back to `/consent`.

## root cause

`OnboardingGate` pins a consent-pending user to `/consent` and only exempted `/guidelines`. The sms consent descriptor in `CONSENT_REGISTRY` links to `/sms-policy`, which was **not** exempt — so opening it (even in a new tab; the checklist links already use `target="_blank"`) re-hit the gate and redirected back to `/consent`. The policy was unreadable.

## what changed

- `frontend/src/auth/guards.tsx`: the consent gate now exempts **every** policy path the consent screen links to, not just `/guidelines`. The exempt set is derived from `CONSENT_REGISTRY` (`c.linkTo`), so the guard stays in sync with the checklist automatically — a future consent type won't silently reintroduce this bug.
- `frontend/src/auth/guards.test.tsx`: added a test that a user needing sms consent can read `/sms-policy` while the gate is active.

## why this approach

Deriving the exempt paths from the same registry that renders the checklist keeps the two in lockstep — the alternative (hardcoding `/sms-policy` alongside `/guidelines`) would drift the next time a consent type is added. The change is scoped strictly to the exemption; gate priority and redirect behavior are unchanged.

## note / follow-up (out of scope)

`guidelinesConsentRedirect` in `models/user.ts` only checks `needsGuidelinesConsent`, not `needsSmsConsent`, so a user needing *only* sms consent isn't pinned to `/consent` by this gate at all. That's a separate concern from this bug (the reported case has the gate already active) and changing it would alter gating behavior, so it's left as a follow-up.

## verification

- `make agent-frontend-typecheck` — pass
- `make agent-frontend-lint` — pass
- `vitest run src/auth/guards.test.tsx src/screens/auth/ConsentScreen.test.tsx` — 31 passed
