### PR TITLE
fix(events): apply field edits before status transition on PATCH (Issue 627)

### DIFF
--- a/backend/community/_events.py
+++ b/backend/community/_events.py
@@ -430,14 +430,16 @@ def update_event(request, event_id: UUID, payload: EventPatchIn):
     new_status = updates.pop("status", None)
     notify_attendees = updates.pop("notify_attendees", False) or False
 
-    # Handle status transition first (may be the only change in the payload)
+    # Apply field edits before the status transition so a draft published in the
+    # same PATCH as a corrected date validates against the new date, not the stale
+    # one (_publish_draft re-checks start_datetime is in the future). Field edits
+    # are allowed on active, cancelled, or draft events.
+    _apply_field_updates(request, event, event_id, updates)
+
     if new_status is not None:
         early = _handle_status_update(request, event, new_status, notify_attendees)
         if early is not None:
             return early
-
-    # Field edits are allowed on active, cancelled, or draft events
-    _apply_field_updates(request, event, event_id, updates)
 
     # Re-fetch to pick up any M2M changes
     event.refresh_from_db()

--- a/backend/community/_events.py
+++ b/backend/community/_events.py
@@ -430,10 +430,7 @@ def update_event(request, event_id: UUID, payload: EventPatchIn):
     new_status = updates.pop("status", None)
     notify_attendees = updates.pop("notify_attendees", False) or False
 
-    # Apply field edits before the status transition so a draft published in the
-    # same PATCH as a corrected date validates against the new date, not the stale
-    # one (_publish_draft re-checks start_datetime is in the future). Field edits
-    # are allowed on active, cancelled, or draft events.
+    # Field edits before the transition so publish validates the corrected date.
     _apply_field_updates(request, event, event_id, updates)
 
     if new_status is not None:

--- a/backend/tests/test_event_drafts.py
+++ b/backend/tests/test_event_drafts.py
@@ -362,6 +362,28 @@ class TestPublishDraft:
         )
         assert response.status_code == 400
 
+    def test_publish_stale_draft_with_corrected_date_in_one_patch(
+        self, api_client, creator_headers, creator
+    ):
+        # Fixing a stale draft's past date and publishing in the same PATCH must
+        # validate against the new date, not the old one.
+        draft = Event.objects.create(
+            title="Stale Draft",
+            start_datetime=past_iso(days=90),
+            created_by=creator,
+            status=EventStatus.DRAFT,
+        )
+        response = api_client.patch(
+            f"/api/community/events/{draft.id}/",
+            data=json.dumps({"status": "active", "start_datetime": future_iso(days=30)}),
+            content_type="application/json",
+            **creator_headers,
+        )
+        assert response.status_code == 200
+        assert response.json()["status"] == "active"
+        draft.refresh_from_db()
+        assert draft.status == EventStatus.ACTIVE
+
     def test_publish_dateless_draft_rejected(self, api_client, creator_headers, creator):
         """A draft with no start_datetime and datetime_tbd=False can't be published.
         Drafts may be saved incomplete, but publishing requires a real date or tbd."""


### PR DESCRIPTION
## Overview

Lets a stale draft be published with a corrected date in a single PATCH (Issue 627).

`update_event` handled the **status transition before** applying field edits. `_publish_draft` (DRAFT → ACTIVE) re-validates that `start_datetime` is in the future — but at that point the event object still held the **old** date, because the field updates hadn't been applied yet. So a PATCH carrying both `status: active` and a corrected future `start_datetime` was rejected with `start must be in the future`.

## Changes

- `backend/community/_events.py` (`update_event`) — apply `_apply_field_updates` **before** `_handle_status_update`. The field-update path already validates the effective (merged) datetime, and once the corrected date is set on the event, `_publish_draft`'s future-check sees it. This also fixes the general class of "publish validation reads stale field values", not just the datetime.
- `backend/tests/test_event_drafts.py` — new test: a stale draft published with a corrected future date in one PATCH now succeeds (200, status active).

## Verification

- New test fails without the reorder (400), passes with it — verified by temporarily reverting the source.
- Full event-lifecycle regression sweep passes (108 tests: `test_event_drafts`, `test_event_management`, `test_event_cancel`, `test_event_email_blast`) — ordering change is behavior-preserving for cancel/uncancel/delete/notify paths.
- ruff lint + ty typecheck clean.

Closes #627
