### PR TITLE
fix(members): wrap role tags to their own line on the members page (Issue 724)

### DIFF
--- a/frontend/src/screens/admin/MembersTab.tsx
+++ b/frontend/src/screens/admin/MembersTab.tsx
@@ -334,58 +334,65 @@ function sortMembers(members: Member[], sort: SortKey): Member[] {
 
 function MemberRow({ member }: { member: Member }) {
   const initials = (member.fullName || member.phoneNumber).slice(0, 2).toLowerCase();
+  const hasTags = member.roles.length > 0 || member.isPaused;
   return (
     <Link
       to={`/admin/members/${member.id}`}
-      className="border-border bg-surface hover:bg-surface-dim flex items-center gap-3 rounded-lg border p-3 transition-colors"
+      className="border-border bg-surface hover:bg-surface-dim flex flex-col gap-2 rounded-lg border p-3 transition-colors"
     >
-      {member.profilePhotoUrl ? (
-        <img
-          src={member.profilePhotoUrl}
-          alt=""
-          className="h-10 w-10 shrink-0 rounded-full object-cover"
-        />
-      ) : (
-        <span
-          aria-hidden="true"
-          className="bg-surface-dim text-foreground-secondary flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm"
-        >
-          {initials || '?'}
-        </span>
-      )}
-      <div className="min-w-0 flex-1">
-        <p className="text-foreground truncate text-sm font-medium">
-          {member.fullName || formatPhone(member.phoneNumber)}
-        </p>
-        <p className="text-foreground-tertiary truncate text-xs">
-          {formatPhone(member.phoneNumber)}
-        </p>
-        {member.email ? (
-          <p className="text-foreground-tertiary truncate text-xs">{member.email.toLowerCase()}</p>
+      <div className="flex items-center gap-3">
+        {member.profilePhotoUrl ? (
+          <img
+            src={member.profilePhotoUrl}
+            alt=""
+            className="h-10 w-10 shrink-0 rounded-full object-cover"
+          />
         ) : (
-          <p className="text-foreground-tertiary/60 truncate text-xs italic">no email</p>
-        )}
-        <p className="text-foreground-tertiary/80 truncate text-xs">
-          {member.lastAttendedAt
-            ? `last attended ${format(member.lastAttendedAt, 'MMM d, yyyy').toLowerCase()}`
-            : 'never attended'}
-        </p>
-      </div>
-      <div className="flex shrink-0 flex-wrap justify-end gap-1">
-        {member.roles.map((role) => (
           <span
-            key={role.id}
-            className="bg-surface-dim text-foreground-secondary rounded-full px-2 py-0.5 text-xs"
+            aria-hidden="true"
+            className="bg-surface-dim text-foreground-secondary flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm"
           >
-            {role.name}
+            {initials || '?'}
           </span>
-        ))}
-        {member.isPaused ? (
-          <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">
-            paused
-          </span>
-        ) : null}
+        )}
+        <div className="min-w-0 flex-1">
+          <p className="text-foreground truncate text-sm font-medium">
+            {member.fullName || formatPhone(member.phoneNumber)}
+          </p>
+          <p className="text-foreground-tertiary truncate text-xs">
+            {formatPhone(member.phoneNumber)}
+          </p>
+          {member.email ? (
+            <p className="text-foreground-tertiary truncate text-xs">
+              {member.email.toLowerCase()}
+            </p>
+          ) : (
+            <p className="text-foreground-tertiary/60 truncate text-xs italic">no email</p>
+          )}
+          <p className="text-foreground-tertiary/80 truncate text-xs">
+            {member.lastAttendedAt
+              ? `last attended ${format(member.lastAttendedAt, 'MMM d, yyyy').toLowerCase()}`
+              : 'never attended'}
+          </p>
+        </div>
       </div>
+      {hasTags ? (
+        <div className="flex flex-wrap gap-1 pl-13">
+          {member.roles.map((role) => (
+            <span
+              key={role.id}
+              className="bg-surface-dim text-foreground-secondary rounded-full px-2 py-0.5 text-xs"
+            >
+              {role.name}
+            </span>
+          ))}
+          {member.isPaused ? (
+            <span className="rounded-full bg-amber-100 px-2 py-0.5 text-xs text-amber-800 dark:bg-amber-900/40 dark:text-amber-200">
+              paused
+            </span>
+          ) : null}
+        </div>
+      ) : null}
     </Link>
   );
 }


### PR DESCRIPTION
## Summary
- role tags in `MemberRow` (admin members page) used `shrink-0` and competed horizontally with the `flex-1` member-info column, truncating name/contact text on narrow mobile widths (reported on iPhone Safari).
- restructured the row into a `flex flex-col`: avatar + info on the top row, role/paused tags on a full-width wrapping row below, indented (`pl-13`) to align under the info column so tags wrap freely instead of crowding member details.

Closes #724

## Test plan
- [ ] open `/admin/members` on a narrow/mobile viewport (iPhone Safari) and confirm member name, phone, email, and last-attended lines are no longer truncated by role tags
- [ ] confirm role tags (and the "paused" pill) wrap onto their own line below the member info and stay legible
- [ ] confirm members with no roles and not paused render without an empty tag row
- [x] `make agent-frontend-typecheck`, `make agent-frontend-lint`, full `vitest` suite (720 passed, 1 skipped)