### PR TITLE
feat(events): serve open graph link previews for event pages (Issue 652)

### DIFF
--- a/backend/config/og_preview.py
+++ b/backend/config/og_preview.py
@@ -1,0 +1,65 @@
+from uuid import UUID
+
+from community.models import Event, EventStatus, PageVisibility
+from django.conf import settings
+from django.http import Http404
+from django.shortcuts import render
+
+from config.media_proxy import media_path
+
+# OG descriptions are truncated by most scrapers around 200 chars; trimming
+# here keeps the tag tidy and avoids dumping a 2000-char body into <head>.
+_OG_DESCRIPTION_MAX = 200
+
+# Anonymous scrapers may only preview what an anonymous user could open in the
+# app: public events that aren't drafts or deleted. Cancelled public events are
+# still viewable (and shareable), so they get a preview too.
+_PREVIEWABLE_STATUSES = frozenset({EventStatus.ACTIVE, EventStatus.CANCELLED})
+
+
+def _absolute(path: str) -> str:
+    """Turn a root-relative path into an absolute URL under the public app origin."""
+    if not path:
+        return ""
+    return f"{settings.FRONTEND_BASE_URL.rstrip('/')}{path}"
+
+
+def _truncate(text: str, limit: int) -> str:
+    text = " ".join(text.split())
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+def event_og_preview(request, event_id: UUID):
+    """Render OG/Twitter meta tags for a PUBLIC event so link scrapers can unfurl it.
+
+    Only public, non-draft, non-deleted events are previewed — mirroring what an
+    anonymous user may see. Anything else 404s so member-only details never leak.
+    """
+    try:
+        event = Event.objects.get(id=event_id)
+    except Event.DoesNotExist:
+        raise Http404
+
+    is_previewable = (
+        event.visibility == PageVisibility.PUBLIC and event.status in _PREVIEWABLE_STATUSES
+    )
+    if not is_previewable:
+        raise Http404
+
+    url = _absolute(f"/events/{event.id}")
+    image = _absolute(media_path(event.photo))
+
+    response = render(
+        request,
+        "og/event_preview.html",
+        {
+            "title": event.title,
+            "description": _truncate(event.description, _OG_DESCRIPTION_MAX),
+            "url": url,
+            "image": image,
+        },
+    )
+    response["X-Robots-Tag"] = "noindex"
+    return response

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -6,6 +6,7 @@ from notifications.sse import notification_stream
 from users.api import router as auth_router
 
 from config.media_proxy import serve_media
+from config.og_preview import event_og_preview
 from config.validation_handlers import register_validation_handlers
 
 api = NinjaAPI(title="PDA API", version="1.0.0")
@@ -20,4 +21,7 @@ urlpatterns = [
     path("api/notifications/stream/", notification_stream),
     # Media proxy — streams files from storage backend (local disk or B2)
     re_path(r"^media/(?P<path>.+)$", serve_media),
+    # OG/Twitter meta tags for link scrapers. nginx routes /events/<id> here
+    # only for scraper user-agents; real browsers get the SPA (see nginx.conf).
+    path("events/<uuid:event_id>/preview/", event_og_preview),
 ]

--- a/backend/templates/og/event_preview.html
+++ b/backend/templates/og/event_preview.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>{{ title }}</title>
+    <meta property="og:type" content="website" />
+    <meta property="og:site_name" content="pda" />
+    <meta property="og:title" content="{{ title }}" />
+    {% if description %}<meta property="og:description" content="{{ description }}" />{% endif %}
+    <meta property="og:url" content="{{ url }}" />
+    {% if image %}<meta property="og:image" content="{{ image }}" />{% endif %}
+    <meta name="twitter:card" content="{% if image %}summary_large_image{% else %}summary{% endif %}" />
+    <meta name="twitter:title" content="{{ title }}" />
+    {% if description %}<meta name="twitter:description" content="{{ description }}" />{% endif %}
+    {% if image %}<meta name="twitter:image" content="{{ image }}" />{% endif %}
+    <meta http-equiv="refresh" content="0; url={{ url }}" />
+  </head>
+  <body>
+    <a href="{{ url }}">{{ title }}</a>
+  </body>
+</html>

