### PR TITLE
feat(events): gate invite button on member rsvp (Issue 688)

### DIFF
--- a/backend/community/_event_invitations.py
+++ b/backend/community/_event_invitations.py
@@ -36,14 +36,8 @@ class InviteIn(BaseModel):
 
 
 def _can_invite_to_event(user, event: Event) -> bool:
-    """Authorize an invite (permission gate only).
-
-    Hosts (creator / co-host) can always invite; managers can always invite;
-    other authed members can invite when invite_permission == ALL_MEMBERS. The
-    frontend additionally hides the button for all_members until the viewer has
-    RSVP'd (Issue 688) — that's a UX nudge only and is intentionally not
-    enforced here.
-    """
+    """Permission gate only — the RSVP nudge for all_members is frontend UX,
+    intentionally not enforced here (Issue 688)."""
     if user.has_permission(PermissionKey.MANAGE_EVENTS):
         return True
     if event.created_by_id == user.pk:

--- a/backend/community/_event_invitations.py
+++ b/backend/community/_event_invitations.py
@@ -36,10 +36,13 @@ class InviteIn(BaseModel):
 
 
 def _can_invite_to_event(user, event: Event) -> bool:
-    """Mirror the frontend canInvite gate.
+    """Authorize an invite (permission gate only).
 
     Hosts (creator / co-host) can always invite; managers can always invite;
