### PR TITLE
refactor(roles): centralize live-member count on Role model

### DIFF
--- a/backend/users/_helpers.py
+++ b/backend/users/_helpers.py
@@ -43,7 +43,7 @@ def _is_last_admin(user: User) -> bool:
         return False
     if not user.roles.filter(pk=admin_role.pk).exists():
         return False
-    return admin_role.users.filter(archived_at__isnull=True).count() <= 1
+    return admin_role.live_member_count() <= 1
 
 
 def _is_admin(user: User) -> bool:

--- a/backend/users/_roles.py
+++ b/backend/users/_roles.py
@@ -5,12 +5,12 @@ import logging
 from community._validation import Code, raise_validation
 from config.audit import audit_log
 from config.auth import gated_jwt
-from django.db.models import Count, Q
+from django.db.models import Count
 from ninja import Router
 from ninja.responses import Status
 
 from users.permissions import PermissionKey
-from users.roles import PROTECTED_ROLE_NAMES, Role
+from users.roles import LIVE_ROLE_MEMBER, PROTECTED_ROLE_NAMES, Role
 from users.schemas import ErrorOut, RoleIn, RoleOut, RolePatchIn
 
 router = Router()
@@ -33,10 +33,7 @@ def list_roles(request):
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="list_roles")
     roles = Role.objects.annotate(
-        user_count=Count(
-            "users",
-            filter=Q(users__archived_at__isnull=True, users__is_member=True),
-        ),
+        user_count=Count("users", filter=LIVE_ROLE_MEMBER),
     )
     return Status(
         200,
@@ -176,7 +173,7 @@ def delete_role(request, role_id: str):
     if role.name in PROTECTED_ROLE_NAMES:
         raise_validation(Code.Role.PROTECTED_CANNOT_DELETE, status_code=400, role_name=role.name)
     role_name = role.name
-    affected_user_count = role.users.filter(archived_at__isnull=True, is_member=True).count()
+    affected_user_count = role.live_member_count()
     role.delete()
     audit_log(
         logging.WARNING,

--- a/backend/users/roles.py
+++ b/backend/users/roles.py
@@ -2,6 +2,7 @@ import uuid
 from typing import TYPE_CHECKING
 
 from django.db import models
+from django.db.models import Q
 
 from users.permissions import PermissionKey
 
@@ -11,6 +12,10 @@ if TYPE_CHECKING:
     from users.models import User
 
 PROTECTED_ROLE_NAMES = ("admin", "member")
+
+# Live members holding a role — excludes archived and non-member rows. Reused as a
+# reverse-relation predicate (annotation filter=) and by Role.live_member_count.
+LIVE_ROLE_MEMBER = Q(users__archived_at__isnull=True, users__is_member=True)
 
 
 class Role(models.Model):
@@ -26,6 +31,10 @@ class Role(models.Model):
 
     def __str__(self):
         return self.name
+
+    def live_member_count(self) -> int:
+        """Count of live members holding this role — excludes archived and non-members."""
+        return self.users.filter(archived_at__isnull=True, is_member=True).count()
 
     @property
     def effective_permissions(self) -> list[str]:


### PR DESCRIPTION
## Summary
- Collapse three spellings of the "live members holding a role" predicate — the role-list count annotation, `delete_role`'s affected-user count, and the last-admin guard — into a single `Role.live_member_count()` method plus a shared `LIVE_ROLE_MEMBER` Q predicate.
- Fix a latent inconsistency: the last-admin guard (`_is_last_admin`) previously excluded archived users but did **not** filter `is_member=True`, unlike the other two counts. It now does, via the shared method.
- No behavior change to the admin user list or the check-phone member lookup — those use `User.objects` (not a role's reverse relation) and intentionally differ, so they were left as-is.

## Test plan
- [x] `make agent-typecheck` — clean
- [x] `make agent-lint` — clean
- [x] role / admin / member-directory / last-admin tests pass locally (SQLite)
- [ ] CI green on Postgres (the 19 local SSE/pg_notify failures are a documented SQLite limitation, reproduced identically on `origin/main`, unrelated to this change)