### PR TITLE
fix(events,notifications): surface silent frontend failures (Issues 633, 634, 635)

### DIFF
--- a/frontend/src/api/notifications.test.ts
+++ b/frontend/src/api/notifications.test.ts
@@ -20,6 +20,7 @@ vi.mock('@/auth/store', () => ({
 import { apiClient } from '@/api/client';
 
 import {
+  notificationKeys,
   useMarkAllNotificationsRead,
   useNotificationHistory,
   useNotifications,
@@ -185,5 +186,25 @@ describe('useMarkAllNotificationsRead', () => {
 
     expect(mockedPost).toHaveBeenCalledWith('/api/notifications/read-all/');
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it('rolls the optimistic caches back when the request fails (issue #635)', async () => {
+    mockedPost.mockRejectedValueOnce(new Error('boom'));
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    qc.setQueryData(notificationKeys.unread, 3);
+    qc.setQueryData(notificationKeys.bell, [{ id: 'n1', isRead: false }]);
+
+    const localWrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: qc }, children);
+    const { result } = renderHook(() => useMarkAllNotificationsRead(), {
+      wrapper: localWrapper,
+    });
+
+    result.current.mutate();
+
+    // Optimistic write lands first, then rolls back to the snapshot on error.
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(qc.getQueryData(notificationKeys.unread)).toBe(3);
+    expect(qc.getQueryData(notificationKeys.bell)).toEqual([{ id: 'n1', isRead: false }]);
   });
 });

--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -129,6 +129,10 @@ export function useMarkAllNotificationsRead() {
       await apiClient.post('/api/notifications/read-all/');
     },
     onMutate: () => {
+      // Snapshot for onError rollback so a failed mark-all doesn't leave the badge stuck at 0.
+      const prevUnread = qc.getQueryData<number>(notificationKeys.unread);
+      const prevBell = qc.getQueryData<AppNotification[]>(notificationKeys.bell);
+      const prevPage = qc.getQueryData<InfiniteData<AppNotification[]>>(notificationKeys.page);
       qc.setQueryData<number>(notificationKeys.unread, 0);
       qc.setQueryData<AppNotification[]>(notificationKeys.bell, (prev) =>
         prev ? prev.map((n) => ({ ...n, isRead: true })) : prev,
@@ -141,6 +145,13 @@ export function useMarkAllNotificationsRead() {
             }
           : prev,
       );
+      return { prevUnread, prevBell, prevPage };
+    },
+    onError: (_err, _vars, context) => {
+      if (!context) return;
+      qc.setQueryData(notificationKeys.unread, context.prevUnread);
+      qc.setQueryData(notificationKeys.bell, context.prevBell);
+      qc.setQueryData(notificationKeys.page, context.prevPage);
     },
     onSuccess: () => {
       void qc.invalidateQueries({ queryKey: notificationKeys.all });

--- a/frontend/src/screens/events/EventAttendancePanel.test.tsx
+++ b/frontend/src/screens/events/EventAttendancePanel.test.tsx
@@ -13,6 +13,15 @@ import {
 } from '@/models/event';
 
 const setAttendanceMutate = vi.fn();
+const toastError = vi.fn();
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: (m: string) => {
+      toastError(m);
+    },
+  },
+}));
 
 vi.mock('@/api/eventStats', () => ({
   useEventStats: vi.fn(),
@@ -134,6 +143,7 @@ beforeEach(() => {
   vi.useFakeTimers();
   vi.setSystemTime(FROZEN_NOW);
   setAttendanceMutate.mockClear();
+  toastError.mockClear();
   vi.mocked(useEventStats).mockReset();
 });
 
@@ -169,10 +179,28 @@ describe('EventAttendancePanel', () => {
     const attendedBtn = screen.getByRole('button', { name: /^attended$/i });
     fireEvent.click(attendedBtn);
 
-    expect(setAttendanceMutate).toHaveBeenCalledWith({
-      userId: 'alice',
-      attendance: AttendanceStatus.Attended,
-    });
+    expect(setAttendanceMutate).toHaveBeenCalledWith(
+      { userId: 'alice', attendance: AttendanceStatus.Attended },
+      expect.objectContaining({ onError: expect.any(Function) }),
+    );
+  });
+
+  it('toasts an error when a check-in fails (issue #634)', () => {
+    mockStats(BASE_STATS);
+    setAttendanceMutate.mockImplementation(
+      (_args: unknown, opts?: { onError?: (err: unknown) => void }) => {
+        opts?.onError?.(new Error('boom'));
+      },
+    );
+    const soonEvent: Event = {
+      ...BASE_EVENT,
+      startDatetime: new Date(Date.now() + 30 * 60 * 1000),
+    };
+    renderPanel(soonEvent);
+
+    fireEvent.click(screen.getByRole('button', { name: /^attended$/i }));
+
+    expect(toastError).toHaveBeenCalledWith(expect.stringMatching(/couldn't save check-in/i));
   });
 
   it('shows check-in buttons after the event (window never closes)', () => {

--- a/frontend/src/screens/events/EventAttendancePanel.tsx
+++ b/frontend/src/screens/events/EventAttendancePanel.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { toast } from 'sonner';
 
 import { useEventStats, useSetAttendance } from '@/api/eventStats';
 import type {
@@ -43,7 +44,10 @@ export function EventAttendancePanel({ event }: Props) {
         <CheckInList
           guests={goingGuests}
           onMark={(userId, attendance) => {
-            setAttendance.mutate({ userId, attendance });
+            setAttendance.mutate(
+              { userId, attendance },
+              { onError: () => toast.error("couldn't save check-in — try again") },
+            );
           }}
           isPending={setAttendance.isPending}
         />

--- a/frontend/src/screens/events/RsvpSection.test.tsx
+++ b/frontend/src/screens/events/RsvpSection.test.tsx
@@ -17,9 +17,10 @@ import {
 import type { User } from '@/models/user';
 
 const setRsvpMutate = vi.fn();
+const removeRsvpMutate = vi.fn();
 vi.mock('@/api/rsvp', () => ({
   useSetRsvp: () => ({ mutateAsync: setRsvpMutate, isPending: false }),
-  useRemoveRsvp: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useRemoveRsvp: () => ({ mutateAsync: removeRsvpMutate, isPending: false }),
 }));
 
 vi.mock('./RsvpGuestList', () => ({
@@ -130,6 +131,8 @@ function renderSection(event: Event) {
 beforeEach(() => {
   setRsvpMutate.mockReset();
   setRsvpMutate.mockResolvedValue(undefined);
+  removeRsvpMutate.mockReset();
+  removeRsvpMutate.mockResolvedValue(undefined);
   useAuthStore.setState({ status: 'authed', user: ME, accessToken: 'tok' });
 });
 
@@ -272,5 +275,16 @@ describe('RsvpSection — spots left', () => {
   it('shows no spots-left text at capacity', () => {
     renderSection(makeEvent({ maxAttendees: 10, attendingCount: 10, myRsvp: null }));
     expect(screen.queryByText(/spots? left/)).not.toBeInTheDocument();
+  });
+});
+
+describe('RsvpSection — leave waitlist error handling (issue #633)', () => {
+  it('surfaces an error when leaving the waitlist fails', async () => {
+    removeRsvpMutate.mockRejectedValue(new Error('boom'));
+    renderSection(makeEvent({ myRsvp: RsvpServerStatus.Waitlisted }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'leave waitlist' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(/couldn't update your rsvp/i);
   });
 });

--- a/frontend/src/screens/events/RsvpSection.tsx
+++ b/frontend/src/screens/events/RsvpSection.tsx
@@ -57,6 +57,15 @@ export function RsvpSection({ event, canSeeInvited }: Props) {
     }
   }
 
+  async function leaveWaitlist() {
+    setError(null);
+    try {
+      await removeRsvp.mutateAsync(event.id);
+    } catch (err) {
+      setError(extractError(err));
+    }
+  }
+
   async function togglePlusOne() {
     if (!myRsvp || onWaitlist) return;
     // Only attending/maybe can bring a +1 (server-enforced on attending; UI
@@ -79,12 +88,7 @@ export function RsvpSection({ event, canSeeInvited }: Props) {
   return (
     <section aria-label="rsvp" className="flex flex-col gap-3">
       {onWaitlist ? (
-        <WaitlistView
-          onLeave={() => {
-            void removeRsvp.mutateAsync(event.id);
-          }}
-          busy={busy}
-        />
+        <WaitlistView onLeave={() => void leaveWaitlist()} busy={busy} />
       ) : (
         <>
           <div className="flex flex-wrap justify-center gap-2">


### PR DESCRIPTION
## Overview

Surfaces three silent frontend failures where a fire-and-forget mutation left the user with no feedback (and, in one case, a lying UI). Grouped because they're the same class of fix.

## Changes

**Issue 633 — waitlist leave has no error handling**
`RsvpSection`'s "leave waitlist" called `removeRsvp.mutateAsync(event.id)` with no try/catch, unlike the pill `apply()` path. A failed leave was silent. Routed through a `leaveWaitlist()` handler that catches and shows the existing error alert.

**Issue 634 — attendance check-in failures are silent**
`EventAttendancePanel` called `setAttendance.mutate({ userId, attendance })` with no `onError`. A failed check-in vanished. Added an `onError` toast, matching the `{ onError: () => toast.error(...) }` pattern already used in `CohostInviteBanner`.

**Issue 635 — mark-all-read optimistic update can lie on failure**
`useMarkAllNotificationsRead` optimistically zeroed the unread badge and marked all three caches read, but had no rollback — the only `onError` (in `NotificationBell`) just logged, so the badge stayed at 0 (a lie) until the next invalidation, and any other caller had no protection at all. Moved rollback into the mutation: `onMutate` snapshots the three caches and returns them as context; `onError` restores them. Now every caller is covered.

## Verification

- Each fix has a regression test that fails without the fix and passes with it (verified by reverting each source change): waitlist-leave error alert, check-in error toast, and mark-all cache rollback.
- Full frontend suite passes (93 files, 679 tests); `NotificationBell` (12 tests) still green — the mutation-level rollback coexists with the caller's existing error logging.
- eslint + prettier + tsc all clean.

Closes #633
Closes #634
Closes #635
