### PR TITLE
fix(auth): exclude non-members from check-phone member gate (Issue 625)

### DIFF
--- a/backend/community/_join_request_submit.py
+++ b/backend/community/_join_request_submit.py
@@ -272,7 +272,9 @@ def check_phone(request, payload: CheckPhoneIn):
         normalized = _validate_phone(payload.phone_number)
     except ValidationException:
         return Status(200, CheckPhoneOut(status=CheckPhoneStatus.UNKNOWN))
-    if User.objects.filter(phone_number=normalized, archived_at__isnull=True).exists():
+    if User.objects.filter(
+        phone_number=normalized, is_member=True, archived_at__isnull=True
+    ).exists():
         return Status(200, CheckPhoneOut(status=CheckPhoneStatus.MEMBER))
     if JoinRequest.objects.filter(
         phone_number=normalized, status=JoinRequestStatus.PENDING

--- a/backend/tests/test_community.py
+++ b/backend/tests/test_community.py
@@ -196,6 +196,20 @@ class TestCheckPhone:
         assert response.status_code == 200
         assert response.json()["status"] == "unknown"
 
+    def test_check_phone_non_member_returns_unknown(self, api_client, db):
+        User.objects.create_user(
+            phone_number="+12025550188",
+            display_name="Public RSVP",
+            is_member=False,
+        )
+        response = api_client.post(
+            "/api/community/check-phone/",
+            {"phone_number": "+12025550188"},
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        assert response.json()["status"] == "unknown"
+
     def test_check_phone_invalid_format_returns_false(self, api_client, db):
         response = api_client.post(
             "/api/community/check-phone/",


### PR DESCRIPTION
## Overview

Fixes the login trap in `POST /api/community/check-phone/` (Issue 625).

The endpoint matched **any** non-archived `User` row, so non-member accounts created by public RSVP (`is_member=False`, unusable password) returned `member`. Login then routed those people to the password step — where they can never authenticate. Now the member gate filters on `is_member=True`, so only real members hit the password flow; non-members and unknown numbers fall through to `/join` as intended.

## Changes

- `backend/community/_join_request_submit.py` — add `is_member=True` to the `check_phone` member lookup.
- `backend/tests/test_community.py` — new test: a non-member (public-RSVP) account returns `unknown`, not `member`.

## Verification

- New test `test_check_phone_non_member_returns_unknown` fails before the fix (`member`), passes after (`unknown`).
- Full `TestCheckPhone` class passes (5/5).
- ruff lint + ty typecheck clean.

Closes #625
