### PR TITLE
fix(public-rsvp): match member email gate case-insensitively (Issue 628)

### DIFF
--- a/backend/community/_public_rsvp.py
+++ b/backend/community/_public_rsvp.py
@@ -122,8 +122,12 @@ def _resolve_non_member(*, request, name: str, email: str, phone: str) -> User:
     Must run inside the surrounding transaction.
     """
     phone_match = User.objects.filter(phone_number=phone, archived_at__isnull=True).first()
+    # iexact so a mixed-case stored member email (e.g. admin-created) still trips
+    # the member gate below — the incoming email is already lowercased.
     email_match = (
-        User.objects.filter(email=email, archived_at__isnull=True).first() if email else None
+        User.objects.filter(email__iexact=email, archived_at__isnull=True).first()
+        if email
+        else None
     )
 
     if (phone_match and phone_match.is_member) or (email_match and email_match.is_member):

--- a/backend/tests/test_public_rsvp.py
+++ b/backend/tests/test_public_rsvp.py
@@ -201,11 +201,11 @@ class TestPublicRsvpMemberCollision:
         assert first_code(response) == Code.Event.MEMBER_CONTACT_MUST_SIGN_IN
         assert not EventRSVP.objects.exists()
 
-    def test_member_email_match_is_case_sensitive(
+    def test_member_email_match_is_case_insensitive(
         self, api_client, official_event, fake_email_sender
     ):
-        # The member gate matches stored emails exactly, so a case-mismatched
-        # submission is not recognized as a member and the RSVP is accepted.
+        # A member whose email is stored mixed-case must still trip the gate when
+        # the RSVP submits the same address in different case.
         User.objects.create_user(
             phone_number="+14155550555",
             display_name="A Member",
@@ -215,8 +215,9 @@ class TestPublicRsvpMemberCollision:
 
         response = post(api_client, official_event, email="sam@example.com")
 
-        assert response.status_code == 200
-        assert EventRSVP.objects.count() == 1
+        assert response.status_code == 409
+        assert first_code(response) == Code.Event.MEMBER_CONTACT_MUST_SIGN_IN
+        assert not EventRSVP.objects.exists()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Overview

Fixes a case-sensitivity hole in the public-RSVP member gate (Issue 628).

`_resolve_non_member` looked up the member by `filter(email=email)` — an exact, case-sensitive match. The incoming form email is already normalized (`.strip().lower()`), but a member whose email is **stored** mixed-case (e.g. an admin-created account like `Sam@Example.COM`) would not match. The `is_member` gate was bypassed, and the member's contact was treated as a non-member — the RSVP was accepted instead of returning `MEMBER_CONTACT_MUST_SIGN_IN` (409).

## Changes

- `backend/community/_public_rsvp.py` — use `email__iexact` for the member/non-member email lookup so a mixed-case stored email still trips the gate. (The join-request flow already lowercases on write; this closes the read-side gap for legacy/admin-created rows.)
- `backend/tests/test_public_rsvp.py` — the existing `test_member_email_match_is_case_sensitive` *documented the bug as intended behavior* (mixed-case → RSVP accepted). Rewritten to `test_member_email_match_is_case_insensitive`, asserting the gate now returns 409 and creates no RSVP.

## Verification

- Rewritten test fails without the fix (200/accepted), passes with it (409) — verified by temporarily reverting the source.
- `test_public_rsvp.py` + `test_public_rsvp_capacity.py` pass (35 total).
- ruff lint + ty typecheck clean.

Closes #628
