### PR TITLE
fix(profile): honor own hidden fields in view-my-profile preview (Issue 791)

### DIFF
--- a/backend/tests/users/test_hide_last_name.py
+++ b/backend/tests/users/test_hide_last_name.py
@@ -80,16 +80,36 @@ class TestProfileHidesLastName:
         assert body["last_name"] == "Lastname"
         assert body["full_name"] == "Hidden Lastname"
 
-    def test_self_sees_own_full_name(self, api_client, hidden_user):
-        from ninja_jwt.tokens import RefreshToken
-
+    def test_self_preview_hides_own_last_name(self, api_client, hidden_user):
+        """view-my-profile is the peer-facing preview, so the owner's own
+        hide_last_name applies to their own view (Issue 791)."""
         refresh = RefreshToken.for_user(hidden_user)
         headers = {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
         response = api_client.get(f"/api/auth/users/{hidden_user.pk}/profile/", **headers)
         assert response.status_code == 200
         body = response.json()
-        assert body["last_name"] == "Lastname"
-        assert body["full_name"] == "Hidden Lastname"
+        assert body["last_name"] == ""
+        assert body["full_name"] == "Hidden"
+
+    def test_self_preview_hides_own_contact_info(self, api_client, db):
+        """view-my-profile suppresses the owner's own hidden phone/email so the
+        preview matches what peers see (Issue 791)."""
+        user = User.objects.create_user(
+            phone_number="+12025550599",
+            password="hiddenpass123",
+            first_name="Quiet",
+            last_name="Member",
+            email="quiet@example.com",
+            show_phone=False,
+            show_email=False,
+        )
+        refresh = RefreshToken.for_user(user)
+        headers = {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
+        response = api_client.get(f"/api/auth/users/{user.pk}/profile/", **headers)
+        assert response.status_code == 200
+        body = response.json()
+        assert body["phone_number"] == ""
+        assert body["email"] == ""
 
 
 @pytest.mark.django_db

--- a/backend/users/_members.py
+++ b/backend/users/_members.py
@@ -58,7 +58,11 @@ def get_member_profile(request, user_id: str):
         raise_validation(Code.Member.NOT_FOUND, status_code=404)
     is_own_profile = str(request.auth.pk) == user_id
     can_manage_users = request.auth.has_permission(PermissionKey.MANAGE_USERS)
-    last_name, full_name = visible_name(user, request.auth)
+    # This is the "view my profile as others see it" preview, so the owner's own
+    # visibility settings must apply to their own view — treat self as a
+    # non-privileged peer (viewer=None) instead of unmasking hidden fields.
+    viewer = None if is_own_profile else request.auth
+    last_name, full_name = visible_name(user, viewer)
     return Status(
         200,
         MemberProfileOut(
@@ -67,8 +71,8 @@ def get_member_profile(request, user_id: str):
             last_name=last_name,
             full_name=full_name,
             nickname=user.nickname or "",
-            phone_number=user.phone_number if (user.show_phone or is_own_profile) else "",
-            email=(user.email or "") if (user.show_email or is_own_profile) else "",
+            phone_number=user.phone_number if user.show_phone else "",
+            email=(user.email or "") if user.show_email else "",
             bio=user.bio or "",
             pronouns=user.pronouns or "",
             birthday=serialize_birthday(user.birthday),


### PR DESCRIPTION
## overview

fixes the privacy bug in the "view my profile" preview (Issue 791). the preview is meant to show a member their profile *as other members see it*, but it was rendering fields the member had chosen to hide (e.g. hiding last name, then viewing own profile, still showed the last name).

## change

`get_member_profile` now treats the owner's own view as a non-privileged peer:
- passes `viewer=None` to `visible_name(...)` for self-view, so a hidden last name is masked in the owner's own preview
- drops the `or is_own_profile` overrides on `phone_number` / `email`, so hidden phone/email are suppressed too

editing controls are unaffected — this only concerns the read/preview rendering.

## tests

- updated `test_self_preview_hides_own_last_name` (renamed from `test_self_sees_own_full_name`) — asserts the owner's own last name/full name are masked
- added `test_self_preview_hides_own_contact_info` — asserts hidden phone/email are suppressed in the owner's preview
- full `test_hide_last_name.py` suite green (18 passed)
