### PR TITLE
chore(frontend): 542 - ban default react import via eslint

### DIFF
--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -59,6 +59,22 @@ export default defineConfig([
         'error',
         { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
       ],
+      // The modern JSX transform means no default React import is needed —
+      // import hooks/types by name (`useEffect`, not `React.useEffect`).
+      'no-restricted-imports': 'off',
+      '@typescript-eslint/no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'react',
+              importNames: ['default'],
+              message:
+                "import hooks and types by name from 'react' — the default React import isn't needed with the modern jsx transform.",
+            },
+          ],
+        },
+      ],
     },
   },
   {

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -3,7 +3,7 @@
 //   authed (RequireAuth)     : settings, profile, ...
 //   permissioned             : admin/*, members, etc.
 //
-// All screens are lazy-loaded (React.lazy) — 1:1 replacement for DeferredScreen.
+// All screens are lazy-loaded (lazy) — 1:1 replacement for DeferredScreen.
 
 import { createBrowserRouter } from 'react-router-dom';
 


### PR DESCRIPTION
## Overview

removes the need for a default `React` import and guards against it returning. investigation found the codebase is already on the modern `react-jsx` transform — there are **zero** `import React from 'react'` statements and **zero** `React.useEffect`-style runtime usages. so this change:

- adds a `@typescript-eslint/no-restricted-imports` rule in `frontend/eslint.config.js` that bans the default (and namespace) `React` import from `'react'`, nudging devs to import hooks and types by name (`useEffect`, not `React.useEffect`). this prevents the pattern from creeping back in.
- fixes a stale `React.lazy` reference in a `frontend/src/router/routes.tsx` comment — the code actually imports `lazy` directly via `./lazyRoute`.

verified locally in the worktree: eslint (`--max-warnings 0`), prettier `--check`, `tsc -b --noEmit`, and the full vitest suite (729 tests, 102 files) all pass. the new rule was confirmed to fire on a probe file containing `import React from 'react'`.

Closes #542

## Test plan

- [x] eslint passes (`--max-warnings 0`)
- [x] prettier `--check` passes
- [x] `tsc -b --noEmit` passes
- [x] vitest suite passes (729 tests)
- [x] confirmed the new lint rule errors on a default `React` import
