### PR TITLE
feat(feedback): auto-label in-app feedback issues (Issue 608)

### DIFF
--- a/backend/community/_feedback.py
+++ b/backend/community/_feedback.py
@@ -160,7 +160,7 @@ _FEEDBACK_TYPE_LABELS: dict[FeedbackType, str] = {
 
 
 def _issue_labels(feedback_types: list[FeedbackType]) -> list[str]:
-    labels = ["feedback"]
+    labels = ["auto", "feedback"]
     for t in feedback_types:
         label = _FEEDBACK_TYPE_LABELS.get(t)
         if label:

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -256,10 +256,14 @@ class TestFeedbackLabels:
         return json.loads(captured["calls"][-1].data.decode())["labels"]
 
     def test_no_types_only_feedback_label(self, api_client, settings, monkeypatch):
-        assert self._labels_for(api_client, settings, monkeypatch, []) == ["feedback"]
+        assert self._labels_for(api_client, settings, monkeypatch, []) == [
+            "auto",
+            "feedback",
+        ]
 
     def test_bug_adds_bug_label(self, api_client, settings, monkeypatch):
         assert self._labels_for(api_client, settings, monkeypatch, ["bug"]) == [
+            "auto",
             "feedback",
             "bug",
         ]
@@ -267,12 +271,12 @@ class TestFeedbackLabels:
     def test_feature_request_adds_feature_label(self, api_client, settings, monkeypatch):
         # Issue: feature requests must be tagged "feature", not "enhancement".
         labels = self._labels_for(api_client, settings, monkeypatch, ["feature request"])
-        assert labels == ["feedback", "feature"]
+        assert labels == ["auto", "feedback", "feature"]
         assert "enhancement" not in labels
 
     def test_both_types_add_both_labels(self, api_client, settings, monkeypatch):
         labels = self._labels_for(api_client, settings, monkeypatch, ["bug", "feature request"])
-        assert labels == ["feedback", "bug", "feature"]
+        assert labels == ["auto", "feedback", "bug", "feature"]
 
     def test_unknown_type_is_rejected(self, api_client, settings, monkeypatch):
         for k, v in _APP_SETTINGS.items():


### PR DESCRIPTION
## Summary
Add `"auto"` as the leading label in `_issue_labels()` (`backend/community/_feedback.py`) so every in-app feedback submission is created with the `auto` tag and picked up by the autonomous issue queue. Previously feedback issues carried only `["feedback"]` (plus `bug`/`feature`) and sat untriaged.

Updated `TestFeedbackLabels` assertions to expect `"auto"` as the leading label.

Closes #608

## Test plan
- [ ] `TestFeedbackLabels` assertions pass with `auto` as first label
- [ ] make agent-ci