### PR TITLE
fix(join-requests): seed non-members across engagement states (Issue 815)

### DIFF
--- a/backend/community/management/commands/_seed_data.py
+++ b/backend/community/management/commands/_seed_data.py
@@ -41,6 +41,14 @@ class SeedEvent:
 
 
 @dataclass
+class SeedNonMember:
+    phone_number: str
+    first_name: str
+    last_name: str = ""
+    email: str = ""
+
+
+@dataclass
 class SeedRSVP:
     """An RSVP to seed, keyed by event title + seed-user phone number.
 
@@ -185,6 +193,15 @@ SEED_EVENTS = [
         rsvp_enabled=True,
         allow_plus_ones=True,
     ),
+    SeedEvent(
+        title="Past Club Meetup (seed)",
+        description="Last cycle's club meetup.",
+        delta_days=-14,
+        duration_hours=2,
+        location="Back Room",
+        event_type=EventType.CLUB,
+        rsvp_enabled=True,
+    ),
 ]
 
 # Seed-user phone numbers (mirror SEED_USERS) referenced by SEED_RSVPS.
@@ -193,6 +210,35 @@ _MEMBER = "+17025550002"
 _JAMIE = "+17025550003"
 _RIN = "+17025550004"
 _ASH = "+17025550005"
+
+# Non-member (join-request applicant) phone numbers, referenced by SEED_RSVPS
+# and SEED_JOIN_REQUESTS so the join-requests list has applicants across a
+# spread of engagement states — attended, upcoming, and neither — instead of
+# every request looking identically brand-new.
+_PRIYA_NON_MEMBER = "+17025550013"
+_RILEY_NON_MEMBER = "+17025550015"
+_TAYLOR_NON_MEMBER = "+17025550016"
+
+SEED_NON_MEMBERS = [
+    SeedNonMember(
+        phone_number=_PRIYA_NON_MEMBER,
+        first_name="Priya",
+        last_name="Raghavendra-Nakamura",
+        email="priya.rn@example.com",
+    ),
+    SeedNonMember(
+        phone_number=_RILEY_NON_MEMBER,
+        first_name="Riley",
+        last_name="Okonkwo-Vasquez",
+        email="riley.ov@example.com",
+    ),
+    SeedNonMember(
+        phone_number=_TAYLOR_NON_MEMBER,
+        first_name="Taylor",
+        last_name="Kim",
+        email="taylor.kim@example.com",
+    ),
+]
 
 SEED_RSVPS = [
     # Vegan Potluck — max_attendees=3. Admin +1 (2 spots) and Member (1 spot)
@@ -229,6 +275,24 @@ SEED_RSVPS = [
     ),
     SeedRSVP("Past Potluck (seed)", _RIN, RSVPStatus.MAYBE),
     SeedRSVP("Past Potluck (seed)", _ASH, RSVPStatus.CANT_GO),
+    # Non-member applicants (see SEED_NON_MEMBERS, SEED_JOIN_REQUESTS) spread
+    # across engagement states, so the join-requests list isn't uniformly blank:
+    # Priya attended once (community); Riley attended a club meetup and has an
+    # upcoming official rsvp; Taylor has only ever rsvp'd, never attended.
+    SeedRSVP(
+        "Past Potluck (seed)",
+        _PRIYA_NON_MEMBER,
+        RSVPStatus.ATTENDING,
+        attendance=AttendanceStatus.ATTENDED,
+    ),
+    SeedRSVP(
+        "Past Club Meetup (seed)",
+        _RILEY_NON_MEMBER,
+        RSVPStatus.ATTENDING,
+        attendance=AttendanceStatus.ATTENDED,
+    ),
+    SeedRSVP("Plant-Based Cooking Workshop", _RILEY_NON_MEMBER, RSVPStatus.ATTENDING),
+    SeedRSVP("Plant-Based Cooking Workshop", _TAYLOR_NON_MEMBER, RSVPStatus.ATTENDING),
 ]
 
 SEED_HOME_PAGE = {
@@ -278,7 +342,7 @@ SEED_JOIN_REQUESTS = [
     SeedJoinRequest(
         first_name="Priya",
         last_name="Raghavendra-Nakamura",
-        phone_number="+17025550013",
+        phone_number=_PRIYA_NON_MEMBER,
         answers={
             "Why do you want to join?": (
                 "i've been plant-based for about six months and am finally ready to find my people. "
@@ -302,7 +366,7 @@ SEED_JOIN_REQUESTS = [
     SeedJoinRequest(
         first_name="Riley",
         last_name="Okonkwo-Vasquez",
-        phone_number="+17025550015",
+        phone_number=_RILEY_NON_MEMBER,
         answers={
             "Why do you want to join?": "food not bombs volunteer, interested in mutual aid + vegan outreach.",
             "How did you hear about us?": "instagram — pda showed up in a story reshare.",
@@ -312,7 +376,7 @@ SEED_JOIN_REQUESTS = [
     SeedJoinRequest(
         first_name="Taylor",
         last_name="Kim",
-        phone_number="+17025550016",
+        phone_number=_TAYLOR_NON_MEMBER,
         answers={
             "Why do you want to join?": "just curious — not vegan yet but open to learning.",
         },

--- a/backend/community/management/commands/seed.py
+++ b/backend/community/management/commands/seed.py
@@ -17,6 +17,7 @@ from ._seed_data import (
     SEED_HOME_PAGE,
     SEED_JOIN_FORM_QUESTIONS,
     SEED_JOIN_REQUESTS,
+    SEED_NON_MEMBERS,
     SEED_RSVPS,
     SEED_USERS,
     SeedUser,
@@ -40,6 +41,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         admin_user = self._seed_users()
+        self._seed_non_members()
         questions = self._seed_join_form_questions()
         self._seed_event_tags()
         events = self._seed_events(admin_user)
@@ -100,6 +102,25 @@ class Command(BaseCommand):
 
         assert admin_user is not None, "SEED_USERS must contain a superuser entry"
         return admin_user
+
+    def _seed_non_members(self) -> None:
+        """Non-member users (e.g. join-request applicants) referenced by SEED_RSVPS."""
+        for data in SEED_NON_MEMBERS:
+            user, created = User.objects.get_or_create(
+                phone_number=data.phone_number,
+                defaults={
+                    "first_name": data.first_name,
+                    "last_name": data.last_name,
+                    "email": data.email,
+                    "is_member": False,
+                },
+            )
+            if created:
+                user.set_unusable_password()
+                user.save(update_fields=["password"])
+            self.stdout.write(
+                f"  {'Created' if created else 'Already exists'} non-member: {user.full_name}"
+            )
 
     def _seed_join_form_questions(self) -> dict[str, JoinFormQuestion]:
         """Seed default join form questions. Returns a label→question mapping."""

--- a/backend/tests/test_seed.py
+++ b/backend/tests/test_seed.py
@@ -11,7 +11,7 @@ def test_seed_creates_expected_data():
 
     assert User.objects.filter(phone_number="+17025550001").exists()
     assert User.objects.filter(phone_number="+17025550002").exists()
-    assert Event.objects.count() == 4
+    assert Event.objects.count() == 5
     assert JoinRequest.objects.count() == 8
 
 
@@ -21,8 +21,8 @@ def test_seed_is_idempotent():
     rsvp_count = EventRSVP.objects.count()
     call_command("seed")
 
-    assert User.objects.filter(phone_number__startswith="+1702555").count() == 5
-    assert Event.objects.count() == 4
+    assert User.objects.filter(phone_number__startswith="+1702555").count() == 8
+    assert Event.objects.count() == 5
     assert JoinRequest.objects.count() == 8
     assert EventRSVP.objects.count() == rsvp_count
 


### PR DESCRIPTION
## Summary
- the join-requests list already renders an rsvp-breakdown note ("attended 2 official events", "rsvp'd for 1 upcoming club event") when a request's linked user has RSVP history — this code path already existed and needed no changes
- the actual bug: local seed data had zero join requests linked to non-members with any attendance/rsvp history, so that note always rendered empty everywhere — making the feature look broken/missing
- seeded 3 non-members across distinct engagement states, each linked by phone number to an existing pending join request:
  - **Priya** — attended a past community event (attendance recorded, but community isn't a bucketed type, so this is a useful edge case showing the breakdown legitimately renders nothing for her)
  - **Riley** — attended a past club meetup + has an upcoming official rsvp (exercises both attended and upcoming buckets)
  - **Taylor Kim** — has an upcoming official rsvp only, never attended
  - **Mo** (unchanged) — no rsvp history at all, the baseline "brand new" case
- added a new past CLUB-type seed event ("Past Club Meetup (seed)") so club attendance has real data to seed against

Closes #815

## Test plan
- [x] `pytest backend/tests/test_seed.py backend/tests/test_join_request_integration.py` — 24/24 pass (updated hardcoded event/user counts for the new event + non-members)
- [x] full backend suite passes (pre-existing SSE/pg_notify failures on sqlite are unrelated, not regressions)
- [x] `make agent-lint`, `make agent-typecheck`, `make agent-complexity` all clean
- [x] verified via Django shell that Priya/Riley/Taylor/Mo each resolve to the expected attended/upcoming counts
- [ ] manually check `/join-requests` in the browser — Riley and Taylor's tiles should show rsvp-breakdown notes; Priya and Mo's should not (by design, per above)