### PR TITLE
fix(consent): match "not now" button style to email modal (Issue 682)

### DIFF
--- a/frontend/src/screens/auth/ConsentScreen.tsx
+++ b/frontend/src/screens/auth/ConsentScreen.tsx
@@ -59,14 +59,15 @@ export default function ConsentScreen() {
         >
           {submitting ? 'saving…' : 'continue'}
         </Button>
-        <button
+        <Button
           type="button"
+          variant="ghost"
+          fullWidth
           disabled={submitting}
           onClick={() => void onSkip()}
-          className="text-foreground-tertiary text-center text-sm underline disabled:opacity-50"
         >
           not now
-        </button>
+        </Button>
       </div>
     </AuthLayout>
   );


### PR DESCRIPTION
## overview

closes Issue 682.

the "not now" dismiss button on the consent screen was a plain underlined link-button, while the email modal (`RequireEmail`) uses the nicer ghost `Button`. this makes the consent screen's "not now" match — same `<Button variant="ghost" fullWidth>` styling — so both dismiss actions look consistent.

## changes

- `frontend/src/screens/auth/ConsentScreen.tsx` — swap the raw `<button>` (underlined link style) for `<Button variant="ghost" fullWidth>`, matching the email modal.

## verification

- `make agent-frontend-typecheck` — clean
- ConsentScreen tests — 9/9 pass
- eslint + prettier — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
