### PR TITLE
fix(nginx): quote event-preview regex + fail loud on nginx death (Issue 652)

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,13 @@ envsubst '${NGINX_PORT}' < /app/nginx.conf.template > /etc/nginx/sites-available
 rm -f /etc/nginx/sites-enabled/default
 ln -s /etc/nginx/sites-available/default /etc/nginx/sites-enabled/default
 
-nginx -g 'daemon off;' &
+# Fail the deploy loudly on a bad config instead of a silent backgrounded death
+# that leaves uvicorn up but the front door dead (→ 502 on every route).
+nginx -t
+
+# If nginx exits for any reason, take the whole container down so Railway
+# restarts it and the failure is visible — don't limp on with only uvicorn.
+nginx -g 'daemon off;' || kill "$$" &
 
 cd backend
 uv run python manage.py migrate

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -1,3 +1,8 @@
+map $http_user_agent $event_unfurl_bot {
+    default 0;
+    "~*(facebookexternalhit|twitterbot|slackbot|whatsapp|telegrambot|discordbot|linkedinbot|pinterest|redditbot|embedly|iframely|skypeuripreview|vkshare|bluesky|mastodon)" 1;
+}
+
 server {
     listen ${NGINX_PORT};
     server_name _;
@@ -53,18 +58,27 @@ server {
     # Facebook, Twitter, etc.) don't run JS, so the SPA can't hand them OG tags.
     # Route just those bots to Django's server-rendered preview; humans keep the
     # SPA. Matched on the event UUID path only (Issue 652).
-    location ~ ^/events/(?<event_uuid>[0-9a-fA-F-]{36})$ {
-        # Social link-unfurl bots only — NOT search-engine crawlers (googlebot,
-        # bingbot, applebot). The preview is noindex, so routing search crawlers
-        # here would deindex real public event pages (Issue 652).
-        if ($http_user_agent ~* "(facebookexternalhit|twitterbot|slackbot|whatsapp|telegrambot|discordbot|linkedinbot|pinterest|redditbot|embedly|iframely|skypeuripreview|vkshare|bluesky|mastodon)") {
-            proxy_pass http://127.0.0.1:8000/events/$event_uuid/preview/;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto https;
+    # Social link-unfurl bots (matched by $event_unfurl_bot) get Django's
+    # server-rendered preview; humans get the SPA. NOT search-engine crawlers
+    # (googlebot, bingbot, applebot) — the preview is noindex, so routing them
+    # here would deindex real public event pages (Issue 652). The regex must be
+    # quoted: an unquoted {36} makes nginx mis-tokenize the block and refuse to
+    # start. proxy_pass lives in a named location because it is not allowed
+    # inside an if inside a regex location.
+    location "~^/events/(?<event_uuid>[0-9a-fA-F-]{36})$" {
+        if ($event_unfurl_bot) {
+            return 418;
         }
+        error_page 418 = @event_preview;
         try_files $uri /index.html;
+    }
+
+    location @event_preview {
+        proxy_pass http://127.0.0.1:8000/events/$event_uuid/preview/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
     }
 
     location / {


### PR DESCRIPTION
## what

Fixes a **staging outage** (502 on every route) introduced by #763 (OG link previews, Issue 652). The new nginx `location` block for event-preview unfurling had two config errors that made **nginx fail its config test and refuse to start**. Since nginx is the front door — it serves the SPA and proxies `/api`, `/media`, `/static` — a dead nginx = full 502, even though uvicorn was up and the container looked healthy.

## the two nginx bugs

1. **Unquoted regex.** `location ~ ^/events/(?<event_uuid>[0-9a-fA-F-]{36})$` — nginx treats `{`/`}` as block delimiters, so an unquoted `{36}` mis-tokenizes the location and PCRE2 throws a misleading `missing closing parenthesis`. → quote the regex.
2. **`proxy_pass`/`proxy_set_header` inside `if` inside a regex location** is not allowed by nginx. → move bot detection to a `map`, move the proxy to a named `@event_preview` location reached via `error_page 418`.

## why it silently 502'd instead of failing the deploy

`entrypoint.sh` runs `nginx -g 'daemon off;' &` (backgrounded), so `set -e` never caught nginx dying. The script marched on to uvicorn; the deploy logged "Uvicorn running" and looked fine while the front door was dead — which is exactly what the deploy logs showed (uvicorn up, zero nginx output).

**Hardening:** run `nginx -t` before starting (bad config now fails the deploy with a clear error), and kill the container if nginx ever exits so Railway's `ON_FAILURE` restart kicks in instead of limping on with only uvicorn.

## verification

Reproduced and fixed in the **exact production pipeline** (`python:3.13-slim` + `apt nginx` + `envsubst`):

- `nginx -t` on the old rendered config → `[emerg] pcre2_compile() failed` (reproduces the outage)
- `nginx -t` on the new rendered config → **successful**
- Behavioral test with a stub Django upstream:
  - browser UA → `/events/{uuid}` → **SPA** ✅
  - `Slackbot` / `facebookexternalhit` → `/events/{uuid}` → **`/events/{uuid}/preview/`** ✅
  - `/api/*` → proxied ✅
  - SPA routes → `index.html` ✅

## deploy note

Merging this to `main` auto-deploys to Railway staging and should restore the site. Behavior for #763 (bots get server-rendered OG previews, humans get the SPA) is preserved.
