### PR TITLE
feat(frontend): 689 - in-app event tag management ui

### DIFF
--- a/frontend/src/api/eventTags.ts
+++ b/frontend/src/api/eventTags.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import type { EventTag } from '@/models/event';
 
@@ -14,14 +14,43 @@ export const eventTagKeys = {
   all: ['event-tags'] as const,
 };
 
+function fromWire(t: WireTag): EventTag {
+  return { id: t.id, name: t.name, slug: t.slug };
+}
+
 export async function fetchEventTags(): Promise<EventTag[]> {
   const { data } = await apiClient.get<WireTag[]>('/api/community/event-tags/');
-  return data.map((t) => ({ id: t.id, name: t.name, slug: t.slug }));
+  return data.map(fromWire);
 }
 
 export function useEventTags() {
   return useQuery({
     queryKey: eventTagKeys.all,
     queryFn: fetchEventTags,
+  });
+}
+
+export function useCreateEventTag() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (name: string): Promise<EventTag> => {
+      const { data } = await apiClient.post<WireTag>('/api/community/event-tags/', { name });
+      return fromWire(data);
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: eventTagKeys.all });
+    },
+  });
+}
+
+export function useDeleteEventTag() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (tagId: string): Promise<void> => {
+      await apiClient.delete(`/api/community/event-tags/${tagId}/`);
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: eventTagKeys.all });
+    },
   });
 }

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -577,8 +577,26 @@ export interface paths {
         /** List Event Tags */
         get: operations["community__event_tags_list_event_tags"];
         put?: never;
-        post?: never;
+        /** Create Event Tag */
+        post: operations["community__event_tags_create_event_tag"];
         delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/community/event-tags/{tag_id}/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /** Delete Event Tag */
+        delete: operations["community__event_tags_delete_event_tag"];
         options?: never;
         head?: never;
         patch?: never;
@@ -3633,6 +3651,11 @@ export interface components {
             /** User Name */
             user_name?: string | null;
         };
+        /** TagIn */
+        TagIn: {
+            /** Name */
+            name: string;
+        };
         /** TagOut */
         TagOut: {
             /** Id */
@@ -5485,6 +5508,95 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["TagOut"][];
+                };
+            };
+        };
+    };
+    community__event_tags_create_event_tag: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["TagIn"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TagOut"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
+    community__event_tags_delete_event_tag: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                tag_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
                 };
             };
         };

--- a/frontend/src/api/validationCodes.gen.ts
+++ b/frontend/src/api/validationCodes.gen.ts
@@ -49,6 +49,11 @@ export const Code = {
     MinTwoOptions: 'poll.min_two_options',
     InvalidAvailability: 'poll.invalid_availability',
   },
