### PR TITLE
chore(seed): 799 - expand staging fixtures for attendance + public rsvp

### DIFF
--- a/backend/community/management/commands/_seed_staging_data.py
+++ b/backend/community/management/commands/_seed_staging_data.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 
-from community.models.choices import EventType, RSVPStatus
+from community.models.choices import AttendanceStatus, EventType, RSVPStatus
 
 PASSWORD = "testPassword1@"
 
@@ -15,6 +15,8 @@ class SeedStagingEvent:
     duration_hours: float
     location: str
     event_type: str = EventType.COMMUNITY
+    rsvp_enabled: bool = False
+    max_attendees: int | None = None
 
 
 def perm_phone(index: int) -> str:
@@ -42,6 +44,11 @@ def nonmember_email(index: int) -> str:
 
 
 NON_MEMBER_EVENT_TITLE = "[staging] official public rsvp demo"
+
+# Official, RSVP-enabled events the attendance + public-RSVP surfaces read from.
+OFFICIAL_PAST_TITLE = "[staging] official past attendance-marked"
+OFFICIAL_TODAY_TITLE = "[staging] official today rsvp open"
+OFFICIAL_FULL_TITLE = "[staging] official over-capacity waitlist"
 
 
 def condition_combinations() -> list[tuple[bool, bool, bool]]:
@@ -153,36 +160,112 @@ STAGING_EVENTS = [
         duration_hours=3,
         location="downtown hub",
         event_type=EventType.OFFICIAL,
+        rsvp_enabled=True,
+        max_attendees=20,
     ),
+    SeedStagingEvent(
+        title=OFFICIAL_PAST_TITLE,
+        description="past official event with attendance marked for the report.",
+        delta_days=-10,
+        duration_hours=3,
+        location="main hall",
+        event_type=EventType.OFFICIAL,
+        rsvp_enabled=True,
+        max_attendees=8,
+    ),
+    SeedStagingEvent(
+        title=OFFICIAL_TODAY_TITLE,
+        description="official event happening today with rsvp open, well under capacity.",
+        delta_days=0,
+        duration_hours=4,
+        location="market square",
+        event_type=EventType.OFFICIAL,
+        rsvp_enabled=True,
+        max_attendees=50,
+    ),
+    SeedStagingEvent(
+        title=OFFICIAL_FULL_TITLE,
+        description="official event at/over capacity to exercise waitlist + promotion.",
+        delta_days=9,
+        duration_hours=3,
+        location="teaching kitchen",
+        event_type=EventType.OFFICIAL,
+        rsvp_enabled=True,
+        max_attendees=2,
+    ),
+]
+
+
+# Non-member manage-token lifecycle states, controlling what the seed leaves behind.
+TOKEN_VALID = "valid"
+TOKEN_EXPIRED = "expired"
+TOKEN_NONE = "none"
+
+
+_ATTENDED = AttendanceStatus.ATTENDED
+_NO_SHOW = AttendanceStatus.NO_SHOW
+
+
+@dataclass
+class RsvpOnEvent:
+    """One RSVP row a seeded user should hold on a named event."""
+
+    event_title: str
+    status: str
+    attendance: str = AttendanceStatus.UNKNOWN
+
+
+def _rsvps(*rows: tuple) -> list[RsvpOnEvent]:
+    """Build RsvpOnEvent rows from compact (title, status[, attendance]) tuples."""
+    return [RsvpOnEvent(*row) for row in rows]
+
+
+_A, _M, _C, _W = RSVPStatus.ATTENDING, RSVPStatus.MAYBE, RSVPStatus.CANT_GO, RSVPStatus.WAITLISTED
+
+
+@dataclass
+class MemberRsvpSpec:
+    """RSVPs to attach to the condition member at ``cond_index``."""
+
+    cond_index: int
+    rsvps: list[RsvpOnEvent]
+
+
+# Members across every RSVP state on the official events; the past event carries
+# attendance marks so the attendance report shows a non-trivial member/non-member mix.
+MEMBER_RSVP_SPECS = [
+    MemberRsvpSpec(0, _rsvps((OFFICIAL_PAST_TITLE, _A, _ATTENDED), (OFFICIAL_TODAY_TITLE, _A))),
+    MemberRsvpSpec(1, _rsvps((OFFICIAL_PAST_TITLE, _A, _NO_SHOW), (OFFICIAL_TODAY_TITLE, _M))),
+    MemberRsvpSpec(2, _rsvps((OFFICIAL_PAST_TITLE, _M), (OFFICIAL_TODAY_TITLE, _C))),
+    MemberRsvpSpec(3, _rsvps((OFFICIAL_PAST_TITLE, _A, _ATTENDED), (OFFICIAL_FULL_TITLE, _A))),
+    MemberRsvpSpec(4, _rsvps((OFFICIAL_FULL_TITLE, _A))),
+    MemberRsvpSpec(5, _rsvps((OFFICIAL_FULL_TITLE, _W))),
 ]
 
 
 @dataclass
 class NonMemberSpec:
     label: str
