### PR TITLE
feat(admin): tentative approval section, manual-approve, rsvp list

### DIFF
--- a/backend/community/_join_requests.py
+++ b/backend/community/_join_requests.py
@@ -45,6 +45,12 @@ class JoinRequestAnswerOut(BaseModel):
     answer: str
 
 
+class JoinRequestRsvpOut(BaseModel):
+    event_id: str
+    title: str
+    start_datetime: datetime | None = None
+
+
 class JoinRequestOut(BaseModel):
     id: str
     first_name: str = ""
@@ -69,6 +75,7 @@ class JoinRequestOut(BaseModel):
     attended_club_count: int = 0
     upcoming_official_count: int = 0
     upcoming_club_count: int = 0
+    rsvp_events: list[JoinRequestRsvpOut] = []
 
 
 class JoinRequestStatusIn(BaseModel):
@@ -143,6 +150,29 @@ def _rsvp_breakdown(user: User | None) -> RsvpBreakdown:
     )
 
 
+def _rsvp_events(user: User | None) -> list[JoinRequestRsvpOut]:
+    """Events (past and future) a tentative applicant has RSVP'd ATTENDING to, oldest first."""
+    if user is None:
+        return []
+    prefetched = getattr(user, "_prefetched_objects_cache", {})
+    rsvps = (
+        user.event_rsvps.all()
+        if "event_rsvps" in prefetched
+        else EventRSVP.objects.filter(user_id=user.id).select_related("event")
+    )
+    events = [
+        rsvp.event
+        for rsvp in rsvps
+        if rsvp.status == RSVPStatus.ATTENDING
+        and rsvp.event.status not in NON_REPORTABLE_EVENT_STATUSES
+    ]
+    events.sort(key=lambda e: e.start_datetime or timezone.now())
+    return [
+        JoinRequestRsvpOut(event_id=str(e.id), title=e.title, start_datetime=e.start_datetime)
+        for e in events
+    ]
+
+
 def _join_request_out(jr: JoinRequest) -> JoinRequestOut:
     answers = [
         JoinRequestAnswerOut(question_id=qid, label=data["label"], answer=data["answer"])
@@ -173,6 +203,7 @@ def _join_request_out(jr: JoinRequest) -> JoinRequestOut:
         attended_club_count=breakdown.attended_club,
         upcoming_official_count=breakdown.upcoming_official,
         upcoming_club_count=breakdown.upcoming_club,
+        rsvp_events=_rsvp_events(user),
     )
 
 

--- a/backend/community/_join_requests.py
+++ b/backend/community/_join_requests.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Iterable
 from datetime import datetime, timedelta
 from typing import NamedTuple
 from uuid import UUID
@@ -102,6 +103,16 @@ class RsvpBreakdown(NamedTuple):
     upcoming_club: int = 0
 
 
+def _is_reportable_attending(rsvp: EventRSVP) -> bool:
+    """Whether an ATTENDING rsvp is for a bucketed, reportable event at all."""
+    event = rsvp.event
+    return (
+        event.event_type in BUCKETED_EVENT_TYPES
+        and event.status not in NON_REPORTABLE_EVENT_STATUSES
+        and rsvp.status == RSVPStatus.ATTENDING
+    )
+
+
 def _rsvp_bucket(rsvp: EventRSVP) -> tuple[str, str] | None:
     """(state, event_type) bucket for a linked user's rsvp, or None if it counts nowhere.
 
@@ -109,18 +120,24 @@ def _rsvp_bucket(rsvp: EventRSVP) -> tuple[str, str] | None:
     future, time-decided event). Non-bucketed types, non-reportable events, and
     non-ATTENDING rsvps fall through to None.
     """
+    if not _is_reportable_attending(rsvp):
+        return None
     event = rsvp.event
-    if event.event_type not in BUCKETED_EVENT_TYPES:
-        return None
-    if event.status in NON_REPORTABLE_EVENT_STATUSES:
-        return None
-    if rsvp.status != RSVPStatus.ATTENDING:
-        return None
     if rsvp.attendance == AttendanceStatus.ATTENDED:
         return ("attended", event.event_type)
     if not event.is_past and not event.datetime_tbd:
         return ("upcoming", event.event_type)
     return None
