### PR TITLE
feat(members): hard-delete never-logged-in approved users (Issue 722)

### DIFF
--- a/backend/community/_validation.py
+++ b/backend/community/_validation.py
@@ -123,6 +123,7 @@ class Code:
         CANNOT_DELETE_SELF = "user.cannot_delete_self"
         CANNOT_DELETE_LAST_ADMIN = "user.cannot_delete_last_admin"
         ALREADY_ARCHIVED = "user.already_archived"
+        CANNOT_HARD_DELETE_LOGGED_IN = "user.cannot_hard_delete_logged_in"
         CANNOT_PAUSE_SELF = "user.cannot_pause_self"
         CANNOT_PAUSE_ADMIN = "user.cannot_pause_admin"
         ROLE_IDS_NOT_FOUND = "user.role_ids_not_found"

--- a/backend/community/validation_codes.json
+++ b/backend/community/validation_codes.json
@@ -496,6 +496,11 @@
         "params": []
       },
       {
+        "name": "CANNOT_HARD_DELETE_LOGGED_IN",
+        "value": "user.cannot_hard_delete_logged_in",
+        "params": []
+      },
+      {
         "name": "CANNOT_PAUSE_SELF",
         "value": "user.cannot_pause_self",
         "params": []

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -4813,6 +4813,11 @@
             "title": "Full Name",
             "type": "string"
           },
+          "has_logged_in": {
+            "default": true,
+            "title": "Has Logged In",
+            "type": "boolean"
+          },
           "hide_last_name": {
             "default": false,
             "title": "Hide Last Name",
@@ -6282,6 +6287,67 @@
           }
         ],
         "summary": "Update User",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/users/{user_id}/hard/": {
+      "delete": {
+        "description": "Permanently remove a member who has never logged in.\n\nUnlike ``delete_user`` (which soft-archives via ``archived_at``), this row is\ngone for good. Restricted to never-logged-in accounts \u2014 an approved entry the\nperson never actually claimed \u2014 so a real member's data is never destroyed.",
+        "operationId": "users__management_hard_delete_user",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Not Found"
+          }
+        },
+        "security": [
+          {
+            "GatedJWTAuth": []
+          }
+        ],
+        "summary": "Hard Delete User",
         "tags": [
           "auth"
         ]

--- a/backend/tests/users/test_users_hard_delete.py
+++ b/backend/tests/users/test_users_hard_delete.py
@@ -1,0 +1,105 @@
+import logging
+
+import pytest
+from community._validation import Code
+from django.utils import timezone
+from tests._asserts import assert_error_code
+from users.models import MagicLoginToken, User
+from users.roles import Role
+
+
+def _capture_audit(caplog):
+    """Attach caplog's handler to the non-propagating pda.audit logger.
+
+    pda.audit has propagate=False (see settings LOGGING), so caplog's root
+    handler never sees its records. Attaching the handler directly captures them.
+    """
+    audit_logger = logging.getLogger("pda.audit")
+    audit_logger.addHandler(caplog.handler)
+    return audit_logger
+
+
+@pytest.mark.django_db
+class TestListHasLoggedIn:
+    def _find(self, response, user):
+        return next(u for u in response.json() if u["id"] == str(user.pk))
+
+    def test_never_logged_in_reports_false(self, api_client, manage_users_headers, other_user):
+        assert other_user.last_login is None
+        response = api_client.get("/api/auth/users/", **manage_users_headers)
+        assert response.status_code == 200
+        assert self._find(response, other_user)["has_logged_in"] is False
+
+    def test_logged_in_reports_true(self, api_client, manage_users_headers, other_user):
+        other_user.last_login = timezone.now()
+        other_user.save(update_fields=["last_login"])
+        response = api_client.get("/api/auth/users/", **manage_users_headers)
+        assert response.status_code == 200
+        assert self._find(response, other_user)["has_logged_in"] is True
+
+
+@pytest.mark.django_db
+class TestHardDeleteUser:
+    def _url(self, user):
+        return f"/api/auth/users/{user.pk}/hard/"
+
+    def test_hard_delete_not_found(self, api_client, manage_users_headers):
+        response = api_client.delete(
+            "/api/auth/users/00000000-0000-0000-0000-000000000000/hard/",
+            **manage_users_headers,
+        )
+        assert response.status_code == 404
+        assert_error_code(response, Code.User.NOT_FOUND)
+
+    def test_hard_delete_requires_auth(self, api_client, other_user):
+        response = api_client.delete(self._url(other_user))
+        assert response.status_code == 401
+
+    def test_hard_delete_requires_permission(self, api_client, auth_headers, other_user):
+        response = api_client.delete(self._url(other_user), **auth_headers)
+        assert response.status_code == 403
+
+    def test_hard_delete_never_logged_in_removes_row_and_cascades(
+        self, api_client, manage_users_headers, other_user
+    ):
+        assert other_user.last_login is None
+        token = MagicLoginToken.create_for_user(other_user)
+        response = api_client.delete(self._url(other_user), **manage_users_headers)
+        assert response.status_code == 204
+        assert not User.objects.filter(pk=other_user.pk).exists()
+        assert not MagicLoginToken.objects.filter(pk=token.pk).exists()
+
+    def test_hard_delete_logged_in_user_returns_400(
+        self, api_client, manage_users_headers, other_user
+    ):
+        other_user.last_login = timezone.now()
+        other_user.save(update_fields=["last_login"])
+
+        response = api_client.delete(self._url(other_user), **manage_users_headers)
+        assert response.status_code == 400
+        assert_error_code(response, Code.User.CANNOT_HARD_DELETE_LOGGED_IN)
+        assert User.objects.filter(pk=other_user.pk).exists()
+
+    def test_hard_delete_self_returns_400(
+        self, api_client, manage_users_headers, manage_users_user
+    ):
+        response = api_client.delete(self._url(manage_users_user), **manage_users_headers)
+        assert response.status_code == 400
+        assert_error_code(response, Code.User.CANNOT_DELETE_SELF)
+
+    def test_hard_delete_last_admin_returns_400(self, api_client, manage_users_headers, other_user):
+        admin_role = Role.objects.get(name="admin", is_default=True)
+        other_user.roles.add(admin_role)
+
+        response = api_client.delete(self._url(other_user), **manage_users_headers)
+        assert response.status_code == 400
+        assert_error_code(response, Code.User.CANNOT_DELETE_LAST_ADMIN)
+
+    def test_hard_delete_emits_audit_log(
+        self, api_client, manage_users_headers, other_user, caplog
+    ):
+        _capture_audit(caplog)
+        with caplog.at_level(logging.WARNING, logger="pda.audit"):
+            response = api_client.delete(self._url(other_user), **manage_users_headers)
+        assert response.status_code == 204
+        assert any("user_hard_deleted" in r.getMessage() for r in caplog.records)

