### PR TITLE
feat(frontend): add copyright notice to site footer (Issue 638)

### DIFF
--- a/frontend/src/layout/AppShell.tsx
+++ b/frontend/src/layout/AppShell.tsx
@@ -10,6 +10,7 @@ import { useAuthStore } from '@/auth/store';
 import { FeedbackButton } from '@/components/FeedbackButton';
 
 import { BottomNav } from './BottomNav';
+import { Footer } from './Footer';
 import { NotificationBell } from './NotificationBell';
 import { PdaMenuSheet } from './PdaMenuSheet';
 
@@ -39,8 +40,11 @@ export function AppShell() {
 
       {/* Pad the bottom so the fixed BottomNav (h-14 + iOS safe area) doesn't
           cover the end of the scroll. Header already eats its own space. */}
-      <div className="flex-1 overflow-x-hidden pb-[calc(3.5rem+env(safe-area-inset-bottom))]">
-        <Outlet />
+      <div className="flex flex-1 flex-col overflow-x-hidden pb-[calc(3.5rem+env(safe-area-inset-bottom))]">
+        <div className="flex-1">
+          <Outlet />
+        </div>
+        <Footer />
       </div>
 
       <div id="pda-menu-sheet">

--- a/frontend/src/layout/Footer.test.tsx
+++ b/frontend/src/layout/Footer.test.tsx
@@ -1,0 +1,14 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { Footer } from './Footer';
+
+describe('Footer', () => {
+  it('renders a lowercase copyright line with the current year', () => {
+    const year = new Date().getFullYear();
+    render(<Footer />);
+
+    const footer = screen.getByRole('contentinfo');
+    expect(footer).toHaveTextContent(`© ${year} protein deficients anonymous`);
+  });
+});

--- a/frontend/src/layout/Footer.tsx
+++ b/frontend/src/layout/Footer.tsx
@@ -1,0 +1,9 @@
+export function Footer() {
+  const year = new Date().getFullYear();
+
+  return (
+    <footer className="border-border text-muted border-t px-4 py-6 text-center text-xs">
+      © {year} protein deficients anonymous
+    </footer>
+  );
+}


### PR DESCRIPTION
## Summary
- Add a `Footer` component that renders a lowercase copyright line (`© <year> protein deficients anonymous`) with a **dynamically computed** current year — no hard-coded year.
- Wire the footer into the shared `AppShell` content area so it renders on both public and authenticated screens.
- Place the footer inside the padded content wrapper (above the fixed mobile `BottomNav`) using a `flex-col` + `flex-1` spacer, so it sits at the bottom of short pages and never collides with or hides behind the nav.

Closes #638

## Test plan
- [ ] Load a public screen (e.g. `/calendar`) and an authenticated screen — copyright footer is visible on both.
- [ ] Confirm the year matches the current year and is not hard-coded.
- [ ] On mobile, scroll to the bottom of a page and confirm the footer clears the bottom navigation (no overlap).
- [ ] `Footer.test.tsx` asserts the lowercase text + dynamic year; full vitest suite passes (730 passed / 1 skipped).