### PR TITLE
feat(events): show visibility as locked read-out for official/club (Issue 695)

### DIFF
--- a/frontend/src/screens/events/form/EventFormDetails.test.tsx
+++ b/frontend/src/screens/events/form/EventFormDetails.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { emptyEventFormValues, type EventFormValues } from '@/api/eventWrites';
+
+import { EventFormDetails } from './EventFormDetails';
+
+function values(overrides: Partial<EventFormValues> = {}): EventFormValues {
+  return { ...emptyEventFormValues(), ...overrides };
+}
+
+describe('EventFormDetails', () => {
+  it('shows the visibility dropdown when not locked', () => {
+    render(
+      <EventFormDetails values={values()} onChange={vi.fn()} errors={{}} typeLocked={false} />,
+    );
+    expect(screen.getByRole('combobox', { name: 'who can see it' })).toBeInTheDocument();
+    expect(screen.queryByText('locked')).not.toBeInTheDocument();
+  });
+
+  it('replaces the dropdown with a locked read-out when type-locked', () => {
+    render(
+      <EventFormDetails
+        values={values({ visibility: 'public' })}
+        onChange={vi.fn()}
+        errors={{}}
+        typeLocked
+      />,
+    );
+    expect(screen.queryByRole('combobox', { name: 'who can see it' })).not.toBeInTheDocument();
+    expect(screen.getByRole('group', { name: /locked to public/i })).toBeInTheDocument();
+    expect(screen.getByText('locked')).toBeInTheDocument();
+    expect(screen.getByText('official and club pda events are always public')).toBeInTheDocument();
+  });
+
+  it('greys out the non-public options in the locked read-out', () => {
+    render(<EventFormDetails values={values()} onChange={vi.fn()} errors={{}} typeLocked />);
+    expect(screen.getByText(/members only/)).toHaveClass('line-through');
+    expect(screen.getByText(/invite only/)).toHaveClass('line-through');
+    expect(screen.getByText(/members only/)).toHaveAttribute('aria-disabled', 'true');
+  });
+});

--- a/frontend/src/screens/events/form/EventFormDetails.tsx
+++ b/frontend/src/screens/events/form/EventFormDetails.tsx
@@ -91,10 +91,7 @@ function LockIcon({ className }: { className?: string }) {
   );
 }
 
-// When the event type forces public, we replace the dropdown with a locked
-// read-out so the constraint reads visually (lock icon + badge), not just as
-// helper text. The greyed non-public options are shown struck to make the
-// forced choice obvious.
+// Forced-public event types show a locked read-out instead of the dropdown so the constraint reads visually.
 function LockedVisibility({ helper }: { helper: string }) {
   return (
     <div

--- a/frontend/src/screens/events/form/EventFormDetails.tsx
+++ b/frontend/src/screens/events/form/EventFormDetails.tsx
@@ -31,8 +31,8 @@ interface Props {
   values: EventFormValues;
   onChange: (patch: Partial<EventFormValues>) => void;
   errors: Partial<Record<keyof EventFormValues, string>>;
-  // Locked when the event is a public-only type (official) — visibility is
-  // forced to public and the select is disabled.
+  // Locked when the event is a public-only type (official/club) — visibility is
+  // forced to public and shown as a locked read-out instead of the dropdown.
   typeLocked: boolean;
 }
 
@@ -54,18 +54,73 @@ export function EventFormDetails({ values, onChange, errors, typeLocked }: Props
         error={errors.description}
       />
 
-      <div className="flex flex-col gap-1">
-        <Select
-          label="who can see it"
-          value={values.visibility}
-          disabled={typeLocked}
-          onChange={(e) => {
-            onChange({ visibility: e.target.value as Visibility });
-          }}
-          options={VISIBILITY_OPTIONS.map((o) => ({ value: o.value, label: o.label }))}
-        />
-        <p className="text-foreground-secondary text-xs">{helper}</p>
+      {typeLocked ? (
+        <LockedVisibility helper={helper} />
+      ) : (
+        <div className="flex flex-col gap-1">
+          <Select
+            label="who can see it"
+            value={values.visibility}
+            onChange={(e) => {
+              onChange({ visibility: e.target.value as Visibility });
+            }}
+            options={VISIBILITY_OPTIONS.map((o) => ({ value: o.value, label: o.label }))}
+          />
+          <p className="text-foreground-secondary text-xs">{helper}</p>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LockIcon({ className }: { className?: string }) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 20 20"
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <rect x="4.5" y="9" width="11" height="7.5" rx="1.5" />
+      <path d="M7 9V6.5a3 3 0 0 1 6 0V9" />
+    </svg>
+  );
+}
+
+// When the event type forces public, we replace the dropdown with a locked
+// read-out so the constraint reads visually (lock icon + badge), not just as
+// helper text. The greyed non-public options are shown struck to make the
+// forced choice obvious.
+function LockedVisibility({ helper }: { helper: string }) {
+  return (
+    <div
+      className="flex flex-col gap-1"
+      role="group"
+      aria-label="who can see it — locked to public"
+    >
+      <span className="text-foreground text-sm font-medium" aria-hidden="true">
+        who can see it
+      </span>
+      <div className="border-border-strong bg-surface-dim flex flex-wrap items-center gap-x-2 gap-y-1 rounded-md border px-3 py-2 text-sm">
+        <LockIcon className="text-foreground-secondary h-4 w-4 shrink-0" />
+        <span className="text-foreground font-medium">
+          public<span className="sr-only"> — selected, locked</span>
+        </span>
+        <span className="text-foreground-secondary line-through" aria-disabled="true">
+          members only<span className="sr-only"> (not available)</span>
+        </span>
+        <span className="text-foreground-secondary line-through" aria-disabled="true">
+          invite only<span className="sr-only"> (not available)</span>
+        </span>
+        <span className="border-border-strong text-foreground-secondary ml-auto rounded-full border px-2 py-0.5 text-xs">
+          locked
+        </span>
       </div>
+      <p className="text-foreground-secondary text-xs">{helper}</p>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Closes #695

- on `/events/add`, when an event is tagged **official** or **club** pda, visibility is forced to public. previously the dropdown was just `disabled`, which greyed uniformly and didn't clearly read as *locked* — reporters said the explanatory text "doesn't stand out".
- replace the disabled dropdown (when the type is locked) with a **locked read-out**: a lock icon, `public` as the active value, `members only` / `invite only` struck through and greyed, and a `locked` badge. the constraint is now discoverable without reading the helper sentence.
- accessible + color-blind-safe: `role="group"` labelled "who can see it — locked to public", `aria-disabled` + `sr-only` cues on the excluded options, and meaning conveyed by icon / strikethrough / text badge rather than color alone.

## Test plan

- [ ] new `EventFormDetails.test.tsx` covers: dropdown shown when unlocked; locked read-out (no combobox, `locked` badge, group label) when type-locked; non-public options greyed + `aria-disabled`.
- [ ] `make agent-frontend-typecheck`, `make agent-frontend-lint`, and full `make agent-frontend-test` (732 passed) all green.
- [ ] manual: on `/events/add`, toggle "make it an official pda event" (or club) and confirm the visibility control switches to the locked read-out.