-    event_titles: list[str]
-    statuses: list[str]
+    rsvps: list[RsvpOnEvent]
+    has_email: bool = True
+    token_state: str = TOKEN_VALID
 
 
 NON_MEMBER_SPECS = [
+    NonMemberSpec("attending (valid token, email)", _rsvps((NON_MEMBER_EVENT_TITLE, _A))),
     NonMemberSpec(
-        label="non-member: attending",
-        event_titles=[NON_MEMBER_EVENT_TITLE],
-        statuses=[RSVPStatus.ATTENDING],
+        "maybe (valid token, no email)", _rsvps((NON_MEMBER_EVENT_TITLE, _M)), has_email=False
     ),
     NonMemberSpec(
-        label="non-member: maybe",
-        event_titles=[NON_MEMBER_EVENT_TITLE],
-        statuses=[RSVPStatus.MAYBE],
+        "can't-go (expired token)",
+        _rsvps((NON_MEMBER_EVENT_TITLE, _C)),
+        token_state=TOKEN_EXPIRED,
     ),
     NonMemberSpec(
-        label="non-member: multi-event",
-        event_titles=[NON_MEMBER_EVENT_TITLE, "[staging] monthly official meeting"],
-        statuses=[RSVPStatus.ATTENDING, RSVPStatus.ATTENDING],
+        "multi-event attended (past + today)",
+        _rsvps((OFFICIAL_PAST_TITLE, _A, _ATTENDED), (OFFICIAL_TODAY_TITLE, _A)),
     ),
-    NonMemberSpec(
-        label="non-member: no-rsvp",
-        event_titles=[],
-        statuses=[],
-    ),
+    NonMemberSpec("past no-show (attendance report)", _rsvps((OFFICIAL_PAST_TITLE, _A, _NO_SHOW))),
+    NonMemberSpec("waitlisted at capacity", _rsvps((OFFICIAL_FULL_TITLE, _W))),
+    NonMemberSpec("no-rsvp (no token)", [], token_state=TOKEN_NONE),
 ]

--- a/backend/community/management/commands/seed_staging.py
+++ b/backend/community/management/commands/seed_staging.py
@@ -1,6 +1,7 @@
 """Seed the staging deploy with events, single-permission roles, and matching users."""
 
 import os
+import secrets
 from datetime import timedelta
 
 from django.conf import settings
@@ -11,13 +12,16 @@ from users.models import NonMemberRsvpToken, User
 from users.permissions import PermissionKey
 from users.roles import Role
 