--- a/backend/users/_management.py
+++ b/backend/users/_management.py
@@ -396,6 +396,56 @@ def delete_user(request, user_id: str):
     return Status(204, None)
 
 
+@router.delete(
+    "/users/{user_id}/hard/",
+    response={204: None, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut},
+    auth=gated_jwt,
+)
+def hard_delete_user(request, user_id: str):
+    """Permanently remove a member who has never logged in.
+
+    Unlike ``delete_user`` (which soft-archives via ``archived_at``), this row is
+    gone for good. Restricted to never-logged-in accounts — an approved entry the
+    person never actually claimed — so a real member's data is never destroyed.
+    """
+    if not request.auth.has_permission(PermissionKey.MANAGE_USERS):
+        audit_log(
+            logging.WARNING,
+            "permission_denied",
+            request,
+            target_type="user",
+            target_id=user_id,
+            details={
+                "endpoint": "hard_delete_user",
+                "required_permission": PermissionKey.MANAGE_USERS,
+            },
+        )
+        raise_validation(Code.Perm.DENIED, status_code=403, action="hard_delete_user")
+    try:
+        user = User.objects.members().get(pk=user_id)
+    except User.DoesNotExist:
+        raise_validation(Code.User.NOT_FOUND, status_code=404)
+    if str(user.pk) == str(request.auth.pk):
+        raise_validation(Code.User.CANNOT_DELETE_SELF, status_code=400)
+    if _is_last_admin(user):
+        raise_validation(Code.User.CANNOT_DELETE_LAST_ADMIN, status_code=400)
+    if user.last_login is not None:
+        raise_validation(Code.User.CANNOT_HARD_DELETE_LOGGED_IN, status_code=400)
+    full_name = user.full_name
+    audit_log(
+        logging.WARNING,
+        "user_hard_deleted",
+        request,
+        target_type="user",
+        target_id=user_id,
+        details={"full_name": full_name},
+    )
+    # Safe because last_login is None: a never-logged-in user has authored no
+    # EventComments (author is on_delete=PROTECT), so the cascade can't raise.
+    user.delete()
+    return Status(204, None)
+
+
 @router.patch(
     "/users/{user_id}/roles/",
     response={200: UserOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut},

--- a/backend/users/schemas.py
+++ b/backend/users/schemas.py
@@ -107,6 +107,9 @@ class UserOut(BaseModel):
     show_email: bool = True
     hide_last_name: bool = False
     is_paused: bool = False
+    # False until the user's first successful login (Django's last_login is null).
+    # Admins use this to spot approved entries that were never actually claimed.
+    has_logged_in: bool = True
     login_link_requested: bool = False
     week_start: str = "sunday"
     calendar_feed_scope: str = "all"
@@ -139,6 +142,7 @@ class UserOut(BaseModel):
             show_email=user.show_email,
             hide_last_name=user.hide_last_name,
             is_paused=user.is_paused,
+            has_logged_in=user.last_login is not None,
             login_link_requested=user.login_link_requested,
             week_start=user.week_start,
             calendar_feed_scope=user.calendar_feed_scope,

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -307,6 +307,30 @@ export interface paths {
         patch: operations["users__management_update_user"];
         trace?: never;
     };
+    "/api/auth/users/{user_id}/hard/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        /**
+         * Hard Delete User
+         * @description Permanently remove a member who has never logged in.
+         *
+         *     Unlike ``delete_user`` (which soft-archives via ``archived_at``), this row is
+         *     gone for good. Restricted to never-logged-in accounts — an approved entry the
+         *     person never actually claimed — so a real member's data is never destroyed.
+         */
+        delete: operations["users__management_hard_delete_user"];
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/auth/users/{user_id}/magic-link/": {
         parameters: {
             query?: never;
@@ -3844,6 +3868,11 @@ export interface components {
              */
             full_name: string;
             /**
+             * Has Logged In
+             * @default true
+             */
+            has_logged_in: boolean;
+            /**
              * Hide Last Name
              * @default false
              */
@@ -4840,6 +4869,53 @@ export interface operations {
             };
             /** @description Conflict */
             409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
+    users__management_hard_delete_user: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/api/validationCodes.gen.ts
+++ b/frontend/src/api/validationCodes.gen.ts
@@ -125,6 +125,7 @@ export const Code = {
     CannotDeleteSelf: 'user.cannot_delete_self',
     CannotDeleteLastAdmin: 'user.cannot_delete_last_admin',
     AlreadyArchived: 'user.already_archived',
+    CannotHardDeleteLoggedIn: 'user.cannot_hard_delete_logged_in',
     CannotPauseSelf: 'user.cannot_pause_self',
     CannotPauseAdmin: 'user.cannot_pause_admin',
     RoleIdsNotFound: 'user.role_ids_not_found',
@@ -298,6 +299,7 @@ export type ValidationCode =
   | 'user.cannot_delete_self'
   | 'user.cannot_delete_last_admin'
   | 'user.already_archived'
+  | 'user.cannot_hard_delete_logged_in'
   | 'user.cannot_pause_self'
   | 'user.cannot_pause_admin'
   | 'user.role_ids_not_found'
@@ -445,6 +447,7 @@ export const CODE_PARAMS: Record<ValidationCode, readonly string[]> = {
   'user.cannot_delete_self': [],
   'user.cannot_delete_last_admin': [],
   'user.already_archived': [],
+  'user.cannot_hard_delete_logged_in': [],
   'user.cannot_pause_self': [],
   'user.cannot_pause_admin': [],
   'user.role_ids_not_found': [],

--- a/frontend/src/api/validationCodes.ts
+++ b/frontend/src/api/validationCodes.ts
@@ -279,7 +279,7 @@ function messageForKnownCode(code: KnownCode, err: FieldError): string {
     case Code.User.AlreadyArchived:
       return 'this user is already archived';
     case Code.User.CannotHardDeleteLoggedIn:
-      return "this member has logged in — archive them instead of deleting";
+      return 'this member has logged in — archive them instead of deleting';
     case Code.User.CannotPauseSelf:
       return "you can't pause your own account";
     case Code.User.CannotPauseAdmin:

--- a/frontend/src/api/validationCodes.ts
+++ b/frontend/src/api/validationCodes.ts
@@ -278,6 +278,8 @@ function messageForKnownCode(code: KnownCode, err: FieldError): string {
       return "can't delete the last admin — promote someone else first";
     case Code.User.AlreadyArchived:
       return 'this user is already archived';
+    case Code.User.CannotHardDeleteLoggedIn:
+      return "this member has logged in — archive them instead of deleting";
     case Code.User.CannotPauseSelf:
       return "you can't pause your own account";
     case Code.User.CannotPauseAdmin:


### PR DESCRIPTION
## overview

adds a way to fully remove approved people who have never logged in (Issue 722). admin feedback: approved entries that were never claimed aren't really members, and archiving them just moves them to a "previously archived" state rather than removing them.

## change

- **backend**: new `DELETE /users/{id}/hard/` endpoint. unlike the soft-archive `delete_user`, this permanently removes the row — but only for never-logged-in accounts (`last_login is null`), with guards against deleting self or the last admin. audit-logged. new `CANNOT_HARD_DELETE_LOGGED_IN` validation code.
- **schema**: `UserOut.has_logged_in` (from `last_login is not None`) so admins can spot unclaimed approved entries.
- **frontend types**: regenerated (`types.gen.ts`, validation codes).
- **tests**: `test_users_hard_delete.py` covers `has_logged_in` reporting + hard-delete guards.

_generated by an autonomous session; opened as draft for review. CI not run locally per request._