+
+
+def _user_event_rsvps(user: User) -> Iterable[EventRSVP]:
+    """Rsvps for a user, reading the prefetched list endpoint cache when available."""
+    prefetched = getattr(user, "_prefetched_objects_cache", {})
+    return (
+        user.event_rsvps.all()
+        if "event_rsvps" in prefetched
+        else EventRSVP.objects.filter(user_id=user.id).select_related("event")
+    )
 
 
 def _rsvp_breakdown(user: User | None) -> RsvpBreakdown:
@@ -131,14 +148,8 @@ def _rsvp_breakdown(user: User | None) -> RsvpBreakdown:
     """
     if user is None:
         return RsvpBreakdown()
-    prefetched = getattr(user, "_prefetched_objects_cache", {})
-    rsvps = (
-        user.event_rsvps.all()
-        if "event_rsvps" in prefetched
-        else EventRSVP.objects.filter(user_id=user.id).select_related("event")
-    )
     counts: dict[tuple[str, str], int] = {}
-    for rsvp in rsvps:
+    for rsvp in _user_event_rsvps(user):
         bucket = _rsvp_bucket(rsvp)
         if bucket is not None:
             counts[bucket] = counts.get(bucket, 0) + 1
@@ -154,19 +165,8 @@ def _rsvp_events(user: User | None) -> list[JoinRequestRsvpOut]:
     """Events (past and future) a tentative applicant has RSVP'd ATTENDING to, oldest first."""
     if user is None:
         return []
-    prefetched = getattr(user, "_prefetched_objects_cache", {})
-    rsvps = (
-        user.event_rsvps.all()
-        if "event_rsvps" in prefetched
-        else EventRSVP.objects.filter(user_id=user.id).select_related("event")
-    )
-    events = [
-        rsvp.event
-        for rsvp in rsvps
-        if rsvp.status == RSVPStatus.ATTENDING
-        and rsvp.event.status not in NON_REPORTABLE_EVENT_STATUSES
-    ]
-    events.sort(key=lambda e: e.start_datetime or timezone.now())
+    events = [rsvp.event for rsvp in _user_event_rsvps(user) if _is_reportable_attending(rsvp)]
+    events.sort(key=lambda e: (e.start_datetime is None, e.start_datetime))
     return [
         JoinRequestRsvpOut(event_id=str(e.id), title=e.title, start_datetime=e.start_datetime)
         for e in events

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -3078,6 +3078,14 @@
             ],
             "title": "Rejected By Name"
           },
+          "rsvp_events": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/JoinRequestRsvpOut"
+            },
+            "title": "Rsvp Events",
+            "type": "array"
+          },
           "status": {
             "title": "Status",
             "type": "string"
@@ -3116,6 +3124,36 @@
           "status"
         ],
         "title": "JoinRequestOut",
+        "type": "object"
+      },
+      "JoinRequestRsvpOut": {
+        "properties": {
+          "event_id": {
+            "title": "Event Id",
+            "type": "string"
+          },
+          "start_datetime": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Datetime"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "event_id",
+          "title"
+        ],
+        "title": "JoinRequestRsvpOut",
         "type": "object"
       },
       "JoinRequestStatusIn": {

--- a/backend/tests/test_join_request_tentative.py
+++ b/backend/tests/test_join_request_tentative.py
@@ -372,3 +372,32 @@ class TestTentativeRsvpEvents:
         response = api_client.get("/api/community/join-requests/", **vettor_headers)
         row = next(r for r in response.json() if r["id"] == str(sample_join_request.id))
         assert row["rsvp_events"] == []
+
+    def test_list_excludes_non_bucketed_event_types(
+        self, api_client, vettor_headers, vettor_user, sample_join_request, open_official_event
+    ):
+        open_official_event.event_type = EventType.COMMUNITY
+        open_official_event.save(update_fields=["event_type"])
+        user = _tentative_user_with_rsvp(sample_join_request, open_official_event, vettor_user)
+        response = api_client.get("/api/community/join-requests/", **vettor_headers)
+        row = next(r for r in response.json() if r["user_id"] == str(user.id))
+        assert row["rsvp_events"] == []
+
+    def test_list_orders_tbd_events_last(
+        self, api_client, vettor_headers, vettor_user, sample_join_request, open_official_event
+    ):
+        host = open_official_event.created_by
+        tbd_event = Event.objects.create(
+            title="TBD Meetup",
+            start_datetime=None,
+            end_datetime=None,
+            datetime_tbd=True,
+            rsvp_enabled=True,
+            event_type=EventType.OFFICIAL,
+            created_by=host,
+        )
+        user = _tentative_user_with_rsvp(sample_join_request, open_official_event, vettor_user)
+        EventRSVP.objects.create(event=tbd_event, user=user, status=RSVPStatus.ATTENDING)
+        response = api_client.get("/api/community/join-requests/", **vettor_headers)
+        row = next(r for r in response.json() if r["user_id"] == str(user.id))
+        assert [e["title"] for e in row["rsvp_events"]] == ["Official Meetup", "TBD Meetup"]

--- a/backend/tests/test_join_request_tentative.py
+++ b/backend/tests/test_join_request_tentative.py
@@ -328,3 +328,47 @@ class TestJoinApprovalEmail:
         )
         recipients = [c.kwargs["to"] for c in fake_email_sender.send.call_args_list]
         assert "checkin@example.com" in recipients
