### PR TITLE
fix(test): add missing nickname to OnboardingProfileStep User fixture (Issue 532)

### DIFF
--- a/frontend/src/screens/auth/OnboardingProfileStep.test.tsx
+++ b/frontend/src/screens/auth/OnboardingProfileStep.test.tsx
@@ -20,6 +20,7 @@ const baseUser: User = {
   id: 'u1',
   phoneNumber: '+15551234567',
   displayName: 'Tester',
+  nickname: '',
   email: 'tester@example.com',
   bio: '',
   pronouns: '',


### PR DESCRIPTION
## summary

Fixes `main` being red on `agent-frontend-typecheck`.

## root cause

PR #730 (nickname, Issue 532) made `nickname` a **required** field on the `User` type. The `OnboardingProfileStep.test.tsx` fixture builds a `User` object literal that never got the field added, so `tsc` fails:

```
OnboardingProfileStep.test.tsx(19,7): error TS2741: Property 'nickname' is missing in type '{...}' but required in type 'User'.
```

All tests pass (721) — this is **typecheck-only**, and a classic semantic merge conflict: #730 and the fixture were each green in isolation and only broke once both landed on main. Every other `User` fixture in the suite already has `nickname`; this was the lone straggler.

## fix

Add `nickname: ''` to the fixture.

## verification

- `make agent-frontend-typecheck` — clean.
- `OnboardingProfileStep.test.tsx` — 5/5 pass.
