### PR TITLE
chore(seed): add join request fixtures to seed_staging

### DIFF
--- a/backend/community/management/commands/_seed_join_requests.py
+++ b/backend/community/management/commands/_seed_join_requests.py
@@ -1,0 +1,56 @@
+"""Join request seeding for the `seed_staging` command."""
+
+from datetime import timedelta
+
+from django.utils import timezone
+from users.models import User
+
+from community.models import JoinFormQuestion, JoinRequest, JoinRequestStatus
+
+from ._seed_staging_data import JOIN_REQUEST_SPECS, joinreq_email, joinreq_phone
+
+
+def reset_join_requests() -> None:
+    JoinRequest.objects.filter(phone_number__startswith="+170255504").delete()
+
+
+def _custom_answers(spec) -> dict:
+    question = JoinFormQuestion.objects.filter(required=True).first()
+    if question is None:
+        return {}
+    return {str(question.id): {"label": question.label, "answer": spec.answer}}
+
+
+def _reviewer_fields(spec, reviewer: User | None, submitted_at) -> dict:
+    if spec.status == JoinRequestStatus.APPROVED:
+        return {"approved_at": submitted_at + timedelta(days=1), "approved_by": reviewer}
+    if spec.status == JoinRequestStatus.REJECTED:
+        return {"rejected_at": submitted_at + timedelta(days=1), "rejected_by": reviewer}
+    return {}
+
+
+def seed_join_requests(stdout, reviewer: User | None) -> list[JoinRequest]:
+    now = timezone.now()
+    requests: list[JoinRequest] = []
+    for index, spec in enumerate(JOIN_REQUEST_SPECS):
+        submitted_at = now - timedelta(days=spec.days_ago)
+        join_request, created = JoinRequest.objects.get_or_create(
+            phone_number=joinreq_phone(index),
+            defaults={
+                "first_name": spec.first_name,
+                "last_name": spec.last_name,
+                "email": joinreq_email(index) if spec.has_email else "",
+                "custom_answers": _custom_answers(spec),
+                "status": spec.status,
+                "sms_consent_at": submitted_at,
+                "guidelines_consent_at": submitted_at,
+                **_reviewer_fields(spec, reviewer, submitted_at),
+            },
+        )
+        if created:
+            JoinRequest.objects.filter(pk=join_request.pk).update(submitted_at=submitted_at)
+        requests.append(join_request)
+        stdout.write(
+            f"  {'created' if created else 'exists'} join request: {join_request.full_name}"
+        )
+    return requests

--- a/backend/community/management/commands/_seed_staging_data.py
+++ b/backend/community/management/commands/_seed_staging_data.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 
-from community.models.choices import AttendanceStatus, EventType, RSVPStatus
+from community.models.choices import AttendanceStatus, EventType, JoinRequestStatus, RSVPStatus
 
 PASSWORD = "testPassword1@"
 
@@ -41,6 +41,14 @@ def nonmember_phone(index: int) -> str:
 
 def nonmember_email(index: int) -> str:
     return f"nonmember{index:02d}@staging.example"
+
+
+def joinreq_phone(index: int) -> str:
+    return f"+170255504{index:02d}"
+
+
+def joinreq_email(index: int) -> str:
+    return f"joinreq{index:02d}@staging.example"
 
 
 NON_MEMBER_EVENT_TITLE = "[staging] official public rsvp demo"
