### PR TITLE
fix: 810 - theme the calendar overflow popover for dark mode

### DIFF
--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -393,6 +393,18 @@ body {
 .rbc-time-view .rbc-time-gutter {
   color: var(--color-muted-foreground);
 }
+/* "n more" popover — themed to match the rest of the calendar. */
+.rbc-overlay.rbc-overlay {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  color: var(--color-foreground);
+  box-shadow: var(--shadow-lg);
+}
+.rbc-overlay .rbc-overlay-header {
+  border-bottom: 1px solid var(--color-border);
+  color: var(--color-foreground);
+}
 
 /* react-day-picker theme — lowercase, brand colors, matching radii/font. */
 .rdp-root {


### PR DESCRIPTION
## Overview

When clicking "x more" on the calendar to view overflow events for a day, the popover was hardcoded to light-mode styling (white background, light border) and didn't adapt to dark mode, making it inconsistent with the rest of the themed calendar.

Themed the `.rbc-overlay` popover (react-big-calendar's overflow popup) using the app's existing CSS variables, matching the pattern already used for the rest of the calendar's dark-mode overrides.

Closes #810

## Test plan

- [x] Verified visually in both light and dark mode locally — popover background, border, and text now match the theme
- [x] `make agent-frontend-typecheck` passes
- [x] `make agent-frontend-lint` passes