+
+
+@pytest.mark.django_db
+class TestTentativeRsvpEvents:
+    def test_list_includes_rsvpd_events(
+        self, api_client, vettor_headers, vettor_user, sample_join_request, open_official_event
+    ):
+        user = _tentative_user_with_rsvp(sample_join_request, open_official_event, vettor_user)
+        response = api_client.get("/api/community/join-requests/", **vettor_headers)
+        assert response.status_code == 200
+        row = next(r for r in response.json() if r["user_id"] == str(user.id))
+        assert [e["title"] for e in row["rsvp_events"]] == ["Official Meetup"]
+
+    def test_list_includes_future_events(
+        self, api_client, vettor_headers, vettor_user, sample_join_request, open_official_event
+    ):
+        user = _tentative_user_with_rsvp(sample_join_request, open_official_event, vettor_user)
+        response = api_client.get("/api/community/join-requests/", **vettor_headers)
+        row = next(r for r in response.json() if r["user_id"] == str(user.id))
+        assert row["rsvp_events"][0]["start_datetime"] is not None
+        assert open_official_event.start_datetime > timezone.now()
+
+    def test_list_excludes_non_attending_rsvps(
+        self, api_client, vettor_headers, vettor_user, sample_join_request, open_official_event
+    ):
+        from community._join_request_approval import _provision_tentative_user
+
+        _provision_tentative_user(sample_join_request, vettor_user)
+        sample_join_request.status = JoinRequestStatus.TENTATIVE
+        sample_join_request.save(update_fields=["status"])
+        sample_join_request.refresh_from_db()
+        EventRSVP.objects.create(
+            event=open_official_event,
+            user=sample_join_request.user,
+            status=RSVPStatus.CANT_GO,
+        )
+        response = api_client.get("/api/community/join-requests/", **vettor_headers)
+        row = next(r for r in response.json() if r["user_id"] == str(sample_join_request.user.id))
+        assert row["rsvp_events"] == []
+
+    def test_list_empty_when_no_rsvps(self, api_client, vettor_headers, sample_join_request):
+        response = api_client.get("/api/community/join-requests/", **vettor_headers)
+        row = next(r for r in response.json() if r["id"] == str(sample_join_request.id))
+        assert row["rsvp_events"] == []

--- a/frontend/src/api/join.test.ts
+++ b/frontend/src/api/join.test.ts
@@ -80,10 +80,38 @@ describe('useJoinRequests', () => {
           upcomingOfficial: 0,
           upcomingClub: 0,
         },
+        rsvpEvents: [],
       },
     ]);
 
     expect(mockedGet).toHaveBeenCalledWith('/api/community/join-requests/');
