### PR TITLE
feat(onboarding): add optional profile step to onboarding wizard

### DIFF
--- a/frontend/src/auth/guards.test.tsx
+++ b/frontend/src/auth/guards.test.tsx
@@ -60,7 +60,12 @@ function makeUser(overrides: Partial<User> = {}): User {
 }
 
 beforeEach(() => {
-  useAuthStore.setState({ status: 'unauthed', user: null, accessToken: null });
+  useAuthStore.setState({
+    status: 'unauthed',
+    user: null,
+    accessToken: null,
+    profileStepActive: false,
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -482,6 +487,30 @@ describe('OnboardingGate', () => {
 
     expect(screen.getByText('guidelines page')).toBeInTheDocument();
     expect(screen.queryByText('onboarding page')).not.toBeInTheDocument();
+  });
+
+  it('keeps an onboarding-complete user on /onboarding while the profile step is active', () => {
+    const user = makeUser({ needsOnboarding: false });
+    useAuthStore.setState({
+      status: 'authed',
+      user,
+      accessToken: 'tok-abc',
+      profileStepActive: true,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/onboarding']}>
+        <Routes>
+          <Route element={<OnboardingGate />}>
+            <Route path="/onboarding" element={<div>onboarding page</div>} />
+            <Route path="/guidelines" element={<div>guidelines page</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('onboarding page')).toBeInTheDocument();
+    expect(screen.queryByText('guidelines page')).not.toBeInTheDocument();
   });
 
   it('redirects an onboarding-complete user on /login to /calendar', () => {

--- a/frontend/src/auth/guards.tsx
+++ b/frontend/src/auth/guards.tsx
@@ -69,6 +69,7 @@ function BootSpinner() {
 
 export function OnboardingGate() {
   const user = useAuthStore((s) => s.user);
+  const profileStepActive = useAuthStore((s) => s.profileStepActive);
   const location = useLocation();
   const path = location.pathname.toLowerCase();
 
@@ -91,7 +92,9 @@ export function OnboardingGate() {
     }
   } else if (user) {
     // Authed user with nothing pending shouldn't sit on onboarding/consent screens.
-    if (path === '/onboarding') return <Navigate to="/guidelines" replace />;
+    // Exception: the optional profile step runs on /onboarding *after* account
+    // setup clears needs_onboarding — keep them here until they finish or skip it.
+    if (path === '/onboarding' && !profileStepActive) return <Navigate to="/guidelines" replace />;
     if (path === '/new-password') return <Navigate to="/calendar" replace />;
     if (path === '/consent') return <Navigate to="/calendar" replace />;
     if (path === '/login') return <Navigate to="/calendar" replace />;

--- a/frontend/src/auth/store.ts
+++ b/frontend/src/auth/store.ts
@@ -28,9 +28,8 @@ interface AuthState {
   // unauthed). Guards the app-level boot spinner so later 'loading' states
   // (login, magic-login) don't unmount the tree.
   booted: boolean;
-  // True while the optional profile step of onboarding is showing. Set once
-  // account setup succeeds — which clears needs_onboarding — so OnboardingGate
-  // doesn't immediately bounce /onboarding to /guidelines and unmount the step.
+  // Keeps OnboardingGate from bouncing /onboarding once account setup clears
+  // needs_onboarding, so the optional profile step can render.
   profileStepActive: boolean;
   login: (phoneNumber: string, password: string) => Promise<void>;
   magicLogin: (token: string) => Promise<void>;
@@ -42,7 +41,7 @@ interface AuthState {
     pronouns?: string | undefined;
     consentTypes?: ConsentTypeValue[] | undefined;
   }) => Promise<void>;
-  // Clears profileStepActive once the user finishes or skips the profile step.
+  startProfileStep: () => void;
   finishProfileStep: () => void;
   acceptConsents: (consentTypes: ConsentTypeValue[]) => Promise<void>;
   changePassword: (current: string, next: string) => Promise<void>;
@@ -107,7 +106,11 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
   async completeOnboarding(payload) {
     const user = await authApi.completeOnboarding(payload);
-    set({ user, profileStepActive: true });
+    set({ user });
+  },
+
+  startProfileStep() {
+    set({ profileStepActive: true });
   },
 
   finishProfileStep() {

--- a/frontend/src/auth/store.ts
+++ b/frontend/src/auth/store.ts
@@ -28,6 +28,10 @@ interface AuthState {
   // unauthed). Guards the app-level boot spinner so later 'loading' states
   // (login, magic-login) don't unmount the tree.
   booted: boolean;
+  // True while the optional profile step of onboarding is showing. Set once
+  // account setup succeeds — which clears needs_onboarding — so OnboardingGate
+  // doesn't immediately bounce /onboarding to /guidelines and unmount the step.
+  profileStepActive: boolean;
   login: (phoneNumber: string, password: string) => Promise<void>;
   magicLogin: (token: string) => Promise<void>;
   restoreSession: () => Promise<void>;
@@ -38,6 +42,8 @@ interface AuthState {
     pronouns?: string | undefined;
     consentTypes?: ConsentTypeValue[] | undefined;
   }) => Promise<void>;
+  // Clears profileStepActive once the user finishes or skips the profile step.
+  finishProfileStep: () => void;
   acceptConsents: (consentTypes: ConsentTypeValue[]) => Promise<void>;
   changePassword: (current: string, next: string) => Promise<void>;
   updateProfile: (patch: authApi.ProfileUpdate) => Promise<void>;
@@ -54,6 +60,7 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   user: null,
   accessToken: null,
   booted: false,
+  profileStepActive: false,
 
   async login(phoneNumber, password) {
     set({ status: 'loading' });
@@ -100,7 +107,11 @@ export const useAuthStore = create<AuthState>((set, get) => ({
 
   async completeOnboarding(payload) {
     const user = await authApi.completeOnboarding(payload);
-    set({ user });
+    set({ user, profileStepActive: true });
+  },
+
+  finishProfileStep() {
+    set({ profileStepActive: false });
   },
 
   async acceptConsents(consentTypes) {
@@ -139,12 +150,12 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   async logout() {
     await authApi.logout();
     queryClient.clear();
-    set({ status: 'unauthed', user: null, accessToken: null });
+    set({ status: 'unauthed', user: null, accessToken: null, profileStepActive: false });
   },
 
   forceLogout() {
     queryClient.clear();
-    set({ status: 'unauthed', user: null, accessToken: null });
+    set({ status: 'unauthed', user: null, accessToken: null, profileStepActive: false });
   },
 }));
 

--- a/frontend/src/screens/auth/NewPasswordScreen.test.tsx
+++ b/frontend/src/screens/auth/NewPasswordScreen.test.tsx
@@ -21,11 +21,13 @@ const VALID = 'abcd1234ABCD!';
 
 describe('NewPasswordScreen', () => {
   const completeOnboarding = vi.fn();
+  const startProfileStep = vi.fn();
 
   beforeEach(() => {
     completeOnboarding.mockReset();
+    startProfileStep.mockReset();
     vi.mocked(useAuthStore).mockImplementation((selector) =>
-      selector({ completeOnboarding } as never),
+      selector({ completeOnboarding, startProfileStep } as never),
     );
   });
 
@@ -57,5 +59,8 @@ describe('NewPasswordScreen', () => {
     await vi.waitFor(() => {
       expect(completeOnboarding).toHaveBeenCalledWith({ newPassword: VALID });
     });
+    // the password-reset flow shares completeOnboarding but must not enter the
+    // onboarding profile step
+    expect(startProfileStep).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/screens/auth/OnboardingProfileStep.test.tsx
+++ b/frontend/src/screens/auth/OnboardingProfileStep.test.tsx
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { OnboardingProfileStep } from './OnboardingProfileStep';
+import { useAuthStore } from '@/auth/store';
+import type { User } from '@/models/user';
+
+vi.mock('@/auth/store', () => ({
+  useAuthStore: vi.fn(),
+}));
+
+// AvatarUpload pulls in image-crop/canvas machinery we don't need here; stub it.
+vi.mock('@/screens/settings/AvatarUpload', () => ({
+  AvatarUpload: () => <div data-testid="avatar-upload" />,
+}));
+
+const baseUser: User = {
+  id: 'u1',
+  phoneNumber: '+15551234567',
+  displayName: 'Tester',
+  email: 'tester@example.com',
+  bio: '',
+  isSuperuser: false,
+  isStaff: false,
+  needsOnboarding: false,
+  needsPasswordReset: false,
+  showPhone: false,
+  showEmail: false,
+  weekStart: 'sunday',
+  calendarFeedScope: 'all',
+  profilePhotoUrl: '',
+  photoUpdatedAt: null,
+  roles: [],
+};
+
+describe('OnboardingProfileStep', () => {
+  const updateProfile = vi.fn();
+  const onDone = vi.fn();
+
+  function mockStore(user: User) {
+    vi.mocked(useAuthStore).mockImplementation((selector) =>
+      selector({ user, updateProfile } as never),
+    );
+  }
+
+  beforeEach(() => {
+    updateProfile.mockReset();
+    onDone.mockReset();
+    updateProfile.mockResolvedValue(undefined);
+    mockStore(baseUser);
+  });
+
+  it('skips without saving when "do this later" is clicked', async () => {
+    render(<OnboardingProfileStep onDone={onDone} />);
+    await userEvent.click(screen.getByRole('button', { name: /do this later/i }));
+    expect(updateProfile).not.toHaveBeenCalled();
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it('saves a non-empty bio then finishes when "done" is clicked', async () => {
+    render(<OnboardingProfileStep onDone={onDone} />);
+    await userEvent.type(screen.getByLabelText(/bio/i), 'i love tofu');
+    await userEvent.click(screen.getByRole('button', { name: /^done$/i }));
+    expect(updateProfile).toHaveBeenCalledWith({ bio: 'i love tofu' });
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it('finishes without calling updateProfile when bio is left empty', async () => {
+    render(<OnboardingProfileStep onDone={onDone} />);
+    await userEvent.click(screen.getByRole('button', { name: /^done$/i }));
+    expect(updateProfile).not.toHaveBeenCalled();
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows the "photo added" confirmation once a profile photo exists', () => {
+    mockStore({ ...baseUser, profilePhotoUrl: 'https://example.com/p.png' });
+    render(<OnboardingProfileStep onDone={onDone} />);
+    expect(screen.getByText(/photo added/i)).toBeInTheDocument();
+  });
+
+  it('does not show the "photo added" confirmation when there is no photo', () => {
+    render(<OnboardingProfileStep onDone={onDone} />);
+    expect(screen.queryByText(/photo added/i)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/auth/OnboardingProfileStep.test.tsx
+++ b/frontend/src/screens/auth/OnboardingProfileStep.test.tsx
@@ -1,9 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { OnboardingProfileStep } from './OnboardingProfileStep';
+import { beforeEach,describe, expect, it, vi } from 'vitest';
+
 import { useAuthStore } from '@/auth/store';
 import type { User } from '@/models/user';
+
+import { OnboardingProfileStep } from './OnboardingProfileStep';
 
 vi.mock('@/auth/store', () => ({
   useAuthStore: vi.fn(),

--- a/frontend/src/screens/auth/OnboardingProfileStep.test.tsx
+++ b/frontend/src/screens/auth/OnboardingProfileStep.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { beforeEach,describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAuthStore } from '@/auth/store';
 import type { User } from '@/models/user';
@@ -22,10 +22,13 @@ const baseUser: User = {
   displayName: 'Tester',
   email: 'tester@example.com',
   bio: '',
+  pronouns: '',
   isSuperuser: false,
   isStaff: false,
   needsOnboarding: false,
   needsPasswordReset: false,
+  needsGuidelinesConsent: false,
+  needsSmsConsent: false,
   showPhone: false,
   showEmail: false,
   weekStart: 'sunday',

--- a/frontend/src/screens/auth/OnboardingProfileStep.tsx
+++ b/frontend/src/screens/auth/OnboardingProfileStep.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/Button';
+import { Textarea } from '@/components/ui/Textarea';
+import { AvatarUpload } from '@/screens/settings/AvatarUpload';
+import { useAuthStore } from '@/auth/store';
+import { extractApiError } from '@/utils/errors';
+
+const MAX_BIO = 500;
+
+interface Props {
+  onDone: () => void;
+}
+
+export function OnboardingProfileStep({ onDone }: Props) {
+  const user = useAuthStore((s) => s.user);
+  const updateProfile = useAuthStore((s) => s.updateProfile);
+  const [bio, setBio] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const hasPhoto = Boolean(user?.profilePhotoUrl);
+
+  async function onFinish() {
+    const trimmed = bio.trim();
+    if (!trimmed) {
+      onDone();
+      return;
+    }
+    setError(null);
+    setSaving(true);
+    try {
+      await updateProfile({ bio: trimmed });
+      onDone();
+    } catch (err) {
+      setError(extractApiError(err, "couldn't save your bio — try again"));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-col items-center gap-2">
+        <AvatarUpload size="lg" />
+        {hasPhoto ? <p className="text-foreground-tertiary text-sm">✓ photo added</p> : null}
+      </div>
+      <Textarea
+        label="bio"
+        value={bio}
+        onChange={(e) => {
+          setBio(e.target.value);
+        }}
+        maxLength={MAX_BIO}
+        rows={4}
+        hint="optional — a sentence or two about you"
+      />
+      {error ? (
+        <p role="alert" className="text-destructive text-sm">
+          {error}
+        </p>
+      ) : null}
+      <Button type="button" fullWidth disabled={saving} onClick={() => void onFinish()}>
+        {saving ? 'saving…' : 'done'}
+      </Button>
+      <button
+        type="button"
+        onClick={onDone}
+        className="text-foreground-tertiary hover:text-foreground text-sm underline transition-colors"
+      >
+        do this later
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/screens/auth/OnboardingProfileStep.tsx
+++ b/frontend/src/screens/auth/OnboardingProfileStep.tsx
@@ -20,6 +20,11 @@ export function OnboardingProfileStep({ onDone }: Props) {
 
   const hasPhoto = Boolean(user?.profilePhotoUrl);
 
+  function onSkip() {
+    setError(null);
+    onDone();
+  }
+
   async function onFinish() {
     const trimmed = bio.trim();
     if (!trimmed) {
@@ -64,8 +69,9 @@ export function OnboardingProfileStep({ onDone }: Props) {
       </Button>
       <button
         type="button"
-        onClick={onDone}
-        className="text-foreground-tertiary hover:text-foreground text-sm underline transition-colors"
+        onClick={onSkip}
+        disabled={saving}
+        className="text-foreground-tertiary hover:text-foreground focus-visible:ring-brand-200 text-sm underline transition-colors focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
       >
         do this later
       </button>

--- a/frontend/src/screens/auth/OnboardingProfileStep.tsx
+++ b/frontend/src/screens/auth/OnboardingProfileStep.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
+
+import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import { Textarea } from '@/components/ui/Textarea';
 import { AvatarUpload } from '@/screens/settings/AvatarUpload';
-import { useAuthStore } from '@/auth/store';
 import { extractApiError } from '@/utils/errors';
 
 const MAX_BIO = 500;

--- a/frontend/src/screens/auth/OnboardingProfileStep.tsx
+++ b/frontend/src/screens/auth/OnboardingProfileStep.tsx
@@ -21,11 +21,6 @@ export function OnboardingProfileStep({ onDone }: Props) {
 
   const hasPhoto = Boolean(user?.profilePhotoUrl);
 
-  function onSkip() {
-    setError(null);
-    onDone();
-  }
-
   async function onFinish() {
     const trimmed = bio.trim();
     if (!trimmed) {
@@ -70,7 +65,7 @@ export function OnboardingProfileStep({ onDone }: Props) {
       </Button>
       <button
         type="button"
-        onClick={onSkip}
+        onClick={onDone}
         disabled={saving}
         className="text-foreground-tertiary hover:text-foreground focus-visible:ring-brand-200 text-sm underline transition-colors focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-50"
       >

--- a/frontend/src/screens/auth/OnboardingScreen.test.tsx
+++ b/frontend/src/screens/auth/OnboardingScreen.test.tsx
@@ -50,9 +50,16 @@ function makeUser(overrides: Partial<User> = {}): User {
 describe('OnboardingScreen', () => {
   const completeOnboarding = vi.fn();
   const updateProfile = vi.fn();
+  const finishProfileStep = vi.fn();
 
-  function setupMock(user: User) {
-    const storeState = { completeOnboarding, updateProfile, user };
+  function setupMock(user: User, profileStepActive = false) {
+    const storeState = {
+      completeOnboarding,
+      updateProfile,
+      finishProfileStep,
+      user,
+      profileStepActive,
+    };
     // Cast via `as never` so partial state satisfies the full AuthState type.
     vi.mocked(useAuthStore).mockImplementation(
       Object.assign((selector: (s: typeof storeState) => unknown) => selector(storeState), {
@@ -64,6 +71,7 @@ describe('OnboardingScreen', () => {
   beforeEach(() => {
     completeOnboarding.mockReset();
     updateProfile.mockReset();
+    finishProfileStep.mockReset();
     updateProfile.mockResolvedValue(undefined);
     setupMock(makeUser());
   });
@@ -173,7 +181,7 @@ describe('OnboardingScreen', () => {
     });
   });
 
-  it('advances to the profile step after successful account setup', async () => {
+  it('calls completeOnboarding on submit and does not error on success', async () => {
     completeOnboarding.mockResolvedValue(undefined);
     render(
       <MemoryRouter>
@@ -184,7 +192,18 @@ describe('OnboardingScreen', () => {
     await userEvent.type(screen.getByLabelText(/^email$/i), 'tester@example.com');
     await userEvent.type(screen.getByLabelText(/^password$/i), 'abcd1234ABCD!');
     await userEvent.click(screen.getByRole('button', { name: /continue/i }));
-    expect(await screen.findByRole('button', { name: /^done$/i })).toBeInTheDocument();
+    expect(completeOnboarding).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText(/couldn't finish onboarding/i)).not.toBeInTheDocument();
+  });
+
+  it('renders the profile step when profileStepActive is set', () => {
+    setupMock(makeUser({ needsOnboarding: false }), true);
+    render(
+      <MemoryRouter>
+        <OnboardingScreen />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole('button', { name: /^done$/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /do this later/i })).toBeInTheDocument();
   });
 

--- a/frontend/src/screens/auth/OnboardingScreen.test.tsx
+++ b/frontend/src/screens/auth/OnboardingScreen.test.tsx
@@ -18,6 +18,10 @@ vi.mock('@/api/client', () => ({
   setAuthBridge: vi.fn(),
 }));
 
+vi.mock('@/screens/settings/AvatarUpload', () => ({
+  AvatarUpload: () => <div data-testid="avatar-upload" />,
+}));
+
 function makeUser(overrides: Partial<User> = {}): User {
   return {
     id: 'u1',
@@ -45,9 +49,10 @@ function makeUser(overrides: Partial<User> = {}): User {
 
 describe('OnboardingScreen', () => {
   const completeOnboarding = vi.fn();
+  const updateProfile = vi.fn();
 
   function setupMock(user: User) {
-    const storeState = { completeOnboarding, user };
+    const storeState = { completeOnboarding, updateProfile, user };
     // Cast via `as never` so partial state satisfies the full AuthState type.
     vi.mocked(useAuthStore).mockImplementation(
       Object.assign((selector: (s: typeof storeState) => unknown) => selector(storeState), {
@@ -58,6 +63,9 @@ describe('OnboardingScreen', () => {
 
   beforeEach(() => {
     completeOnboarding.mockReset();
+    updateProfile.mockReset();
+    updateProfile.mockResolvedValue(undefined);
+    setupMock(makeUser());
   });
 
   it('shows email-required error when email is empty', async () => {
@@ -163,5 +171,35 @@ describe('OnboardingScreen', () => {
       newPassword: 'abcd1234ABCD!',
       consentTypes: ['guidelines', 'sms'],
     });
+  });
+
+  it('advances to the profile step after successful account setup', async () => {
+    completeOnboarding.mockResolvedValue(undefined);
+    render(
+      <MemoryRouter>
+        <OnboardingScreen />
+      </MemoryRouter>,
+    );
+    await userEvent.type(screen.getByLabelText(/display name/i), 'Tester');
+    await userEvent.type(screen.getByLabelText(/^email$/i), 'tester@example.com');
+    await userEvent.type(screen.getByLabelText(/^password$/i), 'abcd1234ABCD!');
+    await userEvent.click(screen.getByRole('button', { name: /continue/i }));
+    expect(await screen.findByRole('button', { name: /^done$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /do this later/i })).toBeInTheDocument();
+  });
+
+  it('stays on the account step when account setup fails', async () => {
+    completeOnboarding.mockRejectedValue(new Error('nope'));
+    render(
+      <MemoryRouter>
+        <OnboardingScreen />
+      </MemoryRouter>,
+    );
+    await userEvent.type(screen.getByLabelText(/display name/i), 'Tester');
+    await userEvent.type(screen.getByLabelText(/^email$/i), 'tester@example.com');
+    await userEvent.type(screen.getByLabelText(/^password$/i), 'abcd1234ABCD!');
+    await userEvent.click(screen.getByRole('button', { name: /continue/i }));
+    expect(await screen.findByText(/couldn't finish onboarding/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^done$/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/auth/OnboardingScreen.test.tsx
+++ b/frontend/src/screens/auth/OnboardingScreen.test.tsx
@@ -50,12 +50,14 @@ function makeUser(overrides: Partial<User> = {}): User {
 describe('OnboardingScreen', () => {
   const completeOnboarding = vi.fn();
   const updateProfile = vi.fn();
+  const startProfileStep = vi.fn();
   const finishProfileStep = vi.fn();
 
   function setupMock(user: User, profileStepActive = false) {
     const storeState = {
       completeOnboarding,
       updateProfile,
+      startProfileStep,
       finishProfileStep,
       user,
       profileStepActive,
@@ -71,6 +73,7 @@ describe('OnboardingScreen', () => {
   beforeEach(() => {
     completeOnboarding.mockReset();
     updateProfile.mockReset();
+    startProfileStep.mockReset();
     finishProfileStep.mockReset();
     updateProfile.mockResolvedValue(undefined);
     setupMock(makeUser());
@@ -181,7 +184,7 @@ describe('OnboardingScreen', () => {
     });
   });
 
-  it('calls completeOnboarding on submit and does not error on success', async () => {
+  it('starts the profile step after successful account setup', async () => {
     completeOnboarding.mockResolvedValue(undefined);
     render(
       <MemoryRouter>
@@ -193,6 +196,7 @@ describe('OnboardingScreen', () => {
     await userEvent.type(screen.getByLabelText(/^password$/i), 'abcd1234ABCD!');
     await userEvent.click(screen.getByRole('button', { name: /continue/i }));
     expect(completeOnboarding).toHaveBeenCalledTimes(1);
+    expect(startProfileStep).toHaveBeenCalledTimes(1);
     expect(screen.queryByText(/couldn't finish onboarding/i)).not.toBeInTheDocument();
   });
 
@@ -219,6 +223,7 @@ describe('OnboardingScreen', () => {
     await userEvent.type(screen.getByLabelText(/^password$/i), 'abcd1234ABCD!');
     await userEvent.click(screen.getByRole('button', { name: /continue/i }));
     expect(await screen.findByText(/couldn't finish onboarding/i)).toBeInTheDocument();
+    expect(startProfileStep).not.toHaveBeenCalled();
     expect(screen.queryByRole('button', { name: /^done$/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/auth/OnboardingScreen.tsx
+++ b/frontend/src/screens/auth/OnboardingScreen.tsx
@@ -13,6 +13,7 @@ import { extractApiError } from '@/utils/errors';
 
 import { AuthLayout } from './AuthLayout';
 import { ConsentChecklist } from './ConsentChecklist';
+import { OnboardingProfileStep } from './OnboardingProfileStep';
 import { PasswordChecklist } from './PasswordChecklist';
 import { passwordRule } from './passwordRule';
 import { useConsentChecklist } from './useConsentChecklist';
@@ -25,6 +26,7 @@ const schema = z.object({
 });
 
 type FormValues = z.infer<typeof schema>;
+type Step = 'account' | 'profile';
 
 export default function OnboardingScreen() {
   const completeOnboarding = useAuthStore((s) => s.completeOnboarding);
@@ -33,6 +35,7 @@ export default function OnboardingScreen() {
   // checkboxes render only for users with outstanding consent (admin-created accounts)
   const user = useAuthStore((s) => s.user);
   const navigate = useNavigate();
+  const [step, setStep] = useState<Step>('account');
   const [serverError, setServerError] = useState<string | null>(null);
   const { consents, checked, toggle, allChecked, acceptedTypes } = useConsentChecklist(user);
 
@@ -58,11 +61,26 @@ export default function OnboardingScreen() {
         newPassword: values.newPassword,
         consentTypes: acceptedTypes,
       });
-      const next = postAuthRedirect(useAuthStore.getState().user) ?? '/calendar';
-      void navigate(next, { replace: true });
+      setStep('profile');
     } catch (err) {
       setServerError(extractApiError(err, "couldn't finish onboarding — try again"));
     }
+  }
+
+  if (step === 'profile') {
+    return (
+      <AuthLayout
+        title="make it yours ✨"
+        subtitle="add a photo and a few words so folks can put a face to your name — you can always do this later"
+      >
+        <OnboardingProfileStep
+          onDone={() => {
+            const next = postAuthRedirect(useAuthStore.getState().user) ?? '/calendar';
+            void navigate(next, { replace: true });
+          }}
+        />
+      </AuthLayout>
+    );
   }
 
   return (

--- a/frontend/src/screens/auth/OnboardingScreen.tsx
+++ b/frontend/src/screens/auth/OnboardingScreen.tsx
@@ -26,16 +26,18 @@ const schema = z.object({
 });
 
 type FormValues = z.infer<typeof schema>;
-type Step = 'account' | 'profile';
 
 export default function OnboardingScreen() {
   const completeOnboarding = useAuthStore((s) => s.completeOnboarding);
+  const finishProfileStep = useAuthStore((s) => s.finishProfileStep);
+  // profileStepActive flips true once account setup succeeds; drives the wizard's
+  // second step. Kept in the store (not local state) so OnboardingGate can see it.
+  const profileStepActive = useAuthStore((s) => s.profileStepActive);
   // prefill name for legacy users approved before email was required
   const existingDisplayName = useAuthStore((s) => s.user?.displayName ?? '');
   // checkboxes render only for users with outstanding consent (admin-created accounts)
   const user = useAuthStore((s) => s.user);
   const navigate = useNavigate();
-  const [step, setStep] = useState<Step>('account');
   const [serverError, setServerError] = useState<string | null>(null);
   const { consents, checked, toggle, allChecked, acceptedTypes } = useConsentChecklist(user);
 
@@ -61,13 +63,12 @@ export default function OnboardingScreen() {
         newPassword: values.newPassword,
         consentTypes: acceptedTypes,
       });
-      setStep('profile');
     } catch (err) {
       setServerError(extractApiError(err, "couldn't finish onboarding — try again"));
     }
   }
 
-  if (step === 'profile') {
+  if (profileStepActive) {
     return (
       <AuthLayout
         title="make it yours ✨"
@@ -75,6 +76,7 @@ export default function OnboardingScreen() {
       >
         <OnboardingProfileStep
           onDone={() => {
+            finishProfileStep();
             const next = postAuthRedirect(useAuthStore.getState().user) ?? '/calendar';
             void navigate(next, { replace: true });
           }}

--- a/frontend/src/screens/auth/OnboardingScreen.tsx
+++ b/frontend/src/screens/auth/OnboardingScreen.tsx
@@ -29,9 +29,8 @@ type FormValues = z.infer<typeof schema>;
 
 export default function OnboardingScreen() {
   const completeOnboarding = useAuthStore((s) => s.completeOnboarding);
+  const startProfileStep = useAuthStore((s) => s.startProfileStep);
   const finishProfileStep = useAuthStore((s) => s.finishProfileStep);
-  // profileStepActive flips true once account setup succeeds; drives the wizard's
-  // second step. Kept in the store (not local state) so OnboardingGate can see it.
   const profileStepActive = useAuthStore((s) => s.profileStepActive);
   // prefill name for legacy users approved before email was required
   const existingDisplayName = useAuthStore((s) => s.user?.displayName ?? '');
@@ -63,6 +62,7 @@ export default function OnboardingScreen() {
         newPassword: values.newPassword,
         consentTypes: acceptedTypes,
       });
+      startProfileStep();
     } catch (err) {
       setServerError(extractApiError(err, "couldn't finish onboarding — try again"));
     }


### PR DESCRIPTION
## Summary
- turn onboarding into a two-step wizard: after account setup (name, email, password, consent), a new optional profile step lets users add a photo and bio
- the profile step is skippable via "do this later" and honors the existing `postAuthRedirect` routing when finished
- new `OnboardingProfileStep` component reuses the settings `AvatarUpload` and updates the bio via `updateProfile`

## Test plan
- [ ] complete account setup → land on the profile step ("make it yours ✨")
- [ ] add a photo + bio → "done" saves the bio and redirects appropriately
- [ ] "do this later" skips straight to the redirect without saving
- [ ] a failed bio save keeps you on the profile step with an error, doesn't advance
- [ ] a failed account setup keeps you on the account step (does not advance to profile)