@@ -268,4 +276,118 @@ NON_MEMBER_SPECS = [
     NonMemberSpec("past no-show (attendance report)", _rsvps((OFFICIAL_PAST_TITLE, _A, _NO_SHOW))),
     NonMemberSpec("waitlisted at capacity", _rsvps((OFFICIAL_FULL_TITLE, _W))),
     NonMemberSpec("no-rsvp (no token)", [], token_state=TOKEN_NONE),
+]
+
+
+@dataclass
+class JoinRequestSpec:
+    first_name: str
+    last_name: str
+    pronouns: str
+    has_email: bool
+    status: str
+    days_ago: int
+    answer: str
+
+
+JOIN_REQUEST_SPECS = [
+    JoinRequestSpec(
+        "Sage",
+        "Blackwood",
+        "they/them",
+        True,
+        JoinRequestStatus.PENDING,
+        0,
+        "I've been vegan for three years and want to connect with a local community.",
+    ),
+    JoinRequestSpec(
+        "Rowan",
+        "Ashfield",
+        "she/her",
+        True,
+        JoinRequestStatus.PENDING,
+        1,
+        "Looking for like-minded folks to organize with on animal liberation.",
+    ),
+    JoinRequestSpec(
+        "Fern",
+        "Whitaker",
+        "he/him",
+        False,
+        JoinRequestStatus.PENDING,
+        2,
+        "A friend recommended this group after I went vegan last month.",
+    ),
+    JoinRequestSpec(
+        "River",
+        "Okafor",
+        "they/them",
+        True,
+        JoinRequestStatus.PENDING,
+        3,
+        "I want to volunteer at events and help with outreach.",
+    ),
+    JoinRequestSpec(
+        "Wren",
+        "Castellano",
+        "she/her",
+        True,
+        JoinRequestStatus.PENDING,
+        5,
+        "Interested in the intersection of veganism and collective liberation.",
+    ),
+    JoinRequestSpec(
+        "Ash",
+        "Delgado",
+        "he/him",
+        False,
+        JoinRequestStatus.PENDING,
+        8,
+        "New to the area and looking for community.",
+    ),
+    JoinRequestSpec(
+        "Juniper",
+        "Osei",
+        "they/them",
+        True,
+        JoinRequestStatus.APPROVED,
+        14,
+        "Been following the group's work for a while and finally ready to join.",
+    ),
+    JoinRequestSpec(
+        "Marlowe",
+        "Fontaine",
+        "she/her",
+        True,
+        JoinRequestStatus.APPROVED,
+        20,
+        "A member invited me after a potluck.",
+    ),
+    JoinRequestSpec(
+        "Briar",
+        "Nakamura",
+        "he/him",
+        True,
+        JoinRequestStatus.APPROVED,
+        30,
+        "I run a plant-based cooking blog and want to get more involved locally.",
+    ),
+    JoinRequestSpec(
+        "Sparrow",
+        "Reyes",
+        "they/them",
+        False,
+        JoinRequestStatus.REJECTED,
+        12,
+        "Just filling out the form to see what happens.",
+    ),
+    JoinRequestSpec(
+        "Indigo",
+        "Marchetti",
+        "she/her",
+        True,
+        JoinRequestStatus.REJECTED,
+        25,
+        "not really sure what this group does but sure",
+    ),
 ]

--- a/backend/community/management/commands/seed_staging.py
+++ b/backend/community/management/commands/seed_staging.py
@@ -14,6 +14,7 @@ from users.roles import Role
 
 from community.models import Event, EventRSVP, EventType, RSVPStatus
 
+from ._seed_join_requests import reset_join_requests, seed_join_requests
 from ._seed_staging_data import (
     MEMBER_RSVP_SPECS,
     NON_MEMBER_EVENT_TITLE,
@@ -63,6 +64,7 @@ class Command(BaseCommand):
             events = self._seed_events(admin)
             self._seed_member_rsvps(cond_users, events)
             non_members = self._seed_non_members(events)
+            join_requests = seed_join_requests(self.stdout, admin)
         self._print_summary(
             {
                 "roles": roles,
@@ -70,6 +72,7 @@ class Command(BaseCommand):
                 "cond_users": cond_users,
                 "events": events,
                 "non_members": non_members,
+                "join_requests": join_requests,
             }
         )
 
@@ -80,6 +83,7 @@ class Command(BaseCommand):
         User.objects.filter(phone_number__startswith="+170255502").delete()
         User.objects.filter(phone_number__startswith="+170255503").delete()
         Role.objects.filter(name__startswith="perm: ").delete()
+        reset_join_requests()
         self.stdout.write("  reset: removed staging-scoped rows")
 
     def _seed_perm_roles(self) -> dict[str, Role]:
@@ -255,7 +259,8 @@ class Command(BaseCommand):
             f"events: {len(result['events'])}  roles: {len(result['roles'])}  "
             f"perm users: {len(result['perm_users'])}  "
             f"condition users: {len(result['cond_users'])}  "
-            f"non-member users: {len(result['non_members'])}"
+            f"non-member users: {len(result['non_members'])}  "
+            f"join requests: {len(result['join_requests'])}"
         )
         self._print_official_events(result["events"])
         self.stdout.write("non-member users (phone -> manage link):")

