### PR TITLE
feat(rsvp): send "rsvp updated" email on public manage-RSVP update (Issue 705)

### DIFF
--- a/backend/community/_public_rsvp_manage.py
+++ b/backend/community/_public_rsvp_manage.py
@@ -7,6 +7,8 @@ from django.db.models import Count, Q
 from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
+from notifications._email_helpers import send_rsvp_updated_email
+from notifications.email_sender import get_email_sender
 from pydantic import BaseModel
 from users.models import NonMemberRsvpToken, User
 
@@ -16,8 +18,10 @@ from community._event_schemas import EventOut
 from community._public_rsvp_shared import (
     PublicRsvpOut,
     PublicRsvpStateOut,
+    _email_details,
     _email_promoted_non_members,
     _load_public_rsvp_event,
+    _log_email_failure,
 )
 from community._shared import ErrorOut
 from community._validation import Code, raise_validation
@@ -91,6 +95,21 @@ def _eligible_event_rsvps(user):
     )
 
 
+def _send_updated_email(request, event: Event, user: User, token_str: str) -> None:
+    """Best-effort "rsvp updated" email. A send failure must NOT roll back the RSVP."""
+    if not user.email:
+        return
+    try:
+        result = send_rsvp_updated_email(
+            sender=get_email_sender(),
+            details=_email_details(event, user, token_str),
+        )
+        if not result.success:
+            raise RuntimeError(result.error or "send returned failure")
+    except Exception as exc:
+        _log_email_failure(request, event, user, exc)
+
+
 @router.get(
     "/public/my-rsvps/",
     response={200: PublicRsvpManageOut, 404: ErrorOut, 429: ErrorOut},
@@ -135,7 +154,7 @@ def update_my_rsvp(request, event_id, payload: PublicRsvpManageIn, token: str = 
         final_status, promoted_user_ids = _apply_rsvp_in_transaction(
             event.id, user, payload.status, payload.has_plus_one
         )
-        NonMemberRsvpToken.issue_or_extend(user)
+        rsvp_token = NonMemberRsvpToken.issue_or_extend(user)
 
     audit_log(
         logging.INFO,
@@ -145,6 +164,7 @@ def update_my_rsvp(request, event_id, payload: PublicRsvpManageIn, token: str = 
         target_id=str(event.id),
         details={"user_id": str(user.pk), "status": final_status},
     )
+    _send_updated_email(request, event, user, rsvp_token.token)
     _email_promoted_non_members(request, event, promoted_user_ids)
 
     fresh_event = (

--- a/backend/notifications/_email_helpers.py
+++ b/backend/notifications/_email_helpers.py
@@ -45,6 +45,23 @@ def send_rsvp_confirmation_email(
     return sender.send(to=details.to, subject=subject, html=html, text=text)
 
 
+def send_rsvp_updated_email(
+    *,
+    sender: EmailSender,
+    details: RsvpEmailDetails,
+) -> SendResult:
+    """Render and send the non-member "your rsvp was updated" email."""
+    context = details.template_context()
+    html = render_to_string("emails/rsvp_updated.html", context)
+    text = render_to_string("emails/rsvp_updated.txt", context)
+    return sender.send(
+        to=details.to,
+        subject="your rsvp was updated",
+        html=html,
+        text=text,
+    )
+
+
 def send_rsvp_waitlist_promoted_email(
     *,
     sender: EmailSender,

--- a/backend/templates/emails/rsvp_updated.html
+++ b/backend/templates/emails/rsvp_updated.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html>
+<body style="margin: 0; padding: 24px; background: #f5f5f3; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #222;">
+  <div style="max-width: 480px; margin: 0 auto; background: #ffffff; border-radius: 8px; padding: 32px;">
+    <p style="margin: 0 0 16px;">hi{% if display_name %} {{ display_name|lower }}{% endif %} —</p>
+    <p style="margin: 0 0 24px;">your rsvp for <strong>{{ event_title|lower }}</strong> was updated 🌱</p>
+    {% if event_when %}<p style="margin: 0 0 8px;">when: {{ event_when|lower }}</p>{% endif %}
+    {% if event_location %}<p style="margin: 0 0 8px;">where: {{ event_location|lower }}</p>{% endif %}
+    {% for link in event_links %}<p style="margin: 0 0 8px; font-size: 13px; word-break: break-all;"><a href="{{ link }}" style="color: #3c6939;">{{ link }}</a></p>{% endfor %}
+    <p style="margin: 24px 0 16px;">manage or change your rsvp anytime:</p>
+    <p style="margin: 0 0 24px;">
+      <a href="{{ manage_url }}" style="display: inline-block; background: #3c6939; color: #ffffff; text-decoration: none; padding: 12px 24px; border-radius: 6px; font-weight: 500;">manage my rsvp</a>
+    </p>
+    <p style="margin: 0 0 8px; font-size: 13px; color: #666;">or paste this into your browser:</p>
+    <p style="margin: 0 0 24px; font-size: 13px; word-break: break-all;"><a href="{{ manage_url }}" style="color: #3c6939;">{{ manage_url }}</a></p>
+    <p style="margin: 0; font-size: 13px; color: #666;">when you join pda you get access to club events and our whatsapp community. <a href="{{ join_url }}" style="color: #3c6939;">click here to join</a>.</p>
+  </div>
+  <p style="text-align: center; margin: 16px 0 0; font-size: 12px; color: #888;">— pda</p>
+</body>
+</html>

--- a/backend/templates/emails/rsvp_updated.txt
+++ b/backend/templates/emails/rsvp_updated.txt
@@ -1,0 +1,15 @@
+hi{% if display_name %} {{ display_name|lower }}{% endif %} —
+
+your rsvp for {{ event_title|lower }} was updated 🌱
+{% if event_when %}
+when: {{ event_when|lower }}{% endif %}{% if event_location %}
+where: {{ event_location|lower }}{% endif %}
+{% for link in event_links %}{{ link }}
+{% endfor %}
+manage or change your rsvp anytime:
+
+{{ manage_url }}
+
+when you join pda you get access to club events and our whatsapp community. click here to join: {{ join_url }}
+
+— pda

--- a/backend/tests/test_public_rsvp_manage.py
+++ b/backend/tests/test_public_rsvp_manage.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 from community.models import (
     EventRSVP,
@@ -7,6 +9,7 @@ from community.models import (
     RSVPStatus,
 )
 from django.utils import timezone
+from notifications.email_sender import SendResult
 from users.models import NonMemberRsvpToken
 
 from tests._public_rsvp_helpers import make_non_member, make_official_event
@@ -139,6 +142,51 @@ class TestPostMyRsvps:
         # same token string still resolves
         resp = api_client.get(f"{GET_URL}?token={token.token}")
         assert resp.status_code == 200
+
+    def test_update_sends_updated_email_with_manage_link(
+        self, api_client, nonmember, official_event, fake_email_sender
+    ):
+        EventRSVP.objects.create(event=official_event, user=nonmember, status=RSVPStatus.MAYBE)
+        token = NonMemberRsvpToken.issue_or_extend(nonmember)
+        resp = api_client.post(
+            f"{_post_url(official_event)}?token={token.token}",
+            {"status": RSVPStatus.ATTENDING},
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        fake_email_sender.send.assert_called_once()
+        sent = fake_email_sender.send.call_args.kwargs
+        assert sent["to"] == nonmember.email
+        assert sent["subject"] == "your rsvp was updated"
+        # The emailed manage link reuses the still-valid token.
+        assert token.token in sent["text"]
+
+    def test_email_failure_does_not_roll_back_update(
+        self, api_client, nonmember, official_event, fake_email_sender, caplog
+    ):
+        EventRSVP.objects.create(event=official_event, user=nonmember, status=RSVPStatus.MAYBE)
+        token = NonMemberRsvpToken.issue_or_extend(nonmember)
+        fake_email_sender.send.return_value = SendResult(success=False, error="boom")
+
+        audit_logger = logging.getLogger("pda.audit")
+        audit_logger.addHandler(caplog.handler)
+        try:
+            with caplog.at_level(logging.WARNING, logger="pda.audit"):
+                resp = api_client.post(
+                    f"{_post_url(official_event)}?token={token.token}",
+                    {"status": RSVPStatus.ATTENDING},
+                    content_type="application/json",
+                )
+        finally:
+            audit_logger.removeHandler(caplog.handler)
+
+        assert resp.status_code == 200
+        rsvp = EventRSVP.objects.get(event=official_event, user=nonmember)
+        assert rsvp.status == RSVPStatus.ATTENDING
+        failures = [
+            r for r in caplog.records if getattr(r, "action", None) == "public_rsvp_email_failed"
+        ]
+        assert len(failures) == 1
 
     def test_invalid_status_400(self, api_client, nonmember, official_event):
         EventRSVP.objects.create(event=official_event, user=nonmember, status=RSVPStatus.MAYBE)


### PR DESCRIPTION
## Summary

Closes #705

Part of the public-RSVP epic (#490). The public manage-RSVP endpoints were built without the "rsvp updated" confirmation email (Email 2 in the design spec) to keep that PR small. This wires it in.

- new `send_rsvp_updated_email` helper alongside the existing confirmation/waitlist helpers in `notifications/_email_helpers.py`, plus `rsvp_updated.html` / `.txt` templates
- subject `your rsvp was updated`; body restates event details and includes a fresh `/my-rsvps?token=...` manage link (reuses `_email_details`)
- `_send_updated_email` wired into the manage `POST` in `_public_rsvp_manage.py` as a **best-effort** send — a failure is logged (`public_rsvp_email_failed`) and does **not** roll back the RSVP, mirroring `_send_confirmation_email`
- the emailed link reuses the existing `issue_or_extend` token so old links stay valid

## Test plan

- [x] `test_update_sends_updated_email_with_manage_link` — updating an RSVP sends a "your rsvp was updated" email whose text contains the still-valid manage token
- [x] `test_email_failure_does_not_roll_back_update` — a send failure logs `public_rsvp_email_failed` and the RSVP update persists (200)
- [x] lint / typecheck / complexity / django check green; RSVP + email suites pass (per-worktree SQLite)