-from community.models import Event, EventRSVP
+from community.models import Event, EventRSVP, EventType, RSVPStatus
 
 from ._seed_staging_data import (
+    MEMBER_RSVP_SPECS,
     NON_MEMBER_EVENT_TITLE,
     NON_MEMBER_SPECS,
     PASSWORD,
     STAGING_EVENTS,
+    TOKEN_EXPIRED,
+    TOKEN_NONE,
     cond_email,
     cond_phone,
     condition_combinations,
@@ -57,8 +61,17 @@ class Command(BaseCommand):
             cond_users = self._seed_condition_users()
             admin = perm_users[0] if perm_users else None
             events = self._seed_events(admin)
+            self._seed_member_rsvps(cond_users, events)
             non_members = self._seed_non_members(events)
-        self._print_summary(roles, perm_users, cond_users, events, non_members)
+        self._print_summary(
+            {
+                "roles": roles,
+                "perm_users": perm_users,
+                "cond_users": cond_users,
+                "events": events,
+                "non_members": non_members,
+            }
+        )
 
     def _reset(self) -> None:
         Event.objects.filter(title__startswith="[staging] ").delete()
@@ -165,6 +178,8 @@ class Command(BaseCommand):
                     "end_datetime": end,
                     "location": data.location,
                     "event_type": data.event_type,
+                    "rsvp_enabled": data.rsvp_enabled,
+                    "max_attendees": data.max_attendees,
                     "created_by": created_by,
                 },
             )
@@ -172,60 +187,93 @@ class Command(BaseCommand):
             self.stdout.write(f"  {'created' if created else 'exists'} event: {data.title}")
         return events
 
+    def _apply_rsvps(self, user, rsvps, events_by_title: dict) -> None:
+        for rsvp in rsvps:
+            event = events_by_title.get(rsvp.event_title)
+            if event is not None:
+                EventRSVP.objects.update_or_create(
+                    event=event,
+                    user=user,
+                    defaults={"status": rsvp.status, "attendance": rsvp.attendance},
+                )
+
+    def _seed_member_rsvps(self, cond_users: list[User], events: list[Event]) -> None:
+        events_by_title = {e.title: e for e in events}
+        for spec in MEMBER_RSVP_SPECS:
+            if spec.cond_index >= len(cond_users):
+                continue
+            self._apply_rsvps(cond_users[spec.cond_index], spec.rsvps, events_by_title)
+        self.stdout.write(f"  seeded member rsvps for {len(MEMBER_RSVP_SPECS)} members")
+
     def _ensure_non_member(self, index: int, spec) -> User:
         user, created = User.objects.get_or_create(
             phone_number=nonmember_phone(index),
             defaults={
                 "first_name": spec.label,
-                "email": nonmember_email(index),
+                "email": nonmember_email(index) if spec.has_email else None,
                 "is_member": False,
             },
         )
+        user.email = nonmember_email(index) if spec.has_email else None
+        user.save(update_fields=["email"])
         if created:
             user.set_unusable_password()
             user.save(update_fields=["password"])
         self.stdout.write(f"  {'created' if created else 'exists'} non-member: {spec.label}")
         return user
 
-    def _attach_spec_rsvps(self, user, spec, events_by_title: dict) -> None:
-        for title, status in zip(spec.event_titles, spec.statuses):
-            event = events_by_title.get(title)
-            if event is not None:
-                EventRSVP.objects.update_or_create(
-                    event=event, user=user, defaults={"status": status}
-                )
-        if spec.event_titles:
-            NonMemberRsvpToken.issue_or_extend(user)
+    def _apply_token_state(self, user, token_state: str) -> None:
+        if token_state == TOKEN_NONE:
+            return
+        if token_state == TOKEN_EXPIRED:
+            existing = user.rsvp_tokens.first()
+            if existing is not None and existing.is_expired:
+                return
+            user.rsvp_tokens.all().delete()
+            NonMemberRsvpToken.objects.create(
+                user=user,
+                token=secrets.token_urlsafe(32),
+                expires_at=timezone.now() - timedelta(days=1),
+            )
+            return
+        NonMemberRsvpToken.issue_or_extend(user)
 
     def _seed_non_members(self, events: list[Event]) -> list[User]:
         events_by_title = {e.title: e for e in events}
         users: list[User] = []
         for index, spec in enumerate(NON_MEMBER_SPECS):
             user = self._ensure_non_member(index, spec)