--- a/backend/tests/test_seed_staging.py
+++ b/backend/tests/test_seed_staging.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 import pytest
 from community.management.commands._seed_staging_data import (
+    JOIN_REQUEST_SPECS,
     NON_MEMBER_EVENT_TITLE,
     NON_MEMBER_SPECS,
     OFFICIAL_FULL_TITLE,
@@ -17,10 +18,19 @@ from community.management.commands._seed_staging_data import (
     condition_combinations,
     condition_label,
     is_seed_allowed,
+    joinreq_phone,
     perm_email,
     perm_phone,
 )
-from community.models import AttendanceStatus, Event, EventRSVP, EventType, RSVPStatus
+from community.models import (
+    AttendanceStatus,
+    Event,
+    EventRSVP,
+    EventType,
+    JoinRequest,
+    JoinRequestStatus,
+    RSVPStatus,
+)
 from django.contrib.auth.hashers import check_password
 from django.core.management import call_command
 from django.utils import timezone
@@ -307,3 +317,65 @@ def test_seed_staging_over_capacity_event_fills_and_waitlists():
     rsvps = EventRSVP.objects.filter(event=full)
     assert rsvps.filter(status=RSVPStatus.ATTENDING).count() >= full.max_attendees
     assert rsvps.filter(status=RSVPStatus.WAITLISTED).exists()
+
+
+def test_join_request_specs_span_all_statuses():
+    statuses = {spec.status for spec in JOIN_REQUEST_SPECS}
+    assert statuses == {
+        JoinRequestStatus.PENDING,
+        JoinRequestStatus.APPROVED,
+        JoinRequestStatus.REJECTED,
+    }
+    assert any(not spec.has_email for spec in JOIN_REQUEST_SPECS)
+    assert any(spec.has_email for spec in JOIN_REQUEST_SPECS)
+
+
+@pytest.mark.django_db
+def test_seed_staging_creates_join_requests_matching_specs():
+    call_command("seed_staging")
+    assert JoinRequest.objects.filter(phone_number__startswith="+170255504").count() == len(
+        JOIN_REQUEST_SPECS
+    )
+    for index, spec in enumerate(JOIN_REQUEST_SPECS):
+        jr = JoinRequest.objects.get(phone_number=joinreq_phone(index))
+        assert jr.status == spec.status
+        assert bool(jr.email) is spec.has_email
+        assert jr.sms_consent_at is not None
+        assert jr.guidelines_consent_at is not None
+        if spec.status == JoinRequestStatus.APPROVED:
+            assert jr.approved_at is not None
+            assert jr.approved_by is not None
+            assert jr.rejected_at is None
+        elif spec.status == JoinRequestStatus.REJECTED:
+            assert jr.rejected_at is not None
+            assert jr.rejected_by is not None
+            assert jr.approved_at is None
+        else:
+            assert jr.approved_at is None
+            assert jr.rejected_at is None
+
+
+@pytest.mark.django_db
+def test_seed_staging_join_requests_carry_custom_answers():
+    call_command("seed_staging")
+    for index in range(len(JOIN_REQUEST_SPECS)):
+        jr = JoinRequest.objects.get(phone_number=joinreq_phone(index))
+        assert jr.custom_answers
+
+
+@pytest.mark.django_db
+def test_seed_staging_join_requests_idempotent():
+    call_command("seed_staging")
+    call_command("seed_staging")
+    assert JoinRequest.objects.filter(phone_number__startswith="+170255504").count() == len(
+        JOIN_REQUEST_SPECS
+    )
+
+
+@pytest.mark.django_db
+def test_seed_staging_reset_removes_join_requests():
+    call_command("seed_staging")
+    call_command("seed_staging", "--reset")
+    assert JoinRequest.objects.filter(phone_number__startswith="+170255504").count() == len(
+        JOIN_REQUEST_SPECS
+    )


### PR DESCRIPTION
## Summary
- Adds 11 seeded `JoinRequest` rows to `seed_staging`, spanning pending/approved/rejected status, with/without email, and custom join-form answers
- New `_seed_join_requests.py` module keeps the seeding logic out of `seed_staging.py` to stay under the file-size limit
- `--reset` now also clears the join-request band

## Test plan
- [x] `pytest backend/tests/test_seed_staging.py` — 30 passed
- [x] `make agent-typecheck`, `make agent-lint`, `make agent-complexity` — all pass
- [ ] Run `seed_staging` on Railway staging after merge and confirm join requests appear in the admin vetting screen