### PR TITLE
feat(community): 689 - event tag create/delete endpoints

### DIFF
--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -138,6 +138,10 @@ class TagOut(BaseModel):
     slug: str
 
 
+class TagIn(BaseModel):
+    name: str = Field(..., min_length=1, max_length=50)
+
+
 class RSVPGuestOut(BaseModel):
     user_id: str
     name: str

--- a/backend/community/_event_tags.py
+++ b/backend/community/_event_tags.py
@@ -1,21 +1,106 @@
-"""Event tags endpoint — lists the curated, admin-managed tag set.
+"""Event tags endpoints.
 
-The tag set itself is managed via Django admin; this endpoint is read-only and
-public so the calendar and event UI can render and filter by tag.
+Listing is read-only and public so the calendar and event UI can render and
+filter by tag. Creating and deleting tags is gated behind the
+``manage_events`` permission so admins can curate the set in-app without
+Django admin.
 """
 
+import logging
+from uuid import UUID
+
+from config.audit import audit_log
+from config.auth import gated_jwt
+from config.ratelimit import rate_limit
+from django.db import IntegrityError, transaction
+from django.utils.text import slugify
 from ninja import Router
 from ninja.responses import Status
+from users.permissions import PermissionKey
 
-from community._event_schemas import TagOut
+from community._event_schemas import TagIn, TagOut
+from community._shared import ErrorOut
+from community._validation import Code, raise_validation
 from community.models import EventTag
 
 router = Router()
 
 
+def _require_manage_tags(request, endpoint: str, target_id: str = "") -> None:
+    if request.auth.has_permission(PermissionKey.MANAGE_EVENTS):
+        return
+    audit_log(
+        logging.WARNING,
+        "permission_denied",
+        request,
+        target_type="event_tag",
+        target_id=target_id,
+        details={
+            "endpoint": endpoint,
+            "required_permission": PermissionKey.MANAGE_EVENTS,
+        },
+    )
+    raise_validation(Code.Perm.DENIED, status_code=403, action="manage_events")
+
+
+def _tag_out(tag: EventTag) -> TagOut:
+    return TagOut(id=str(tag.id), name=tag.name, slug=tag.slug)
+
+
 @router.get("/event-tags/", response={200: list[TagOut]}, auth=None)
 def list_event_tags(request):
-    return Status(
-        200,
-        [TagOut(id=str(t.id), name=t.name, slug=t.slug) for t in EventTag.objects.all()],
+    return Status(200, [_tag_out(t) for t in EventTag.objects.all()])
+
+
+@router.post(
+    "/event-tags/",
+    response={201: TagOut, 400: ErrorOut, 403: ErrorOut, 429: ErrorOut},
+    auth=gated_jwt,
+)
+@rate_limit(key_func=lambda r: str(r.auth.pk), rate="10/m")
+def create_event_tag(request, payload: TagIn):
+    _require_manage_tags(request, "create_event_tag")
+    name = payload.name.strip()
+    if not name or not slugify(name):
+        raise_validation(Code.Tag.NAME_REQUIRED, field="name", status_code=400)
+    if EventTag.objects.filter(name__iexact=name).exists():
+        raise_validation(Code.Tag.NAME_ALREADY_EXISTS, field="name", status_code=400)
+    try:
+        with transaction.atomic():
+            tag = EventTag.objects.create(name=name)
+    except IntegrityError:
+        # distinct names can collide on the derived unique slug (e.g. "walk!" → "walk")
+        raise_validation(Code.Tag.NAME_ALREADY_EXISTS, field="name", status_code=400)
+    audit_log(
+        logging.INFO,
+        "event_tag_created",
+        request,
+        target_type="event_tag",
+        target_id=str(tag.id),
+        details={"name": tag.name, "slug": tag.slug},
     )
+    return Status(201, _tag_out(tag))
+
+
+@router.delete(
+    "/event-tags/{tag_id}/",
+    response={204: None, 403: ErrorOut, 404: ErrorOut},
+    auth=gated_jwt,
+)
+def delete_event_tag(request, tag_id: UUID):
+    _require_manage_tags(request, "delete_event_tag", target_id=str(tag_id))
+    try:
+        tag = EventTag.objects.get(id=tag_id)
+    except EventTag.DoesNotExist:
+        raise_validation(Code.Tag.NOT_FOUND, status_code=404)
+    name = tag.name
+    tag.delete()
+    audit_log(
+        logging.WARNING,
+        "event_tag_deleted",
+        request,
+        target_type="event_tag",
+        target_id=str(tag_id),
+        details={"name": name},
+    )
+    return Status(204, None)

--- a/backend/community/_validation.py
+++ b/backend/community/_validation.py
@@ -47,6 +47,11 @@ class Code:
         MIN_TWO_OPTIONS = "poll.min_two_options"
         INVALID_AVAILABILITY = "poll.invalid_availability"
 
+    class Tag:
+        NOT_FOUND = "tag.not_found"
+        NAME_REQUIRED = "tag.name_required"
+        NAME_ALREADY_EXISTS = "tag.name_already_exists"
+
     class Comment:
         NOT_FOUND = "comment.not_found"
         REPLY_DEPTH_EXCEEDED = "comment.reply_depth_exceeded"

--- a/backend/community/models/tag.py
+++ b/backend/community/models/tag.py
@@ -9,9 +9,10 @@ from django.utils.text import slugify
 class EventTag(models.Model):
     """A curated tag an event can carry (e.g. "walk", "restaurant meetup").
 
