### PR TITLE
fix(join-requests): clear logged-in users from approved list (Issue 725)

### DIFF
--- a/backend/community/_join_requests.py
+++ b/backend/community/_join_requests.py
@@ -189,9 +189,9 @@ def list_join_requests(request):
         raise_validation(Code.Perm.DENIED, status_code=403, action="list_join_requests")
 
     cutoff = timezone.now() - timedelta(days=APPROVED_GRACE_DAYS)
-    expired_phones = User.objects.filter(
-        needs_onboarding=False, onboarded_at__lt=cutoff
-    ).values_list("phone_number", flat=True)
+    expired_phones = User.objects.filter(onboarded_at__lt=cutoff).values_list(
+        "phone_number", flat=True
+    )
     # Legacy users onboarded before onboarded_at existed have it as null;
     # treat them as already-expired so they don't linger in the list forever.
     legacy_onboarded_phones = User.objects.filter(

--- a/backend/tests/test_join_request_list_visibility.py
+++ b/backend/tests/test_join_request_list_visibility.py
@@ -1,0 +1,52 @@
+"""Tests for onboarding-driven visibility of approved join requests in the list."""
+
+from datetime import timedelta
+
+import pytest
+from community.models import JoinRequestStatus
+from django.utils import timezone
+from users.models import User
+
+
+@pytest.mark.django_db
+class TestJoinRequestListVisibility:
+    def test_list_excludes_reapproved_onboarded_user_past_grace(
+        self, api_client, vettor_headers, sample_join_request
+    ):
+        api_client.patch(
+            f"/api/community/join-requests/{sample_join_request.id}/",
+            {"status": JoinRequestStatus.APPROVED},
+            content_type="application/json",
+            **vettor_headers,
+        )
+        # onboarded_at is set once and never cleared; a re-approval flips
+        # needs_onboarding back to True, leaving the contradictory state that
+        # used to keep the request in the approved list forever.
+        user = User.objects.get(phone_number=sample_join_request.phone_number)
+        user.onboarded_at = timezone.now() - timedelta(days=60)
+        user.needs_onboarding = True
+        user.save(update_fields=["onboarded_at", "needs_onboarding"])
+
+        response = api_client.get("/api/community/join-requests/", **vettor_headers)
+        assert response.status_code == 200
+        ids = [r["id"] for r in response.json()]
+        assert str(sample_join_request.id) not in ids
+
+    def test_list_includes_onboarded_user_within_grace(
+        self, api_client, vettor_headers, sample_join_request
+    ):
+        api_client.patch(
+            f"/api/community/join-requests/{sample_join_request.id}/",
+            {"status": JoinRequestStatus.APPROVED},
+            content_type="application/json",
+            **vettor_headers,
+        )
+        user = User.objects.get(phone_number=sample_join_request.phone_number)
+        user.onboarded_at = timezone.now() - timedelta(days=1)
+        user.needs_onboarding = False
+        user.save(update_fields=["onboarded_at", "needs_onboarding"])
+
+        response = api_client.get("/api/community/join-requests/", **vettor_headers)
+        assert response.status_code == 200
+        ids = [r["id"] for r in response.json()]
+        assert str(sample_join_request.id) in ids


### PR DESCRIPTION
## Summary

Closes #725

A user who logged in ~2 months ago still lingered in the admin `/join-requests` **approved** list. Root cause: the approved-list exclusion in `list_join_requests` only dropped users who **completed the onboarding form** (which sets `onboarded_at` / clears `needs_onboarding`) — login itself recorded nothing. So anyone who authenticated via a magic link but never finished onboarding stayed in *approved* forever, regardless of how long ago they logged in. Per issues #725 and #722, the approved list is meant to hold people who have **not yet logged in**.

- record `last_login` on **first** login and magic-login (`stamp_first_login`) — first-only so the grace timer anchors to first login rather than sliding forward on every login
- broaden the `list_join_requests` exclusion to also drop approved requests whose linked user logged in past the 3-day grace window
- expose `last_login` on `JoinRequestOut`; the admin "logged in / hasn't logged in yet" status now reflects actual login rather than onboarding-form completion
- data migration `0036` backfills `last_login` from the most recent **used** magic token to correct existing lingering records (login never stamped it historically)

## Test plan

- [x] backend: `test_login_stamps_last_login`, `test_login_does_not_refresh_existing_last_login`, `test_magic_login_stamps_last_login`
- [x] backend: `TestJoinRequestListVisibility` — logged-in-but-never-onboarded user excluded after grace, included within grace
- [x] frontend: `join.test.ts` maps `lastLogin`; full vitest suite green
- [x] `migrate users` applies `0036` cleanly; backfill keys off the latest `used=True` token
- [ ] on staging: confirm a formerly-lingering approved record clears once backfilled / after next login