-            self._attach_spec_rsvps(user, spec, events_by_title)
+            self._apply_rsvps(user, spec.rsvps, events_by_title)
+            self._apply_token_state(user, spec.token_state)
             users.append(user)
         return users
 
-    def _print_summary(self, roles, perm_users, cond_users, events, non_members) -> None:
+    def _print_summary(self, result: dict) -> None:
         self.stdout.write("")
         self.stdout.write(f"password for all seeded users: {PASSWORD}")
         self.stdout.write(
-            f"events: {len(events)}  roles: {len(roles)}  "
-            f"perm users: {len(perm_users)}  condition users: {len(cond_users)}  "
-            f"non-member users: {len(non_members)}"
+            f"events: {len(result['events'])}  roles: {len(result['roles'])}  "
+            f"perm users: {len(result['perm_users'])}  "
+            f"condition users: {len(result['cond_users'])}  "
+            f"non-member users: {len(result['non_members'])}"
         )
-        self.stdout.write("per-permission users (phone -> role):")
-        for user in perm_users:
-            names = ", ".join(user.roles.values_list("name", flat=True))
-            self.stdout.write(f"  {user.phone_number} -> {names}")
-        self.stdout.write("profile-condition users (phone -> pattern):")
-        for user in cond_users:
-            self.stdout.write(f"  {user.phone_number} -> {user.full_name}")
+        self._print_official_events(result["events"])
         self.stdout.write("non-member users (phone -> manage link):")
-        for user in non_members:
-            token = NonMemberRsvpToken.objects.filter(user=user).first()
-            if token is None:
-                self.stdout.write(f"  {user.phone_number} -> (no rsvp)")
+        for user in result["non_members"]:
+            token = NonMemberRsvpToken.objects.filter(user=user).order_by("-created_at").first()
+            if token is None or not token.is_valid:
+                state = "expired token" if token is not None else "no token"
+                self.stdout.write(f"  {user.phone_number} -> ({state})")
                 continue
             url = f"{settings.FRONTEND_BASE_URL}/my-rsvps?token={token.token}"
             self.stdout.write(f"  {user.phone_number} -> {url}")
+
+    def _print_official_events(self, events: list[Event]) -> None:
+        official = [e for e in events if e.event_type == EventType.OFFICIAL and e.rsvp_enabled]
+        self.stdout.write("official rsvp events (title -> attending/waitlisted, cap):")
+        for event in official:
+            rsvps = list(event.rsvps.all())
+            attending = sum(1 for r in rsvps if r.status == RSVPStatus.ATTENDING)
+            waitlisted = sum(1 for r in rsvps if r.status == RSVPStatus.WAITLISTED)
+            cap = event.max_attendees if event.max_attendees is not None else "∞"
+            self.stdout.write(f"  '{event.title}' -> {attending}/{waitlisted}, cap {cap}")

