### PR TITLE
fix: 824 - show profile step after first-time password setup

### DIFF
--- a/frontend/src/screens/auth/NewPasswordScreen.test.tsx
+++ b/frontend/src/screens/auth/NewPasswordScreen.test.tsx
@@ -4,6 +4,8 @@ import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAuthStore } from '@/auth/store';
+import type { User } from '@/models/user';
+import { makeUser } from '@/test/fixtures';
 
 import NewPasswordScreen from './NewPasswordScreen';
 
@@ -17,18 +19,37 @@ vi.mock('@/api/client', () => ({
   setAuthBridge: vi.fn(),
 }));
 
+vi.mock('@/screens/settings/AvatarUpload', () => ({
+  AvatarUpload: () => <div data-testid="avatar-upload" />,
+}));
+
 const VALID = 'abcd1234ABCD!';
 
 describe('NewPasswordScreen', () => {
   const completeOnboarding = vi.fn();
   const startProfileStep = vi.fn();
+  const finishProfileStep = vi.fn();
+
+  function setupMock(user: User, profileStepActive = false) {
+    const storeState = {
+      completeOnboarding,
+      startProfileStep,
+      finishProfileStep,
+      user,
+      profileStepActive,
+    };
+    vi.mocked(useAuthStore).mockImplementation(
+      Object.assign((selector: (s: typeof storeState) => unknown) => selector(storeState), {
+        getState: () => ({ user }),
+      }) as never,
+    );
+  }
 
   beforeEach(() => {
     completeOnboarding.mockReset();
     startProfileStep.mockReset();
-    vi.mocked(useAuthStore).mockImplementation((selector) =>
-      selector({ completeOnboarding, startProfileStep } as never),
-    );
+    finishProfileStep.mockReset();
+    setupMock(makeUser({ needsOnboarding: false, needsPasswordReset: true }));
   });
 
   it('blocks submit when confirmation does not match', async () => {
@@ -45,8 +66,9 @@ describe('NewPasswordScreen', () => {
     expect(completeOnboarding).not.toHaveBeenCalled();
   });
 
-  it('submits the new password when confirmation matches', async () => {
+  it('submits the new password when confirmation matches, and does not enter the profile step on a real password reset', async () => {
     completeOnboarding.mockResolvedValue(undefined);
+    setupMock(makeUser({ needsOnboarding: false, needsPasswordReset: true }));
     render(
       <MemoryRouter>
         <NewPasswordScreen />
@@ -59,8 +81,36 @@ describe('NewPasswordScreen', () => {
     await vi.waitFor(() => {
       expect(completeOnboarding).toHaveBeenCalledWith({ newPassword: VALID });
     });
-    // the password-reset flow shares completeOnboarding but must not enter the
-    // onboarding profile step
+    // a self-service password reset is an already-onboarded member — no profile step
     expect(startProfileStep).not.toHaveBeenCalled();
+  });
+
+  it('enters the profile step after a first-time join-request user sets their password', async () => {
+    completeOnboarding.mockResolvedValue(undefined);
+    setupMock(makeUser({ needsOnboarding: true, needsPasswordReset: false }));
+    render(
+      <MemoryRouter>
+        <NewPasswordScreen />
+      </MemoryRouter>,
+    );
+    await userEvent.type(screen.getByLabelText(/^new password$/i), VALID);
+    await userEvent.type(screen.getByLabelText(/confirm new password/i), VALID);
+    await userEvent.click(screen.getByRole('button', { name: /save password/i }));
+
+    await vi.waitFor(() => {
+      expect(completeOnboarding).toHaveBeenCalledWith({ newPassword: VALID });
+    });
+    expect(startProfileStep).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the profile step when profileStepActive is set', () => {
+    setupMock(makeUser({ needsOnboarding: true }), true);
+    render(
+      <MemoryRouter>
+        <NewPasswordScreen />
+      </MemoryRouter>,
+    );
+    expect(screen.getByRole('button', { name: /^done$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /do this later/i })).toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/auth/NewPasswordScreen.tsx
+++ b/frontend/src/screens/auth/NewPasswordScreen.tsx
@@ -7,9 +7,11 @@ import { z } from 'zod';
 import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import { PasswordField } from '@/components/ui/PasswordField';
+import { postAuthRedirect } from '@/models/user';
 import { extractApiError } from '@/utils/errors';
 
 import { AuthLayout } from './AuthLayout';
+import { OnboardingProfileStep } from './OnboardingProfileStep';
 import { PasswordChecklist } from './PasswordChecklist';
 import { passwordRule } from './passwordRule';
 
@@ -26,9 +28,14 @@ const schema = z
 type FormValues = z.infer<typeof schema>;
 
 export default function NewPasswordScreen() {
-  // Post-reset: the user arrived here via magic-login with needs_onboarding=true
-  // but an existing displayName — they only need to set a new password.
+  // Shared by two populations: self-service password resets (already-onboarded
+  // members — skip straight to the app) and first-time join-request users who
+  // already have name+email but have never seen the profile step.
   const completeOnboarding = useAuthStore((s) => s.completeOnboarding);
+  const startProfileStep = useAuthStore((s) => s.startProfileStep);
+  const finishProfileStep = useAuthStore((s) => s.finishProfileStep);
+  const profileStepActive = useAuthStore((s) => s.profileStepActive);
+  const needsOnboarding = useAuthStore((s) => s.user?.needsOnboarding ?? false);
   const navigate = useNavigate();
   const [serverError, setServerError] = useState<string | null>(null);
 
@@ -47,10 +54,31 @@ export default function NewPasswordScreen() {
     setServerError(null);
     try {
       await completeOnboarding({ newPassword: values.newPassword });
-      void navigate('/calendar', { replace: true });
+      if (needsOnboarding) {
+        startProfileStep();
+      } else {
+        void navigate('/calendar', { replace: true });
+      }
     } catch (err) {
       setServerError(extractApiError(err, "couldn't save password — try again"));
     }
+  }
+
+  if (profileStepActive) {
+    return (
+      <AuthLayout
+        title="make it yours ✨"
+        subtitle="add a photo and a few words so folks can put a face to your name — you can always do this later"
+      >
+        <OnboardingProfileStep
+          onDone={() => {
+            finishProfileStep();
+            const next = postAuthRedirect(useAuthStore.getState().user) ?? '/calendar';
+            void navigate(next, { replace: true });
+          }}
+        />
+      </AuthLayout>
+    );
   }
 
   return (


### PR DESCRIPTION
## Overview

`/new-password` is shared by two different populations: self-service password resets (existing members who forgot their password — already onboarded, should skip straight to the app) and first-time join-request users, who already have a name and email carried over from their join request but have never set a password. Because they already have name+email, `passwordSetupRedirect` routes them to `/new-password` rather than `/onboarding` — but `/new-password` never entered the optional "make it yours" profile step (avatar/bio) that `OnboardingScreen` added, so these users set a password and landed straight in the app without ever seeing it.

`NewPasswordScreen` now checks `needsOnboarding` on the authenticated user: if set, it enters the same profile step `OnboardingScreen` uses after saving the password; otherwise (a real password reset, `needsPasswordReset`) it continues straight to `/calendar` as before.

Closes #824

## Test plan

- [x] Added `NewPasswordScreen` tests covering both populations: a real password reset does not enter the profile step; a first-time join-request user (`needsOnboarding: true`) does enter it and can complete/skip it
- [x] Full frontend test suite passes (`make agent-frontend-test`)
- [x] Frontend typecheck + lint clean (`make agent-frontend-typecheck`, `make agent-frontend-lint`)
- [x] Backend test suite passes against isolated per-worktree DB (unrelated to this change — frontend-only)
- [x] Verified via Django test client that a user shaped like the reported scenario (`needsOnboarding=True`, `needsPasswordReset=False`, name+email already set) hits the fixed code path
