### PR TITLE
feat(join-requests): sort approved list by approved date, newest first (Issue 698)

### DIFF
--- a/frontend/src/screens/admin/JoinRequestsScreen.test.tsx
+++ b/frontend/src/screens/admin/JoinRequestsScreen.test.tsx
@@ -1,0 +1,140 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type * as JoinApi from '@/api/join';
+import { JoinRequestStatus, type JoinRequestSummary } from '@/api/join';
+
+vi.mock('@/api/join', async (importActual) => {
+  const actual = await importActual<typeof JoinApi>();
+  return {
+    ...actual,
+    useJoinRequests: vi.fn(),
+    useDecideJoinRequest: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+    useUnrejectJoinRequest: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+    useResendMagicLink: vi.fn(() => ({ mutateAsync: vi.fn(), isPending: false })),
+  };
+});
+
+import { useJoinRequests } from '@/api/join';
+
+import JoinRequestsScreen from './JoinRequestsScreen';
+
+const mockUseJoinRequests = vi.mocked(useJoinRequests);
+
+function makeRequest(overrides: Partial<JoinRequestSummary> = {}): JoinRequestSummary {
+  return {
+    id: 'jr-1',
+    fullName: 'Ada Lovelace',
+    phoneNumber: '+15551230001',
+    answers: [],
+    submittedAt: '2026-01-01T00:00:00Z',
+    status: JoinRequestStatus.APPROVED,
+    userId: null,
+    previouslyArchived: false,
+    approvedAt: null,
+    approvedByName: null,
+    rejectedAt: null,
+    rejectedByName: null,
+    onboardedAt: null,
+    ...overrides,
+  };
+}
+
+function renderScreen() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <JoinRequestsScreen />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+function mockResult(data: JoinRequestSummary[]) {
+  mockUseJoinRequests.mockReturnValue({
+    isPending: false,
+    isError: false,
+    data,
+  } as ReturnType<typeof useJoinRequests>);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('JoinRequestsScreen', () => {
+  it('sorts approved requests by approved date, most recent first', async () => {
+    mockResult([
+      makeRequest({
+        id: 'older',
+        fullName: 'Older Approval',
+        approvedAt: '2026-01-10T00:00:00Z',
+      }),
+      makeRequest({
+        id: 'newer',
+        fullName: 'Newer Approval',
+        approvedAt: '2026-02-10T00:00:00Z',
+      }),
+    ]);
+
+    renderScreen();
+    await userEvent.click(screen.getByRole('radio', { name: 'approved' }));
+
+    const headings = screen.getAllByRole('heading', { level: 2 }).map((h) => h.textContent);
+    expect(headings).toEqual(['Newer Approval', 'Older Approval']);
+  });
+
+  it('shows a discoverable sort hint on the pending tab', () => {
+    mockResult([makeRequest({ status: JoinRequestStatus.PENDING })]);
+
+    renderScreen();
+
+    expect(screen.getByText('sorted newest first')).toBeInTheDocument();
+  });
+
+  it('shows the sort hint within the approved-tab explainer', async () => {
+    mockResult([makeRequest({ approvedAt: '2026-01-10T00:00:00Z' })]);
+
+    renderScreen();
+    await userEvent.click(screen.getByRole('radio', { name: 'approved' }));
+
+    expect(screen.getByText(/sorted newest first/)).toBeInTheDocument();
+  });
+
+  it('hides the sort hint when there are no rows', () => {
+    mockResult([]);
+
+    renderScreen();
+
+    expect(screen.queryByText(/sorted newest first/)).not.toBeInTheDocument();
+  });
+
+  it('falls back to submitted date when no decision timestamp exists', async () => {
+    mockResult([
+      makeRequest({
+        id: 'first',
+        fullName: 'First Pending',
+        status: JoinRequestStatus.PENDING,
+        submittedAt: '2026-01-05T00:00:00Z',
+      }),
+      makeRequest({
+        id: 'second',
+        fullName: 'Second Pending',
+        status: JoinRequestStatus.PENDING,
+        submittedAt: '2026-03-05T00:00:00Z',
+      }),
+    ]);
+
+    renderScreen();
+
+    const list = screen.getByRole('list');
+    const headings = within(list)
+      .getAllByRole('heading', { level: 2 })
+      .map((h) => h.textContent);
+    expect(headings).toEqual(['Second Pending', 'First Pending']);
+  });
+});

--- a/frontend/src/screens/admin/JoinRequestsScreen.tsx
+++ b/frontend/src/screens/admin/JoinRequestsScreen.tsx
@@ -51,8 +51,8 @@ export default function JoinRequestsScreen() {
   } | null>(null);
 
   const visible = useMemo(() => {
-    if (filter === Filter.ALL) return data;
-    return data.filter((r) => r.status === filter);
+    const rows = filter === Filter.ALL ? data : data.filter((r) => r.status === filter);
+    return [...rows].sort((a, b) => sortKey(b) - sortKey(a));
   }, [data, filter]);
 
   if (isPending) return <ContentLoading />;
@@ -144,12 +144,7 @@ export default function JoinRequestsScreen() {
         />
       </div>
 
-      {filter === Filter.APPROVED ? (
-        <p className="text-muted mb-3 text-xs">
-          approved members show here until 3 days after their first login — this tab clears them out
-          automatically once they're settled in
-        </p>
-      ) : null}
+      <SortHint filter={filter} hasRows={visible.length > 0} />
 
       {error ? (
         <p role="alert" className="text-destructive mb-3 text-sm">
@@ -334,6 +329,24 @@ const STATUS_TONES: Record<JoinRequestStatus, string> = {
   [JoinRequestStatus.APPROVED]: 'bg-success-subtle text-success',
   [JoinRequestStatus.REJECTED]: 'bg-surface-raised text-foreground-secondary',
 };
+
+function SortHint({ filter, hasRows }: { filter: Filter; hasRows: boolean }) {
+  if (filter === Filter.APPROVED) {
+    return (
+      <p className="text-muted mb-3 text-xs">
+        sorted newest first — approved members show here until 3 days after their first login, then
+        this tab clears them out automatically
+      </p>
+    );
+  }
+  if (!hasRows) return null;
+  return <p className="text-muted mb-3 text-xs">sorted newest first</p>;
+}
+
+function sortKey(request: JoinRequestSummary): number {
+  const stamp = request.approvedAt ?? request.rejectedAt ?? request.submittedAt;
+  return new Date(stamp).getTime();
+}
 
 function extractError(err: unknown): string {
   return extractApiErrorOr(err, "couldn't complete that action — try again");


### PR DESCRIPTION
## Summary

Closes #698

- the `/join-requests` admin list previously had no defined ordering, so the reporter couldn't tell what order entries were in.
- now sorts every filter by most-recent activity, newest first — approved date for approved rows, rejected date for rejected rows, submitted date otherwise (`sortKey = approvedAt ?? rejectedAt ?? submittedAt`).
- surfaces the ordering with a lowercase "sorted newest first" hint under the filter control (merged into the approved-tab explainer so the approved tab shows a single line).

## Test plan

- [x] `frontend` unit tests: new `JoinRequestsScreen.test.tsx` covers approved-date sort, submitted-date fallback, and the hint's presence/absence (5/5 pass)
- [x] `make agent-frontend-lint`, `make agent-frontend-typecheck`, prettier — all clean
- [ ] manual: open `/join-requests`, switch to the **approved** tab, confirm most-recently-approved members appear first and the "sorted newest first" hint is visible