### PR TITLE
fix: 685 - gate login-link-request notifications on manage_users

### DIFF
--- a/backend/notifications/service.py
+++ b/backend/notifications/service.py
@@ -149,7 +149,7 @@ def create_magic_link_request_notifications(user: User) -> None:
         User.objects.members()
         .filter(
             Q(roles__name="admin", roles__is_default=True)
-            | Q(roles__permissions__contains=PermissionKey.APPROVE_JOIN_REQUESTS)
+            | Q(roles__permissions__contains=PermissionKey.MANAGE_USERS)
         )
         .distinct()
     )

--- a/backend/tests/test_request_login_link.py
+++ b/backend/tests/test_request_login_link.py
@@ -12,14 +12,14 @@ from users.permissions import PermissionKey
 from users.roles import Role
 
 
-def _make_approver():
-    """Create a user with APPROVE_JOIN_REQUESTS permission and return them."""
-    approver = User.objects.create_user(
-        phone_number="+12025559001", password="pass", display_name="Approver"
+def _make_user_manager():
+    """Create a user with MANAGE_USERS permission and return them."""
+    manager = User.objects.create_user(
+        phone_number="+12025559001", password="pass", display_name="Manager"
     )
-    role = Role.objects.create(name="vetter", permissions=[PermissionKey.APPROVE_JOIN_REQUESTS])
-    approver.roles.add(role)
-    return approver
+    role = Role.objects.create(name="user-manager", permissions=[PermissionKey.MANAGE_USERS])
+    manager.roles.add(role)
+    return manager
 
 
 _URL = "/api/community/request-login-link/"
@@ -74,32 +74,42 @@ class TestRequestLoginLink:
         api_client.post(_URL, {"phone_number": "+12025559998"}, content_type="application/json")
         assert MagicLoginToken.objects.count() == 0
 
-    def test_creates_notification_for_approvers(self, api_client):
+    def test_creates_notification_for_user_managers(self, api_client):
         user = User.objects.create_user(
             phone_number=_PHONE, password="pass", display_name="Invited Person"
         )
+        manager = _make_user_manager()
+
+        api_client.post(_URL, {"phone_number": _PHONE}, content_type="application/json")
+
+        notif = Notification.objects.get(recipient=manager)
+        assert notif.notification_type == NotificationType.MAGIC_LINK_REQUEST
+        assert user.display_name in notif.message
+        assert notif.related_user_id == user.pk  # ty: ignore[unresolved-attribute]
+        assert "token" not in notif.message.lower()
+
+    def test_does_not_notify_approvers_without_manage_users(self, api_client):
+        """A user who can only approve join requests must NOT be notified — they cannot
+        grant the login link (that needs manage_users)."""
+        User.objects.create_user(
+            phone_number=_PHONE, password="pass", display_name="Invited Person"
+        )
         approver = User.objects.create_user(
-            phone_number="+12025559001", password="pass", display_name="Approver"
+            phone_number="+12025559002", password="pass", display_name="Approver"
         )
         role = Role.objects.create(name="vetter", permissions=[PermissionKey.APPROVE_JOIN_REQUESTS])
         approver.roles.add(role)
 
         api_client.post(_URL, {"phone_number": _PHONE}, content_type="application/json")
 
-        notif = Notification.objects.get(recipient=approver)
-        assert notif.notification_type == NotificationType.MAGIC_LINK_REQUEST
-        assert user.display_name in notif.message
-        assert notif.related_user_id == user.pk  # ty: ignore[unresolved-attribute]
-        assert "token" not in notif.message.lower()
+        assert not Notification.objects.filter(recipient=approver).exists()
 
     def test_does_not_create_notification_for_unknown_phone(self, api_client):
-        approver = User.objects.create_user(phone_number="+12025559001", password="pass")
-        role = Role.objects.create(name="vetter", permissions=[PermissionKey.APPROVE_JOIN_REQUESTS])
-        approver.roles.add(role)
+        manager = _make_user_manager()
 
         api_client.post(_URL, {"phone_number": "+12025559999"}, content_type="application/json")
 
-        assert not Notification.objects.filter(recipient=approver).exists()
+        assert not Notification.objects.filter(recipient=manager).exists()
 
     def test_rate_limit_prevents_duplicate_tokens_within_cooldown(self, api_client):
         user = User.objects.create_user(phone_number=_PHONE, password="pass")
@@ -217,7 +227,7 @@ class TestRequestLoginLinkEmailDelivery:
 
     def test_admin_fallback_sets_login_link_requested(self, api_client, fake_email_sender):
         """No-email fallback dedupes admin notifications via login_link_requested."""
-        _make_approver()
+        _make_user_manager()
         user = User.objects.create_user(
             phone_number="+12025550102",
             display_name="NoEmail",
@@ -234,7 +244,7 @@ class TestRequestLoginLinkEmailDelivery:
     def test_user_with_email_send_succeeds_skips_admin_notification(
         self, api_client, fake_email_sender
     ):
-        approver = _make_approver()
+        manager = _make_user_manager()
         user = User.objects.create_user(
             phone_number="+12025550101",
             display_name="Sam",
@@ -248,14 +258,14 @@ class TestRequestLoginLinkEmailDelivery:
         # Email sent successfully — admin notification must NOT fire
         fake_email_sender.send.assert_called_once()
         assert not Notification.objects.filter(
-            recipient=approver,
+            recipient=manager,
             notification_type=NotificationType.MAGIC_LINK_REQUEST,
             related_user=user,
         ).exists()
 
     def test_user_with_email_send_fails_still_returns_200(self, api_client, fake_email_sender):
         fake_email_sender.send.return_value = SendResult(success=False, error="invalid recipient")
-        approver = _make_approver()
+        manager = _make_user_manager()
         user = User.objects.create_user(
             phone_number="+12025550101",
             display_name="Sam",
@@ -270,12 +280,12 @@ class TestRequestLoginLinkEmailDelivery:
         fake_email_sender.send.assert_called_once()
         # Admin notification fallback SHOULD fire on email send failure
         notif = Notification.objects.get(
-            recipient=approver, notification_type=NotificationType.MAGIC_LINK_REQUEST
+            recipient=manager, notification_type=NotificationType.MAGIC_LINK_REQUEST
         )
         assert notif.related_user_id == user.pk  # ty: ignore[unresolved-attribute]
 
     def test_user_with_no_email_skips_send(self, api_client, fake_email_sender):
-        approver = _make_approver()
+        manager = _make_user_manager()
         user = User.objects.create_user(
             phone_number="+12025550101",
             display_name="Sam",
@@ -292,7 +302,7 @@ class TestRequestLoginLinkEmailDelivery:
         fake_email_sender.send.assert_not_called()
         # Admin notification still fires — no-email path is unchanged
         notif = Notification.objects.get(
-            recipient=approver, notification_type=NotificationType.MAGIC_LINK_REQUEST
+            recipient=manager, notification_type=NotificationType.MAGIC_LINK_REQUEST
         )
         assert notif.related_user_id == user.pk  # ty: ignore[unresolved-attribute]
 
@@ -301,7 +311,7 @@ class TestRequestLoginLinkEmailDelivery:
         bug in helper, etc.), the endpoint still returns 200 and the admin
         notification fallback fires."""
         fake_email_sender.send.side_effect = RuntimeError("unexpected boom")
-        approver = _make_approver()
+        manager = _make_user_manager()
         user = User.objects.create_user(
             phone_number="+12025550101",
             display_name="Sam",
@@ -315,6 +325,6 @@ class TestRequestLoginLinkEmailDelivery:
         assert resp.status_code == 200
         # Admin notification fallback should have fired
         notif = Notification.objects.get(
-            recipient=approver, notification_type=NotificationType.MAGIC_LINK_REQUEST
+            recipient=manager, notification_type=NotificationType.MAGIC_LINK_REQUEST
         )
         assert notif.related_user_id == user.pk  # ty: ignore[unresolved-attribute]


### PR DESCRIPTION
## Overview

Users with only `approve_join_requests` were being notified when a member requested a new login (magic) link, but generating that link requires `manage_users`. They'd land on `/admin/members/{id}` and be blocked by the route guard (or get a 403), unable to fulfill the request — while `manage_users` holders who *could* grant it weren't notified.

The recipient query in `create_magic_link_request_notifications` now gates on `PermissionKey.MANAGE_USERS` (the default `admin` role still included), matching who can actually grant the link. This mirrors the fix for a copy-paste from the join-request notification, which correctly keeps `approve_join_requests`.

Closes #685

## Test plan

- [x] `backend/tests/test_request_login_link.py` — updated recipient setup to `manage_users`; added `test_does_not_notify_approvers_without_manage_users` asserting an approve-only user is NOT notified (22 pass).
- [x] `backend/tests/test_in_app_notifications.py` — join-request notification tests unaffected (21 pass).
- [x] ruff lint/format + `ty` typecheck clean.