+  });
+
+  it('maps rsvp_events from the wire', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'jr-3',
+          full_name: 'Sam Rivera',
+          phone_number: '+12125550111',
+          answers: [],
+          submitted_at: '2024-04-01T09:00:00Z',
+          status: 'tentative',
+          user_id: 'user-3',
+          rsvp_events: [
+            { event_id: 'evt-1', title: 'Potluck', start_datetime: '2026-03-01T18:00:00Z' },
+          ],
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useJoinRequests(), { wrapper: wrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.[0]?.rsvpEvents).toEqual([
+      { eventId: 'evt-1', title: 'Potluck', startDatetime: '2026-03-01T18:00:00Z' },
+    ]);
   });
 
   it('maps the rsvp breakdown buckets from the wire', async () => {

--- a/frontend/src/api/join.ts
+++ b/frontend/src/api/join.ts
@@ -112,6 +112,7 @@ export async function checkPhone(phoneNumber: string): Promise<CheckPhoneStatus>
 
 export const JoinRequestStatus = {
   PENDING: 'pending',
+  TENTATIVE: 'tentative',
   APPROVED: 'approved',
   REJECTED: 'rejected',
 } as const;
@@ -130,6 +131,12 @@ export interface RsvpBreakdown {
   upcomingClub: number;
 }
 
+export interface JoinRequestRsvpEvent {
+  eventId: string;
+  title: string;
+  startDatetime: string | null;
+}
+
 export interface JoinRequestSummary {
   id: string;
   fullName: string;
@@ -146,12 +153,19 @@ export interface JoinRequestSummary {
   rejectedByName: string | null;
   onboardedAt: string | null;
   rsvpBreakdown: RsvpBreakdown;
+  rsvpEvents: JoinRequestRsvpEvent[];
 }
 
 interface WireAnswer {
   question_id: string;
   label: string;
   answer: string;
+}
+
+interface WireRsvpEvent {
+  event_id: string;
+  title: string;
+  start_datetime: string | null;
 }
 
 interface WireJoinRequest {
@@ -173,6 +187,7 @@ interface WireJoinRequest {
   attended_club_count?: number;
   upcoming_official_count?: number;
   upcoming_club_count?: number;
+  rsvp_events?: WireRsvpEvent[];
 }
 
 function mapJoinRequest(w: WireJoinRequest): JoinRequestSummary {
@@ -201,6 +216,11 @@ function mapJoinRequest(w: WireJoinRequest): JoinRequestSummary {
       upcomingOfficial: w.upcoming_official_count ?? 0,
       upcomingClub: w.upcoming_club_count ?? 0,
     },
+    rsvpEvents: (w.rsvp_events ?? []).map((e) => ({
+      eventId: e.event_id,
+      title: e.title,
+      startDatetime: e.start_datetime,
+    })),
   };
 }
 

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -3122,6 +3122,11 @@ export interface components {
             rejected_at?: string | null;
             /** Rejected By Name */
             rejected_by_name?: string | null;
+            /**
+             * Rsvp Events
+             * @default []
+             */
+            rsvp_events: components["schemas"]["JoinRequestRsvpOut"][];
             /** Status */
             status: string;
             /**
@@ -3141,6 +3146,15 @@ export interface components {
             upcoming_official_count: number;
             /** User Id */
             user_id?: string | null;
+        };
+        /** JoinRequestRsvpOut */
+        JoinRequestRsvpOut: {
+            /** Event Id */
+            event_id: string;
+            /** Start Datetime */
+            start_datetime?: string | null;
+            /** Title */
+            title: string;
         };
         /** JoinRequestStatusIn */
         JoinRequestStatusIn: {

--- a/frontend/src/screens/admin/JoinRequestTentativeSection.tsx
+++ b/frontend/src/screens/admin/JoinRequestTentativeSection.tsx
@@ -1,0 +1,44 @@
+import { format } from 'date-fns';
+
+import type { JoinRequestRsvpEvent, JoinRequestSummary } from '@/api/join';
+import { Button } from '@/components/ui/Button';
+
+export function TentativeActions({
+  request,
+  busy,
+  onApprove,
+}: {
+  request: JoinRequestSummary;
+  busy: boolean;
+  onApprove: () => void;
+}) {
+  return (
+    <div className="mt-3 flex flex-col gap-3">
+      <RsvpEventList events={request.rsvpEvents} />
+      <div>
+        <Button onClick={onApprove} disabled={busy}>
+          manually approve
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function RsvpEventList({ events }: { events: JoinRequestRsvpEvent[] }) {
+  if (events.length === 0) return null;
+  return (
+    <div>
+      <p className="text-muted text-xs font-medium">rsvp&rsquo;d to</p>
+      <ul className="mt-1 flex flex-col gap-0.5">
+        {events.map((e) => (
+          <li key={e.eventId} className="text-foreground-secondary text-xs">
+            {e.title}
+            {e.startDatetime
+              ? ` · ${format(new Date(e.startDatetime), 'MMM d, h:mm a').toLowerCase()}`
+              : ''}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/src/screens/admin/JoinRequestsScreen.test.tsx
+++ b/frontend/src/screens/admin/JoinRequestsScreen.test.tsx
@@ -18,7 +18,7 @@ vi.mock('@/api/join', async (importOriginal) => {
   };
 });
 
-import { useJoinRequests } from '@/api/join';
+import { useDecideJoinRequest, useJoinRequests } from '@/api/join';
 
 import JoinRequestsScreen from './JoinRequestsScreen';
 
@@ -46,6 +46,7 @@ function makeRequest(overrides: Partial<JoinRequestSummary> = {}): JoinRequestSu
       upcomingOfficial: 0,
       upcomingClub: 0,
     },
+    rsvpEvents: [],
     ...overrides,
   };
 }
@@ -247,5 +248,62 @@ describe('JoinRequestsScreen search', () => {
     await user.type(screen.getByLabelText(/^search$/i), 'zzz');
 
     expect(screen.getByText(/nothing matches/i)).toBeInTheDocument();
+  });
+});
+
+describe('JoinRequestsScreen tentative section', () => {
+  it('shows a manually approve button for tentative requests', async () => {
+    mockResult([makeRequest({ status: JoinRequestStatus.TENTATIVE })]);
+
+    renderScreen();
+    await userEvent.click(screen.getByRole('radio', { name: 'tentative' }));
+
+    expect(screen.getByRole('button', { name: 'manually approve' })).toBeInTheDocument();
+  });
+
+  it('shows rsvp events for a tentative request', async () => {
+    mockResult([
+      makeRequest({
+        status: JoinRequestStatus.TENTATIVE,
+        rsvpEvents: [
+          { eventId: 'e1', title: 'Potluck', startDatetime: '2026-03-01T18:00:00Z' },
+          { eventId: 'e2', title: 'Movie Night', startDatetime: null },
+        ],
+      }),
+    ]);
+
+    renderScreen();
+    await userEvent.click(screen.getByRole('radio', { name: 'tentative' }));
+
+    expect(screen.getByText(/Potluck/)).toBeInTheDocument();
+    expect(screen.getByText(/Movie Night/)).toBeInTheDocument();
+  });
+
+  it('hides the rsvp list entirely when there are no rsvps', async () => {
+    mockResult([makeRequest({ status: JoinRequestStatus.TENTATIVE, rsvpEvents: [] })]);
+
+    renderScreen();
+    await userEvent.click(screen.getByRole('radio', { name: 'tentative' }));
+
+    expect(screen.queryByText(/rsvp/i)).not.toBeInTheDocument();
+  });
+
+  it('calls decide with approved status when manually approve is clicked', async () => {
+    const mutateAsync = vi.fn().mockResolvedValue({ magicLinkToken: null });
+    vi.mocked(useDecideJoinRequest).mockReturnValue({
+      mutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useDecideJoinRequest>);
+    mockResult([makeRequest({ id: 'jr-tentative', status: JoinRequestStatus.TENTATIVE })]);
+
+    renderScreen();
+    await userEvent.click(screen.getByRole('radio', { name: 'tentative' }));
+    await userEvent.click(screen.getByRole('button', { name: 'manually approve' }));
+    await userEvent.click(screen.getByRole('button', { name: 'approve' }));
+
+    expect(mutateAsync).toHaveBeenCalledWith({
+      id: 'jr-tentative',
+      status: JoinRequestStatus.APPROVED,
+    });
   });
 });

--- a/frontend/src/screens/admin/JoinRequestsScreen.tsx
+++ b/frontend/src/screens/admin/JoinRequestsScreen.tsx
@@ -20,6 +20,7 @@ import { cn } from '@/utils/cn';
 import { formatPhone } from '@/utils/formatPhone';
 
 import { ApprovalCredentialsDialog } from './ApprovalCredentialsDialog';
+import { TentativeActions } from './JoinRequestTentativeSection';
 
 const Filter = {
   ALL: 'all',
@@ -32,6 +33,7 @@ type Decision = typeof JoinRequestStatus.APPROVED | typeof JoinRequestStatus.REJ
 const FILTERS: { value: Filter; label: string }[] = [
   { value: Filter.ALL, label: 'all' },
   { value: Filter.PENDING, label: 'pending' },
+  { value: Filter.TENTATIVE, label: 'tentative' },
   { value: Filter.APPROVED, label: 'approved' },
   { value: Filter.REJECTED, label: 'rejected' },
 ];
@@ -227,6 +229,7 @@ function JoinRequestCard({
   onResend: () => void;
 }) {
   const isPending = request.status === JoinRequestStatus.PENDING;
+  const isTentative = request.status === JoinRequestStatus.TENTATIVE;
   const isRejected = request.status === JoinRequestStatus.REJECTED;
   const canResend = request.status === JoinRequestStatus.APPROVED && request.onboardedAt === null;
   return (
@@ -284,6 +287,14 @@ function JoinRequestCard({
             reject
           </Button>
         </div>
+      ) : isTentative ? (
+        <TentativeActions
+          request={request}
+          busy={busy}
+          onApprove={() => {
+            onDecide(JoinRequestStatus.APPROVED);
+          }}
+        />
       ) : (
         <>
           <DecisionAttribution request={request} />
@@ -380,6 +391,7 @@ function StatusBadge({ status }: { status: JoinRequestStatus }) {
 
 const STATUS_TONES: Record<JoinRequestStatus, string> = {
   [JoinRequestStatus.PENDING]: 'bg-warning-subtle text-warning',
+  [JoinRequestStatus.TENTATIVE]: 'bg-highlight-subtle text-highlight',
   [JoinRequestStatus.APPROVED]: 'bg-success-subtle text-success',
   [JoinRequestStatus.REJECTED]: 'bg-surface-raised text-foreground-secondary',
 };
@@ -390,6 +402,14 @@ function SortHint({ filter, hasRows }: { filter: Filter; hasRows: boolean }) {
       <p className="text-muted mb-3 text-xs">
         sorted newest first — approved members show here until 3 days after their first login, then
         this tab clears them out automatically
+      </p>
+    );
+  }
+  if (filter === Filter.TENTATIVE) {
+    return (
+      <p className="text-muted mb-3 text-xs">
+        approved once they come to an event — they&rsquo;ll be promoted automatically when checked
+        in, or you can approve them manually below
       </p>
     );
   }


### PR DESCRIPTION
## Summary
- Adds the admin "approved once they come to an event" section to the Join Requests screen for tentatively-approved people.
- Backend: `JoinRequestRsvpOut` + `rsvp_events` field on `JoinRequestOut`, populated from prefetched ATTENDING rsvps (past + future), excluding non-reportable event statuses. No new endpoint — reuses `PATCH /join-requests/{id}/` with `status: "approved"` for manual full-approval (promotion + confirmation email already implemented in #785).
- Frontend: `TENTATIVE` added to `JoinRequestStatus`, `STATUS_TONES` (uses the existing `highlight`/lavender-family token, color-blind safe), and the segmented filter. New `JoinRequestTentativeSection.tsx` component renders a manual-approve button and the rsvp'd-events list — hidden entirely when the person has no rsvps, per the issue.
- All new user-facing text is lowercase.

Closes #777

## Test plan
- [x] `make agent-test` (backend, isolated sqlite worktree db) — all passing except 5 pre-existing SSE/pg_notify failures unrelated to this change (sqlite can't exercise `pg_notify`)
- [x] `make agent-typecheck` / `make agent-lint` / `make agent-complexity` — clean
- [x] `make agent-frontend-test` / `make agent-frontend-typecheck` / `make agent-frontend-lint` / `make agent-frontend-format-check` — clean
- [x] `make check-codes` / `make frontend-types-check` — schema + generated types in sync
- [ ] manual click-through on staging once deployed