### PR TITLE
feat(users): add show non-members toggle to members directory (Issue 706)

### DIFF
--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -4719,6 +4719,11 @@
             "title": "Id",
             "type": "string"
           },
+          "is_member": {
+            "default": true,
+            "title": "Is Member",
+            "type": "boolean"
+          },
           "is_paused": {
             "default": false,
             "title": "Is Paused",
@@ -5911,7 +5916,18 @@
     "/api/auth/users/": {
       "get": {
         "operationId": "users__management_list_users",
-        "parameters": [],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "include_non_members",
+            "required": false,
+            "schema": {
+              "default": false,
+              "title": "Include Non Members",
+              "type": "boolean"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "content": {

--- a/backend/tests/users/test_users_admin_extended.py
+++ b/backend/tests/users/test_users_admin_extended.py
@@ -111,6 +111,19 @@ class TestUpdateUser:
         ids = [u["id"] for u in response.json()]
         assert str(other_user.pk) not in ids
 
+    def test_admin_list_includes_non_members_when_opted_in(
+        self, api_client, manage_users_headers, other_user
+    ):
+        other_user.is_member = False
+        other_user.save(update_fields=["is_member"])
+        response = api_client.get(
+            "/api/auth/users/?include_non_members=true", **manage_users_headers
+        )
+        assert response.status_code == 200
+        rows = {u["id"]: u for u in response.json()}
+        assert str(other_user.pk) in rows
+        assert rows[str(other_user.pk)]["is_member"] is False
+
     def test_admin_update_non_member_returns_404(
         self, api_client, manage_users_headers, other_user
     ):

--- a/backend/users/_management.py
+++ b/backend/users/_management.py
@@ -237,7 +237,7 @@ def search_users(request, q: str = ""):
     response={200: list[UserOut], 403: ErrorOut},
     auth=gated_jwt,
 )
-def list_users(request):
+def list_users(request, include_non_members: bool = False):
     if not request.auth.has_permission(PermissionKey.MANAGE_USERS):
         audit_log(
             logging.WARNING,
@@ -249,9 +249,10 @@ def list_users(request):
     # shares attendance_q + reportable_events_q with the report so the surfaces can't drift.
     attended = attendance_q(AttendanceStatus.ATTENDED, prefix="event_rsvps")
     reportable = reportable_events_q(prefix="event_rsvps__event")
+    # Default stays members-only; the opt-in adds non-members (public-RSVP users).
+    base = User.objects.all() if include_non_members else User.objects.members()
     users = (
-        User.objects.members()
-        .filter(archived_at__isnull=True)
+        base.filter(archived_at__isnull=True)
         .prefetch_related("roles")
         .annotate(
             last_attended=dj_models.Max(

--- a/backend/users/schemas.py
+++ b/backend/users/schemas.py
@@ -79,6 +79,7 @@ class UserOut(BaseModel):
     email: str = ""
     bio: str = ""
     pronouns: str = ""
+    is_member: bool = True
     is_superuser: bool = False
     needs_onboarding: bool = False
     needs_password_reset: bool = False
@@ -109,6 +110,7 @@ class UserOut(BaseModel):
             email=user.email or "",
             bio=user.bio or "",
             pronouns=user.pronouns or "",
+            is_member=user.is_member,
             is_superuser=user.is_superuser,
             needs_onboarding=user.needs_onboarding,
             needs_password_reset=user.needs_password_reset,

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -3760,6 +3760,11 @@ export interface components {
             /** Id */
             id: string;
             /**
+             * Is Member
+             * @default true
+             */
+            is_member: boolean;
+            /**
              * Is Paused
              * @default false
              */
@@ -4573,7 +4578,9 @@ export interface operations {
     };
     users__management_list_users: {
         parameters: {
-            query?: never;
+            query?: {
+                include_non_members?: boolean;
+            };
             header?: never;
             path?: never;
             cookie?: never;

--- a/frontend/src/api/users.test.ts
+++ b/frontend/src/api/users.test.ts
@@ -80,7 +80,7 @@ describe('useUsers', () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockedGet).toHaveBeenCalledWith('/api/auth/users/');
+    expect(mockedGet).toHaveBeenCalledWith('/api/auth/users/', undefined);
     expect(result.current.data).toHaveLength(1);
     const [member] = result.current.data!;
     expect(member?.fullName).toBe('Ada');
@@ -95,6 +95,32 @@ describe('useUsers', () => {
       isDefault: true,
       permissions: [],
     });
+  });
+
+  it('requests non-members and maps is_member when opted in', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'u2',
+          display_name: 'Guest',
+          full_name: 'Guest',
+          phone_number: '+15551230002',
+          email: 'guest@example.com',
+          is_member: false,
+          roles: [],
+        },
+      ],
+    });
+
+    const qc = makeQc();
+    const { result } = renderHook(() => useUsers(true), { wrapper: makeWrapper(qc) });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockedGet).toHaveBeenCalledWith('/api/auth/users/', {
+      params: { include_non_members: true },
+    });
+    expect(result.current.data?.[0]?.isMember).toBe(false);
   });
 
   it('propagates errors from the API', async () => {

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -27,6 +27,7 @@ export interface Member {
   profilePhotoUrl: string;
   showPhone: boolean;
   showEmail: boolean;
+  isMember: boolean;
   isSuperuser: boolean;
   isPaused: boolean;
   needsOnboarding: boolean;
@@ -56,6 +57,7 @@ interface WireMember {
   profile_photo_url?: string;
   show_phone?: boolean;
   show_email?: boolean;
+  is_member?: boolean;
   is_superuser?: boolean;
   is_paused?: boolean;
   needs_onboarding?: boolean;
@@ -85,6 +87,7 @@ function fromWire(w: WireMember): Member {
     profilePhotoUrl: w.profile_photo_url ?? '',
     showPhone: w.show_phone ?? true,
     showEmail: w.show_email ?? true,
+    isMember: w.is_member ?? true,
     isSuperuser: w.is_superuser ?? false,
     isPaused: w.is_paused ?? false,
     needsOnboarding: w.needs_onboarding ?? false,
@@ -98,11 +101,12 @@ function fromWire(w: WireMember): Member {
 
 export const USERS_KEY = ['users'] as const;
 
-export function useUsers() {
+export function useUsers(includeNonMembers = false) {
   return useQuery({
-    queryKey: USERS_KEY,
+    queryKey: [...USERS_KEY, { includeNonMembers }] as const,
     queryFn: async () => {
-      const { data } = await apiClient.get<WireMember[]>('/api/auth/users/');
+      const config = includeNonMembers ? { params: { include_non_members: true } } : undefined;
+      const { data } = await apiClient.get<WireMember[]>('/api/auth/users/', config);
       return data.map(fromWire);
     },
   });

--- a/frontend/src/screens/admin/MemberDetailScreen.test.tsx
+++ b/frontend/src/screens/admin/MemberDetailScreen.test.tsx
@@ -38,6 +38,7 @@ const member: Member = {
   profilePhotoUrl: '',
   showPhone: true,
   showEmail: true,
+  isMember: true,
   isSuperuser: false,
   isPaused: false,
   needsOnboarding: false,

--- a/frontend/src/screens/admin/MembersScreen.test.tsx
+++ b/frontend/src/screens/admin/MembersScreen.test.tsx
@@ -79,6 +79,7 @@ function makeMember(overrides: Partial<Member> = {}): Member {
     profilePhotoUrl: '',
     showPhone: true,
     showEmail: true,
+    isMember: true,
     isSuperuser: false,
     isPaused: false,
     needsOnboarding: false,
@@ -313,5 +314,22 @@ describe('MembersScreen', () => {
       .getAllByRole('link')
       .map((link) => link.querySelector('p')?.textContent ?? '');
     expect(rowNames).toEqual(['Recent Attendee', 'Older Attendee', 'Never Attendee']);
+  });
+
+  it('marks non-members with a badge and renders them as non-clickable rows', () => {
+    mockUsersResult({
+      data: [
+        makeMember({ id: 'm1', fullName: 'Ada Member', isMember: true }),
+        makeMember({ id: 'm2', fullName: 'Guest Rsvp', isMember: false }),
+      ],
+    });
+
+    renderScreen();
+
+    expect(screen.getByText('non-member')).toBeInTheDocument();
+    // Only the member row is a link; the non-member row is a plain div.
+    const links = screen.getAllByRole('link');
+    expect(links).toHaveLength(1);
+    expect(links[0]?.textContent).toContain('Ada Member');
   });
 });

--- a/frontend/src/screens/admin/MembersTab.tsx
+++ b/frontend/src/screens/admin/MembersTab.tsx
@@ -10,6 +10,7 @@ import { type Member, useUsers } from '@/api/users';
 import { Button } from '@/components/ui/Button';
 import { Select } from '@/components/ui/Select';
 import { TextField } from '@/components/ui/TextField';
+import { Toggle } from '@/components/ui/Toggle';
 import { ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 import { formatPhone } from '@/utils/formatPhone';
 
@@ -25,7 +26,8 @@ const SORT_OPTIONS: { value: SortKey; label: string }[] = [
 ];
 
 export function MembersTab() {
-  const { data = [], isPending, isError } = useUsers();
+  const [showNonMembers, setShowNonMembers] = useState(false);
+  const { data = [], isPending, isError } = useUsers(showNonMembers);
   const { data: allRoles = [] } = useRoles();
   const [query, setQuery] = useState('');
   const [sort, setSort] = useState<SortKey>('name');
@@ -96,9 +98,17 @@ export function MembersTab() {
         ) : null}
       </div>
 
+      <div className="mb-4 sm:w-64">
+        <Toggle
+          label="show non-members"
+          checked={showNonMembers}
+          onChange={setShowNonMembers}
+        />
+      </div>
+
       {data.length > 0 ? (
         <p className="text-foreground-tertiary mb-3 text-sm">
-          {data.length === 1 ? '1 member' : `${String(data.length)} members`}
+          {data.length === 1 ? '1 user' : `${String(data.length)} users`}
         </p>
       ) : null}
 
@@ -334,12 +344,30 @@ function sortMembers(members: Member[], sort: SortKey): Member[] {
 
 function MemberRow({ member }: { member: Member }) {
   const initials = (member.fullName || member.phoneNumber).slice(0, 2).toLowerCase();
-  const hasTags = member.roles.length > 0 || member.isPaused;
+
+  // Non-members have no detail page, so the row is a plain div, not a link.
+  if (!member.isMember) {
+    return (
+      <div className="border-border bg-surface flex flex-col gap-2 rounded-lg border p-3">
+        <MemberRowBody member={member} initials={initials} />
+      </div>
+    );
+  }
+
   return (
     <Link
       to={`/admin/members/${member.id}`}
       className="border-border bg-surface hover:bg-surface-dim flex flex-col gap-2 rounded-lg border p-3 transition-colors"
     >
+      <MemberRowBody member={member} initials={initials} />
+    </Link>
+  );
+}
+
+function MemberRowBody({ member, initials }: { member: Member; initials: string }) {
+  const hasTags = !member.isMember || member.roles.length > 0 || member.isPaused;
+  return (
+    <>
       <div className="flex items-center gap-3">
         {member.profilePhotoUrl ? (
           <img
@@ -391,8 +419,13 @@ function MemberRow({ member }: { member: Member }) {
               paused
             </span>
           ) : null}
+          {!member.isMember ? (
+            <span className="rounded-full bg-sky-100 px-2 py-0.5 text-xs text-sky-800 dark:bg-sky-900/40 dark:text-sky-200">
+              non-member
+            </span>
+          ) : null}
         </div>
       ) : null}
-    </Link>
+    </>
   );
 }

--- a/frontend/src/screens/admin/MembersTab.tsx
+++ b/frontend/src/screens/admin/MembersTab.tsx
@@ -99,11 +99,7 @@ export function MembersTab() {
       </div>
 
       <div className="mb-4 sm:w-64">
-        <Toggle
-          label="show non-members"
-          checked={showNonMembers}
-          onChange={setShowNonMembers}
-        />
+        <Toggle label="show non-members" checked={showNonMembers} onChange={setShowNonMembers} />
       </div>
 
       {data.length > 0 ? (


### PR DESCRIPTION
## Summary
Closes #706

- **backend**: `list_users` accepts an `include_non_members` query param (defaults to members-only, preserving existing behavior). `UserOut` now exposes `is_member`.
- **frontend**: `useUsers(includeNonMembers)` passes the param through; a "show non-members" toggle in `MembersTab` flips it. Non-member rows render a `non-member` badge and are non-clickable (they have no detail page). The count label now reads "users" since the list can include non-members.

## Test plan
- [ ] `/admin/members` defaults to members-only; toggling "show non-members" reveals public-RSVP (non-member) users
- [ ] non-member rows show a badge and do not navigate on click; member rows still link to the detail page
- [ ] backend `test_users_admin_extended.py` covers the include-non-members path (35 passed)
- [ ] frontend tests cover `is_member` mapping + non-member row rendering (26 passed)