### PR TITLE
refactor(members): replace non-members toggle with tabs (Issue 787)

### DIFF
--- a/frontend/src/screens/admin/MembersScreen.test.tsx
+++ b/frontend/src/screens/admin/MembersScreen.test.tsx
@@ -224,7 +224,7 @@ describe('MembersScreen', () => {
     expect(screen.getByRole('button', { name: /add member/i })).toBeInTheDocument();
   });
 
-  it('renders the Members/Roles tab switcher for users with manage_roles', () => {
+  it('renders the members/non-members/roles tab switcher for users with manage_roles', () => {
     useAuthStore.setState({
       status: 'authed',
       user: adminUser([Permission.ManageUsers, Permission.ManageRoles]),
@@ -234,13 +234,14 @@ describe('MembersScreen', () => {
 
     renderScreen();
 
-    const group = screen.getByRole('radiogroup', { name: /members or roles/i });
+    const group = screen.getByRole('radiogroup', { name: /members, non-members, or roles/i });
     expect(group).toBeInTheDocument();
     expect(screen.getByRole('radio', { name: 'members' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'non-members' })).toBeInTheDocument();
     expect(screen.getByRole('radio', { name: 'roles' })).toBeInTheDocument();
   });
 
-  it('hides the tab switcher when the user lacks manage_roles', () => {
+  it('hides only the roles tab when the user lacks manage_roles', () => {
     useAuthStore.setState({
       status: 'authed',
       user: {
@@ -260,7 +261,39 @@ describe('MembersScreen', () => {
 
     renderScreen();
 
-    expect(screen.queryByRole('radiogroup', { name: /members or roles/i })).not.toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'members' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'non-members' })).toBeInTheDocument();
+    expect(screen.queryByRole('radio', { name: 'roles' })).not.toBeInTheDocument();
+  });
+
+  it('switches to the non-members tab and shows only non-members', async () => {
+    mockUsersResult({
+      data: [
+        makeMember({ id: 'm1', fullName: 'Ada Member', isMember: true }),
+        makeMember({ id: 'm2', fullName: 'Guest Rsvp', isMember: false }),
+      ],
+    });
+
+    renderScreen();
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('radio', { name: 'non-members' }));
+
+    expect(screen.getByText('Guest Rsvp')).toBeInTheDocument();
+    expect(screen.queryByText('Ada Member')).not.toBeInTheDocument();
+    // The non-members tab has no add-member controls.
+    expect(screen.queryByRole('button', { name: /add member/i })).not.toBeInTheDocument();
+  });
+
+  it('shows the non-members empty state when there are no non-members', async () => {
+    mockUsersResult({
+      data: [makeMember({ id: 'm1', fullName: 'Ada Member', isMember: true })],
+    });
+
+    renderScreen();
+    const user = userEvent.setup();
+    await user.click(screen.getByRole('radio', { name: 'non-members' }));
+
+    expect(screen.getByText(/no non-members yet/i)).toBeInTheDocument();
   });
 
   it('shows last-attended date for a member who has attended', () => {

--- a/frontend/src/screens/admin/MembersScreen.tsx
+++ b/frontend/src/screens/admin/MembersScreen.tsx
@@ -1,5 +1,6 @@
-// Admin: /members — two-tab shell switching between the member list and
-// role management. Mirrors the Flutter TabController(length:2) layout.
+// Admin: /members — a tabbed shell switching between the member list, the
+// non-member list (both share MembersTab, parameterized by mode), and role
+// management.
 
 import { useState } from 'react';
 
@@ -8,39 +9,36 @@ import { SegmentedControl } from '@/components/ui/SegmentedControl';
 import { hasPermission, Permission } from '@/models/permissions';
 import { ContentContainer } from '@/screens/public/ContentContainer';
 
-import { MembersTab } from './MembersTab';
+import { MembersTab, type MembersMode } from './MembersTab';
 import { RolesTab } from './RolesTab';
 
-type TabKey = 'members' | 'roles';
+type TabKey = MembersMode | 'roles';
 
 export default function MembersScreen() {
   const user = useAuthStore((s) => s.user);
   const canManageRoles = hasPermission(user, Permission.ManageRoles);
   const [tab, setTab] = useState<TabKey>('members');
 
-  const tabOptions: { value: TabKey; label: string }[] = canManageRoles
-    ? [
-        { value: 'members', label: 'members' },
-        { value: 'roles', label: 'roles' },
-      ]
-    : [{ value: 'members', label: 'members' }];
+  const tabOptions: { value: TabKey; label: string }[] = [
+    { value: 'members', label: 'members' },
+    { value: 'non-members', label: 'non-members' },
+    ...(canManageRoles ? [{ value: 'roles' as const, label: 'roles' }] : []),
+  ];
 
   return (
     <ContentContainer>
       <header className="mb-4">
         <h1 className="mb-3 text-2xl font-medium tracking-tight">members</h1>
-        {canManageRoles ? (
-          <SegmentedControl
-            name="members-tab"
-            ariaLabel="members or roles"
-            options={tabOptions}
-            value={tab}
-            onChange={setTab}
-          />
-        ) : null}
+        <SegmentedControl
+          name="members-tab"
+          ariaLabel="members, non-members, or roles"
+          options={tabOptions}
+          value={tab}
+          onChange={setTab}
+        />
       </header>
 
-      {tab === 'members' || !canManageRoles ? <MembersTab /> : <RolesTab />}
+      {tab === 'roles' ? <RolesTab /> : <MembersTab key={tab} mode={tab} />}
     </ContentContainer>
   );
 }

--- a/frontend/src/screens/admin/MembersScreen.tsx
+++ b/frontend/src/screens/admin/MembersScreen.tsx
@@ -9,7 +9,7 @@ import { SegmentedControl } from '@/components/ui/SegmentedControl';
 import { hasPermission, Permission } from '@/models/permissions';
 import { ContentContainer } from '@/screens/public/ContentContainer';
 
-import { MembersTab, type MembersMode } from './MembersTab';
+import { type MembersMode, MembersTab } from './MembersTab';
 import { RolesTab } from './RolesTab';
 
 type TabKey = MembersMode | 'roles';

--- a/frontend/src/screens/admin/MembersTab.tsx
+++ b/frontend/src/screens/admin/MembersTab.tsx
@@ -1,5 +1,6 @@
-// Members tab body — the actual list/filter/sort/create UI. The outer
-// MembersScreen shell just switches between this and the RolesTab.
+// Members tab body — the actual list/filter/sort/create UI. Shared between the
+// members and non-members tabs (parameterized by `mode`); the outer
+// MembersScreen shell switches between this and the RolesTab.
 
 import { format } from 'date-fns';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -10,12 +11,13 @@ import { type Member, useUsers } from '@/api/users';
 import { Button } from '@/components/ui/Button';
 import { Select } from '@/components/ui/Select';
 import { TextField } from '@/components/ui/TextField';
-import { Toggle } from '@/components/ui/Toggle';
 import { ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 import { formatPhone } from '@/utils/formatPhone';
 
 import { BulkCreateDialog } from './BulkCreateDialog';
 import { MemberCreateDialog } from './MemberCreateDialog';
+
+export type MembersMode = 'members' | 'non-members';
 
 type SortKey = 'name' | 'newest' | 'lastAttended';
 
@@ -25,9 +27,15 @@ const SORT_OPTIONS: { value: SortKey; label: string }[] = [
   { value: 'lastAttended', label: 'last attended' },
 ];
 
-export function MembersTab() {
-  const [showNonMembers, setShowNonMembers] = useState(false);
-  const { data = [], isPending, isError } = useUsers(showNonMembers);
+export function MembersTab({ mode }: { mode: MembersMode }) {
+  const isNonMembers = mode === 'non-members';
+  // The list endpoint returns members-only by default and all users when
+  // opted in; the non-members tab keeps only the non-members from that set.
+  const { data: fetched = [], isPending, isError } = useUsers(isNonMembers);
+  const data = useMemo(
+    () => (isNonMembers ? fetched.filter((m) => !m.isMember) : fetched),
+    [fetched, isNonMembers],
+  );
   const { data: allRoles = [] } = useRoles();
   const [query, setQuery] = useState('');
   const [sort, setSort] = useState<SortKey>('name');
@@ -43,27 +51,38 @@ export function MembersTab() {
   );
 
   if (isPending) return <ContentLoading />;
-  if (isError) return <ContentError message="couldn't load members — try refreshing" />;
+  if (isError)
+    return (
+      <ContentError
+        message={
+          isNonMembers
+            ? "couldn't load non-members — try refreshing"
+            : "couldn't load members — try refreshing"
+        }
+      />
+    );
 
   return (
     <>
-      <div className="mb-4 flex justify-end gap-2">
-        <Button
-          variant="secondary"
-          onClick={() => {
-            setBulkOpen(true);
-          }}
-        >
-          bulk add
-        </Button>
-        <Button
-          onClick={() => {
-            setCreateOpen(true);
-          }}
-        >
-          add member
-        </Button>
-      </div>
+      {isNonMembers ? null : (
+        <div className="mb-4 flex justify-end gap-2">
+          <Button
+            variant="secondary"
+            onClick={() => {
+              setBulkOpen(true);
+            }}
+          >
+            bulk add
+          </Button>
+          <Button
+            onClick={() => {
+              setCreateOpen(true);
+            }}
+          >
+            add member
+          </Button>
+        </div>
+      )}
 
       <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end">
         <div className="flex-1">
@@ -98,10 +117,6 @@ export function MembersTab() {
         ) : null}
       </div>
 
-      <div className="mb-4 sm:w-64">
-        <Toggle label="show non-members" checked={showNonMembers} onChange={setShowNonMembers} />
-      </div>
-
       {data.length > 0 ? (
         <p className="text-foreground-tertiary mb-3 text-sm">
           {data.length === 1 ? '1 user' : `${String(data.length)} users`}
@@ -112,6 +127,7 @@ export function MembersTab() {
         members={visible}
         selectedRoles={selectedRoles}
         hasAnyMembers={data.length > 0}
+        mode={mode}
       />
 
       {createOpen ? (
@@ -139,15 +155,18 @@ function MembersList({
   members,
   selectedRoles,
   hasAnyMembers,
+  mode,
 }: {
   members: Member[];
   selectedRoles: Set<string>;
   hasAnyMembers: boolean;
+  mode: MembersMode;
 }) {
   if (members.length === 0) {
+    const emptyLabel = mode === 'non-members' ? 'no non-members yet 🌿' : 'no members yet 🌿';
     return (
       <p className="text-sm text-neutral-500">
-        {!hasAnyMembers ? 'no members yet 🌿' : 'nothing matches — try clearing filters'}
+        {!hasAnyMembers ? emptyLabel : 'nothing matches — try clearing filters'}
       </p>
     );
   }


### PR DESCRIPTION
## overview

replaces the show/hide non-members toggle on `/admin/members` with top-level tabs — **members**, **non-members**, **roles** (Issue 787). the members and non-members pages are essentially identical, so they share `MembersTab` parameterized by `mode`; roles stays as it is today.

## change

- `MembersScreen`: 3-way `SegmentedControl` (members / non-members / roles, roles only when the user can manage roles). renders `MembersTab` with a `mode` prop, keyed by tab so state resets on switch.
- `MembersTab`: new `mode: 'members' | 'non-members'` prop. drops the `showNonMembers` `Toggle`; non-members tab fetches all users and filters to `!isMember`, hides the add/bulk-add controls, and uses non-member empty/error copy.
- all user-facing text lowercase per convention.

## tests

- `MembersScreen.test.tsx` updated for the tabbed layout — 15 passed.
- `tsc --noEmit` clean.