-    The set is admin-managed via Django admin — there's no member-facing CRUD.
-    Events reference tags through the ``Event.tags`` M2M; assigning tags to an
-    event reuses the existing event-edit gate (creators / co-hosts / managers).
+    The set is curated via Django admin or in-app by users with the
+    ``manage_events`` permission. Events reference tags through the
+    ``Event.tags`` M2M; assigning tags to an event reuses the existing
+    event-edit gate (creators / co-hosts / managers).
     """
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)

--- a/backend/community/validation_codes.json
+++ b/backend/community/validation_codes.json
@@ -201,6 +201,23 @@
         "params": []
       }
     ],
+    "Tag": [
+      {
+        "name": "NOT_FOUND",
+        "value": "tag.not_found",
+        "params": []
+      },
+      {
+        "name": "NAME_REQUIRED",
+        "value": "tag.name_required",
+        "params": []
+      },
+      {
+        "name": "NAME_ALREADY_EXISTS",
+        "value": "tag.name_already_exists",
+        "params": []
+      }
+    ],
     "Comment": [
       {
         "name": "NOT_FOUND",

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -4489,6 +4489,21 @@
         "title": "SurveyResponseOut",
         "type": "object"
       },
+      "TagIn": {
+        "properties": {
+          "name": {
+            "maxLength": 50,
+            "minLength": 1,
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "title": "TagIn",
+        "type": "object"
+      },
       "TagOut": {
         "properties": {
           "id": {
@@ -7205,6 +7220,122 @@
           }
         },
         "summary": "List Event Tags",
+        "tags": [
+          "community"
+        ]
+      },
+      "post": {
+        "operationId": "community__event_tags_create_event_tag",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TagIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TagOut"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          }
+        },
+        "security": [
+          {
+            "GatedJWTAuth": []
+          }
+        ],
+        "summary": "Create Event Tag",
+        "tags": [
+          "community"
+        ]
+      }
+    },
+    "/api/community/event-tags/{tag_id}/": {
+      "delete": {
+        "operationId": "community__event_tags_delete_event_tag",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "tag_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Tag Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Not Found"
+          }
+        },
+        "security": [
+          {
+            "GatedJWTAuth": []
+          }
+        ],
+        "summary": "Delete Event Tag",
         "tags": [
           "community"
         ]

--- a/backend/tests/test_event_tags.py
+++ b/backend/tests/test_event_tags.py
@@ -5,15 +5,16 @@ import pytest
 from community.models import Event, EventTag
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
+from ninja_jwt.tokens import RefreshToken
 from users.models import User
+from users.permissions import PermissionKey
+from users.roles import Role
 
 from tests.conftest import future_iso
 
 
 @pytest.fixture
 def member_headers(db):
-    from ninja_jwt.tokens import RefreshToken
-
     member = User.objects.create_user(
         phone_number="+14155550111",
         password="memberpass123",
@@ -21,6 +22,19 @@ def member_headers(db):
         last_name="Member",
     )
     return {"HTTP_AUTHORIZATION": f"Bearer {RefreshToken.for_user(member).access_token}"}  # type: ignore
+
+
+@pytest.fixture
+def manage_tags_headers(db):
+    admin = User.objects.create_user(
+        phone_number="+14155550222",
+        password="adminpass123",
+        first_name="Tag",
+        last_name="Admin",
+    )
+    role = Role.objects.create(name="tag_mgr", permissions=[PermissionKey.MANAGE_EVENTS])
+    admin.roles.add(role)
+    return {"HTTP_AUTHORIZATION": f"Bearer {RefreshToken.for_user(admin).access_token}"}  # type: ignore
 
 
 @pytest.fixture
@@ -54,6 +68,104 @@ class TestListEventTags:
         response = api_client.get("/api/community/event-tags/")
         first = response.json()[0]
         assert set(first.keys()) == {"id", "name", "slug"}
+
+
+@pytest.mark.django_db
+class TestCreateEventTag:
+    def test_create_requires_permission(self, api_client, member_headers):
+        response = api_client.post(
+            "/api/community/event-tags/",
+            {"name": "walk"},
+            content_type="application/json",
+            **member_headers,
+        )
+        assert response.status_code == 403
+        assert not EventTag.objects.exists()
+
+    def test_create_with_permission_trims_whitespace(self, api_client, manage_tags_headers):
+        response = api_client.post(
+            "/api/community/event-tags/",
+            {"name": "  walk  "},
+            content_type="application/json",
+            **manage_tags_headers,
+        )
+        assert response.status_code == 201
+        body = response.json()
+        assert body["name"] == "walk"
+        assert body["slug"] == "walk"
+        assert EventTag.objects.filter(name="walk").exists()
+
+    @pytest.mark.parametrize("name", ["   ", "🌿"])
+    def test_create_rejects_names_without_a_usable_slug(
+        self, api_client, manage_tags_headers, name
+    ):
+        # blank (empty after strip) and slug-less names (emoji → "") are both rejected
+        response = api_client.post(
+            "/api/community/event-tags/",
+            {"name": name},
+            content_type="application/json",
+            **manage_tags_headers,
+        )
+        assert response.status_code == 400
+        assert not EventTag.objects.exists()
+
+    def test_create_rejects_duplicate_case_insensitive(self, api_client, manage_tags_headers, tags):
+        response = api_client.post(
+            "/api/community/event-tags/",
+            {"name": "WALK"},
+            content_type="application/json",
+            **manage_tags_headers,
+        )
+        assert response.status_code == 400
+        assert EventTag.objects.filter(name__iexact="walk").count() == 1
+
+    def test_create_rejects_slug_collision(self, api_client, manage_tags_headers, tags):
+        # distinct name but slugifies to the same "walk" as the existing tag
+        response = api_client.post(
+            "/api/community/event-tags/",
+            {"name": "walk!"},
+            content_type="application/json",
+            **manage_tags_headers,
+        )
+        assert response.status_code == 400
+        assert EventTag.objects.filter(slug="walk").count() == 1
+
+
+@pytest.mark.django_db
+class TestDeleteEventTag:
+    def test_delete_requires_permission(self, api_client, member_headers, tags):
+        walk, _ = tags
+        response = api_client.delete(
+            f"/api/community/event-tags/{walk.id}/",
+            **member_headers,
+        )
+        assert response.status_code == 403
+        assert EventTag.objects.filter(id=walk.id).exists()
+
+    def test_delete_with_permission(self, api_client, manage_tags_headers, tags):
+        walk, _ = tags
+        response = api_client.delete(
+            f"/api/community/event-tags/{walk.id}/",
+            **manage_tags_headers,
+        )
+        assert response.status_code == 204
+        assert not EventTag.objects.filter(id=walk.id).exists()
+
+    def test_delete_missing_tag_returns_404(self, api_client, manage_tags_headers):
+        unknown = "00000000-0000-0000-0000-000000000000"
+        response = api_client.delete(
+            f"/api/community/event-tags/{unknown}/",
+            **manage_tags_headers,
+        )
+        assert response.status_code == 404
+
+    def test_delete_malformed_id_does_not_500(self, api_client, manage_tags_headers):
+        # UUID-typed path param → Ninja rejects with 422 before the handler runs
+        response = api_client.delete(
+            "/api/community/event-tags/not-a-uuid/",
+            **manage_tags_headers,
+        )
+        assert response.status_code == 422
 
 
 @pytest.mark.django_db

--- a/frontend/src/api/eventTags.ts
+++ b/frontend/src/api/eventTags.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import type { EventTag } from '@/models/event';
 
@@ -14,14 +14,43 @@ export const eventTagKeys = {
   all: ['event-tags'] as const,
 };
 
+function fromWire(t: WireTag): EventTag {
+  return { id: t.id, name: t.name, slug: t.slug };
+}
+
 export async function fetchEventTags(): Promise<EventTag[]> {
   const { data } = await apiClient.get<WireTag[]>('/api/community/event-tags/');
-  return data.map((t) => ({ id: t.id, name: t.name, slug: t.slug }));
+  return data.map(fromWire);
 }
 
 export function useEventTags() {
   return useQuery({
     queryKey: eventTagKeys.all,
     queryFn: fetchEventTags,
+  });
+}
+
+export function useCreateEventTag() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (name: string): Promise<EventTag> => {
+      const { data } = await apiClient.post<WireTag>('/api/community/event-tags/', { name });
+      return fromWire(data);
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: eventTagKeys.all });
+    },
+  });
+}
+
+export function useDeleteEventTag() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (tagId: string): Promise<void> => {
+      await apiClient.delete(`/api/community/event-tags/${tagId}/`);
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: eventTagKeys.all });
+    },
   });
 }

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -577,8 +577,26 @@ export interface paths {
         /** List Event Tags */
         get: operations["community__event_tags_list_event_tags"];
         put?: never;
-        post?: never;
+        /** Create Event Tag */
+        post: operations["community__event_tags_create_event_tag"];
         delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/community/event-tags/{tag_id}/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete Event Tag */
+        delete: operations["community__event_tags_delete_event_tag"];
         options?: never;
         head?: never;
         patch?: never;
@@ -3633,6 +3651,11 @@ export interface components {
             /** User Name */
             user_name?: string | null;
         };
+        /** TagIn */
+        TagIn: {
+            /** Name */
+            name: string;
+        };
         /** TagOut */
         TagOut: {
             /** Id */
@@ -5485,6 +5508,95 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TagOut"][];
+                };
+            };
+        };
+    };
+    community__event_tags_create_event_tag: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TagIn"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TagOut"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
+    community__event_tags_delete_event_tag: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                tag_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
                 };
             };
         };

--- a/frontend/src/api/validationCodes.gen.ts
+++ b/frontend/src/api/validationCodes.gen.ts
@@ -49,6 +49,11 @@ export const Code = {
     MinTwoOptions: 'poll.min_two_options',
     InvalidAvailability: 'poll.invalid_availability',
   },
+  Tag: {
+    NotFound: 'tag.not_found',
+    NameRequired: 'tag.name_required',
+    NameAlreadyExists: 'tag.name_already_exists',
+  },
   Comment: {
     NotFound: 'comment.not_found',
     ReplyDepthExceeded: 'comment.reply_depth_exceeded',
@@ -240,6 +245,9 @@ export type ValidationCode =
   | 'poll.winning_option_not_found'
   | 'poll.min_two_options'
   | 'poll.invalid_availability'
+  | 'tag.not_found'
+  | 'tag.name_required'
+  | 'tag.name_already_exists'
   | 'comment.not_found'
   | 'comment.reply_depth_exceeded'
   | 'comment.invalid_emoji'
@@ -384,6 +392,9 @@ export const CODE_PARAMS: Record<ValidationCode, readonly string[]> = {
   'poll.winning_option_not_found': [],
   'poll.min_two_options': [],
   'poll.invalid_availability': [],
+  'tag.not_found': [],
+  'tag.name_required': [],
+  'tag.name_already_exists': [],
   'comment.not_found': [],
   'comment.reply_depth_exceeded': [],
   'comment.invalid_emoji': [],

--- a/frontend/src/api/validationCodes.ts
+++ b/frontend/src/api/validationCodes.ts
@@ -143,6 +143,14 @@ function messageForKnownCode(code: KnownCode, err: FieldError): string {
     case Code.Comment.EventMismatch:
       return "that reply target isn't in this event";
 
+    // Tag
+    case Code.Tag.NotFound:
+      return 'tag not found';
+    case Code.Tag.NameRequired:
+      return 'enter a tag name';
+    case Code.Tag.NameAlreadyExists:
+      return 'a tag with that name already exists';
+
     // URL
     case Code.Url.Invalid:
       return 'enter a valid url';

--- a/frontend/src/screens/admin/EventManagementScreen.tsx
+++ b/frontend/src/screens/admin/EventManagementScreen.tsx
@@ -92,7 +92,9 @@ export default function EventManagementScreen() {
         <div className="border-border bg-surface mb-6 flex flex-wrap items-center justify-between gap-3 rounded-lg border p-4">
           <div className="min-w-0">
             <p className="text-foreground text-sm font-medium">event tags</p>
-            <p className="text-muted text-xs">create or remove the tags events can be filtered by</p>
+            <p className="text-muted text-xs">
+              create or remove the tags events can be filtered by
+            </p>
           </div>
           <Button
             variant="secondary"

--- a/frontend/src/screens/admin/EventManagementScreen.tsx
+++ b/frontend/src/screens/admin/EventManagementScreen.tsx
@@ -8,11 +8,14 @@ import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { useEvents } from '@/api/events';
+import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import { SegmentedControl } from '@/components/ui/SegmentedControl';
 import { Select } from '@/components/ui/Select';
 import { TextField } from '@/components/ui/TextField';
 import { type Event, EventType } from '@/models/event';
+import { hasPermission, Permission } from '@/models/permissions';
+import { TagManagerDialog } from '@/screens/events/TagManagerDialog';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 
 type Bucket = 'upcoming' | 'past' | 'drafts' | 'cancelled';
@@ -55,6 +58,9 @@ function sortEvents(events: readonly Event[], sort: Sort): Event[] {
 
 export default function EventManagementScreen() {
   const { data = [], isPending, isError } = useEvents();
+  const user = useAuthStore((s) => s.user);
+  const canManageTags = hasPermission(user, Permission.ManageEvents);
+  const [tagDialogOpen, setTagDialogOpen] = useState(false);
   const [bucket, setBucket] = useState<Bucket>('upcoming');
   const [sort, setSort] = useState<Sort>('date');
   const [search, setSearch] = useState('');
@@ -81,6 +87,32 @@ export default function EventManagementScreen() {
           new event
         </Link>
       </header>
+
+      {canManageTags ? (
+        <div className="border-border bg-surface mb-6 flex flex-wrap items-center justify-between gap-3 rounded-lg border p-4">
+          <div className="min-w-0">
+            <p className="text-foreground text-sm font-medium">event tags</p>
+            <p className="text-muted text-xs">create or remove the tags events can be filtered by</p>
+          </div>
+          <Button
+            variant="secondary"
+            onClick={() => {
+              setTagDialogOpen(true);
+            }}
+          >
+            manage tags
+          </Button>
+        </div>
+      ) : null}
+
+      {canManageTags ? (
+        <TagManagerDialog
+          open={tagDialogOpen}
+          onClose={() => {
+            setTagDialogOpen(false);
+          }}
+        />
+      ) : null}
 
       <div className="mb-4 flex flex-wrap items-end gap-3">
         <div className="min-w-[180px] flex-1">

--- a/frontend/src/screens/events/TagManagerDialog.tsx
+++ b/frontend/src/screens/events/TagManagerDialog.tsx
@@ -1,0 +1,148 @@
+import { type SyntheticEvent, useState } from 'react';
+
+import { useCreateEventTag, useDeleteEventTag, useEventTags } from '@/api/eventTags';
+import { Button } from '@/components/ui/Button';
+import { Dialog } from '@/components/ui/Dialog';
+import { TextField } from '@/components/ui/TextField';
+import { extractApiError } from '@/utils/errors';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function TagManagerDialog({ open, onClose }: Props) {
+  const { data: tags = [], isPending, isError } = useEventTags();
+  const createTag = useCreateEventTag();
+  const deleteTag = useDeleteEventTag();
+
+  const [name, setName] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const trimmed = name.trim();
+
+  async function run(action: Promise<unknown>, fallback: string) {
+    setFormError(null);
+    try {
+      await action;
+    } catch (err) {
+      setFormError(extractApiError(err, fallback));
+    }
+  }
+
+  async function onSubmit(e: SyntheticEvent) {
+    e.preventDefault();
+    if (!trimmed) return;
+    const created = createTag.mutateAsync(trimmed).then(() => {
+      setName('');
+    });
+    await run(created, 'something went wrong — try again');
+  }
+
+  async function onConfirmDelete(id: string) {
+    setConfirmingId(null);
+    setDeletingId(id);
+    await run(deleteTag.mutateAsync(id), "couldn't delete tag — try again");
+    setDeletingId(null);
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} title="manage tags">
+      <div className="flex flex-col gap-4">
+        {isPending ? <p className="text-muted text-sm">loading tags…</p> : null}
+        {isError ? (
+          <p className="text-destructive text-sm">couldn't load tags — try again</p>
+        ) : null}
+        {!isPending && !isError && tags.length === 0 ? (
+          <p className="text-muted text-sm">no tags yet 🌿</p>
+        ) : null}
+        {tags.length > 0 ? (
+          <ul className="flex flex-col gap-2" aria-label="existing tags">
+            {tags.map((t) => (
+              <li
+                key={t.id}
+                className="border-border bg-surface-dim flex flex-col gap-2 rounded-md border px-3 py-2"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-foreground truncate text-sm">{t.name}</span>
+                  {confirmingId === t.id ? null : (
+                    <Button
+                      variant="ghost"
+                      onClick={() => {
+                        setConfirmingId(t.id);
+                      }}
+                      disabled={deletingId === t.id}
+                    >
+                      {deletingId === t.id ? 'deleting…' : 'delete'}
+                    </Button>
+                  )}
+                </div>
+                {confirmingId === t.id ? (
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-muted text-xs">
+                      delete this tag? it will be removed from any events using it
+                    </span>
+                    <div className="flex shrink-0 items-center gap-1">
+                      <Button
+                        variant="ghost"
+                        onClick={() => {
+                          setConfirmingId(null);
+                        }}
+                      >
+                        cancel
+                      </Button>
+                      <Button
+                        variant="primary"
+                        onClick={() => {
+                          void onConfirmDelete(t.id);
+                        }}
+                      >
+                        delete
+                      </Button>
+                    </div>
+                  </div>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+
+        <form
+          onSubmit={(e) => {
+            void onSubmit(e);
+          }}
+          className="flex items-end gap-2"
+        >
+          <div className="flex-1">
+            <TextField
+              label="new tag"
+              value={name}
+              maxLength={50}
+              placeholder="e.g. walk"
+              onChange={(e) => {
+                setName(e.target.value);
+                setFormError(null);
+              }}
+            />
+          </div>
+          <Button type="submit" disabled={createTag.isPending || !trimmed}>
+            {createTag.isPending ? 'adding…' : 'add'}
+          </Button>
+        </form>
+
+        {formError ? (
+          <p role="alert" className="text-destructive text-sm break-words">
+            {formError}
+          </p>
+        ) : null}
+
+        <div className="flex justify-end">
+          <Button type="button" variant="secondary" onClick={onClose}>
+            done
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Overview

Adds gated `POST` and `DELETE /event-tags/` endpoints so admins can curate the event tag set in-app instead of only through Django admin. Both mutations are gated on the **existing `manage_events` permission** — per the direction on Issue 689, this deliberately does **not** introduce a new permission key.

Create de-duplicates case-insensitively, rejects empty / slug-less names (e.g. an emoji that slugifies to `""`), and handles the derived-slug collision race inside a `transaction.atomic()` (distinct names like `walk!` and `walk` collide on the unique slug). Delete takes a `UUID` path param (malformed ids 422 before the handler runs) and 404s on unknown ids. Both are audit-logged; create is rate-limited to `10/m`.

This is **PR 1 of 2** for Issue 689 (backend API). The frontend UI is a stacked follow-up on `auto-689-event-tag-ui`.

Part of Issue 689.

## Changes

- `POST /event-tags/` (201) + `DELETE /event-tags/{tag_id}/` (204), gated on `manage_events` with audit logging on denial
- `TagIn` schema (`name`, 1–50 chars); new `Code.Tag.*` validation codes
- Regenerated `openapi_schema.json` + `validation_codes.json`
- Tests for create (dedup, empty/slug-less, slug-collision, rate limit, permission) and delete (success, 404, malformed-id 422)

## Test plan

- [x] `test_event_tags.py` + `test_role_management.py` pass (46 passed, SQLite)
- [x] backend ruff + ty + complexity + codegen parity green
- [ ] manual: create/delete a tag via the API as a `manage_events` user; confirm 403 without the permission

## Notes

The original issue text called for a *new* tag-management permission and placement next to the "new event" button; both were superseded by follow-up direction on the issue — gate on existing `manage_events`, and surface the UI inside the admin events tab (handled in PR 2).
