### PR TITLE
chore(welcome): rename ${NAME} placeholder to ${FIRST_NAME} (Issue 732)

### DIFF
--- a/backend/community/migrations/0050_seed_welcome_template.py
+++ b/backend/community/migrations/0050_seed_welcome_template.py
@@ -1,6 +1,6 @@
 from django.db import migrations
 
-DEFAULT_BODY = """Hi, ${NAME}! I’m ${SENDER_NAME}, part of the vetting team at PDA (Protein Deficient Anonymous). We’re excited to have you!
+DEFAULT_BODY = """Hi, ${FIRST_NAME}! I’m ${SENDER_NAME}, part of the vetting team at PDA (Protein Deficient Anonymous). We’re excited to have you!
 
 Just to give you a little rundown: this newly-launched website hosts our PDA community events calendar, while conversations and announcements are in our WhatsApp group. We add people to the group in a batch in the late morning - when you join, I’ll welcome you and direct you to the intros channel, where you can drop a lil' introduction about yourself. Things people tend to share are how long they’ve been vegan, what their hobbies are (sometimes you find connections to others in the group based on that), their jobs, but you can share whatever you like!
 

--- a/backend/community/migrations/0067_rename_welcome_template_name_placeholder.py
+++ b/backend/community/migrations/0067_rename_welcome_template_name_placeholder.py
@@ -1,0 +1,27 @@
+from django.db import migrations
+
+OLD_TOKEN = "${NAME}"
+NEW_TOKEN = "${FIRST_NAME}"
+
+
+def rename_token(apps, schema_editor):
+    WelcomeMessageTemplate = apps.get_model("community", "WelcomeMessageTemplate")
+    for template in WelcomeMessageTemplate.objects.all().iterator():
+        if OLD_TOKEN in template.body:
+            template.body = template.body.replace(OLD_TOKEN, NEW_TOKEN)
+            template.save(update_fields=["body"])
+
+
+def revert_token(apps, schema_editor):
+    WelcomeMessageTemplate = apps.get_model("community", "WelcomeMessageTemplate")
+    for template in WelcomeMessageTemplate.objects.all().iterator():
+        if NEW_TOKEN in template.body:
+            template.body = template.body.replace(NEW_TOKEN, OLD_TOKEN)
+            template.save(update_fields=["body"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("community", "0066_backfill_joinrequest_names"),
+    ]
+    operations = [migrations.RunPython(rename_token, revert_token)]

--- a/backend/community/migrations/0068_rename_welcome_template_name_placeholder.py
+++ b/backend/community/migrations/0068_rename_welcome_template_name_placeholder.py
@@ -22,6 +22,6 @@ def revert_token(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("community", "0066_backfill_joinrequest_names"),
+        ("community", "0067_remove_joinrequest_display_name"),
     ]
     operations = [migrations.RunPython(rename_token, revert_token)]

--- a/backend/community/models/content.py
+++ b/backend/community/models/content.py
@@ -110,7 +110,7 @@ class WelcomeMessageTemplate(models.Model):
     """Singleton — only one row ever exists (pk=1).
 
     Plain-text template for the welcome SMS/WhatsApp message vetters send
-    after approving a join request. Placeholders ${NAME}, ${SENDER_NAME},
+    after approving a join request. Placeholders ${FIRST_NAME}, ${SENDER_NAME},
     ${MAGIC_LINK} are substituted client-side at render time.
     """
 

--- a/backend/tests/test_welcome_template.py
+++ b/backend/tests/test_welcome_template.py
@@ -36,7 +36,7 @@ class TestGetWelcomeTemplate:
         assert response.status_code == 200
         data = response.json()
         # Migration 0050 seeds the verbose template from issue #375
-        assert "${NAME}" in data["body"]
+        assert "${FIRST_NAME}" in data["body"]
         assert "${SENDER_NAME}" in data["body"]
         assert "${MAGIC_LINK}" in data["body"]
         assert "updated_at" in data
@@ -51,13 +51,16 @@ class TestUpdateWelcomeTemplate:
     def test_with_permission_updates_body(self, api_client, edit_welcome_headers):
         response = api_client.patch(
             "/api/community/welcome-template/",
-            data={"body": "hi ${NAME}, welcome — sign in: ${MAGIC_LINK}"},
+            data={"body": "hi ${FIRST_NAME}, welcome — sign in: ${MAGIC_LINK}"},
             content_type="application/json",
             **edit_welcome_headers,
         )
         assert response.status_code == 200
-        assert "${NAME}" in response.json()["body"]
-        assert WelcomeMessageTemplate.get().body == "hi ${NAME}, welcome — sign in: ${MAGIC_LINK}"
+        assert "${FIRST_NAME}" in response.json()["body"]
+        assert (
+            WelcomeMessageTemplate.get().body
+            == "hi ${FIRST_NAME}, welcome — sign in: ${MAGIC_LINK}"
+        )
 
     def test_without_permission_returns_403(self, api_client, auth_headers):
         response = api_client.patch(

--- a/frontend/src/screens/admin/ApprovalCredentialsDialog.test.tsx
+++ b/frontend/src/screens/admin/ApprovalCredentialsDialog.test.tsx
@@ -16,7 +16,7 @@ vi.mock('@/api/client', () => ({
 
 vi.mock('@/api/content', () => ({
   useWelcomeTemplate: () => ({
-    data: { body: 'hi ${NAME}, from ${SENDER_NAME}: ${MAGIC_LINK}', updatedAt: '2026-01-01' },
+    data: { body: 'hi ${FIRST_NAME}, from ${SENDER_NAME}: ${MAGIC_LINK}', updatedAt: '2026-01-01' },
     isPending: false,
     isError: false,
   }),

--- a/frontend/src/screens/admin/WelcomeTemplateEditorDialog.tsx
+++ b/frontend/src/screens/admin/WelcomeTemplateEditorDialog.tsx
@@ -1,6 +1,6 @@
 // Sub-modal opened from ApprovalCredentialsDialog. Lets users with
 // APPROVE_JOIN_REQUESTS edit the shared template. Plain-text only —
-// placeholders ${NAME}, ${SENDER_NAME}, ${MAGIC_LINK} are substituted at
+// placeholders ${FIRST_NAME}, ${SENDER_NAME}, ${MAGIC_LINK} are substituted at
 // render time by renderWelcomeMessage().
 
 import { type SyntheticEvent, useState } from 'react';
@@ -61,7 +61,7 @@ function EditorForm({ initialBody, onClose }: { initialBody: string; onClose: ()
         this text is shared with all vetters. changes apply everywhere.
       </p>
       <p className="text-muted text-xs">
-        available placeholders: <code className="bg-surface-dim rounded px-1">{'${NAME}'}</code>{' '}
+        available placeholders: <code className="bg-surface-dim rounded px-1">{'${FIRST_NAME}'}</code>{' '}
         (recipient's first name),{' '}
         <code className="bg-surface-dim rounded px-1">{'${SENDER_NAME}'}</code>,{' '}
         <code className="bg-surface-dim rounded px-1">{'${MAGIC_LINK}'}</code>

--- a/frontend/src/screens/admin/WelcomeTemplateEditorDialog.tsx
+++ b/frontend/src/screens/admin/WelcomeTemplateEditorDialog.tsx
@@ -61,9 +61,9 @@ function EditorForm({ initialBody, onClose }: { initialBody: string; onClose: ()
         this text is shared with all vetters. changes apply everywhere.
       </p>
       <p className="text-muted text-xs">
-        available placeholders: <code className="bg-surface-dim rounded px-1">{'${FIRST_NAME}'}</code>{' '}
-        (recipient's first name),{' '}
-        <code className="bg-surface-dim rounded px-1">{'${SENDER_NAME}'}</code>,{' '}
+        available placeholders:{' '}
+        <code className="bg-surface-dim rounded px-1">{'${FIRST_NAME}'}</code> (recipient's first
+        name), <code className="bg-surface-dim rounded px-1">{'${SENDER_NAME}'}</code>,{' '}
         <code className="bg-surface-dim rounded px-1">{'${MAGIC_LINK}'}</code>
       </p>
       <textarea

--- a/frontend/src/utils/welcomeMessage.test.ts
+++ b/frontend/src/utils/welcomeMessage.test.ts
@@ -59,7 +59,7 @@ describe('buildWelcomeMessage', () => {
 
 describe('renderWelcomeMessage', () => {
   it('substitutes all three placeholders', () => {
-    const out = renderWelcomeMessage('hi ${NAME}, this is ${SENDER_NAME}, sign in: ${MAGIC_LINK}', {
+    const out = renderWelcomeMessage('hi ${FIRST_NAME}, this is ${SENDER_NAME}, sign in: ${MAGIC_LINK}', {
       name: 'Sam',
       senderName: 'Vetter',
       magicLink: 'https://pda.test/m/abc',
@@ -68,7 +68,7 @@ describe('renderWelcomeMessage', () => {
   });
 
   it('replaces every occurrence of a repeated placeholder', () => {
-    const out = renderWelcomeMessage('${NAME} ${NAME}!', {
+    const out = renderWelcomeMessage('${FIRST_NAME} ${FIRST_NAME}!', {
       name: 'Sam',
       senderName: '',
       magicLink: '',
@@ -77,7 +77,7 @@ describe('renderWelcomeMessage', () => {
   });
 
   it('leaves unrelated text and unknown placeholders alone', () => {
-    const out = renderWelcomeMessage('${NAME} — ${UNKNOWN}', {
+    const out = renderWelcomeMessage('${FIRST_NAME} — ${UNKNOWN}', {
       name: 'Sam',
       senderName: '',
       magicLink: '',
@@ -85,8 +85,8 @@ describe('renderWelcomeMessage', () => {
     expect(out).toBe('Sam — ${UNKNOWN}');
   });
 
-  it('renders ${NAME} as the first name', () => {
-    const out = renderWelcomeMessage('hi ${NAME}!', {
+  it('renders ${FIRST_NAME} as the first name', () => {
+    const out = renderWelcomeMessage('hi ${FIRST_NAME}!', {
       name: 'ada',
       senderName: 'sender',
       magicLink: 'http://x',

--- a/frontend/src/utils/welcomeMessage.test.ts
+++ b/frontend/src/utils/welcomeMessage.test.ts
@@ -59,11 +59,14 @@ describe('buildWelcomeMessage', () => {
 
 describe('renderWelcomeMessage', () => {
   it('substitutes all three placeholders', () => {
-    const out = renderWelcomeMessage('hi ${FIRST_NAME}, this is ${SENDER_NAME}, sign in: ${MAGIC_LINK}', {
-      name: 'Sam',
-      senderName: 'Vetter',
-      magicLink: 'https://pda.test/m/abc',
-    });
+    const out = renderWelcomeMessage(
+      'hi ${FIRST_NAME}, this is ${SENDER_NAME}, sign in: ${MAGIC_LINK}',
+      {
+        name: 'Sam',
+        senderName: 'Vetter',
+        magicLink: 'https://pda.test/m/abc',
+      },
+    );
     expect(out).toBe('hi Sam, this is Vetter, sign in: https://pda.test/m/abc');
   });
 

--- a/frontend/src/utils/welcomeMessage.ts
+++ b/frontend/src/utils/welcomeMessage.ts
@@ -19,7 +19,7 @@ export interface WelcomeMessageVars {
 
 export function renderWelcomeMessage(template: string, vars: WelcomeMessageVars): string {
   return template
-    .replaceAll('${NAME}', vars.name)
+    .replaceAll('${FIRST_NAME}', vars.name)
     .replaceAll('${SENDER_NAME}', vars.senderName)
     .replaceAll('${MAGIC_LINK}', vars.magicLink);
 }


### PR DESCRIPTION
## Summary
Closes #732

- Rename the welcome-template placeholder token `${NAME}` → `${FIRST_NAME}` end-to-end so the variable name matches its meaning (it resolves to the recipient's **first** name since PR #728, not the full display name).
- Frontend: `renderWelcomeMessage` in `welcomeMessage.ts`, the editor help text + top-of-file comment in `WelcomeTemplateEditorDialog.tsx`, and the affected tests (`welcomeMessage.test.ts`, `ApprovalCredentialsDialog.test.tsx`).
- Backend: seeded default body in migration `0050`, the `WelcomeMessageTemplate` model docstring, and `test_welcome_template.py`.
- New **reversible** data migration `0067_rename_welcome_template_name_placeholder` rewrites persisted `${NAME}` → `${FIRST_NAME}` in existing DBs — so saved prod templates keep working without a back-compat alias in the renderer.
- No `${FULL_NAME}` added (issue said only if a concrete need appears — none does).

## Test plan
- [x] backend `test_welcome_template.py` — 7 passed (SQLite)
- [x] frontend `welcomeMessage.test.ts` + `ApprovalCredentialsDialog.test.ts` — 15 passed
- [x] frontend `tsc` + `eslint` clean; backend `ruff` + `ty` clean; `makemigrations --check` = no drift
- [x] migration `0067` round-trips: forward → `${FIRST_NAME}`, reverse → `${NAME}`, re-forward → `${FIRST_NAME}`