--- a/backend/tests/test_seed_staging.py
+++ b/backend/tests/test_seed_staging.py
@@ -4,8 +4,14 @@ import pytest
 from community.management.commands._seed_staging_data import (
     NON_MEMBER_EVENT_TITLE,
     NON_MEMBER_SPECS,
+    OFFICIAL_FULL_TITLE,
+    OFFICIAL_PAST_TITLE,
+    OFFICIAL_TODAY_TITLE,
     PASSWORD,
     STAGING_EVENTS,
+    TOKEN_EXPIRED,
+    TOKEN_NONE,
+    TOKEN_VALID,
     cond_email,
     cond_phone,
     condition_combinations,
@@ -14,7 +20,7 @@ from community.management.commands._seed_staging_data import (
     perm_email,
     perm_phone,
 )
-from community.models import Event, EventRSVP
+from community.models import AttendanceStatus, Event, EventRSVP, EventType, RSVPStatus
 from django.contrib.auth.hashers import check_password
 from django.core.management import call_command
 from django.utils import timezone
@@ -162,6 +168,7 @@ def test_seed_staging_events_span_past_current_future():
 @pytest.mark.django_db
 def test_seed_staging_is_idempotent():
     call_command("seed_staging")
+    rsvps = EventRSVP.objects.count()
     call_command("seed_staging")
     assert User.objects.filter(phone_number__startswith="+170255501").count() == len(
         PermissionKey.values
@@ -169,6 +176,7 @@ def test_seed_staging_is_idempotent():
     assert User.objects.filter(phone_number__startswith="+170255502").count() == 8
     assert Role.objects.filter(name__startswith="perm: ").count() == len(PermissionKey.values)
     assert Event.objects.filter(title__startswith="[staging] ").count() == len(STAGING_EVENTS)
+    assert EventRSVP.objects.count() == rsvps
 
 
 @pytest.mark.django_db
@@ -194,27 +202,27 @@ def test_seed_staging_refuses_in_production(monkeypatch):
 
 
 @pytest.mark.django_db
-def test_seed_staging_creates_non_members():
+def test_seed_staging_non_member_lifecycle_matches_specs():
     call_command("seed_staging")
-    non_members = User.objects.filter(phone_number__startswith="+170255503")
-    assert non_members.count() == len(NON_MEMBER_SPECS)
-    for u in non_members:
-        assert u.is_member is False
-        assert not u.has_usable_password()
-
-
-@pytest.mark.django_db
-def test_seed_staging_non_members_have_valid_tokens_and_rsvps():
-    call_command("seed_staging")
-    rsvped = User.objects.filter(
-        phone_number__startswith="+170255503", event_rsvps__isnull=False
-    ).distinct()
-    assert rsvped.exists()
-    for u in rsvped:
-        token = NonMemberRsvpToken.objects.filter(user=u).first()
-        assert token is not None and token.is_valid
-    demo = Event.objects.get(title=NON_MEMBER_EVENT_TITLE)
-    assert EventRSVP.objects.filter(event=demo).exists()
+    assert User.objects.filter(phone_number__startswith="+170255503").count() == len(
+        NON_MEMBER_SPECS
+    )
+    states = {TOKEN_VALID: 0, TOKEN_EXPIRED: 0, TOKEN_NONE: 0, "with_email": 0, "no_email": 0}
+    for index, spec in enumerate(NON_MEMBER_SPECS):
+        user = User.objects.get(phone_number=f"+170255503{index:02d}")
+        assert user.is_member is False and not user.has_usable_password()
+        assert bool(user.email) is spec.has_email
+        states["with_email" if spec.has_email else "no_email"] += 1
+        states[spec.token_state] += 1
+        token = NonMemberRsvpToken.objects.filter(user=user).first()
+        if spec.token_state == TOKEN_NONE:
+            assert token is None
+        elif spec.token_state == TOKEN_EXPIRED:
+            assert token is not None and token.is_expired and not token.is_valid
+        elif spec.rsvps:
+            assert token is not None and token.is_valid
+    assert all(v > 0 for v in states.values())
+    assert EventRSVP.objects.filter(event__title=NON_MEMBER_EVENT_TITLE).exists()
 
 
 @pytest.mark.django_db
@@ -241,3 +249,61 @@ def test_seed_staging_non_members_idempotent():
     assert User.objects.filter(phone_number__startswith="+170255503").count() == len(
         NON_MEMBER_SPECS
     )
+
+
+def test_official_events_span_past_today_future_with_capacity_variety():
+    official = [e for e in STAGING_EVENTS if e.event_type == EventType.OFFICIAL and e.rsvp_enabled]
+    assert len(official) >= 3
+    assert any(e.delta_days < 0 for e in official)
+    assert any(e.delta_days == 0 for e in official)
+    assert any(e.delta_days > 0 for e in official)
+    caps = [e.max_attendees for e in official if e.max_attendees is not None]
+    assert min(caps) <= 2  # at/over capacity to exercise the waitlist
+    assert max(caps) >= 20  # well under capacity
+
+
+@pytest.mark.django_db
+def test_seed_staging_official_events_are_rsvp_enabled():
+    call_command("seed_staging")
+    for title in (OFFICIAL_PAST_TITLE, OFFICIAL_TODAY_TITLE, OFFICIAL_FULL_TITLE):
+        event = Event.objects.get(title=title)
+        assert event.event_type == EventType.OFFICIAL
+        assert event.rsvp_enabled is True
+        assert event.max_attendees is not None
+
+
+@pytest.mark.django_db
+def test_seed_staging_members_cover_all_rsvp_states():
+    call_command("seed_staging")
+    states = set(
+        EventRSVP.objects.filter(user__phone_number__startswith="+170255502").values_list(
+            "status", flat=True
+        )
+    )
+    assert {
+        RSVPStatus.ATTENDING,
+        RSVPStatus.MAYBE,
+        RSVPStatus.CANT_GO,
+        RSVPStatus.WAITLISTED,
+    } <= states
+
+
+@pytest.mark.django_db
+def test_seed_staging_past_official_has_member_and_non_member_attendance_marks():
+    call_command("seed_staging")
+    marked = EventRSVP.objects.filter(
+        event__title=OFFICIAL_PAST_TITLE,
+        status=RSVPStatus.ATTENDING,
+        attendance__in=[AttendanceStatus.ATTENDED, AttendanceStatus.NO_SHOW],
+    )
+    assert marked.filter(user__is_member=True).exists()
+    assert marked.filter(user__is_member=False).exists()
+
+
+@pytest.mark.django_db
+def test_seed_staging_over_capacity_event_fills_and_waitlists():
+    call_command("seed_staging")
+    full = Event.objects.get(title=OFFICIAL_FULL_TITLE)
+    rsvps = EventRSVP.objects.filter(event=full)
+    assert rsvps.filter(status=RSVPStatus.ATTENDING).count() >= full.max_attendees
+    assert rsvps.filter(status=RSVPStatus.WAITLISTED).exists()


### PR DESCRIPTION
## Overview

Expands the `seed_staging` management command so the attendance-reporting and public non-member RSVP surfaces (shipped in 0.4.0–0.8.1) can be exercised by hand on staging.

- Enables RSVP on the existing official demo event and adds three new `EventType.OFFICIAL`, `rsvp_enabled` events spanning past / today / future: a **past attendance-marked** event (cap 8) that the attendance report reads, a **today** event (cap 50, well under capacity), and an **over-capacity** event (cap 2) to exercise waitlisting.
- Seeds **members** (the existing profile-condition users) with RSVPs across every state — attending / maybe / can't-go / waitlisted — and stamps `attended` / `no_show` marks on the past official event so the admin attendance report shows a non-trivial member + non-member mix.
- Seeds **non-members** across lifecycle states: manage-token valid / expired / none, email / no-email, single- vs multi-event, and waitlisted at capacity.
- Summary output now lists the official RSVP events with per-state counts + capacity, and maps expired/absent non-member tokens to a clear status instead of a dead link.

The command stays idempotent and honors `--reset` / `--force` and the staging-only guard.

**Scope note:** the issue's name/nickname/onboarding-variety criterion is a deliberate "light touch" and is deferred to a small follow-up PR to keep this changeset focused and under the 400-line review limit. The core attendance + public-RSVP criteria are covered here.

Part of Issue 799.

## Test plan

- [x] `backend/tests/test_seed_staging.py` extended and passing (25 tests) — covers the new official events, member RSVP states, attendance marks, over-capacity waitlisting, non-member token lifecycle, idempotency, and `--reset`.
- [x] Verified the admin attendance report query surfaces the past official event with a member + non-member mix (3 attended / 2 no-show).
- [ ] Manual: run `railway run --environment staging python backend/manage.py seed_staging` and confirm the attendance report + `/my-rsvps` links render.
