### PR TITLE
fix(group-text): reset recipient selection per open and event (Issue 636)

### DIFF
--- a/frontend/src/screens/events/GroupTextDialog.test.tsx
+++ b/frontend/src/screens/events/GroupTextDialog.test.tsx
@@ -132,4 +132,37 @@ describe('GroupTextDialog', () => {
     render(<GroupTextDialog eventId="e1" open onClose={noop} />);
     expect(screen.getByText(/no one has a number/i)).toBeInTheDocument();
   });
+
+  it('resets the selection to defaults when reopened', () => {
+    mockLoaded(recipients());
+    const { rerender } = render(<GroupTextDialog eventId="e1" open onClose={noop} />);
+    fireEvent.click(screen.getByRole('button', { name: /^maybe/i }));
+    expect(screen.getAllByRole('button', { pressed: true }).map((el) => el.textContent)).toEqual([
+      'going1',
+    ]);
+
+    rerender(<GroupTextDialog eventId="e1" open={false} onClose={noop} />);
+    rerender(<GroupTextDialog eventId="e1" open onClose={noop} />);
+
+    expect(screen.getAllByRole('button', { pressed: true }).map((el) => el.textContent)).toEqual([
+      'going1',
+      'maybe1',
+    ]);
+  });
+
+  it('resets the selection to defaults when the event changes', () => {
+    mockLoaded(recipients());
+    const { rerender } = render(<GroupTextDialog eventId="e1" open onClose={noop} />);
+    fireEvent.click(screen.getByRole('button', { name: /^maybe/i }));
+    expect(screen.getAllByRole('button', { pressed: true }).map((el) => el.textContent)).toEqual([
+      'going1',
+    ]);
+
+    rerender(<GroupTextDialog eventId="e2" open onClose={noop} />);
+
+    expect(screen.getAllByRole('button', { pressed: true }).map((el) => el.textContent)).toEqual([
+      'going1',
+      'maybe1',
+    ]);
+  });
 });

--- a/frontend/src/screens/events/GroupTextDialog.tsx
+++ b/frontend/src/screens/events/GroupTextDialog.tsx
@@ -22,16 +22,6 @@ interface Props {
 
 export function GroupTextDialog({ eventId, open, onClose }: Props) {
   const recipientsQ = useTextRecipients(eventId, open);
-  const [selected, setSelected] = useState<Set<RecipientGroupValue>>(() => new Set(DEFAULT_GROUPS));
-
-  function toggle(value: RecipientGroupValue) {
-    setSelected((prev) => {
-      const next = new Set(prev);
-      if (next.has(value)) next.delete(value);
-      else next.add(value);
-      return next;
-    });
-  }
 
   return (
     <Dialog open={open} onClose={onClose} title="group text">
@@ -40,12 +30,9 @@ export function GroupTextDialog({ eventId, open, onClose }: Props) {
       ) : recipientsQ.isError ? (
         <p className="text-muted text-sm">couldn't load numbers — try again</p>
       ) : (
-        <RecipientPicker
-          recipients={recipientsQ.data}
-          selected={selected}
-          onToggle={toggle}
-          onClose={onClose}
-        />
+        // key by eventId so the selection resets to defaults for a different
+        // event; the picker also unmounts on close, so each open starts fresh.
+        <RecipientPicker key={eventId} recipients={recipientsQ.data} onClose={onClose} />
       )}
     </Dialog>
   );
@@ -53,15 +40,22 @@ export function GroupTextDialog({ eventId, open, onClose }: Props) {
 
 function RecipientPicker({
   recipients,
-  selected,
-  onToggle,
   onClose,
 }: {
   recipients: TextRecipients;
-  selected: Set<RecipientGroupValue>;
-  onToggle: (value: RecipientGroupValue) => void;
   onClose: () => void;
 }) {
+  const [selected, setSelected] = useState<Set<RecipientGroupValue>>(() => new Set(DEFAULT_GROUPS));
+
+  function onToggle(value: RecipientGroupValue) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(value)) next.delete(value);
+      else next.add(value);
+      return next;
+    });
+  }
+
   const options = availableGroups(recipients);
   const phones = collectPhones(recipients, selected);
   const smsUri = buildSmsUri(phones);


### PR DESCRIPTION
## Overview

Resets the group-text recipient selection so it never carries over (Issue 636).

`GroupTextDialog` held the `selected` chip state, but that component stays mounted while only its `open` prop toggles (the parent `GroupTextButton` always renders it). So a selection made in one session survived a close→reopen — and, worse, survived an `eventId` change — meaning the user could send a text to the **wrong recipients**.

## Changes

- `frontend/src/screens/events/GroupTextDialog.tsx` — move the `selected` state (and its `toggle`) down into `RecipientPicker`. `Dialog` returns `null` when closed, so the picker unmounts on close and its `useState` reinitializes to the defaults on each open. The picker is also keyed by `eventId` so switching events resets the selection too.
- `frontend/src/screens/events/GroupTextDialog.test.tsx` — two regression tests: selection resets to defaults (a) when the dialog is reopened, and (b) when the event changes.

## Verification

- Both new tests fail against the original component and pass with the fix — verified by running them against `HEAD`'s source.
- Full `GroupTextDialog.test.tsx` passes (11 tests); the 9 pre-existing behaviors are unchanged.
- eslint + prettier + tsc all clean.

Closes #636
