### PR TITLE
fix(rsvp): enforce allow_plus_ones server-side (Issue 631)

### DIFF
--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -75,6 +75,10 @@ def _resolve_rsvp_status(
     Returns (status, has_plus_one). Raises ValidationException if a +1 is
     denied at capacity.
     """
+    # Don't trust the client: a stale/crafted +1 must not inflate a disallowed event.
+    if not event.allow_plus_ones:
+        has_plus_one = False
+
     if requested_status != RSVPStatus.ATTENDING or event.max_attendees is None:
         return requested_status, has_plus_one
 

--- a/backend/tests/test_event_capacity.py
+++ b/backend/tests/test_event_capacity.py
@@ -78,6 +78,7 @@ def capped_event(db, test_user):
         start_datetime=future_iso(days=30),
         rsvp_enabled=True,
         max_attendees=2,
+        allow_plus_ones=True,
         created_by=test_user,
     )
 
@@ -127,6 +128,25 @@ class TestEventCapacity:
         resp = _rsvp(api_client, capped_event, headers2)
         assert resp.status_code == 200
         assert resp.json()["my_rsvp"] == RSVPStatus.WAITLISTED
+
+    def test_plus_one_ignored_when_event_disallows(
+        self, api_client, test_user, headers1, headers2, user1
+    ):
+        event = Event.objects.create(
+            title="No Plus Ones",
+            start_datetime=future_iso(days=30),
+            rsvp_enabled=True,
+            max_attendees=2,
+            allow_plus_ones=False,
+            created_by=test_user,
+        )
+        resp = _rsvp(api_client, event, headers1, has_plus_one=True)
+        assert resp.status_code == 200
+        assert resp.json()["my_rsvp"] == RSVPStatus.ATTENDING
+        assert EventRSVP.objects.get(event=event, user=user1).has_plus_one is False
+        # +1 was dropped, so the second spot is still open (not consumed).
+        resp2 = _rsvp(api_client, event, headers2)
+        assert resp2.json()["my_rsvp"] == RSVPStatus.ATTENDING
 
     def test_plus_one_denied_at_capacity(self, api_client, capped_event, headers1, headers2):
         _rsvp(api_client, capped_event, headers1)


### PR DESCRIPTION
## Overview

Enforces `event.allow_plus_ones` on the server (Issue 631).

`_resolve_rsvp_status` trusted `has_plus_one` from the request and never checked `event.allow_plus_ones`. The frontend hides the +1 control, but a stale or crafted request could still send `has_plus_one: true` on an event that disallows +1s — the server stored it and counted it toward capacity, corrupting the attendee count.

## Changes

- `backend/community/_event_rsvps.py` — coerce `has_plus_one` to `False` when `event.allow_plus_ones` is false, before the capacity math. Both the member (`upsert_rsvp`) and public RSVP paths funnel through `_resolve_rsvp_status`, so this covers both.
- `backend/tests/test_event_capacity.py`:
  - New test `test_plus_one_ignored_when_event_disallows`: a smuggled +1 on a disallowed event is dropped (not stored, and doesn't consume a second capacity spot).
  - `capped_event` fixture now sets `allow_plus_ones=True` — the existing +1 capacity-math tests always intended a legitimately-allowed +1; they only passed before because the server never enforced the flag.

## Verification

- New test fails without the fix (`has_plus_one` stored as `True`), passes with it — verified by temporarily reverting the source.
- `test_event_capacity.py` (26), `test_public_rsvp_capacity.py`, `test_public_rsvp.py`, `test_seed.py` all pass (68 total). Seed data writes `EventRSVP` directly (not via the API), so seeded +1s are unaffected.
- ruff lint + ty typecheck clean.

Closes #631
