### PR TITLE
fix(join-requests): lock row during approval to close race (Issue 632)

### DIFF
--- a/backend/community/_join_requests.py
+++ b/backend/community/_join_requests.py
@@ -195,20 +195,21 @@ def update_join_request_status(request, id: UUID, payload: JoinRequestStatusIn):
             allowed=valid_statuses,
         )
 
-    try:
-        join_request = JoinRequest.objects.get(id=id)
-    except JoinRequest.DoesNotExist:
-        raise_validation(Code.JoinRequest.NOT_FOUND, status_code=404)
-
-    if join_request.status in (JoinRequestStatus.APPROVED, JoinRequestStatus.REJECTED):
-        raise_validation(Code.JoinRequest.ALREADY_DECIDED, status_code=400)
-
-    # Stamp + provision together so a mid-provision failure never leaves the
-    # request APPROVED with a half-promoted user (member flag set but no role,
-    # or no magic link issued).
+    # select_for_update() serializes concurrent approvals: the second blocks until
+    # the first commits, then sees APPROVED and gets ALREADY_DECIDED. Provisioning
+    # shares the transaction so a mid-provision failure never leaves the request
+    # APPROVED with a half-promoted user.
     magic_token = None
     user_created = False
     with transaction.atomic():
+        try:
+            join_request = JoinRequest.objects.select_for_update().get(id=id)
+        except JoinRequest.DoesNotExist:
+            raise_validation(Code.JoinRequest.NOT_FOUND, status_code=404)
+
+        if join_request.status in (JoinRequestStatus.APPROVED, JoinRequestStatus.REJECTED):
+            raise_validation(Code.JoinRequest.ALREADY_DECIDED, status_code=400)
+
         _stamp_decision(join_request, payload.status, request.auth)
         if payload.status == JoinRequestStatus.APPROVED:
             magic_token, user_created = _provision_approved_user(join_request, request.auth)

--- a/backend/community/_join_requests.py
+++ b/backend/community/_join_requests.py
@@ -195,10 +195,7 @@ def update_join_request_status(request, id: UUID, payload: JoinRequestStatusIn):
             allowed=valid_statuses,
         )
 
-    # select_for_update() serializes concurrent approvals: the second blocks until
-    # the first commits, then sees APPROVED and gets ALREADY_DECIDED. Provisioning
-    # shares the transaction so a mid-provision failure never leaves the request
-    # APPROVED with a half-promoted user.
+    # select_for_update() serializes concurrent approvals so only one provisions.
     magic_token = None
     user_created = False
     with transaction.atomic():

--- a/backend/tests/test_join_request_management.py
+++ b/backend/tests/test_join_request_management.py
@@ -143,6 +143,31 @@ class TestJoinRequestManagement:
         assert response.status_code == 400
         assert_error_code(response, Code.JoinRequest.ALREADY_DECIDED)
 
+    def test_approve_locks_row_for_update(
+        self, api_client, vettor_headers, sample_join_request, monkeypatch
+    ):
+        # The already-decided guard only closes the concurrent-approval race if
+        # the row is locked before the check. Assert select_for_update() is used.
+        from community import _join_requests
+
+        original = JoinRequest.objects.select_for_update
+        called = False
+
+        def spy(*args, **kwargs):
+            nonlocal called
+            called = True
+            return original(*args, **kwargs)
+
+        monkeypatch.setattr(_join_requests.JoinRequest.objects, "select_for_update", spy)
+        response = api_client.patch(
+            f"/api/community/join-requests/{sample_join_request.id}/",
+            {"status": "approved"},
+            content_type="application/json",
+            **vettor_headers,
+        )
+        assert response.status_code == 200
+        assert called
+
     def test_reject_after_reject_fails(self, api_client, vettor_headers, sample_join_request):
         api_client.patch(
             f"/api/community/join-requests/{sample_join_request.id}/",


### PR DESCRIPTION
## Overview

Fixes a join-request approval race (Issue 632).

`update_join_request_status` fetched the join request and ran the already-decided guard **outside any lock**, then opened `transaction.atomic()` only for stamping + provisioning. Two admins approving the same request concurrently could both pass the guard before either committed, and both provision a user (double member flag / duplicate magic link).

## Changes

- `backend/community/_join_requests.py` — move the fetch and the already-decided check **inside** the existing `transaction.atomic()` block, and fetch with `select_for_update()`. The second concurrent approval now blocks on the row lock until the first commits, then sees `APPROVED` and returns `ALREADY_DECIDED`. Matches the existing `select_for_update()` pattern in `_event_rsvps.py`.
- `backend/tests/test_join_request_management.py` — new test asserting the approval path acquires the row lock (`select_for_update`).

## Verification

- New test `test_approve_locks_row_for_update` fails without the lock, passes with it (verified by temporarily reverting the source).
- Full `test_join_request_management.py` suite passes (30/30) — the refactor preserves all existing behavior (not-found, already-decided, provisioning, actor/timestamp stamping).
- ruff lint + ty typecheck clean.

Closes #632
