### PR TITLE
fix(sms): use vetter first name for ${SENDER_NAME} (Issue 817)

### DIFF
--- a/frontend/src/screens/admin/ApprovalCredentialsDialog.test.tsx
+++ b/frontend/src/screens/admin/ApprovalCredentialsDialog.test.tsx
@@ -64,11 +64,11 @@ describe('ApprovalCredentialsDialog', () => {
     renderDialog(makeUser());
     const sms = screen.getByText('send via sms').closest('a');
     const wa = screen.getByText('send via whatsapp').closest('a');
-    // Expected body: "hi Sam, from Vetter Vee: <magic-link>"
+    // Expected body: "hi Sam, from Vetter: <magic-link>"
     expect(sms?.getAttribute('href')).toContain('sms:+12025551234?body=');
-    expect(sms?.getAttribute('href')).toContain(encodeURIComponent('hi Sam, from Vetter Vee: '));
+    expect(sms?.getAttribute('href')).toContain(encodeURIComponent('hi Sam, from Vetter: '));
     expect(wa?.getAttribute('href')).toContain('https://wa.me/12025551234?text=');
-    expect(wa?.getAttribute('href')).toContain(encodeURIComponent('hi Sam, from Vetter Vee: '));
+    expect(wa?.getAttribute('href')).toContain(encodeURIComponent('hi Sam, from Vetter: '));
   });
 
   it('opens send links in a new tab with safe rel', () => {

--- a/frontend/src/screens/admin/ApprovalCredentialsDialog.tsx
+++ b/frontend/src/screens/admin/ApprovalCredentialsDialog.tsx
@@ -45,7 +45,7 @@ export function ApprovalCredentialsDialog({
 
   if (!magicLinkToken) return null;
   const magicLinkUrl = buildMagicLinkUrl(magicLinkToken);
-  const senderName = currentUser?.fullName ?? '';
+  const senderName = currentUser?.firstName ?? '';
   // If the template fetch fails, fall back to the legacy hardcoded body so
   // vetters can still send a message.
   const welcomeMessage = templateQ.data


### PR DESCRIPTION
## Summary
- `ApprovalCredentialsDialog` substituted `${SENDER_NAME}` in the welcome SMS/WhatsApp template with the vetter's **full name** (`currentUser.fullName`) instead of their first name — so approved members received a message like "I'm Vetter Vee" instead of "I'm Vetter".
- Fixed to use `currentUser.firstName`.
- Updated the existing dialog test to assert on the first-name-only sender text.

Closes #817

## Test plan
- [x] `npx vitest run src/screens/admin/ApprovalCredentialsDialog.test.tsx src/utils/welcomeMessage.test.ts` — 15 passed
- [x] `npx tsc --noEmit` — clean
- [ ] Manually approve a join request and confirm the sms/whatsapp preview shows only the vetter's first name after `${SENDER_NAME}`