-    other authed members can invite when invite_permission == ALL_MEMBERS.
+    other authed members can invite when invite_permission == ALL_MEMBERS. The
+    frontend additionally hides the button for all_members until the viewer has
+    RSVP'd (Issue 688) — that's a UX nudge only and is intentionally not
+    enforced here.
     """
     if user.has_permission(PermissionKey.MANAGE_EVENTS):
         return True

--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -5,7 +5,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
-import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
+import {
+  EventStatus,
+  EventType,
+  EventVisibility,
+  InvitePermission,
+  RsvpStatus,
+} from '@/models/event';
+import { Permission } from '@/models/permissions';
 import type { User } from '@/models/user';
 
 const rescindMutate = vi.fn();
@@ -110,6 +117,21 @@ const STRANGER: User = {
   id: 'user-stranger',
   firstName: 'Stranger',
   fullName: 'Stranger',
+};
+
+const MANAGER: User = {
+  ...STRANGER,
+  id: 'user-manager',
+  firstName: 'Manager',
+  fullName: 'Manager',
+  roles: [
+    {
+      id: 'role-events',
+      name: 'events team',
+      isDefault: false,
+      permissions: [Permission.ManageEvents],
+    },
+  ],
 };
 
 function renderSection(event: Event) {
@@ -259,7 +281,76 @@ describe('EventMemberSection — rsvp-disabled gates (#666, #667)', () => {
 
   it('shows the invite members button when rsvp is enabled and the viewer may invite', () => {
     useAuthStore.setState({ status: 'authed', user: STRANGER, accessToken: 'tok' });
-    renderSection(RSVP_ENABLED_EVENT);
+    renderSection({ ...RSVP_ENABLED_EVENT, myRsvp: RsvpStatus.Attending });
+    expect(screen.getByRole('button', { name: /invite members/i })).toBeInTheDocument();
+  });
+});
+
+describe('EventMemberSection — invite gating on member rsvp (#688)', () => {
+  const ALL_MEMBERS_EVENT: Event = {
+    ...BASE_EVENT,
+    rsvpEnabled: true,
+    invitePermission: InvitePermission.AllMembers,
+  };
+
+  it('hides invite for a non-cohost who has NOT rsvpd', () => {
+    useAuthStore.setState({ status: 'authed', user: STRANGER, accessToken: 'tok' });
+    renderSection({ ...ALL_MEMBERS_EVENT, myRsvp: null });
+    expect(screen.queryByRole('button', { name: /invite members/i })).not.toBeInTheDocument();
+  });
+
+  it('shows invite for a non-cohost who rsvpd attending', () => {
+    useAuthStore.setState({ status: 'authed', user: STRANGER, accessToken: 'tok' });
+    renderSection({ ...ALL_MEMBERS_EVENT, myRsvp: RsvpStatus.Attending });
+    expect(screen.getByRole('button', { name: /invite members/i })).toBeInTheDocument();
+  });
+
+  it('shows invite for a non-cohost who rsvpd maybe', () => {
+    useAuthStore.setState({ status: 'authed', user: STRANGER, accessToken: 'tok' });
+    renderSection({ ...ALL_MEMBERS_EVENT, myRsvp: RsvpStatus.Maybe });
+    expect(screen.getByRole('button', { name: /invite members/i })).toBeInTheDocument();
+  });
+
+  it('hides invite for a non-cohost who rsvpd cant_go', () => {
+    useAuthStore.setState({ status: 'authed', user: STRANGER, accessToken: 'tok' });
+    renderSection({ ...ALL_MEMBERS_EVENT, myRsvp: RsvpStatus.CantGo });
+    expect(screen.queryByRole('button', { name: /invite members/i })).not.toBeInTheDocument();
+  });
+
+  it('never shows invite to a non-cohost when invitePermission is co_hosts_only', () => {
+    useAuthStore.setState({ status: 'authed', user: STRANGER, accessToken: 'tok' });
+    renderSection({
+      ...ALL_MEMBERS_EVENT,
+      invitePermission: InvitePermission.CoHostsOnly,
+      myRsvp: RsvpStatus.Attending,
+    });
+    expect(screen.queryByRole('button', { name: /invite members/i })).not.toBeInTheDocument();
+  });
+
+  it('shows invite to the creator regardless of their own rsvp', () => {
+    useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
+    renderSection({ ...ALL_MEMBERS_EVENT, myRsvp: null });
+    expect(screen.getByRole('button', { name: /invite members/i })).toBeInTheDocument();
+  });
+
+  it('shows invite to a non-cohost event manager regardless of their own rsvp', () => {
+    useAuthStore.setState({ status: 'authed', user: MANAGER, accessToken: 'tok' });
+    renderSection({
+      ...ALL_MEMBERS_EVENT,
+      invitePermission: InvitePermission.CoHostsOnly,
+      myRsvp: null,
+    });
+    expect(screen.getByRole('button', { name: /invite members/i })).toBeInTheDocument();
+  });
+
+  it('shows invite to a co-host regardless of their own rsvp, even when co_hosts_only', () => {
+    useAuthStore.setState({ status: 'authed', user: COHOST_BOB, accessToken: 'tok' });
+    renderSection({
+      ...ACCEPTED_COHOST_EVENT,
+      rsvpEnabled: true,
+      invitePermission: InvitePermission.CoHostsOnly,
+      myRsvp: null,
+    });
     expect(screen.getByRole('button', { name: /invite members/i })).toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -38,9 +38,6 @@ export function EventMemberSection({ event }: Props) {
   const canSeeInvited = isCoHost || canManageEvents;
   const isCancelled = event.status === EventStatus.Cancelled;
   const rsvpDisabled = !event.rsvpEnabled;
-  // Ordinary members may invite others only once they've committed to going —
-  // attending/maybe count (matches MyEventsScreen's "engaged" bar); cant_go,
-  // waitlisted, and null don't. Cohosts/managers bypass this entirely.
   const hasRsvpd = event.myRsvp === RsvpStatus.Attending || event.myRsvp === RsvpStatus.Maybe;
   const canInvite =
     !isCancelled &&

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -9,7 +9,7 @@ import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import { useConfirm } from '@/components/ui/useConfirm';
 import type { Event, PendingCohostInvite } from '@/models/event';
-import { EventStatus, InvitePermission } from '@/models/event';
+import { EventStatus, InvitePermission, RsvpStatus } from '@/models/event';
 import { hasPermission } from '@/models/permissions';
 import { Permission } from '@/models/permissions';
 import { buildEventLinks } from '@/utils/eventLinks';
@@ -38,11 +38,17 @@ export function EventMemberSection({ event }: Props) {
   const canSeeInvited = isCoHost || canManageEvents;
   const isCancelled = event.status === EventStatus.Cancelled;
   const rsvpDisabled = !event.rsvpEnabled;
+  // Ordinary members may invite others only once they've committed to going —
+  // attending/maybe count (matches MyEventsScreen's "engaged" bar); cant_go,
+  // waitlisted, and null don't. Cohosts/managers bypass this entirely.
+  const hasRsvpd = event.myRsvp === RsvpStatus.Attending || event.myRsvp === RsvpStatus.Maybe;
   const canInvite =
     !isCancelled &&
     !event.isPast &&
     !rsvpDisabled &&
-    (isCoHost || event.invitePermission === InvitePermission.AllMembers);
+    (isCoHost ||
+      canManageEvents ||
+      (event.invitePermission === InvitePermission.AllMembers && hasRsvpd));
   const showRsvp = !event.isPast && event.rsvpEnabled && event.status !== EventStatus.Cancelled;
   const showStandaloneInvited = !showRsvp && canSeeInvited && event.invitedCount > 0;
 


### PR DESCRIPTION
## Summary

Closes #688

- Non-cohost members now only see the "invite members" button on the event detail screen once they've RSVP'd — `attending` or `maybe` count as committed (matches `MyEventsScreen`'s "engaged" bar); `cant_go`, `waitlisted`, and no-RSVP do not. This is layered on top of the existing `invitePermission === all_members` requirement.
- Co-hosts, the creator, and event managers (`manage_events`) keep inviting regardless of their own RSVP status — the RSVP requirement applies only to the ordinary `all_members` path.
- Backend invite authorization is unchanged; its docstring now notes the RSVP gate is intentionally a frontend-only UX nudge, not enforced server-side.

## Test plan

- [x] `EventMemberSection.test.tsx` — new `#688` suite covers: non-cohost not-RSVP'd (hidden), attending/maybe (shown), cant_go (hidden), `co_hosts_only` override (hidden), and creator / event-manager / co-host bypass with no RSVP (shown).
- [x] frontend typecheck + full vitest suite (737 passed) + eslint/prettier clean
- [x] backend ruff clean; invitation tests pass on sqlite dev.db