### PR TITLE
fix(events): move invite members button into the rsvp section (Issue 788)

### DIFF
--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -284,6 +284,14 @@ describe('EventMemberSection — rsvp-disabled gates (#666, #667)', () => {
     useAuthStore.setState({ status: 'authed', user: STRANGER, accessToken: 'tok' });
     renderSection({ ...RSVP_ENABLED_EVENT, myRsvp: RsvpStatus.Attending });
     expect(screen.getByRole('button', { name: /invite members/i })).toBeInTheDocument();
+  });
+
+  it('renders the invite members button inside the rsvp section (#788)', () => {
+    useAuthStore.setState({ status: 'authed', user: STRANGER, accessToken: 'tok' });
+    renderSection({ ...RSVP_ENABLED_EVENT, myRsvp: RsvpStatus.Attending });
+    const rsvpCard = screen.getByRole('heading', { name: 'rsvp' }).closest('section');
+    expect(rsvpCard).not.toBeNull();
+    expect(within(rsvpCard!).getByRole('button', { name: /invite members/i })).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -63,10 +63,15 @@ export function EventMemberSection({ event }: Props) {
       {showRsvp ? (
         <Card label="rsvp">
           <RsvpSection event={event} canSeeInvited={canSeeInvited} />
-          {isCoHost ? (
-            <div className="mt-4 flex justify-end gap-2">
-              <EmailBlastButton event={event} />
-              <GroupTextButton event={event} />
+          {canInvite || isCoHost ? (
+            <div className="mt-4 flex flex-wrap justify-end gap-2">
+              {canInvite ? <InviteSection event={event} /> : null}
+              {isCoHost ? (
+                <>
+                  <EmailBlastButton event={event} />
+                  <GroupTextButton event={event} />
+                </>
+              ) : null}
             </div>
           ) : null}
         </Card>
@@ -76,7 +81,6 @@ export function EventMemberSection({ event }: Props) {
           <InvitedList event={event} />
         </Card>
       ) : null}
-      {canInvite ? <InviteSection event={event} /> : null}
       {rsvpDisabled ? null : <EventCommentsCard eventId={event.id} />}
       <EventAdminActions event={event} />
       <ReportEventButton eventId={event.id} />
@@ -451,7 +455,7 @@ function formatPrice(price: string): string {
 function InviteSection({ event }: { event: Event }) {
   const [open, setOpen] = useState(false);
   return (
-    <div className="flex justify-center">
+    <>
       <Button
         variant="secondary"
         onClick={() => {
@@ -467,6 +471,6 @@ function InviteSection({ event }: { event: Event }) {
           setOpen(false);
         }}
       />
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary

Closes #788

- moved the "invite members" button on the event detail screen (`/events/:id`) from its standalone spot below the rsvp/invited cards into the **rsvp card's actions row**, alongside the co-host email-blast / group-text buttons — inviting members is part of the attendance flow, so it now reads as one coherent block.
- removed the old standalone `<InviteSection>` render; `InviteSection` is now a fragment (the parent flex row handles alignment).
- permission gating is unchanged: `canInvite` is a strict subset of `showRsvp` (both require `!isCancelled && !isPast && !rsvpDisabled`), so the rsvp card is always present whenever the button should appear — no regression in when/for-whom the button shows.

## Test plan

- [ ] on a future, rsvp-enabled event, the "invite members" button renders inside the rsvp card (not below it) for anyone eligible to invite (co-host, event manager, or a member who rsvpd going/maybe when invitePermission is all-members).
- [ ] no duplicate invite button remains in the old location.
- [ ] button opens the invite dialog and behaves exactly as before.
- [x] `EventMemberSection.test.tsx` — 27 tests pass, incl. new placement assertion (`#788`).
- [x] frontend prettier + eslint + `tsc --noEmit` clean.