### PR TITLE
feat(events): gate date-poll button on "date & time tbd" (Issue 696)

### DIFF
--- a/frontend/src/screens/events/form/EventFormBasics.test.tsx
+++ b/frontend/src/screens/events/form/EventFormBasics.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { emptyEventFormValues, type EventFormValues } from '@/api/eventWrites';
+
+import { EventFormBasics } from './EventFormBasics';
+
+function values(overrides: Partial<EventFormValues> = {}): EventFormValues {
+  return { ...emptyEventFormValues(), ...overrides };
+}
+
+function renderBasics(overrides: Partial<EventFormValues> = {}) {
+  return render(
+    <EventFormBasics
+      values={values(overrides)}
+      onChange={vi.fn()}
+      errors={{}}
+      canTagOfficial={false}
+      canTagClub={false}
+    />,
+  );
+}
+
+describe('EventFormBasics poll button gating', () => {
+  it('hides the poll button when a fixed date is selected', () => {
+    renderBasics({ datetimeTbd: false });
+    expect(screen.queryByRole('button', { name: 'poll for dates' })).not.toBeInTheDocument();
+    expect(screen.getByText('starts')).toBeInTheDocument();
+  });
+
+  it('shows the poll button only once date & time is tbd', () => {
+    renderBasics({ datetimeTbd: true });
+    expect(screen.getByRole('button', { name: 'poll for dates' })).toBeInTheDocument();
+    expect(screen.queryByText('starts')).not.toBeInTheDocument();
+  });
+
+  it('hides the poll button when a poll is already active (timeLocked wins over tbd)', () => {
+    render(
+      <EventFormBasics
+        values={values({ datetimeTbd: true })}
+        onChange={vi.fn()}
+        errors={{}}
+        canTagOfficial={false}
+        canTagClub={false}
+        timeLocked
+      />,
+    );
+    expect(screen.queryByRole('button', { name: 'poll for dates' })).not.toBeInTheDocument();
+    expect(screen.getByText(/date locked/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/events/form/EventFormBasics.tsx
+++ b/frontend/src/screens/events/form/EventFormBasics.tsx
@@ -1,10 +1,10 @@
-// Always-visible zone: title, type toggle, tbd toggle, start + end, poll
+// Always-visible zone: title, type toggle, tbd toggle, start + end / poll
 // button, location. Description / visibility live in the details section.
 //
-// Layout order (when no poll/buffered dates): tbd toggle → start/end pickers
-// → centered "poll for dates" button. The tbd toggle stays above the pickers
-// so checking it cleanly hides the picker row without making any control
-// below shift in place.
+// Layout order (when no poll/buffered dates): tbd toggle → either the
+// start/end pickers (fixed time) or the "poll for dates" button (tbd). The
+// button shares the pickers' slot and is gated on tbd — a poll only makes
+// sense when the date isn't fixed.
 //
 // Poll integration: the "poll for dates" button has two modes:
 //   - create-flow (no existing event): opens PollCreateDialog in buffer
@@ -57,10 +57,12 @@ export function EventFormBasics({
   const isCreateFlow = !existingEventId;
   const bufferedDates =
     bufferedPollOptions && bufferedPollOptions.length > 0 ? bufferedPollOptions : null;
-  // Show the "propose dates" button when:
+  // Show the "poll for dates" button only when the time is tbd — a poll
+  // only makes sense when the date isn't fixed. Beyond that, show it when:
   //   - edit flow, no poll yet (live mode), OR
   //   - create flow, nothing buffered yet (buffer mode).
-  const canShowProposeButton = !timeLocked && (isCreateFlow ? !bufferedDates : !existingHasPoll);
+  const canShowProposeButton =
+    values.datetimeTbd && !timeLocked && (isCreateFlow ? !bufferedDates : !existingHasPoll);
 
   return (
     <div className="border-brand-100 bg-surface flex flex-col gap-4 rounded-[var(--radius-md)] border p-4 shadow-(--shadow-sm)">
@@ -136,7 +138,7 @@ export function EventFormBasics({
               onClick={() => {
                 setPollOpen(true);
               }}
-              className="self-center"
+              className="self-start"
             >
               poll for dates
             </Button>


### PR DESCRIPTION
## Summary
- The "poll for dates" button on the add-event form (`/events/add`) now only appears when **date & time tbd** is selected — a poll only makes sense when the date isn't fixed.
- Repositioned the button so it takes the date-pickers' slot (rendered in place of the pickers when tbd is on) instead of sitting below them, and aligned it `self-start`.
- Added `EventFormBasics.test.tsx` covering the fixed-date, tbd, and `timeLocked` states.

Closes #696

## Test plan
- [ ] on `/events/add`, with a fixed date the "poll for dates" button is hidden and the start/end pickers show
- [ ] toggling **date & time tbd** on hides the pickers and reveals the "poll for dates" button in their place
- [ ] editing an event with an active poll still shows the "date locked" message and no poll button
- [ ] `make agent-frontend-test` passes (includes the new EventFormBasics tests)