--- a/backend/tests/test_og_preview.py
+++ b/backend/tests/test_og_preview.py
@@ -1,0 +1,145 @@
+import io
+import uuid
+
+import pytest
+from community.models import Event, EventStatus, PageVisibility
+from django.core.files.uploadedfile import SimpleUploadedFile
+from PIL import Image
+
+from tests.conftest import future_iso
+
+
+def _make_test_image():
+    buf = io.BytesIO()
+    Image.new("RGB", (20, 20)).save(buf, format="JPEG")
+    buf.seek(0)
+    return SimpleUploadedFile("test.jpg", buf.read(), content_type="image/jpeg")
+
+
+def _preview_url(event_id) -> str:
+    return f"/events/{event_id}/preview/"
+
+
+@pytest.fixture
+def public_event(db):
+    return Event.objects.create(
+        title="Vegan Potluck",
+        description="Bring a dish to share at the park.",
+        start_datetime=future_iso(),
+        location="Central Park",
+        visibility=PageVisibility.PUBLIC,
+        status=EventStatus.ACTIVE,
+        photo=_make_test_image(),
+    )
+
+
+@pytest.mark.django_db
+class TestEventOgPreview:
+    def test_public_event_renders_og_tags(self, api_client, public_event, settings):
+        settings.FRONTEND_BASE_URL = "https://pda.example.com"
+        response = api_client.get(_preview_url(public_event.id))
+
+        assert response.status_code == 200
+        html = response.content.decode()
+        assert '<meta property="og:title" content="Vegan Potluck"' in html
+        assert (
+            '<meta property="og:description" content="Bring a dish to share at the park."' in html
+        )
+        assert (
+            f'<meta property="og:url" content="https://pda.example.com/events/{public_event.id}"'
+            in html
+        )
+        assert (
+            '<meta property="og:image" content="https://pda.example.com/media/event_photos/' in html
+        )
+        assert '<meta name="twitter:card" content="summary_large_image"' in html
+
+    def test_event_without_photo_uses_summary_card(self, api_client, db, settings):
+        settings.FRONTEND_BASE_URL = "https://pda.example.com"
+        event = Event.objects.create(
+            title="No Photo Event",
+            start_datetime=future_iso(),
+            visibility=PageVisibility.PUBLIC,
+            status=EventStatus.ACTIVE,
+        )
+        response = api_client.get(_preview_url(event.id))
+
+        assert response.status_code == 200
+        html = response.content.decode()
+        assert '<meta name="twitter:card" content="summary"' in html
+        assert "og:image" not in html
+
+    def test_members_only_event_is_hidden(self, api_client, db):
+        event = Event.objects.create(
+            title="Secret Members Event",
+            start_datetime=future_iso(),
+            visibility=PageVisibility.MEMBERS_ONLY,
+            status=EventStatus.ACTIVE,
+        )
+        response = api_client.get(_preview_url(event.id))
+        assert response.status_code == 404
+
+    def test_invite_only_event_is_hidden(self, api_client, db):
+        event = Event.objects.create(
+            title="Invite Only Event",
+            start_datetime=future_iso(),
+            visibility=PageVisibility.INVITE_ONLY,
+            status=EventStatus.ACTIVE,
+        )
+        response = api_client.get(_preview_url(event.id))
+        assert response.status_code == 404
+
+    def test_cancelled_public_event_still_previews(self, api_client, db, settings):
+        settings.FRONTEND_BASE_URL = "https://pda.example.com"
+        event = Event.objects.create(
+            title="Cancelled Event",
+            start_datetime=future_iso(),
+            visibility=PageVisibility.PUBLIC,
+            status=EventStatus.CANCELLED,
+        )
+        response = api_client.get(_preview_url(event.id))
+
+        assert response.status_code == 200
+        assert '<meta property="og:title" content="Cancelled Event"' in response.content.decode()
+
+    def test_draft_event_is_hidden(self, api_client, db):
+        event = Event.objects.create(
+            title="Draft Event",
+            start_datetime=future_iso(),
+            visibility=PageVisibility.PUBLIC,
+            status=EventStatus.DRAFT,
+        )
+        response = api_client.get(_preview_url(event.id))
+        assert response.status_code == 404
+
+    def test_missing_event_returns_404(self, api_client, db):
+        response = api_client.get(_preview_url(uuid.uuid4()))
+        assert response.status_code == 404
+
+    def test_description_is_truncated(self, api_client, db, settings):
+        settings.FRONTEND_BASE_URL = "https://pda.example.com"
+        event = Event.objects.create(
+            title="Long Description Event",
+            description="word " * 100,
+            start_datetime=future_iso(),
+            visibility=PageVisibility.PUBLIC,
+            status=EventStatus.ACTIVE,
+        )
+        response = api_client.get(_preview_url(event.id))
+
+        html = response.content.decode()
+        assert "…" in html
+
+    def test_title_is_html_escaped(self, api_client, db, settings):
+        settings.FRONTEND_BASE_URL = "https://pda.example.com"
+        event = Event.objects.create(
+            title='Evil "><script>alert(1)</script>',
+            start_datetime=future_iso(),
+            visibility=PageVisibility.PUBLIC,
+            status=EventStatus.ACTIVE,
+        )
+        response = api_client.get(_preview_url(event.id))
+
+        html = response.content.decode()
+        assert "<script>alert(1)</script>" not in html
+        assert "&lt;script&gt;" in html

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -49,6 +49,24 @@ server {
         try_files $uri =404;
     }
 
