### PR TITLE
feat(events): default event end to start + 2h when omitted (Issue 697)

### DIFF
--- a/backend/community/_calendar.py
+++ b/backend/community/_calendar.py
@@ -174,7 +174,7 @@ def _build_vevent(event, request: HttpRequest, is_authed: bool):
         vevent.add("dtstart", event.start_datetime)
         vevent.add(
             "dtend",
-            event.end_datetime or event.start_datetime + timedelta(hours=2),
+            Event.default_end(event.start_datetime, event.end_datetime),
         )
     vevent.add("summary", event.title)
     target_url = request.build_absolute_uri(f"/events/{event.id}")

--- a/backend/community/_events.py
+++ b/backend/community/_events.py
@@ -329,7 +329,7 @@ def create_event(request, payload: EventIn):
         title=payload.title,
         description=payload.description,
         start_datetime=payload.start_datetime,
-        end_datetime=payload.end_datetime,
+        end_datetime=Event.default_end(payload.start_datetime, payload.end_datetime),
         location=payload.location,
         latitude=payload.latitude,
         longitude=payload.longitude,

--- a/backend/community/models/event.py
+++ b/backend/community/models/event.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 from django.db import models
@@ -21,6 +22,9 @@ if TYPE_CHECKING:
     from community.models.comment import EventComment
     from community.models.poll import EventPoll
     from community.models.survey import Survey
+
+
+DEFAULT_EVENT_DURATION = timedelta(hours=2)
 
 
 class Event(models.Model):
@@ -100,6 +104,13 @@ class Event(models.Model):
     class Meta:
         app_label = "community"
         ordering = ["start_datetime"]
+
+    @staticmethod
+    def default_end(start: datetime | None, end: datetime | None) -> datetime | None:
+        """End time falling back to start + DEFAULT_EVENT_DURATION when unset."""
+        if end is not None or start is None:
+            return end
+        return start + DEFAULT_EVENT_DURATION
 
     @property
     def is_past(self) -> bool:

--- a/backend/tests/test_event_management.py
+++ b/backend/tests/test_event_management.py
@@ -1,5 +1,7 @@
 """Tests for event create/update/delete management endpoints."""
 
+from datetime import timedelta
+
 import pytest
 from community._validation import Code
 from community.api import EventPatchIn
@@ -229,7 +231,9 @@ class TestEventManagement:
         assert data["title"] == "Community Meetup"
         assert data["location"] == "The Vegan Cafe"
 
-    def test_create_event_without_end_datetime(self, api_client, manage_events_headers):
+    def test_create_event_without_end_datetime_defaults_to_start_plus_two_hours(
+        self, api_client, manage_events_headers
+    ):
         response = api_client.post(
             "/api/community/events/",
             {
@@ -240,7 +244,8 @@ class TestEventManagement:
             **manage_events_headers,
         )
         assert response.status_code == 201
-        assert response.json()["end_datetime"] is None
+        event = Event.objects.get(id=response.json()["id"])
+        assert event.end_datetime == event.start_datetime + timedelta(hours=2)
 
     def test_create_event_end_before_start_returns_400(self, api_client, manage_events_headers):
         response = api_client.post(

--- a/frontend/src/components/ui/DateTimePicker.tsx
+++ b/frontend/src/components/ui/DateTimePicker.tsx
@@ -14,6 +14,8 @@ interface Props {
   disabled?: boolean;
   error?: string | undefined;
   optional?: boolean;
+  /** Helper text shown below the field when there's no error. */
+  hint?: string;
   /** Disable calendar days before today (inclusive). For event start times. */
   disablePast?: boolean;
 }
@@ -37,6 +39,7 @@ export function DateTimePicker({
   disabled,
   error,
   optional,
+  hint,
   disablePast,
 }: Props) {
   const [open, setOpen] = useState(false);
@@ -150,6 +153,7 @@ export function DateTimePicker({
       )}
 
       {error ? <p className="text-destructive text-xs">{error}</p> : null}
+      {!error && hint ? <p className="text-muted-foreground text-xs">{hint}</p> : null}
     </div>
   );
 }

--- a/frontend/src/screens/events/form/EventFormBasics.tsx
+++ b/frontend/src/screens/events/form/EventFormBasics.tsx
@@ -126,6 +126,7 @@ export function EventFormBasics({
                 }}
                 error={errors.endDatetime}
                 optional
+                hint="defaults to 2 hours after start if left blank"
               />
             </div>
           ) : null}


### PR DESCRIPTION
## Summary
- event **end** time is now optional on the add-event form; when left blank the backend fills it with **start + 2 hours** (canonical, so all clients agree) via a new `Event.default_end()` helper + `DEFAULT_EVENT_DURATION` constant
- the ICS calendar builder reuses `Event.default_end()` instead of its own inline `start + 2h` fallback
- the "ends" field in the form shows helper text — "defaults to 2 hours after start if left blank" — via a new optional `hint` prop on `DateTimePicker`
- the PATCH/update path is intentionally left unchanged, so an event with a start can still be made open-ended by clearing its end (existing behavior preserved)

Closes #697

## Test plan
- [ ] create an event with a start but no end → end persists as start + 2h
- [ ] the add-event form "ends" field shows the lowercase helper text
- [ ] editing an existing event and clearing its end still leaves it open-ended (null)
- [ ] the event's ICS feed entry uses start + 2h when no explicit end is set
- [ ] backend: `test_event_management.py` passes (incl. updated default-end test)