### PR TITLE
refactor(community): unify public-RSVP eligibility gate (Issue 715)

### DIFF
--- a/backend/community/_public_rsvp_manage.py
+++ b/backend/community/_public_rsvp_manage.py
@@ -21,14 +21,8 @@ from community._public_rsvp_shared import (
 )
 from community._shared import ErrorOut
 from community._validation import Code, raise_validation
-from community.models import (
-    Event,
-    EventRSVP,
-    EventStatus,
-    EventType,
-    PageVisibility,
-    RSVPStatus,
-)
+from community.models import Event, EventRSVP, RSVPStatus
+from community.models.event import public_rsvp_eligible_q
 
 router = Router()
 
@@ -66,19 +60,8 @@ def _resolve_token_user(token: str) -> User:
 def _eligible_event_rsvps(user):
     """The user's RSVPs on events still public-RSVP-eligible, matching _load_public_rsvp_event."""
     # Ineligible events must drop out, else their member-only details leak to the token holder.
-    now = timezone.now()
-    past = Q(event__datetime_tbd=False) & (
-        Q(event__end_datetime__lt=now)
-        | Q(event__end_datetime__isnull=True, event__start_datetime__lt=now)
-    )
     return (
-        user.event_rsvps.filter(
-            event__event_type=EventType.OFFICIAL,
-            event__status=EventStatus.ACTIVE,
-            event__visibility=PageVisibility.PUBLIC,
-            event__rsvp_enabled=True,
-        )
-        .exclude(past)
+        user.event_rsvps.filter(public_rsvp_eligible_q(timezone.now(), prefix="event__"))
         .annotate(
             event_comment_count=Count(
                 "event__comments",

--- a/backend/community/_public_rsvp_shared.py
+++ b/backend/community/_public_rsvp_shared.py
@@ -14,7 +14,7 @@ from users.models import NonMemberRsvpToken, User
 from community._event_schemas import EventOut
 from community._shared import logger
 from community._validation import Code, raise_validation
-from community.models import Event, EventStatus, EventType, PageVisibility
+from community.models import Event
 
 
 class PublicRsvpStateOut(BaseModel):
@@ -30,14 +30,7 @@ class PublicRsvpOut(BaseModel):
 def _load_public_rsvp_event(event_id) -> Event:
     """Fetch a public-RSVP-eligible event, else 404 (every ineligible state hides as NOT_FOUND)."""
     event = Event.objects.prefetch_related("co_hosts", "invited_users").filter(id=event_id).first()
-    if (
-        event is None
-        or event.event_type != EventType.OFFICIAL
-        or event.status != EventStatus.ACTIVE
-        or event.visibility != PageVisibility.PUBLIC
-        or not event.rsvp_enabled
-        or event.is_past
-    ):
+    if event is None or not event.is_public_rsvp_eligible:
         raise_validation(Code.Event.NOT_FOUND, status_code=404)
     return event
 

--- a/backend/community/models/event.py
+++ b/backend/community/models/event.py
@@ -2,6 +2,7 @@ import uuid
 from typing import TYPE_CHECKING
 
 from django.db import models
+from django.db.models import Q
 from django.utils import timezone
 
 from community.models.choices import (
@@ -21,6 +22,30 @@ if TYPE_CHECKING:
     from community.models.comment import EventComment
     from community.models.poll import EventPoll
     from community.models.survey import Survey
+
+
+def _is_past_q(now, prefix: str = "") -> Q:
+    """Queryset mirror of Event.is_past, over the field path at `prefix` (e.g. "event__")."""
+    end = f"{prefix}end_datetime"
+    start = f"{prefix}start_datetime"
+    return Q(**{f"{prefix}datetime_tbd": False}) & (
+        Q(**{f"{end}__lt": now}) | Q(**{f"{end}__isnull": True, f"{start}__lt": now})
+    )
+
+
+def public_rsvp_eligible_q(now, prefix: str = "") -> Q:
+    """The single public-RSVP eligibility gate as a Q, over the field path at `prefix`.
+
+    Object-level (Event.is_public_rsvp_eligible) and queryset-level callers share this,
+    so the gate can never drift between the write path and the read path.
+    """
+    return (
+        Q(**{f"{prefix}event_type": EventType.OFFICIAL})
+        & Q(**{f"{prefix}status": EventStatus.ACTIVE})
+        & Q(**{f"{prefix}visibility": PageVisibility.PUBLIC})
+        & Q(**{f"{prefix}rsvp_enabled": True})
+        & ~_is_past_q(now, prefix)
+    )
 
 
 class Event(models.Model):
@@ -100,6 +125,17 @@ class Event(models.Model):
     class Meta:
         app_label = "community"
         ordering = ["start_datetime"]
+
+    @property
+    def is_public_rsvp_eligible(self) -> bool:
+        """Object-level mirror of public_rsvp_eligible_q()."""
+        return (
+            self.event_type == EventType.OFFICIAL
+            and self.status == EventStatus.ACTIVE
+            and self.visibility == PageVisibility.PUBLIC
+            and self.rsvp_enabled
+            and not self.is_past
+        )
 
     @property
     def is_past(self) -> bool:


### PR DESCRIPTION
## Summary

Closes #715

The public-RSVP-eligible gate (`event_type=OFFICIAL`, `status=ACTIVE`, `visibility=PUBLIC`, `rsvp_enabled=True`, not past) was expressed **twice** — object-level in `_load_public_rsvp_event` (write path) and as a hand-rolled queryset gate in `_eligible_event_rsvps` (read path, added in #711 to stop member-only-detail leaks). The two could silently drift; drift on the read path re-opens exactly the leak #711 closed.

- Extract a **single source of truth** in `community/models/event.py`:
  - `public_rsvp_eligible_q(now, prefix="")` — prefix-aware `Q`-builder for the whole gate.
  - `_is_past_q(now, prefix="")` — queryset mirror of the `Event.is_past` property (the missing queryset-level `is_past` #711 had to hand-roll).
  - `Event.is_public_rsvp_eligible` — object-level property mirroring the same gate.
- Refactor both call sites to enforce from that one place: the write path uses the property; the read path passes `prefix="event__"` to reuse the identical `Q` over `EventRSVP` querysets.
- No migration (no schema/manager change). Behavior is identical — `.exclude(past)` is equivalent to `.filter(~_is_past_q)` here (same generated SQL, same NULL/TBD handling), confirmed empirically.

## Test plan

- [x] `test_public_rsvp_manage.py::TestGetMyRsvpsHidesIneligibleEvents` (the #711 leak regression net) and the full public-rsvp suites pass — 60 tests green.
- [x] `ty` typecheck, `ruff` lint/format, cognitive-complexity + file-size checks all clean.
- [ ] CI green on GitHub (runs against Postgres; local verification used per-worktree SQLite).

> Note: 2 pre-existing `test_event_flags.py` tests fail under **local SQLite only** (`notifications/service.py` uses a JSONField `contains` lookup unsupported by SQLite). Unrelated to this diff — they pass on Postgres/CI.