### PR TITLE
feat(join-requests): 723 - add search to join-requests screen

### DIFF
--- a/backend/community/_join_requests.py
+++ b/backend/community/_join_requests.py
@@ -43,6 +43,7 @@ class JoinRequestOut(BaseModel):
     last_name: str = ""
     full_name: str = ""
     phone_number: str
+    email: str = ""
     answers: list[JoinRequestAnswerOut] = []
     submitted_at: datetime
     status: str
@@ -100,6 +101,7 @@ def _join_request_out(jr: JoinRequest) -> JoinRequestOut:
         last_name=jr.last_name,
         full_name=jr.full_name,
         phone_number=jr.phone_number,
+        email=jr.email,
         answers=answers,
         submitted_at=jr.submitted_at,
         status=jr.status,

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -2941,6 +2941,11 @@
             "title": "Attached User Official Rsvp Count",
             "type": "integer"
           },
+          "email": {
+            "default": "",
+            "title": "Email",
+            "type": "string"
+          },
           "first_name": {
             "default": "",
             "title": "First Name",

--- a/backend/tests/test_join_request_management.py
+++ b/backend/tests/test_join_request_management.py
@@ -32,6 +32,18 @@ class TestJoinRequestManagement:
         assert data[0]["full_name"] == "Sprout Seedling"
         assert data[0]["status"] == JoinRequestStatus.PENDING
 
+    def test_list_includes_email(self, api_client, vettor_headers, db):
+        JoinRequest.objects.create(
+            first_name="Fern",
+            last_name="Frond",
+            phone_number="+16505559999",
+            email="fern@example.com",
+        )
+        response = api_client.get("/api/community/join-requests/", **vettor_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert data[0]["email"] == "fern@example.com"
+
     def test_admin_can_access_list(self, api_client, db):
         admin = User.objects.create_superuser(
             phone_number="+12025550001",

--- a/frontend/src/api/join.test.ts
+++ b/frontend/src/api/join.test.ts
@@ -63,6 +63,7 @@ describe('useJoinRequests', () => {
         id: 'jr-1',
         fullName: 'Alex Smith',
         phoneNumber: '+12125551234',
+        email: '',
         answers: [{ questionId: 'q-1', label: 'Why join?', answer: 'Community' }],
         submittedAt: '2024-04-01T09:00:00Z',
         status: 'pending',

--- a/frontend/src/api/join.ts
+++ b/frontend/src/api/join.ts
@@ -127,6 +127,7 @@ export interface JoinRequestSummary {
   id: string;
   fullName: string;
   phoneNumber: string;
+  email: string;
   answers: JoinRequestAnswer[];
   submittedAt: string;
   status: JoinRequestStatus;
@@ -149,6 +150,7 @@ interface WireJoinRequest {
   id: string;
   full_name: string;
   phone_number: string;
+  email?: string;
   answers: WireAnswer[];
   submitted_at: string;
   status: JoinRequestStatus;
@@ -166,6 +168,7 @@ function mapJoinRequest(w: WireJoinRequest): JoinRequestSummary {
     id: w.id,
     fullName: w.full_name,
     phoneNumber: w.phone_number,
+    email: w.email ?? '',
     answers: w.answers.map((a) => ({
       questionId: a.question_id,
       label: a.label,

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -2996,6 +2996,11 @@ export interface components {
              */
             attached_user_official_rsvp_count: number;
             /**
+             * Email
+             * @default
+             */
+            email: string;
+            /**
              * First Name
              * @default
              */

--- a/frontend/src/screens/admin/JoinRequestsScreen.test.tsx
+++ b/frontend/src/screens/admin/JoinRequestsScreen.test.tsx
@@ -100,7 +100,9 @@ describe('JoinRequestsScreen sort', () => {
   });
 
   it('shows the sort hint within the approved-tab explainer', async () => {
-    mockResult([makeRequest({ status: JoinRequestStatus.APPROVED, approvedAt: '2026-01-10T00:00:00Z' })]);
+    mockResult([
+      makeRequest({ status: JoinRequestStatus.APPROVED, approvedAt: '2026-01-10T00:00:00Z' }),
+    ]);
 
     renderScreen();
     await userEvent.click(screen.getByRole('radio', { name: 'approved' }));

--- a/frontend/src/screens/admin/JoinRequestsScreen.test.tsx
+++ b/frontend/src/screens/admin/JoinRequestsScreen.test.tsx
@@ -7,8 +7,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type * as JoinApi from '@/api/join';
 import { JoinRequestStatus, type JoinRequestSummary } from '@/api/join';
 
-vi.mock('@/api/join', async (importActual) => {
-  const actual = await importActual<typeof JoinApi>();
+vi.mock('@/api/join', async (importOriginal) => {
+  const actual = await importOriginal<typeof JoinApi>();
   return {
     ...actual,
     useJoinRequests: vi.fn(),
@@ -28,10 +28,11 @@ function makeRequest(overrides: Partial<JoinRequestSummary> = {}): JoinRequestSu
   return {
     id: 'jr-1',
     fullName: 'Ada Lovelace',
-    phoneNumber: '+15551230001',
+    phoneNumber: '+16505550001',
+    email: 'ada@example.com',
     answers: [],
     submittedAt: '2026-01-01T00:00:00Z',
-    status: JoinRequestStatus.APPROVED,
+    status: JoinRequestStatus.PENDING,
     userId: null,
     previouslyArchived: false,
     approvedAt: null,
@@ -66,17 +67,19 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe('JoinRequestsScreen', () => {
+describe('JoinRequestsScreen sort', () => {
   it('sorts approved requests by approved date, most recent first', async () => {
     mockResult([
       makeRequest({
         id: 'older',
         fullName: 'Older Approval',
+        status: JoinRequestStatus.APPROVED,
         approvedAt: '2026-01-10T00:00:00Z',
       }),
       makeRequest({
         id: 'newer',
         fullName: 'Newer Approval',
+        status: JoinRequestStatus.APPROVED,
         approvedAt: '2026-02-10T00:00:00Z',
       }),
     ]);
@@ -97,7 +100,7 @@ describe('JoinRequestsScreen', () => {
   });
 
   it('shows the sort hint within the approved-tab explainer', async () => {
-    mockResult([makeRequest({ approvedAt: '2026-01-10T00:00:00Z' })]);
+    mockResult([makeRequest({ status: JoinRequestStatus.APPROVED, approvedAt: '2026-01-10T00:00:00Z' })]);
 
     renderScreen();
     await userEvent.click(screen.getByRole('radio', { name: 'approved' }));
@@ -136,5 +139,45 @@ describe('JoinRequestsScreen', () => {
       .getAllByRole('heading', { level: 2 })
       .map((h) => h.textContent);
     expect(headings).toEqual(['Second Pending', 'First Pending']);
+  });
+});
+
+describe('JoinRequestsScreen search', () => {
+  it('filters by name', async () => {
+    mockResult([
+      makeRequest({ id: 'a', fullName: 'Ada Lovelace', email: 'ada@example.com' }),
+      makeRequest({ id: 'g', fullName: 'Grace Hopper', email: 'grace@example.com' }),
+    ]);
+
+    renderScreen();
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/^search$/i), 'grace');
+
+    expect(screen.getByText('Grace Hopper')).toBeInTheDocument();
+    expect(screen.queryByText('Ada Lovelace')).not.toBeInTheDocument();
+  });
+
+  it('filters by email', async () => {
+    mockResult([
+      makeRequest({ id: 'a', fullName: 'Ada Lovelace', email: 'ada@example.com' }),
+      makeRequest({ id: 'g', fullName: 'Grace Hopper', email: 'grace@example.com' }),
+    ]);
+
+    renderScreen();
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/^search$/i), 'grace@');
+
+    expect(screen.getByText('Grace Hopper')).toBeInTheDocument();
+    expect(screen.queryByText('Ada Lovelace')).not.toBeInTheDocument();
+  });
+
+  it('shows a no-match message when the search matches nothing', async () => {
+    mockResult([makeRequest({ fullName: 'Ada Lovelace' })]);
+
+    renderScreen();
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/^search$/i), 'zzz');
+
+    expect(screen.getByText(/nothing matches/i)).toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/admin/JoinRequestsScreen.tsx
+++ b/frontend/src/screens/admin/JoinRequestsScreen.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/api/join';
 import { Button } from '@/components/ui/Button';
 import { SegmentedControl } from '@/components/ui/SegmentedControl';
+import { TextField } from '@/components/ui/TextField';
 import { useConfirm } from '@/components/ui/useConfirm';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 import { cn } from '@/utils/cn';
@@ -42,6 +43,7 @@ export default function JoinRequestsScreen() {
   const { confirm, element: confirmElement } = useConfirm();
 
   const [filter, setFilter] = useState<Filter>(Filter.PENDING);
+  const [query, setQuery] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [credsFor, setCredsFor] = useState<{
     fullName: string;
@@ -51,9 +53,12 @@ export default function JoinRequestsScreen() {
   } | null>(null);
 
   const visible = useMemo(() => {
-    const rows = filter === Filter.ALL ? data : data.filter((r) => r.status === filter);
+    const q = query.trim().toLowerCase();
+    const rows = data.filter(
+      (r) => (filter === Filter.ALL || r.status === filter) && matchesQuery(r, q),
+    );
     return [...rows].sort((a, b) => sortKey(b) - sortKey(a));
-  }, [data, filter]);
+  }, [data, filter, query]);
 
   if (isPending) return <ContentLoading />;
   if (isError) return <ContentError message="couldn't load join requests — try refreshing" />;
@@ -144,6 +149,18 @@ export default function JoinRequestsScreen() {
         />
       </div>
 
+      <div className="mb-4">
+        <TextField
+          label="search"
+          placeholder="name, phone, or email"
+          value={query}
+          maxLength={100}
+          onChange={(e) => {
+            setQuery(e.target.value);
+          }}
+        />
+      </div>
+
       <SortHint filter={filter} hasRows={visible.length > 0} />
 
       {error ? (
@@ -153,7 +170,9 @@ export default function JoinRequestsScreen() {
       ) : null}
 
       {visible.length === 0 ? (
-        <p className="text-muted text-sm">nothing here 🌿</p>
+        <p className="text-muted text-sm">
+          {query.trim() ? 'nothing matches — try a different search' : 'nothing here 🌿'}
+        </p>
       ) : (
         <ul className="flex flex-col gap-3">
           {visible.map((r) => (
@@ -346,6 +365,15 @@ function SortHint({ filter, hasRows }: { filter: Filter; hasRows: boolean }) {
 function sortKey(request: JoinRequestSummary): number {
   const stamp = request.approvedAt ?? request.rejectedAt ?? request.submittedAt;
   return new Date(stamp).getTime();
+}
+
+function matchesQuery(request: JoinRequestSummary, q: string): boolean {
+  if (!q) return true;
+  return (
+    request.fullName.toLowerCase().includes(q) ||
+    request.phoneNumber.toLowerCase().includes(q) ||
+    request.email.toLowerCase().includes(q)
+  );
 }
 
 function extractError(err: unknown): string {


### PR DESCRIPTION
## Overview

adds a search box to the join-requests admin screen, mirroring the members-list search. filters client-side by name, phone, and email so admins can quickly find a specific request instead of scrolling.

To make search-by-email work, `email` is now exposed on the `JoinRequestOut` API schema — it was already stored on the `JoinRequest` model, just not surfaced. Regenerated the frontend API types accordingly.

Closes #723

## Test plan

- [x] backend: `test_list_includes_email` verifies email is returned by the list endpoint
- [x] frontend: `JoinRequestsScreen.test.tsx` covers search by name, search by email, and the "nothing matches" empty state
- [x] frontend CI green (lint, format, typecheck, types-check, 732 tests)
- [ ] manual: open `/join-requests`, type a name/email, confirm the list filters