+  Tag: {
+    NotFound: 'tag.not_found',
+    NameRequired: 'tag.name_required',
+    NameAlreadyExists: 'tag.name_already_exists',
+  },
   Comment: {
     NotFound: 'comment.not_found',
     ReplyDepthExceeded: 'comment.reply_depth_exceeded',
@@ -240,6 +245,9 @@ export type ValidationCode =
   | 'poll.winning_option_not_found'
   | 'poll.min_two_options'
   | 'poll.invalid_availability'
+  | 'tag.not_found'
+  | 'tag.name_required'
+  | 'tag.name_already_exists'
   | 'comment.not_found'
   | 'comment.reply_depth_exceeded'
   | 'comment.invalid_emoji'
@@ -384,6 +392,9 @@ export const CODE_PARAMS: Record<ValidationCode, readonly string[]> = {
   'poll.winning_option_not_found': [],
   'poll.min_two_options': [],
   'poll.invalid_availability': [],
+  'tag.not_found': [],
+  'tag.name_required': [],
+  'tag.name_already_exists': [],
   'comment.not_found': [],
   'comment.reply_depth_exceeded': [],
   'comment.invalid_emoji': [],

--- a/frontend/src/api/validationCodes.ts
+++ b/frontend/src/api/validationCodes.ts
@@ -143,6 +143,14 @@ function messageForKnownCode(code: KnownCode, err: FieldError): string {
     case Code.Comment.EventMismatch:
       return "that reply target isn't in this event";
 
+    // Tag
+    case Code.Tag.NotFound:
+      return 'tag not found';
+    case Code.Tag.NameRequired:
+      return 'enter a tag name';
+    case Code.Tag.NameAlreadyExists:
+      return 'a tag with that name already exists';
+
     // URL
     case Code.Url.Invalid:
       return 'enter a valid url';

--- a/frontend/src/screens/admin/EventManagementScreen.tsx
+++ b/frontend/src/screens/admin/EventManagementScreen.tsx
@@ -8,11 +8,14 @@ import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { useEvents } from '@/api/events';
+import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import { SegmentedControl } from '@/components/ui/SegmentedControl';
 import { Select } from '@/components/ui/Select';
 import { TextField } from '@/components/ui/TextField';
 import { type Event, EventType } from '@/models/event';
+import { hasPermission, Permission } from '@/models/permissions';
+import { TagManagerDialog } from '@/screens/events/TagManagerDialog';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 
 type Bucket = 'upcoming' | 'past' | 'drafts' | 'cancelled';
@@ -55,6 +58,9 @@ function sortEvents(events: readonly Event[], sort: Sort): Event[] {
 
 export default function EventManagementScreen() {
   const { data = [], isPending, isError } = useEvents();
+  const user = useAuthStore((s) => s.user);
+  const canManageTags = hasPermission(user, Permission.ManageEvents);
+  const [tagDialogOpen, setTagDialogOpen] = useState(false);
   const [bucket, setBucket] = useState<Bucket>('upcoming');
   const [sort, setSort] = useState<Sort>('date');
   const [search, setSearch] = useState('');
@@ -81,6 +87,32 @@ export default function EventManagementScreen() {
           new event
         </Link>
       </header>
+
+      {canManageTags ? (
+        <div className="border-border bg-surface mb-6 flex flex-wrap items-center justify-between gap-3 rounded-lg border p-4">
+          <div className="min-w-0">
+            <p className="text-foreground text-sm font-medium">event tags</p>
+            <p className="text-muted text-xs">create or remove the tags events can be filtered by</p>
+          </div>
+          <Button
+            variant="secondary"
+            onClick={() => {
+              setTagDialogOpen(true);
+            }}
+          >
+            manage tags
+          </Button>
+        </div>
+      ) : null}
+
+      {canManageTags ? (
+        <TagManagerDialog
+          open={tagDialogOpen}
+          onClose={() => {
+            setTagDialogOpen(false);
+          }}
+        />
+      ) : null}
 
       <div className="mb-4 flex flex-wrap items-end gap-3">
         <div className="min-w-[180px] flex-1">

--- a/frontend/src/screens/events/TagManagerDialog.tsx
+++ b/frontend/src/screens/events/TagManagerDialog.tsx
@@ -1,0 +1,148 @@
+import { type SyntheticEvent, useState } from 'react';
+
+import { useCreateEventTag, useDeleteEventTag, useEventTags } from '@/api/eventTags';
+import { Button } from '@/components/ui/Button';
+import { Dialog } from '@/components/ui/Dialog';
+import { TextField } from '@/components/ui/TextField';
+import { extractApiError } from '@/utils/errors';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function TagManagerDialog({ open, onClose }: Props) {
+  const { data: tags = [], isPending, isError } = useEventTags();
+  const createTag = useCreateEventTag();
+  const deleteTag = useDeleteEventTag();
+
+  const [name, setName] = useState('');
+  const [formError, setFormError] = useState<string | null>(null);
+  const [confirmingId, setConfirmingId] = useState<string | null>(null);
+  const [deletingId, setDeletingId] = useState<string | null>(null);
+  const trimmed = name.trim();
+
+  async function run(action: Promise<unknown>, fallback: string) {
+    setFormError(null);
+    try {
+      await action;
+    } catch (err) {
+      setFormError(extractApiError(err, fallback));
+    }
+  }
+
+  async function onSubmit(e: SyntheticEvent) {
+    e.preventDefault();
+    if (!trimmed) return;
+    const created = createTag.mutateAsync(trimmed).then(() => {
+      setName('');
+    });
+    await run(created, 'something went wrong — try again');
+  }
+
+  async function onConfirmDelete(id: string) {
+    setConfirmingId(null);
+    setDeletingId(id);
+    await run(deleteTag.mutateAsync(id), "couldn't delete tag — try again");
+    setDeletingId(null);
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} title="manage tags">
+      <div className="flex flex-col gap-4">
+        {isPending ? <p className="text-muted text-sm">loading tags…</p> : null}
+        {isError ? (
+          <p className="text-destructive text-sm">couldn't load tags — try again</p>
+        ) : null}
+        {!isPending && !isError && tags.length === 0 ? (
+          <p className="text-muted text-sm">no tags yet 🌿</p>
+        ) : null}
+        {tags.length > 0 ? (
+          <ul className="flex flex-col gap-2" aria-label="existing tags">
+            {tags.map((t) => (
+              <li
+                key={t.id}
+                className="border-border bg-surface-dim flex flex-col gap-2 rounded-md border px-3 py-2"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-foreground truncate text-sm">{t.name}</span>
+                  {confirmingId === t.id ? null : (
+                    <Button
+                      variant="ghost"
+                      onClick={() => {
+                        setConfirmingId(t.id);
+                      }}
+                      disabled={deletingId === t.id}
+                    >
+                      {deletingId === t.id ? 'deleting…' : 'delete'}
+                    </Button>
+                  )}
+                </div>
+                {confirmingId === t.id ? (
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-muted text-xs">
+                      delete this tag? it will be removed from any events using it
+                    </span>
+                    <div className="flex shrink-0 items-center gap-1">
+                      <Button
+                        variant="ghost"
+                        onClick={() => {
+                          setConfirmingId(null);
+                        }}
+                      >
+                        cancel
+                      </Button>
+                      <Button
+                        variant="primary"
+                        onClick={() => {
+                          void onConfirmDelete(t.id);
+                        }}
+                      >
+                        delete
+                      </Button>
+                    </div>
+                  </div>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        ) : null}
+
+        <form
+          onSubmit={(e) => {
+            void onSubmit(e);
+          }}
+          className="flex items-end gap-2"
+        >
+          <div className="flex-1">
+            <TextField
+              label="new tag"
+              value={name}
+              maxLength={50}
+              placeholder="e.g. walk"
+              onChange={(e) => {
+                setName(e.target.value);
+                setFormError(null);
+              }}
+            />
+          </div>
+          <Button type="submit" disabled={createTag.isPending || !trimmed}>
+            {createTag.isPending ? 'adding…' : 'add'}
+          </Button>
+        </form>
+
+        {formError ? (
+          <p role="alert" className="text-destructive text-sm break-words">
+            {formError}
+          </p>
+        ) : null}
+
+        <div className="flex justify-end">
+          <Button type="button" variant="secondary" onClick={onClose}>
+            done
+          </Button>
+        </div>
+      </div>
+    </Dialog>
+  );
+}


### PR DESCRIPTION
## Overview

Adds the in-app UI for managing event tags. Inside the admin **events** management screen (`/events/manage`), users with `manage_events` see an "event tags" panel with a **manage tags** button that opens a `TagManagerDialog` for creating and deleting tags. Newly created tags immediately appear in the event-form tag picker (the `useEventTags()` query is invalidated), replacing the "no tags yet 🌿" empty state.

Delete uses an **inline per-row confirmation** (not a nested modal) that warns the tag will be removed from any events using it — chosen over a `useConfirm` dialog to avoid a nested-Dialog Escape-key conflict.

This is **PR 2 of 2** for Issue 689 (frontend UI), **stacked on** `auto-689-event-tag-api` (#772). Merge the backend PR first.

Closes #689.

## Changes

- `useCreateEventTag` / `useDeleteEventTag` hooks (invalidate `useEventTags`)
- `TagManagerDialog` — list + create form + inline-confirm delete, all gated behind `manage_events`
- "event tags" panel in `EventManagementScreen`, shown only with `manage_events`
- Regenerated `types.gen.ts` + `validationCodes.*` for the new endpoints

## Test plan

- [x] frontend typecheck + eslint + types-parity green
- [x] vitest suite passes (746 passed)
- [ ] manual: as a `manage_events` user, create a tag → it appears in the event form picker; delete a tag → inline confirm → gone. Confirm the panel is hidden without the permission.

## Notes

Per follow-up direction on Issue 689, the tag UI lives in the **admin events tab** (not a standalone button next to "new event"), and gating uses the existing `manage_events` permission rather than a new key.
