### PR TITLE
test(frontend): fix vitest timeouts at the source (Issue 780)

### DIFF
--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -56,6 +56,10 @@ function renderWith(initialEntries: string[] = ['/login']) {
 // PhoneInput accepts national-format input when the country dropdown is US.
 const US_PHONE_NATIONAL = '2125551234';
 
+function fillPhone(value = US_PHONE_NATIONAL) {
+  fireEvent.change(screen.getByLabelText(/phone number/i), { target: { value } });
+}
+
 describe('LoginScreen', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -73,7 +77,7 @@ describe('LoginScreen', () => {
     const user = userEvent.setup();
     renderWith();
 
-    await user.type(screen.getByLabelText(/phone number/i), US_PHONE_NATIONAL);
+    fillPhone();
     await user.click(screen.getByRole('button', { name: /continue/i }));
 
     await waitFor(() => {
@@ -87,7 +91,7 @@ describe('LoginScreen', () => {
     const user = userEvent.setup();
     renderWith();
 
-    await user.type(screen.getByLabelText(/phone number/i), US_PHONE_NATIONAL);
+    fillPhone();
     await user.click(screen.getByRole('button', { name: /continue/i }));
 
     await waitFor(() => {
@@ -100,7 +104,7 @@ describe('LoginScreen', () => {
     const user = userEvent.setup();
     renderWith();
 
-    await user.type(screen.getByLabelText(/phone number/i), US_PHONE_NATIONAL);
+    fillPhone();
     await user.click(screen.getByRole('button', { name: /continue/i }));
 
     await waitFor(() => {
@@ -122,7 +126,7 @@ describe('LoginScreen', () => {
     const user = userEvent.setup();
     renderWith();
 
-    await user.type(screen.getByLabelText(/phone number/i), US_PHONE_NATIONAL);
+    fillPhone();
     await user.click(screen.getByRole('button', { name: /continue/i }));
 
     await waitFor(() => {

--- a/frontend/src/components/ui/PhoneField.tsx
+++ b/frontend/src/components/ui/PhoneField.tsx
@@ -7,6 +7,8 @@ import flags from 'react-phone-number-input/flags';
 
 import { cn } from '@/utils/cn';
 
+import { getPhoneCountries } from './phoneCountries';
+
 interface Props {
   label: string;
   value: string;
@@ -34,6 +36,7 @@ export function PhoneField({
 }: Props) {
   const inputId = id ?? `field-${label.replace(/\s+/g, '-').toLowerCase()}`;
   const describedBy = error ? `${inputId}-error` : hint ? `${inputId}-hint` : undefined;
+  const testCountries = getPhoneCountries();
   return (
     <div className="flex flex-col gap-1">
       <label htmlFor={inputId} className="text-foreground text-sm font-medium">
@@ -45,6 +48,7 @@ export function PhoneField({
         flags={flags}
         defaultCountry={defaultCountry}
         countryCallingCodeEditable={false}
+        {...(testCountries !== undefined ? { countries: testCountries } : {})}
         {...(name !== undefined ? { name } : {})}
         {...(autoComplete !== undefined ? { autoComplete } : {})}
         value={value as Value}

--- a/frontend/src/components/ui/phoneCountries.ts
+++ b/frontend/src/components/ui/phoneCountries.ts
@@ -1,0 +1,15 @@
+import type { Country } from 'react-phone-number-input';
+
+let restrictedCountries: Country[] | undefined;
+
+export function getPhoneCountries(): Country[] | undefined {
+  return restrictedCountries;
+}
+
+// Tests render PhoneField in ~6 suites; the full 245-option country <select>
+// makes every render/keystroke/axe pass 10-88x slower and trips CI timeouts
+// under parallel load. Narrowing the list in the test setup keeps production
+// showing all countries while making the suite fast.
+export function setPhoneCountriesForTesting(countries: Country[]): void {
+  restrictedCountries = countries;
+}

--- a/frontend/src/screens/admin/MemberCreateDialog.test.tsx
+++ b/frontend/src/screens/admin/MemberCreateDialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -36,7 +36,7 @@ describe('MemberCreateDialog', () => {
 
   it('does not submit when first name is blank', async () => {
     render(<MemberCreateDialog open onClose={() => {}} />);
-    await userEvent.type(screen.getByLabelText(/phone number/i), '+12025550101');
+    fireEvent.change(screen.getByLabelText(/phone number/i), { target: { value: '+12025550101' } });
     await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
     expect(mutateAsync).not.toHaveBeenCalled();
   });
@@ -44,7 +44,7 @@ describe('MemberCreateDialog', () => {
   it('submits with first name and no last name / email when left blank', async () => {
     render(<MemberCreateDialog open onClose={() => {}} />);
     await userEvent.type(screen.getByLabelText(/first name/i), 'Ada');
-    await userEvent.type(screen.getByLabelText(/phone number/i), '+12025550101');
+    fireEvent.change(screen.getByLabelText(/phone number/i), { target: { value: '+12025550101' } });
     await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
     expect(mutateAsync).toHaveBeenCalledWith({
       phoneNumber: '+12025550101',
@@ -56,7 +56,7 @@ describe('MemberCreateDialog', () => {
     render(<MemberCreateDialog open onClose={() => {}} />);
     await userEvent.type(screen.getByLabelText(/first name/i), 'Ada');
     await userEvent.type(screen.getByLabelText(/last name/i), 'Lovelace');
-    await userEvent.type(screen.getByLabelText(/phone number/i), '+12025550101');
+    fireEvent.change(screen.getByLabelText(/phone number/i), { target: { value: '+12025550101' } });
     await userEvent.type(screen.getByLabelText(/email/i), 'new@example.com');
     await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
     expect(mutateAsync).toHaveBeenCalledWith({

--- a/frontend/src/screens/auth/RequestLoginLinkDialog.test.tsx
+++ b/frontend/src/screens/auth/RequestLoginLinkDialog.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -25,7 +25,7 @@ describe('RequestLoginLinkDialog', () => {
   it('shows email delivery copy when backend reports email delivery', async () => {
     mutateAsync.mockResolvedValue({ detail: 'ok', delivery: 'email' });
     render(<RequestLoginLinkDialog open onClose={() => {}} />);
-    await userEvent.type(screen.getByLabelText(/phone number/i), '+12025550101');
+    fireEvent.change(screen.getByLabelText(/phone number/i), { target: { value: '+12025550101' } });
     await userEvent.click(screen.getByRole('button', { name: /request link/i }));
     expect(
       await screen.findByText(/we sent a login link to the email on file/i),
@@ -35,7 +35,7 @@ describe('RequestLoginLinkDialog', () => {
   it('shows admin-follow-up copy when backend reports admin delivery', async () => {
     mutateAsync.mockResolvedValue({ detail: 'ok', delivery: 'admin' });
     render(<RequestLoginLinkDialog open onClose={() => {}} />);
-    await userEvent.type(screen.getByLabelText(/phone number/i), '+12025550101');
+    fireEvent.change(screen.getByLabelText(/phone number/i), { target: { value: '+12025550101' } });
     await userEvent.click(screen.getByRole('button', { name: /request link/i }));
     expect(
       await screen.findByText(/an admin will follow up with your login link/i),
@@ -45,7 +45,7 @@ describe('RequestLoginLinkDialog', () => {
   it('shows cooldown copy when backend reports cooldown delivery', async () => {
     mutateAsync.mockResolvedValue({ detail: 'ok', delivery: 'cooldown' });
     render(<RequestLoginLinkDialog open onClose={() => {}} />);
-    await userEvent.type(screen.getByLabelText(/phone number/i), '+12025550101');
+    fireEvent.change(screen.getByLabelText(/phone number/i), { target: { value: '+12025550101' } });
     await userEvent.click(screen.getByRole('button', { name: /request link/i }));
     expect(await screen.findByText(/you recently requested a login link/i)).toBeInTheDocument();
   });

--- a/frontend/src/screens/public/JoinScreen.test.tsx
+++ b/frontend/src/screens/public/JoinScreen.test.tsx
@@ -36,8 +36,8 @@ const defaultSubmitResult = {
   mutateAsync: vi.fn(),
 } as unknown as ReturnType<typeof useSubmitJoinRequest>;
 
-// One-shot fill via fireEvent.change: typing key-by-key costs ~350ms per test
-// (245-option country select re-renders each keystroke) and starves the suite under load.
+// One-shot fill via fireEvent.change: key-by-key typing re-renders the country
+// <select> on every keystroke, so a single change event is much cheaper.
 function fillPhone(value = '(555) 123-4567') {
   fireEvent.change(screen.getByLabelText(/phone number/i), { target: { value } });
 }

--- a/frontend/src/screens/public/JoinScreen.test.tsx
+++ b/frontend/src/screens/public/JoinScreen.test.tsx
@@ -36,7 +36,8 @@ const defaultSubmitResult = {
   mutateAsync: vi.fn(),
 } as unknown as ReturnType<typeof useSubmitJoinRequest>;
 
-// One-shot fill: typing costs ~350ms per test (245-option country select re-renders each keystroke), tripping the 5s timeout under load.
+// One-shot fill via fireEvent.change: typing key-by-key costs ~350ms per test
+// (245-option country select re-renders each keystroke) and starves the suite under load.
 function fillPhone(value = '(555) 123-4567') {
   fireEvent.change(screen.getByLabelText(/phone number/i), { target: { value } });
 }

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -5,7 +5,11 @@ import { cleanup } from '@testing-library/react';
 import { afterEach, expect } from 'vitest';
 import * as axeMatchers from 'vitest-axe/matchers';
 
+import { setPhoneCountriesForTesting } from '@/components/ui/phoneCountries';
+
 expect.extend(axeMatchers);
+
+setPhoneCountriesForTesting(['US', 'CA', 'GB', 'AU']);
 
 afterEach(() => {
   cleanup();

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -14,9 +14,5 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
     css: true,
-    // Heavy renders (245-option country <select>, axe passes) are slow but
-    // correct; under parallel CI load they trip vitest's 5s default and flake.
-    testTimeout: 15000,
-    hookTimeout: 15000,
   },
 });

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -14,5 +14,9 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./src/test/setup.ts'],
     css: true,
+    // Heavy renders (245-option country <select>, axe passes) are slow but
+    // correct; under parallel CI load they trip vitest's 5s default and flake.
+    testTimeout: 15000,
+    hookTimeout: 15000,
   },
 });


### PR DESCRIPTION
## Summary

Closes #780

The `Frontend` CI job intermittently failed with test **timeouts** (not assertion failures) across a rotating set of phone-input suites (JoinScreen, LoginScreen a11y, RequestLoginLinkDialog, PublicRsvp a11y, App). Rather than raise the timeout ceiling, this fixes the underlying cost.

**Root cause (measured):** the 245-option country `<select>` from `react-phone-number-input`.
- An `axe` pass over a rendered `PhoneField` takes **~888ms vs ~10ms** baseline (~88x) — entirely the 245 `<option>` nodes.
- `user.type` re-renders all 245 options on **every keystroke** (~172ms for a 12-char number).

Under parallel CI load these stack up and trip vitest's 5s default `testTimeout`.

**Fix the cost, not the ceiling:**
- **Narrow the country list in the test environment only.** A tiny `phoneCountries` module holds a configurable list that `src/test/setup.ts` sets to `['US','CA','GB','AU']`. `PhoneField` spreads the `countries` prop **conditionally**, so production is byte-identical (all countries) — only tests slim it. axe drops **~888ms → ~83ms**; the two a11y suites go from **~2.64s → ~0.44s** of test time (~6x).
- **Replace remaining key-by-key `user.type(phone)` with a single `fireEvent.change`** in `App`, `RequestLoginLinkDialog`, and `MemberCreateDialog` tests (1 render vs 12). Verified equivalent — both produce the same valid E.164 value (`+12125551234`, `isValidPhoneNumber` true).
- **Revert the global `testTimeout`/`hookTimeout` bump.** All 751 tests pass under the default 5s with no crutch, so genuinely hung tests still surface fast.

## Test plan

- [x] `tsc -b` (CI build config, `exactOptionalPropertyTypes: true`) — clean
- [x] eslint + prettier — clean
- [x] Full frontend suite: **751 passed / 1 skipped** under the default 5s timeout (no per-suite crutch)
- [x] Measured before/after on the two a11y suites: 2.64s → 0.44s test time
- [ ] Watch CI on this PR across a few pushes to confirm no timeout regressions
