### PR TITLE
fix(join-requests): show email address in join request list (Issue 813)

### DIFF
--- a/frontend/src/screens/admin/JoinRequestsScreen.test.tsx
+++ b/frontend/src/screens/admin/JoinRequestsScreen.test.tsx
@@ -200,6 +200,16 @@ describe('JoinRequestsScreen sort', () => {
   });
 });
 
+describe('JoinRequestsScreen card', () => {
+  it('shows the email address next to the phone number', () => {
+    mockResult([makeRequest({ fullName: 'Ada Lovelace', email: 'ada@example.com' })]);
+
+    renderScreen();
+
+    expect(screen.getByText(/ada@example\.com/)).toBeInTheDocument();
+  });
+});
+
 describe('JoinRequestsScreen search', () => {
   it('filters by name', async () => {
     mockResult([

--- a/frontend/src/screens/admin/JoinRequestsScreen.tsx
+++ b/frontend/src/screens/admin/JoinRequestsScreen.tsx
@@ -235,7 +235,7 @@ function JoinRequestCard({
         <div>
           <h2 className="text-base font-medium">{request.fullName}</h2>
           <p className="text-muted text-xs">
-            {formatPhone(request.phoneNumber)} · submitted{' '}
+            {formatPhone(request.phoneNumber)} · {request.email} · submitted{' '}
             {format(new Date(request.submittedAt), 'MMM d, h:mm a')}
           </p>
           <RsvpBreakdownNote breakdown={request.rsvpBreakdown} />


### PR DESCRIPTION
## Summary
- the join requests list let admins search by email but never displayed it, so there was no way to actually see a requester's email address
- shows the email next to the phone number in the join request card header
- adds a test asserting the email renders in the card

Closes #813

## Test plan
- [x] `pnpm exec vitest run src/screens/admin/JoinRequestsScreen.test.tsx` — all 12 tests pass
- [x] `make agent-frontend-typecheck` — clean
- [x] `make agent-frontend-lint` — clean
- [ ] manually check `/join-requests` in the browser to confirm email shows next to phone number