### PR TITLE
test(backend): 782 - add fast MD5 password hasher for tests

### DIFF
--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from community.models import JoinFormQuestion, JoinRequest
+from django.conf import settings as django_settings
 from django.core.cache import cache
 from django.test import Client
 from django.utils import timezone
@@ -28,6 +29,11 @@ def past_iso(days: int = 1) -> str:
     """ISO 8601 string N days in the past. Use for testing stale-draft scenarios,
     retroactive data, etc. — never for normal create/edit flows (those are rejected)."""
     return (timezone.now() - timedelta(days=days)).isoformat()
+
+
+def pytest_configure() -> None:
+    # Fast MD5 hasher for tests only — default PBKDF2 is ~600k iterations per create_user.
+    django_settings.PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Overview

Adds a fast test-only password hasher so the backend test suite stops paying a full PBKDF2-SHA256 hash (~600k iterations) on every `create_user(...)`. A `pytest_configure()` hook in `backend/tests/conftest.py` overrides `PASSWORD_HASHERS` to `MD5PasswordHasher` for the test run only — Django reads hashers lazily, so this takes effect for all tests (and every xdist worker runs it independently). No production path changes; `DJANGO_SETTINGS_MODULE` and `config.settings` are untouched.

Placement follows the issue's recommendation (conftest `pytest_configure`, not a separate `settings_test.py`): smallest diff, strictly test-scoped, zero prod impact.

Closes #782

## Measured win

- `test_auth_update_me.py` (11 tests): ~12.7s → ~1.7s (~87%)
- `test_seed_staging.py` slow tests: 16.58s → all now under 0.6s

## Test plan

- [x] Full suite green on Postgres (the CI database): **1343 passed, 0 failed**
- [x] `make agent-lint` and `make agent-typecheck` clean
- [x] `check_password` / `has_usable_password` still work under MD5 (auth path is `RefreshToken.for_user`; no test verifies real hash strength)
- [x] Before/after wall-clock captured via `pytest --durations`