+    # Event detail pages: link-unfurling scrapers (iMessage, Slack, WhatsApp,
+    # Facebook, Twitter, etc.) don't run JS, so the SPA can't hand them OG tags.
+    # Route just those bots to Django's server-rendered preview; humans keep the
+    # SPA. Matched on the event UUID path only (Issue 652).
+    location ~ ^/events/(?<event_uuid>[0-9a-fA-F-]{36})$ {
+        # Social link-unfurl bots only — NOT search-engine crawlers (googlebot,
+        # bingbot, applebot). The preview is noindex, so routing search crawlers
+        # here would deindex real public event pages (Issue 652).
+        if ($http_user_agent ~* "(facebookexternalhit|twitterbot|slackbot|whatsapp|telegrambot|discordbot|linkedinbot|pinterest|redditbot|embedly|iframely|skypeuripreview|vkshare|bluesky|mastodon)") {
+            proxy_pass http://127.0.0.1:8000/events/$event_uuid/preview/;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto https;
+        }
+        try_files $uri /index.html;
+    }
+
     location / {
         try_files $uri $uri/ /index.html;
     }


### PR DESCRIPTION
## Summary

Closes #652

- Share an event link in iMessage/Slack/WhatsApp and it now unfurls into a rich preview with the event photo, title, and description.
- Adds a server-rendered OG/Twitter Card view (`backend/config/og_preview.py` + `templates/og/event_preview.html`) at `/events/<uuid>/preview/`. The SPA is static (nginx `try_files … /index.html`) and scrapers don't run JS, so nginx routes **only known social-unfurl user-agents** for `/events/<uuid>` to this Django view; real browsers keep getting the SPA untouched.
- **No leak of gated content:** only public, non-draft, non-deleted events are previewed (mirrors the anonymous branch of `_enforce_event_read_visibility`). MEMBERS_ONLY / INVITE_ONLY / DRAFT / deleted → 404. Cancelled public events (viewable + shareable in-app) still preview.
- `og:image` / `og:url` are absolute URLs built from `settings.FRONTEND_BASE_URL`; the image is served by the existing auth-free `/media/` proxy, so it's publicly fetchable by scrapers.
- Search-engine crawlers (googlebot, bingbot, applebot) are deliberately **not** routed here — the preview is `noindex`, so serving it to them would deindex real event pages.

## Notes

- The authoritative nginx config is the repo-root `nginx.conf.template` (used by the `Dockerfile`); the stale `frontend/nginx.conf.template` is a different deploy topology and is intentionally left untouched.

## Test plan

- [x] `backend/tests/test_og_preview.py` — 9 tests: public event renders full OG/Twitter tags with absolute image URL; no-photo → `summary` card, photo → `summary_large_image`; MEMBERS_ONLY / INVITE_ONLY / DRAFT / missing → 404; cancelled public event still previews; long description truncated; title HTML-escaped (attribute-injection guard).
- [x] Backend `agent-lint` / `agent-typecheck` / `agent-complexity` / `check-codes` clean; frontend CI green (unchanged — no frontend files touched).
- [ ] Manual: paste a public event URL into iMessage/Slack and confirm the photo + title unfurl; confirm a members-only event URL shows no preview.
