### PR TITLE
fix(notifications): use portable role-permission filter for sqlite (Issue 737)

### DIFF
--- a/backend/notifications/service.py
+++ b/backend/notifications/service.py
@@ -5,10 +5,10 @@ from typing import TYPE_CHECKING
 
 from community.models import RSVPStatus
 from django.db import DatabaseError, connection
-from django.db.models import Q
 from users._helpers import visible_display_name
 from users.models import User
 from users.permissions import PermissionKey
+from users.roles import Role
 
 from notifications.models import Notification, NotificationType
 
@@ -105,10 +105,7 @@ def broadcast_event_update(
 def create_join_request_notifications(display_name: str) -> None:
     recipients = (
         User.objects.members()
-        .filter(
-            Q(roles__name="admin", roles__is_default=True)
-            | Q(roles__permissions__contains=PermissionKey.APPROVE_JOIN_REQUESTS)
-        )
+        .filter(roles__id__in=Role.ids_with_permission(PermissionKey.APPROVE_JOIN_REQUESTS))
         .distinct()
     )
 
@@ -129,10 +126,7 @@ def create_event_flag_notifications(event: Event, flagger: User) -> None:
     flagger_name = flagger.display_name or flagger.phone_number
     recipients = (
         User.objects.members()
-        .filter(
-            Q(roles__name="admin", roles__is_default=True)
-            | Q(roles__permissions__contains=PermissionKey.MANAGE_EVENTS)
-        )
+        .filter(roles__id__in=Role.ids_with_permission(PermissionKey.MANAGE_EVENTS))
         .distinct()
     )
 
@@ -154,10 +148,7 @@ def create_magic_link_request_notifications(user: User) -> None:
     display = user.display_name or user.phone_number
     recipients = (
         User.objects.members()
-        .filter(
-            Q(roles__name="admin", roles__is_default=True)
-            | Q(roles__permissions__contains=PermissionKey.MANAGE_USERS)
-        )
+        .filter(roles__id__in=Role.ids_with_permission(PermissionKey.MANAGE_USERS))
         .distinct()
     )
 

--- a/backend/users/roles.py
+++ b/backend/users/roles.py
@@ -36,3 +36,13 @@ class Role(models.Model):
         if not isinstance(stored, list):
             return []
         return [p for p in stored if isinstance(p, str)]
+
+    @classmethod
+    def ids_with_permission(cls, permission: str) -> list[str]:
+        """Ids of roles granting ``permission``, honoring the admin-default rule.
+
+        Resolved in Python via ``effective_permissions`` rather than a
+        ``permissions__contains`` JSONField lookup, which is unsupported on
+        SQLite. Callers filter users with ``roles__id__in`` for a portable query.
+        """
+        return [str(r.id) for r in cls.objects.all() if permission in r.effective_permissions]


### PR DESCRIPTION
## Summary

Closes #737

- Replaced the `permissions__contains` JSONField lookup (unsupported on SQLite, works only on Postgres) in the three notification recipient resolvers with a backend-portable query.
- Added `Role.ids_with_permission()`, which resolves matching role ids in Python via the existing `effective_permissions` property, then filters recipients with `roles__id__in`.
- Because `effective_permissions` already applies the admin-default rule (default `admin` role grants all keys), the redundant `Q(roles__name="admin", roles__is_default=True)` clause was dropped — behavior is preserved.

This is the issue's preferred **option 1**: a portable query form that also removes the local/prod behavior gap, rather than a vendor branch or skip.

## Test plan

- [x] The 14 previously-failing tests pass on SQLite `dev.db` (`test_in_app_notifications.py`, `test_event_flags.py`, `test_join_request_submission.py`, `test_request_login_link.py`).
- [x] Full backend suite on SQLite: 1295 passed; only the 5 pre-existing `test_sse.py::TestSseStreamAuth` failures remain (known Postgres-only `pg_notify`/SSE limitation, explicitly out of scope per the issue).
- [x] `ruff` lint + format, `ty` typecheck, and cognitive-complexity checks all clean.
- [ ] Notification recipient resolution unchanged on Postgres (prod) — verified by the passing recipient tests, which cover admin-default, explicit-permission, no-permission, and multi-role de-dup cases.