### PR TITLE
refactor(frontend): 734 - delegate makeUser test factories to shared fixture

### DIFF
--- a/frontend/src/auth/guards.test.tsx
+++ b/frontend/src/auth/guards.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Permission } from '@/models/permissions';
 import type { User } from '@/models/user';
+import { makeUser as makeSharedUser } from '@/test/fixtures';
 
 import { EmailGate, OnboardingGate, RequireAuth, RequirePermission } from './guards';
 import { useAuthStore } from './store';
@@ -35,32 +36,15 @@ vi.mock('@/api/auth', () => ({
 // ---------------------------------------------------------------------------
 
 function makeUser(overrides: Partial<User> = {}): User {
-  return {
+  return makeSharedUser({
     id: 'user-1',
     phoneNumber: '+12125551234',
     firstName: 'Alice',
     lastName: '',
     fullName: 'Alice',
-    nickname: '',
     email: 'alice@example.com',
-    bio: '',
-    pronouns: '',
-    isSuperuser: false,
-    isStaff: false,
-    needsOnboarding: false,
-    needsPasswordReset: false,
-    needsGuidelinesConsent: false,
-    needsSmsConsent: false,
-    showPhone: false,
-    showEmail: false,
-    hideLastName: false,
-    weekStart: 'sunday',
-    calendarFeedScope: 'all',
-    profilePhotoUrl: '',
-    photoUpdatedAt: null,
-    roles: [],
     ...overrides,
-  };
+  });
 }
 
 beforeEach(() => {

--- a/frontend/src/components/FeedbackButton.a11y.test.tsx
+++ b/frontend/src/components/FeedbackButton.a11y.test.tsx
@@ -7,6 +7,7 @@ import { axe } from 'vitest-axe';
 
 import { useAuthStore } from '@/auth/store';
 import type { User } from '@/models/user';
+import { makeUser as makeSharedUser } from '@/test/fixtures';
 
 const submitFeedbackMock = vi.fn();
 const useSubmitFeedbackMock =
@@ -29,32 +30,15 @@ vi.mock('sonner', () => ({
 import { FeedbackButton } from './FeedbackButton';
 
 function makeUser(overrides: Partial<User> = {}): User {
-  return {
+  return makeSharedUser({
     id: 'user-1',
     phoneNumber: '+12125551234',
     firstName: 'alice',
     lastName: '',
     fullName: 'alice',
-    nickname: '',
     email: 'alice@example.com',
-    bio: '',
-    pronouns: '',
-    isSuperuser: false,
-    isStaff: false,
-    needsOnboarding: false,
-    needsPasswordReset: false,
-    needsGuidelinesConsent: false,
-    needsSmsConsent: false,
-    showPhone: false,
-    showEmail: false,
-    hideLastName: false,
-    weekStart: 'sunday',
-    calendarFeedScope: 'all',
-    profilePhotoUrl: '',
-    photoUpdatedAt: null,
-    roles: [],
     ...overrides,
-  };
+  });
 }
 
 function renderButton() {

--- a/frontend/src/components/FeedbackButton.test.tsx
+++ b/frontend/src/components/FeedbackButton.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAuthStore } from '@/auth/store';
 import type { User } from '@/models/user';
+import { makeUser as makeSharedUser } from '@/test/fixtures';
 
 const submitFeedbackMock = vi.fn();
 
@@ -32,32 +33,15 @@ import { FeedbackButton } from './FeedbackButton';
 const mockedUseSubmitFeedback = vi.mocked(useSubmitFeedback);
 
 function makeUser(overrides: Partial<User> = {}): User {
-  return {
+  return makeSharedUser({
     id: 'user-1',
     phoneNumber: '+12125551234',
     firstName: 'alice',
     lastName: '',
     fullName: 'alice',
-    nickname: '',
     email: 'alice@example.com',
-    bio: '',
-    pronouns: '',
-    isSuperuser: false,
-    isStaff: false,
-    needsOnboarding: false,
-    needsPasswordReset: false,
-    needsGuidelinesConsent: false,
-    needsSmsConsent: false,
-    showPhone: false,
-    showEmail: false,
-    hideLastName: false,
-    weekStart: 'sunday',
-    calendarFeedScope: 'all',
-    profilePhotoUrl: '',
-    photoUpdatedAt: null,
-    roles: [],
     ...overrides,
-  };
+  });
 }
 
 function renderButton(initialPath = '/calendar') {

--- a/frontend/src/models/user.test.ts
+++ b/frontend/src/models/user.test.ts
@@ -1,34 +1,18 @@
 import { describe, expect, it } from 'vitest';
 
+import { makeUser as makeSharedUser } from '@/test/fixtures';
+
 import { consentRedirect, passwordSetupRedirect, postAuthRedirect, type User } from './user';
 
 function makeUser(overrides: Partial<User> = {}): User {
-  return {
+  return makeSharedUser({
     id: 'u1',
-    phoneNumber: '+12125550001',
     firstName: 'Alice',
     lastName: 'Anderson',
     fullName: 'Alice Anderson',
-    nickname: '',
     email: 'alice@example.com',
-    bio: '',
-    pronouns: '',
-    isSuperuser: false,
-    isStaff: false,
-    needsOnboarding: false,
-    needsPasswordReset: false,
-    needsGuidelinesConsent: false,
-    needsSmsConsent: false,
-    showPhone: false,
-    showEmail: false,
-    hideLastName: false,
-    weekStart: 'sunday',
-    calendarFeedScope: 'all',
-    profilePhotoUrl: '',
-    photoUpdatedAt: null,
-    roles: [],
     ...overrides,
-  };
+  });
 }
 
 describe('passwordSetupRedirect', () => {

--- a/frontend/src/screens/admin/ApprovalCredentialsDialog.test.tsx
+++ b/frontend/src/screens/admin/ApprovalCredentialsDialog.test.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAuthStore } from '@/auth/store';
 import type { User } from '@/models/user';
+import { makeUser as makeSharedUser } from '@/test/fixtures';
 
 import { ApprovalCredentialsDialog } from './ApprovalCredentialsDialog';
 
@@ -23,32 +24,14 @@ vi.mock('@/api/content', () => ({
 }));
 
 function makeUser(overrides?: Partial<User>): User {
-  return {
+  return makeSharedUser({
     id: 'u1',
     phoneNumber: '+12125550000',
     firstName: 'Vetter',
     lastName: 'Vee',
     fullName: 'Vetter Vee',
-    nickname: '',
-    email: '',
-    bio: '',
-    pronouns: '',
-    isSuperuser: false,
-    isStaff: false,
-    needsOnboarding: false,
-    needsPasswordReset: false,
-    needsGuidelinesConsent: false,
-    needsSmsConsent: false,
-    showPhone: false,
-    showEmail: false,
-    hideLastName: false,
-    weekStart: 'sunday',
-    calendarFeedScope: 'all',
-    profilePhotoUrl: '',
-    photoUpdatedAt: null,
-    roles: [],
     ...overrides,
-  };
+  });
 }
 
 beforeEach(() => {

--- a/frontend/src/screens/auth/MagicLoginScreen.test.tsx
+++ b/frontend/src/screens/auth/MagicLoginScreen.test.tsx
@@ -3,6 +3,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { User } from '@/models/user';
+import { makeUser as makeSharedUser } from '@/test/fixtures';
 
 import MagicLoginScreen from './MagicLoginScreen';
 
@@ -15,32 +16,14 @@ const magicLoginMock = vi.fn(async () => {
 });
 
 function makeUser(overrides: Partial<User> = {}): User {
-  return {
+  return makeSharedUser({
     id: 'u1',
-    phoneNumber: '+12125550001',
     firstName: 'Alice',
     lastName: '',
     fullName: 'Alice',
-    nickname: '',
     email: 'alice@example.com',
-    bio: '',
-    pronouns: '',
-    isSuperuser: false,
-    isStaff: false,
-    needsOnboarding: false,
-    needsPasswordReset: false,
-    needsGuidelinesConsent: false,
-    needsSmsConsent: false,
-    showPhone: false,
-    showEmail: false,
-    hideLastName: false,
-    weekStart: 'sunday',
-    calendarFeedScope: 'all',
-    profilePhotoUrl: '',
-    photoUpdatedAt: null,
-    roles: [],
     ...overrides,
-  };
+  });
 }
 
 vi.mock('@/auth/store', () => ({

--- a/frontend/src/screens/auth/OnboardingScreen.test.tsx
+++ b/frontend/src/screens/auth/OnboardingScreen.test.tsx
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAuthStore } from '@/auth/store';
 import type { User } from '@/models/user';
+import { makeUser as makeSharedUser } from '@/test/fixtures';
 
 import OnboardingScreen from './OnboardingScreen';
 
@@ -23,32 +24,14 @@ vi.mock('@/screens/settings/AvatarUpload', () => ({
 }));
 
 function makeUser(overrides: Partial<User> = {}): User {
-  return {
+  return makeSharedUser({
     id: 'u1',
-    phoneNumber: '+12125550001',
     firstName: '',
     lastName: '',
     fullName: '',
-    nickname: '',
-    email: '',
-    bio: '',
-    pronouns: '',
-    isSuperuser: false,
-    isStaff: false,
     needsOnboarding: true,
-    needsPasswordReset: false,
-    needsGuidelinesConsent: false,
-    needsSmsConsent: false,
-    showPhone: false,
-    showEmail: false,
-    hideLastName: false,
-    weekStart: 'sunday',
-    calendarFeedScope: 'all',
-    profilePhotoUrl: '',
-    photoUpdatedAt: null,
-    roles: [],
     ...overrides,
-  };
+  });
 }
 
 describe('OnboardingScreen', () => {


### PR DESCRIPTION
## Overview

Frontend tests each defined their own local `makeUser` factory that re-listed every `User` field. Adding or renaming a field on `User` therefore forced edits across all of them — the fan-out pain called out by issue #734 (PR #730 was the concrete example).

This migrates seven test files so their local `makeUser` now delegates to the shared `makeUser` from `@/test/fixtures` (which already exists from PR #730), passing only the fields that file's tests depend on as pre-applied overrides. A new or renamed `User` field now touches only the shared factory. Behavior is preserved field-for-field — every default that differed from the shared factory is still passed as an override.

**Scope note:** this is **PR1** of the consolidation, kept small to stay well under the review-size limit (159 changed lines). Follow-up PRs will migrate the `makeEvent` factories (~12 files) and the custom-signature `makeUser(id, permissions)` in `EventAdminActions.test.tsx`, and add a shared `makeGuest` factory.

Migrated files:
- `frontend/src/models/user.test.ts`
- `frontend/src/auth/guards.test.tsx`
- `frontend/src/components/FeedbackButton.test.tsx`
- `frontend/src/components/FeedbackButton.a11y.test.tsx`
- `frontend/src/screens/admin/ApprovalCredentialsDialog.test.tsx`
- `frontend/src/screens/auth/MagicLoginScreen.test.tsx`
- `frontend/src/screens/auth/OnboardingScreen.test.tsx`

Part of Issue 734.

## Test plan

- [x] `make agent-frontend-test` — 102 files / 729 passed / 1 skipped
- [x] `make agent-frontend-typecheck` — clean
- [x] `make agent-frontend-lint` — clean
