### PR TITLE
fix(public-rsvp): extend non-member token instead of minting fresh (Issue 630)

### DIFF
--- a/backend/community/_public_rsvp.py
+++ b/backend/community/_public_rsvp.py
@@ -205,7 +205,7 @@ def _email_promoted_non_members(request, event: Event, promoted_user_ids: list[s
         if not user.email:
             continue
         try:
-            token = NonMemberRsvpToken.issue(user)
+            token = NonMemberRsvpToken.issue_or_extend(user)
             result = send_rsvp_waitlist_promoted_email(
                 sender=get_email_sender(),
                 details=_email_details(event, user, token.token),
@@ -249,7 +249,7 @@ def submit_public_rsvp(request, event_id, payload: PublicRsvpIn):
         final_status, promoted_user_ids = _apply_rsvp_in_transaction(
             event.id, user, payload.status, payload.has_plus_one
         )
-        token = NonMemberRsvpToken.issue(user)
+        token = NonMemberRsvpToken.issue_or_extend(user)
 
     audit_log(
         logging.INFO,

--- a/backend/tests/test_public_rsvp.py
+++ b/backend/tests/test_public_rsvp.py
@@ -159,18 +159,23 @@ class TestPublicRsvpDedup:
         assert new_user.email is None
         assert EventRSVP.objects.filter(user=new_user).exists()
 
-    def test_multiple_rsvps_accumulate_fresh_tokens(
+    def test_multiple_rsvps_reuse_the_same_token(
         self, api_client, official_event, fake_email_sender
     ):
         other_event = make_official_event(
             title="Second Official", start_datetime=future_iso(days=20)
         )
         post(api_client, official_event)
+        first_token = NonMemberRsvpToken.objects.get(user__phone_number="+14155550123").token
         post(api_client, other_event)
 
         user = User.objects.get(phone_number="+14155550123")
         assert EventRSVP.objects.filter(user=user).count() == 2
-        assert NonMemberRsvpToken.objects.filter(user=user).count() == 2
+        # A second RSVP extends the existing valid token rather than minting a new
+        # one, so a link saved from a previous email keeps resolving.
+        tokens = NonMemberRsvpToken.objects.filter(user=user)
+        assert tokens.count() == 1
+        assert tokens.first().token == first_token
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Overview

Makes public RSVP extend the non-member's existing token instead of minting a fresh one (Issue 630).

The `NonMemberRsvpToken` docstring is explicit: *"On a non-member's RSVP we EXTEND their existing valid token (see `issue_or_extend`) rather than minting a new one, so a link saved from a previous email keeps working."* But `_public_rsvp.py` called `issue()` in **both** places it mints a token — the submit path and the waitlist-promotion email path — creating a new row on every RSVP and accumulating redundant tokens.

## Changes

- `backend/community/_public_rsvp.py` — both call sites now use `issue_or_extend()`, which reuses and extends a still-valid token (same token string, pushed-out expiry) and only mints fresh when none is valid.
- `backend/tests/test_public_rsvp.py` — `test_multiple_rsvps_accumulate_fresh_tokens` *documented the buggy behavior* (2 RSVPs → 2 tokens). Rewritten to `test_multiple_rsvps_reuse_the_same_token`: a second RSVP keeps a single token whose string is unchanged, so a previously-saved link still resolves.

## Verification

- Rewritten test fails without the fix (count 2), passes with it (count 1, same token) — verified by temporarily reverting the source.
- `test_public_rsvp.py`, `test_public_rsvp_capacity.py`, `test_nonmember_rsvp_token.py` all pass (50 total). The model's own `issue_or_extend` unit tests already cover extend/expire/revoke/member-rejection.
- ruff lint + ty typecheck clean.

Closes #630
