### PR TITLE
feat(events): make rsvp pills horizontally scrollable (Issue 620)

### DIFF
--- a/frontend/src/components/ui/RsvpStatusPicker.test.tsx
+++ b/frontend/src/components/ui/RsvpStatusPicker.test.tsx
@@ -27,6 +27,19 @@ describe('RsvpStatusPicker', () => {
     expect(onSelect).toHaveBeenCalledWith('attending');
   });
 
+  it('lays the pills out in a single horizontally scrollable row', () => {
+    render(<RsvpStatusPicker value={null} onSelect={vi.fn()} />);
+    const row = screen.getByRole('button', { name: 'maybe' }).parentElement;
+    expect(row).toHaveClass('overflow-x-auto');
+    expect(row).not.toHaveClass('flex-wrap');
+    expect(row).toHaveClass('justify-center-safe');
+  });
+
+  it('keeps each pill from shrinking so labels are never truncated', () => {
+    render(<RsvpStatusPicker value={null} onSelect={vi.fn()} />);
+    expect(screen.getByRole('button', { name: "i'm going" })).toHaveClass('shrink-0');
+  });
+
   it('applies labelFor overrides', () => {
     render(
       <RsvpStatusPicker

--- a/frontend/src/components/ui/RsvpStatusPicker.tsx
+++ b/frontend/src/components/ui/RsvpStatusPicker.tsx
@@ -17,7 +17,7 @@ interface Props {
 
 export function RsvpStatusPicker({ value, onSelect, disabled = false, labelFor }: Props) {
   return (
-    <div className="flex flex-wrap justify-center gap-2">
+    <div className="-mx-1 flex justify-center-safe gap-2 overflow-x-auto px-1 py-1">
       {PILLS.map((p) => {
         const label = labelFor ? labelFor(p.status, p.label) : p.label;
         const active = value === p.status;
@@ -31,7 +31,7 @@ export function RsvpStatusPicker({ value, onSelect, disabled = false, labelFor }
               onSelect(p.status);
             }}
             className={cn(
-              'inline-flex h-10 items-center rounded-full px-4 text-sm font-medium transition-colors disabled:cursor-not-allowed',
+              'inline-flex h-10 shrink-0 items-center rounded-full px-4 text-sm font-medium transition-colors disabled:cursor-not-allowed',
               active
                 ? 'bg-brand-600 text-brand-on'
                 : 'border-border-strong text-foreground-secondary hover:bg-background border',


### PR DESCRIPTION
## Summary
- Swapped the wrapping flex row in `RsvpStatusPicker` for a single-row horizontal scroll container (`overflow-x-auto`), so the rsvp pills ("i'm going" / "maybe" / "can't go" and the "join the waitlist" variant) no longer wrap into uneven rows or shift surrounding layout on narrow screens.
- Used `justify-center-safe` (Tailwind v4) so centering is preserved on wide screens where all pills fit, but falls back to start-alignment on overflow — this keeps the leftmost pill reachable instead of clipping it past the scroll origin (a bug plain `justify-center` + `overflow-x-auto` would introduce).
- Added `shrink-0` to each pill so labels are never truncated, and added tests covering the scroll-container layout and non-shrinking pills.

Closes #620

## Test plan
- [ ] On a narrow viewport, the rsvp pills stay on one row and scroll horizontally; every pill (including the leftmost) is reachable via touch/trackpad.
- [ ] On a wide viewport, the pills remain centered with no visual regression.
- [ ] `make agent-frontend-test` passes (RsvpStatusPicker + RsvpSection suites).