### PR TITLE
feat(members): collect first/last name in add-member dialog — PR1 (Issue 694)

### DIFF
--- a/frontend/src/api/users.test.ts
+++ b/frontend/src/api/users.test.ts
@@ -141,12 +141,16 @@ describe('useCreateUser', () => {
 
     const created = await result.current.mutateAsync({
       phoneNumber: '+15551230002',
+      firstName: 'Grace',
+      lastName: 'Hopper',
       email: 'grace@example.com',
       roleId: 'role-xyz',
     });
 
     expect(mockedPost).toHaveBeenCalledWith('/api/auth/create-user/', {
       phone_number: '+15551230002',
+      first_name: 'Grace',
+      last_name: 'Hopper',
       email: 'grace@example.com',
       role_id: 'role-xyz',
     });

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -111,6 +111,8 @@ export function useUsers() {
 
 export interface CreateUserInput {
   phoneNumber: string;
+  firstName?: string;
+  lastName?: string;
   email?: string;
   roleId?: string;
 }
@@ -137,6 +139,8 @@ export function useCreateUser() {
   return useMutation({
     mutationFn: async (input: CreateUserInput): Promise<CreateUserResult> => {
       const body: Record<string, unknown> = { phone_number: input.phoneNumber };
+      if (input.firstName !== undefined) body.first_name = input.firstName;
+      if (input.lastName !== undefined) body.last_name = input.lastName;
       if (input.email !== undefined) body.email = input.email;
       if (input.roleId !== undefined) body.role_id = input.roleId;
       const { data } = await apiClient.post<WireCreateResult>('/api/auth/create-user/', body);

--- a/frontend/src/screens/admin/MemberCreateDialog.test.tsx
+++ b/frontend/src/screens/admin/MemberCreateDialog.test.tsx
@@ -34,20 +34,35 @@ describe('MemberCreateDialog', () => {
     expect(screen.getByText(/asked for one at first login/i)).toBeInTheDocument();
   });
 
-  it('submits with no email when left blank', async () => {
+  it('does not submit when first name is blank', async () => {
     render(<MemberCreateDialog open onClose={() => {}} />);
     await userEvent.type(screen.getByLabelText(/phone number/i), '+12025550101');
     await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
-    expect(mutateAsync).toHaveBeenCalledWith({ phoneNumber: '+12025550101' });
+    expect(mutateAsync).not.toHaveBeenCalled();
   });
 
-  it('submits with email when filled', async () => {
+  it('submits with first name and no last name / email when left blank', async () => {
     render(<MemberCreateDialog open onClose={() => {}} />);
+    await userEvent.type(screen.getByLabelText(/first name/i), 'Ada');
+    await userEvent.type(screen.getByLabelText(/phone number/i), '+12025550101');
+    await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
+    expect(mutateAsync).toHaveBeenCalledWith({
+      phoneNumber: '+12025550101',
+      firstName: 'Ada',
+    });
+  });
+
+  it('submits with last name and email when filled', async () => {
+    render(<MemberCreateDialog open onClose={() => {}} />);
+    await userEvent.type(screen.getByLabelText(/first name/i), 'Ada');
+    await userEvent.type(screen.getByLabelText(/last name/i), 'Lovelace');
     await userEvent.type(screen.getByLabelText(/phone number/i), '+12025550101');
     await userEvent.type(screen.getByLabelText(/email/i), 'new@example.com');
     await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
     expect(mutateAsync).toHaveBeenCalledWith({
       phoneNumber: '+12025550101',
+      firstName: 'Ada',
+      lastName: 'Lovelace',
       email: 'new@example.com',
     });
   });

--- a/frontend/src/screens/admin/MemberCreateDialog.tsx
+++ b/frontend/src/screens/admin/MemberCreateDialog.tsx
@@ -19,6 +19,8 @@ interface Props {
 
 export function MemberCreateDialog({ open, onClose }: Props) {
   const createUser = useCreateUser();
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
   const [phone, setPhone] = useState('');
   const [email, setEmail] = useState('');
   const [formError, setFormError] = useState<string | null>(null);
@@ -28,15 +30,22 @@ export function MemberCreateDialog({ open, onClose }: Props) {
   async function onSubmit(e: SyntheticEvent) {
     e.preventDefault();
     setFormError(null);
+    if (!firstName.trim()) {
+      setFormError('first name is required');
+      return;
+    }
     if (!phone.trim()) {
       setFormError('phone number is required');
       return;
     }
     try {
-      const trimmed = email.trim();
+      const trimmedLast = lastName.trim();
+      const trimmedEmail = email.trim();
       const created = await createUser.mutateAsync({
         phoneNumber: phone.trim(),
-        ...(trimmed ? { email: trimmed } : {}),
+        firstName: firstName.trim(),
+        ...(trimmedLast ? { lastName: trimmedLast } : {}),
+        ...(trimmedEmail ? { email: trimmedEmail } : {}),
       });
       setResult(created);
     } catch (err) {
@@ -45,6 +54,8 @@ export function MemberCreateDialog({ open, onClose }: Props) {
   }
 
   function handleClose() {
+    setFirstName('');
+    setLastName('');
     setPhone('');
     setEmail('');
     setFormError(null);
@@ -69,8 +80,24 @@ export function MemberCreateDialog({ open, onClose }: Props) {
     <Dialog open={open} onClose={handleClose} title="add member">
       <form onSubmit={(e) => void onSubmit(e)} className="flex flex-col gap-3">
         <TextField
+          label="first name"
+          value={firstName}
+          maxLength={64}
+          onChange={(e) => {
+            setFirstName(e.target.value);
+          }}
+          required
+        />
+        <TextField
+          label="last name (optional)"
+          value={lastName}
+          maxLength={64}
+          onChange={(e) => {
+            setLastName(e.target.value);
+          }}
+        />
+        <TextField
           label="phone number"
-          hint="they'll set their name during onboarding"
           value={phone}
           maxLength={20}
           onChange={(e) => {


### PR DESCRIPTION
## Summary

Part of Issue 694 (add-member and bulk-add forms weren't updated for the first/last name split). This is **PR1 of 2**.

- The **add member** dialog on `/admin/members` now collects **first name** (required) and **last name** (optional) in addition to phone + optional email, instead of leaving the name to onboarding.
- `CreateUserInput` and `useCreateUser` now send `first_name` / `last_name` to `/api/auth/create-user/`, which already accepts them.
- First-name-required validation matches the rest of the app (onboarding, member edit).

**Follow-up (PR2):** bulk-add currently collects phone numbers only; adding per-member first/last name there is a larger backend-schema change and ships separately so this stays under the PR size cap.

## Test plan

- [ ] open the add-member dialog on `/admin/members` — first name + last name fields appear above phone
- [ ] submitting without a first name is blocked
- [ ] created member shows the entered first/last name in the members list
- [ ] `MemberCreateDialog.test.tsx` and `users.test.ts` pass (`pnpm exec vitest run src/screens/admin/MemberCreateDialog.test.tsx src/api/users.test.ts`)