### PR TITLE
feat(users): strip non-member roles when a user is paused (Issue 708)

### DIFF
--- a/backend/tests/users/test_users_admin_extended.py
+++ b/backend/tests/users/test_users_admin_extended.py
@@ -1,5 +1,7 @@
 """Tests for user update, profile, delete, and magic link."""
 
+import logging
+
 import pytest
 from community._validation import Code
 from django.utils import timezone
@@ -8,6 +10,17 @@ from notifications.models import Notification, NotificationType
 from tests._asserts import assert_error_code
 from users.models import MagicLoginToken, User
 from users.roles import Role
+
+
+def _capture_audit(caplog):
+    """Attach caplog's handler to the non-propagating pda.audit logger.
+
+    pda.audit has propagate=False (see settings LOGGING), so caplog's root
+    handler never sees its records. Attaching the handler directly captures them.
+    """
+    audit_logger = logging.getLogger("pda.audit")
+    audit_logger.addHandler(caplog.handler)
+    return audit_logger
 
 
 @pytest.mark.django_db
@@ -54,6 +67,72 @@ class TestUpdateUser:
         assert response.status_code == 200
         other_user.refresh_from_db()
         assert other_user.is_paused is True
+
+    def test_pause_strips_non_member_roles(
+        self, api_client, manage_users_headers, other_user, caplog
+    ):
+        member_role = Role.objects.get(name="member", is_default=True)
+        extra_role = Role.objects.create(name="organizer")
+        other_user.roles.add(member_role, extra_role)
+        audit_logger = _capture_audit(caplog)
+        try:
+            with caplog.at_level(logging.WARNING, logger="pda.audit"):
+                response = api_client.patch(
+                    f"/api/auth/users/{other_user.pk}/",
+                    {"is_paused": True},
+                    content_type="application/json",
+                    **manage_users_headers,
+                )
+        finally:
+            audit_logger.removeHandler(caplog.handler)
+        assert response.status_code == 200
+        role_names = set(other_user.roles.values_list("name", flat=True))
+        assert role_names == {"member"}
+        paused_logs = [r for r in caplog.records if getattr(r, "action", None) == "user_paused"]
+        assert len(paused_logs) == 1
+        assert paused_logs[0].details == {"removed_role_ids": [str(extra_role.id)]}
+
+    def test_pause_member_only_is_noop_for_roles(
+        self, api_client, manage_users_headers, other_user, caplog
+    ):
+        member_role = Role.objects.get(name="member", is_default=True)
+        other_user.roles.add(member_role)
+        audit_logger = _capture_audit(caplog)
+        try:
+            with caplog.at_level(logging.WARNING, logger="pda.audit"):
+                response = api_client.patch(
+                    f"/api/auth/users/{other_user.pk}/",
+                    {"is_paused": True},
+                    content_type="application/json",
+                    **manage_users_headers,
+                )
+        finally:
+            audit_logger.removeHandler(caplog.handler)
+        assert response.status_code == 200
+        role_names = set(other_user.roles.values_list("name", flat=True))
+        assert role_names == {"member"}
+        paused_logs = [r for r in caplog.records if getattr(r, "action", None) == "user_paused"]
+        assert len(paused_logs) == 1
+        assert paused_logs[0].details == {"removed_role_ids": []}
+
+    def test_unpause_does_not_restore_roles(self, api_client, manage_users_headers, other_user):
+        member_role = Role.objects.get(name="member", is_default=True)
+        extra_role = Role.objects.create(name="organizer")
+        other_user.roles.add(member_role, extra_role)
+        other_user.is_paused = True
+        other_user.roles.remove(extra_role)
+        other_user.save(update_fields=["is_paused"])
+        response = api_client.patch(
+            f"/api/auth/users/{other_user.pk}/",
+            {"is_paused": False},
+            content_type="application/json",
+            **manage_users_headers,
+        )
+        assert response.status_code == 200
+        other_user.refresh_from_db()
+        assert other_user.is_paused is False
+        role_names = set(other_user.roles.values_list("name", flat=True))
+        assert role_names == {"member"}
 
     def test_update_user_requires_auth(self, api_client, other_user):
         response = api_client.patch(

--- a/backend/users/_helpers.py
+++ b/backend/users/_helpers.py
@@ -259,3 +259,16 @@ def _validate_member_role_required(new_roles: list[Role]) -> None:
         return
     if member_role not in new_roles:
         raise_validation(Code.Role.MEMBER_ROLE_REQUIRED, status_code=400)
+
+
+def _strip_non_member_roles(user: User) -> list[str]:
+    """Remove every role from user except the built-in member role.
+
+    Called on the pause transition so a paused member holds no elevated role.
+    Returns the ids of the removed roles (for audit logging).
+    """
+    removed = list(user.roles.exclude(name="member", is_default=True))
+    if not removed:
+        return []
+    user.roles.remove(*removed)
+    return [str(r.id) for r in removed]

--- a/backend/users/_management.py
+++ b/backend/users/_management.py
@@ -21,6 +21,7 @@ from users._helpers import (
     _is_admin,
     _is_last_admin,
     _resolve_name_fields,
+    _strip_non_member_roles,
     _validate_admin_role_change,
     _validate_member_role_required,
     _validate_phone,
@@ -288,26 +289,41 @@ def update_user(request, user_id: str, payload: UserPatchIn):
     _apply_user_patch(user, user_id, payload, requester_id=str(request.auth.pk))
     user.save()
 
-    if payload.is_paused is not None and payload.is_paused != old_is_paused:
-        action = "user_paused" if payload.is_paused else "user_unpaused"
-        audit_log(logging.WARNING, action, request, target_type="user", target_id=user_id)
-    else:
-        changed = [
-            f
-            for f in ("phone_number", "first_name", "last_name", "email")
-            if getattr(payload, f, None) is not None
-        ]
-        if changed:
-            audit_log(
-                logging.INFO,
-                "user_updated",
-                request,
-                target_type="user",
-                target_id=user_id,
-                details={"fields_changed": changed},
-            )
-
+    _audit_user_update(request, user, user_id, payload, old_is_paused)
     return Status(200, UserOut.from_user(user))
+
+
+def _audit_user_update(
+    request, user: User, user_id: str, payload: UserPatchIn, old_is_paused: bool
+) -> None:
+    """Emit the audit entry for an update_user PATCH.
+
+    A pause transition takes priority — pausing also strips non-member roles and
+    records the removed ids. Otherwise a plain field change logs user_updated.
+    """
+    is_pause_transition = payload.is_paused is not None and payload.is_paused != old_is_paused
+    if is_pause_transition:
+        action = "user_paused" if payload.is_paused else "user_unpaused"
+        details = {"removed_role_ids": _strip_non_member_roles(user)} if payload.is_paused else None
+        audit_log(
+            logging.WARNING, action, request, target_type="user", target_id=user_id, details=details
+        )
+        return
+
+    changed = [
+        f
+        for f in ("phone_number", "first_name", "last_name", "email")
+        if getattr(payload, f, None) is not None
+    ]
+    if changed:
+        audit_log(
+            logging.INFO,
+            "user_updated",
+            request,
+            target_type="user",
+            target_id=user_id,
+            details={"fields_changed": changed},
+        )
 
 
 def _patch_phone(user: User, user_id: str, phone_number: str) -> None:


### PR DESCRIPTION
## Summary

- On the `is_paused` false→true transition in `update_user`, strip every role from the user except the default `member` role, so a paused member drops out of role filters/counts and loses role-granted permissions (auth is already blocked at the gate; this removes the persistent data-level grants).
- Only fires on the pause transition — a PATCH to an already-paused user does not re-strip, and unpausing does not restore roles (an admin re-grants manually; no snapshot is stored).
- The removed role ids are captured in the existing `user_paused` audit entry as `details.removed_role_ids`.
- Admins already can't be paused (`_validate_pause_change`), so the last-admin/admin-role guard is unaffected.
- Extracted the post-save audit logic into `_audit_user_update` to keep `update_user` within the cognitive-complexity limit.

Closes #708

## Test plan

- [x] `test_pause_strips_non_member_roles` — pausing a member with an extra role leaves only `member`; audit log records the removed role id
- [x] `test_pause_member_only_is_noop_for_roles` — pausing a member-only user leaves `member`; audit log records an empty `removed_role_ids`
- [x] `test_unpause_does_not_restore_roles` — unpausing does not restore stripped roles
- [x] Full `test_users_admin_extended.py` suite passes (37/37) on SQLite; lint, typecheck, complexity, and schema-code checks green
