### PR TITLE
fix: 824 - fix onboarding-gate race that skipped the profile step

### DIFF
--- a/frontend/src/auth/guards.test.tsx
+++ b/frontend/src/auth/guards.test.tsx
@@ -543,6 +543,66 @@ describe('OnboardingGate', () => {
     expect(screen.queryByText('guidelines page')).not.toBeInTheDocument();
   });
 
+  it('keeps a user with pending consent on /new-password while the profile step is active', () => {
+    // completeOnboarding clears needsOnboarding immediately, so setupTarget goes
+    // null and the gate would otherwise fall through to the consent branch —
+    // which must also respect profileStepActive, same as the setup branch does.
+    const user = makeUser({
+      needsOnboarding: false,
+      needsGuidelinesConsent: true,
+      firstName: 'Jamie',
+      fullName: 'Jamie',
+      email: 'jamie@example.com',
+    });
+    useAuthStore.setState({
+      status: 'authed',
+      user,
+      accessToken: 'tok-abc',
+      profileStepActive: true,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/new-password']}>
+        <Routes>
+          <Route element={<OnboardingGate />}>
+            <Route path="/new-password" element={<div>new password page</div>} />
+            <Route path="/consent" element={<div>consent page</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('new password page')).toBeInTheDocument();
+    expect(screen.queryByText('consent page')).not.toBeInTheDocument();
+  });
+
+  it('keeps a user with pending consent on /onboarding while the profile step is active', () => {
+    const user = makeUser({
+      needsOnboarding: false,
+      needsGuidelinesConsent: true,
+    });
+    useAuthStore.setState({
+      status: 'authed',
+      user,
+      accessToken: 'tok-abc',
+      profileStepActive: true,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/onboarding']}>
+        <Routes>
+          <Route element={<OnboardingGate />}>
+            <Route path="/onboarding" element={<div>onboarding page</div>} />
+            <Route path="/consent" element={<div>consent page</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('onboarding page')).toBeInTheDocument();
+    expect(screen.queryByText('consent page')).not.toBeInTheDocument();
+  });
+
   it('redirects an onboarding-complete user on /login to /calendar', () => {
     const user = makeUser({ needsOnboarding: false });
     useAuthStore.setState({ status: 'authed', user, accessToken: 'tok-abc' });

--- a/frontend/src/auth/guards.test.tsx
+++ b/frontend/src/auth/guards.test.tsx
@@ -288,6 +288,39 @@ describe('OnboardingGate', () => {
     expect(screen.queryByText('calendar page')).not.toBeInTheDocument();
   });
 
+  it('keeps a first-time join-request user on /new-password while the profile step is active', () => {
+    // Once account setup clears needsOnboarding, this user's setupTarget becomes
+    // null — same as a fully-onboarded user — so the gate must check
+    // profileStepActive before bouncing them off /new-password, same as it
+    // already does for /onboarding.
+    const user = makeUser({
+      needsOnboarding: false,
+      firstName: 'Jamie',
+      fullName: 'Jamie',
+      email: 'jamie@example.com',
+    });
+    useAuthStore.setState({
+      status: 'authed',
+      user,
+      accessToken: 'tok-abc',
+      profileStepActive: true,
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/new-password']}>
+        <Routes>
+          <Route element={<OnboardingGate />}>
+            <Route path="/new-password" element={<div>new password page</div>} />
+            <Route path="/calendar" element={<div>calendar page</div>} />
+          </Route>
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText('new password page')).toBeInTheDocument();
+    expect(screen.queryByText('calendar page')).not.toBeInTheDocument();
+  });
+
   it('redirects a needsGuidelinesConsent user to /consent', () => {
     const user = makeUser({ needsGuidelinesConsent: true });
     useAuthStore.setState({ status: 'authed', user, accessToken: 'tok-abc' });

--- a/frontend/src/auth/guards.tsx
+++ b/frontend/src/auth/guards.tsx
@@ -92,10 +92,11 @@ export function OnboardingGate() {
     }
   } else if (user) {
     // Authed user with nothing pending shouldn't sit on onboarding/consent screens.
-    // Exception: the optional profile step runs on /onboarding *after* account
-    // setup clears needs_onboarding — keep them here until they finish or skip it.
+    // Exception: the optional profile step runs on /onboarding OR /new-password
+    // *after* account setup clears needs_onboarding — keep them here until they
+    // finish or skip it.
     if (path === '/onboarding' && !profileStepActive) return <Navigate to="/guidelines" replace />;
-    if (path === '/new-password') return <Navigate to="/calendar" replace />;
+    if (path === '/new-password' && !profileStepActive) return <Navigate to="/calendar" replace />;
     if (path === '/consent') return <Navigate to="/calendar" replace />;
     if (path === '/login') return <Navigate to="/calendar" replace />;
   }

--- a/frontend/src/auth/guards.tsx
+++ b/frontend/src/auth/guards.tsx
@@ -73,6 +73,16 @@ export function OnboardingGate() {
   const location = useLocation();
   const path = location.pathname.toLowerCase();
 
+  // The optional profile step runs on /onboarding or /new-password right after
+  // completeOnboarding clears needs_onboarding — before consent is even checked,
+  // since setup (including the profile step) always finishes before consent.
+  // Check this first: otherwise the moment needs_onboarding clears, setupTarget
+  // goes null and this render would fall through to the consent branch (or the
+  // "nothing pending" branch) and bounce the user away mid-step.
+  if ((path === '/onboarding' || path === '/new-password') && profileStepActive) {
+    return <Outlet />;
+  }
+
   // passwordSetupRedirect is the shared source of truth (also used by
   // MagicLoginScreen) for where a setup-pending user must go. Password setup
   // takes priority over the consent gate — a brand-new user sets their name +
@@ -92,11 +102,8 @@ export function OnboardingGate() {
     }
   } else if (user) {
     // Authed user with nothing pending shouldn't sit on onboarding/consent screens.
-    // Exception: the optional profile step runs on /onboarding OR /new-password
-    // *after* account setup clears needs_onboarding — keep them here until they
-    // finish or skip it.
-    if (path === '/onboarding' && !profileStepActive) return <Navigate to="/guidelines" replace />;
-    if (path === '/new-password' && !profileStepActive) return <Navigate to="/calendar" replace />;
+    if (path === '/onboarding') return <Navigate to="/guidelines" replace />;
+    if (path === '/new-password') return <Navigate to="/calendar" replace />;
     if (path === '/consent') return <Navigate to="/calendar" replace />;
     if (path === '/login') return <Navigate to="/calendar" replace />;
   }

--- a/frontend/src/auth/guards.tsx
+++ b/frontend/src/auth/guards.tsx
@@ -73,13 +73,8 @@ export function OnboardingGate() {
   const location = useLocation();
   const path = location.pathname.toLowerCase();
 
-  // The optional profile step runs on /onboarding or /new-password right after
-  // completeOnboarding clears needs_onboarding — before consent is even checked,
-  // since setup (including the profile step) always finishes before consent.
-  // Check this first: otherwise the moment needs_onboarding clears, setupTarget
-  // goes null and this render would fall through to the consent branch (or the
-  // "nothing pending" branch) and bounce the user away mid-step.
-  if ((path === '/onboarding' || path === '/new-password') && profileStepActive) {
+  // Checked before setupTarget goes null post-completeOnboarding, or this would bounce the user mid-step.
+  if (user && (path === '/onboarding' || path === '/new-password') && profileStepActive) {
     return <Outlet />;
   }
 

--- a/frontend/src/auth/store.test.ts
+++ b/frontend/src/auth/store.test.ts
@@ -167,6 +167,37 @@ describe('useAuthStore', () => {
     });
   });
 
+  describe('completeOnboarding', () => {
+    it('sets user without touching profileStepActive by default', async () => {
+      useAuthStore.setState({ status: 'authed', user: mockUser, profileStepActive: false });
+      const updated: User = { ...mockUser, needsOnboarding: false };
+      vi.mocked(authApi.completeOnboarding).mockResolvedValueOnce(updated);
+
+      await useAuthStore.getState().completeOnboarding({ newPassword: 'abcd1234ABCD!' });
+
+      expect(useAuthStore.getState().user).toEqual(updated);
+      expect(useAuthStore.getState().profileStepActive).toBe(false);
+    });
+
+    it('sets user and profileStepActive atomically in one update when startProfileStep is requested', async () => {
+      // Regression: completeOnboarding() and startProfileStep() as two separate
+      // store updates left a render in between with needsOnboarding=false AND
+      // profileStepActive=false, which OnboardingGate would act on and bounce
+      // the user away (to /guidelines or /consent) before the second update
+      // landed. Setting both in the same set() call closes that gap.
+      useAuthStore.setState({ status: 'authed', user: mockUser, profileStepActive: false });
+      const updated: User = { ...mockUser, needsOnboarding: false };
+      vi.mocked(authApi.completeOnboarding).mockResolvedValueOnce(updated);
+
+      await useAuthStore
+        .getState()
+        .completeOnboarding({ newPassword: 'abcd1234ABCD!', startProfileStep: true });
+
+      expect(useAuthStore.getState().user).toEqual(updated);
+      expect(useAuthStore.getState().profileStepActive).toBe(true);
+    });
+  });
+
   describe('logout', () => {
     it('sets status to unauthed and clears user and accessToken', async () => {
       // Start in an authed state.

--- a/frontend/src/auth/store.ts
+++ b/frontend/src/auth/store.ts
@@ -41,10 +41,7 @@ interface AuthState {
     email?: string | undefined;
     pronouns?: string | undefined;
     consentTypes?: ConsentTypeValue[] | undefined;
-    // Set alongside `user` in the same store update — a separate
-    // startProfileStep() call afterward leaves a render in between where
-    // needsOnboarding and profileStepActive are both false, which
-    // OnboardingGate would act on and bounce the user away mid-setup.
+    // Set atomically with `user` — a separate follow-up call would leave a render gap.
     startProfileStep?: boolean;
   }) => Promise<void>;
   finishProfileStep: () => void;

--- a/frontend/src/auth/store.ts
+++ b/frontend/src/auth/store.ts
@@ -41,8 +41,12 @@ interface AuthState {
     email?: string | undefined;
     pronouns?: string | undefined;
     consentTypes?: ConsentTypeValue[] | undefined;
+    // Set alongside `user` in the same store update — a separate
+    // startProfileStep() call afterward leaves a render in between where
+    // needsOnboarding and profileStepActive are both false, which
+    // OnboardingGate would act on and bounce the user away mid-setup.
+    startProfileStep?: boolean;
   }) => Promise<void>;
-  startProfileStep: () => void;
   finishProfileStep: () => void;
   acceptConsents: (consentTypes: ConsentTypeValue[]) => Promise<void>;
   changePassword: (current: string, next: string) => Promise<void>;
@@ -106,12 +110,9 @@ export const useAuthStore = create<AuthState>((set, get) => ({
   },
 
   async completeOnboarding(payload) {
-    const user = await authApi.completeOnboarding(payload);
-    set({ user });
-  },
-
-  startProfileStep() {
-    set({ profileStepActive: true });
+    const { startProfileStep: shouldStartProfileStep, ...apiPayload } = payload;
+    const user = await authApi.completeOnboarding(apiPayload);
+    set(shouldStartProfileStep ? { user, profileStepActive: true } : { user });
   },
 
   finishProfileStep() {

--- a/frontend/src/screens/auth/NewPasswordScreen.test.tsx
+++ b/frontend/src/screens/auth/NewPasswordScreen.test.tsx
@@ -27,13 +27,11 @@ const VALID = 'abcd1234ABCD!';
 
 describe('NewPasswordScreen', () => {
   const completeOnboarding = vi.fn();
-  const startProfileStep = vi.fn();
   const finishProfileStep = vi.fn();
 
   function setupMock(user: User, profileStepActive = false) {
     const storeState = {
       completeOnboarding,
-      startProfileStep,
       finishProfileStep,
       user,
       profileStepActive,
@@ -47,7 +45,6 @@ describe('NewPasswordScreen', () => {
 
   beforeEach(() => {
     completeOnboarding.mockReset();
-    startProfileStep.mockReset();
     finishProfileStep.mockReset();
     setupMock(makeUser({ needsOnboarding: false, needsPasswordReset: true }));
   });
@@ -66,7 +63,7 @@ describe('NewPasswordScreen', () => {
     expect(completeOnboarding).not.toHaveBeenCalled();
   });
 
-  it('submits the new password when confirmation matches, and does not enter the profile step on a real password reset', async () => {
+  it('submits the new password when confirmation matches, and does not request the profile step on a real password reset', async () => {
     completeOnboarding.mockResolvedValue(undefined);
     setupMock(makeUser({ needsOnboarding: false, needsPasswordReset: true }));
     render(
@@ -78,14 +75,16 @@ describe('NewPasswordScreen', () => {
     await userEvent.type(screen.getByLabelText(/confirm new password/i), VALID);
     await userEvent.click(screen.getByRole('button', { name: /save password/i }));
 
-    await vi.waitFor(() => {
-      expect(completeOnboarding).toHaveBeenCalledWith({ newPassword: VALID });
-    });
     // a self-service password reset is an already-onboarded member — no profile step
-    expect(startProfileStep).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      expect(completeOnboarding).toHaveBeenCalledWith({
+        newPassword: VALID,
+        startProfileStep: false,
+      });
+    });
   });
 
-  it('enters the profile step after a first-time join-request user sets their password', async () => {
+  it('requests the profile step after a first-time join-request user sets their password', async () => {
     completeOnboarding.mockResolvedValue(undefined);
     setupMock(makeUser({ needsOnboarding: true, needsPasswordReset: false }));
     render(
@@ -98,9 +97,11 @@ describe('NewPasswordScreen', () => {
     await userEvent.click(screen.getByRole('button', { name: /save password/i }));
 
     await vi.waitFor(() => {
-      expect(completeOnboarding).toHaveBeenCalledWith({ newPassword: VALID });
+      expect(completeOnboarding).toHaveBeenCalledWith({
+        newPassword: VALID,
+        startProfileStep: true,
+      });
     });
-    expect(startProfileStep).toHaveBeenCalledTimes(1);
   });
 
   it('renders the profile step when profileStepActive is set', () => {

--- a/frontend/src/screens/auth/NewPasswordScreen.tsx
+++ b/frontend/src/screens/auth/NewPasswordScreen.tsx
@@ -32,7 +32,6 @@ export default function NewPasswordScreen() {
   // members — skip straight to the app) and first-time join-request users who
   // already have name+email but have never seen the profile step.
   const completeOnboarding = useAuthStore((s) => s.completeOnboarding);
-  const startProfileStep = useAuthStore((s) => s.startProfileStep);
   const finishProfileStep = useAuthStore((s) => s.finishProfileStep);
   const profileStepActive = useAuthStore((s) => s.profileStepActive);
   const needsOnboarding = useAuthStore((s) => s.user?.needsOnboarding ?? false);
@@ -53,10 +52,11 @@ export default function NewPasswordScreen() {
   async function onSubmit(values: FormValues) {
     setServerError(null);
     try {
-      await completeOnboarding({ newPassword: values.newPassword });
-      if (needsOnboarding) {
-        startProfileStep();
-      } else {
+      await completeOnboarding({
+        newPassword: values.newPassword,
+        startProfileStep: needsOnboarding,
+      });
+      if (!needsOnboarding) {
         void navigate('/calendar', { replace: true });
       }
     } catch (err) {

--- a/frontend/src/screens/auth/NewPasswordScreen.tsx
+++ b/frontend/src/screens/auth/NewPasswordScreen.tsx
@@ -56,9 +56,8 @@ export default function NewPasswordScreen() {
         newPassword: values.newPassword,
         startProfileStep: needsOnboarding,
       });
-      if (!needsOnboarding) {
-        void navigate('/calendar', { replace: true });
-      }
+      if (needsOnboarding) return;
+      void navigate('/calendar', { replace: true });
     } catch (err) {
       setServerError(extractApiError(err, "couldn't save password — try again"));
     }

--- a/frontend/src/screens/auth/OnboardingScreen.test.tsx
+++ b/frontend/src/screens/auth/OnboardingScreen.test.tsx
@@ -37,14 +37,12 @@ function makeUser(overrides: Partial<User> = {}): User {
 describe('OnboardingScreen', () => {
   const completeOnboarding = vi.fn();
   const updateProfile = vi.fn();
-  const startProfileStep = vi.fn();
   const finishProfileStep = vi.fn();
 
   function setupMock(user: User, profileStepActive = false) {
     const storeState = {
       completeOnboarding,
       updateProfile,
-      startProfileStep,
       finishProfileStep,
       user,
       profileStepActive,
@@ -60,7 +58,6 @@ describe('OnboardingScreen', () => {
   beforeEach(() => {
     completeOnboarding.mockReset();
     updateProfile.mockReset();
-    startProfileStep.mockReset();
     finishProfileStep.mockReset();
     updateProfile.mockResolvedValue(undefined);
     setupMock(makeUser());
@@ -99,6 +96,7 @@ describe('OnboardingScreen', () => {
       email: 'tester@example.com',
       newPassword: 'abcd1234ABCD!',
       consentTypes: [],
+      startProfileStep: true,
     });
   });
 
@@ -122,6 +120,7 @@ describe('OnboardingScreen', () => {
       pronouns: 'they/them',
       newPassword: 'abcd1234ABCD!',
       consentTypes: [],
+      startProfileStep: true,
     });
   });
 
@@ -172,10 +171,11 @@ describe('OnboardingScreen', () => {
       email: 'tester@example.com',
       newPassword: 'abcd1234ABCD!',
       consentTypes: ['guidelines', 'sms'],
+      startProfileStep: true,
     });
   });
 
-  it('starts the profile step after successful account setup', async () => {
+  it('requests the profile step in the same completeOnboarding call', async () => {
     completeOnboarding.mockResolvedValue(undefined);
     render(
       <MemoryRouter>
@@ -187,7 +187,9 @@ describe('OnboardingScreen', () => {
     await userEvent.type(screen.getByLabelText(/^password$/i), 'abcd1234ABCD!');
     await userEvent.click(screen.getByRole('button', { name: /continue/i }));
     expect(completeOnboarding).toHaveBeenCalledTimes(1);
-    expect(startProfileStep).toHaveBeenCalledTimes(1);
+    expect(completeOnboarding).toHaveBeenCalledWith(
+      expect.objectContaining({ startProfileStep: true }),
+    );
     expect(screen.queryByText(/couldn't finish onboarding/i)).not.toBeInTheDocument();
   });
 
@@ -214,7 +216,6 @@ describe('OnboardingScreen', () => {
     await userEvent.type(screen.getByLabelText(/^password$/i), 'abcd1234ABCD!');
     await userEvent.click(screen.getByRole('button', { name: /continue/i }));
     expect(await screen.findByText(/couldn't finish onboarding/i)).toBeInTheDocument();
-    expect(startProfileStep).not.toHaveBeenCalled();
     expect(screen.queryByRole('button', { name: /^done$/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/auth/OnboardingScreen.tsx
+++ b/frontend/src/screens/auth/OnboardingScreen.tsx
@@ -30,7 +30,6 @@ type FormValues = z.infer<typeof schema>;
 
 export default function OnboardingScreen() {
   const completeOnboarding = useAuthStore((s) => s.completeOnboarding);
-  const startProfileStep = useAuthStore((s) => s.startProfileStep);
   const finishProfileStep = useAuthStore((s) => s.finishProfileStep);
   const profileStepActive = useAuthStore((s) => s.profileStepActive);
   // prefill name for legacy users approved before email was required
@@ -70,8 +69,8 @@ export default function OnboardingScreen() {
         ...(pronouns ? { pronouns } : {}),
         newPassword: values.newPassword,
         consentTypes: acceptedTypes,
+        startProfileStep: true,
       });
-      startProfileStep();
     } catch (err) {
       setServerError(extractApiError(err, "couldn't finish onboarding — try again"));
     }


### PR DESCRIPTION
## Overview

Follow-up to #828 (Issue #824), which taught `NewPasswordScreen` to enter the optional "make it yours" profile step for first-time join-request users. Testing that fix live surfaced two further bugs that kept the profile step from ever actually showing:

1. **`OnboardingGate` didn't know about the profile step on `/new-password`.** The moment `completeOnboarding()` clears `needsOnboarding`, the gate's `setupTarget` goes `null` — the gate already had an exception for this on `/onboarding` (checking `profileStepActive`), but not on `/new-password`, so it unconditionally bounced to `/calendar`.
2. **A render race between two separate store updates.** Even after fixing (1), `completeOnboarding()` and the follow-up `startProfileStep()` call were two separate `set()` calls. React rendered once in between with `needsOnboarding: false` AND `profileStepActive: false` simultaneously — and `OnboardingGate`'s `<Navigate>` to `/consent` (or `/guidelines`) fired during that single render, before the second update landed. This only reproduced for users who owe consent *and* the profile step at the same time (i.e. real join-request users), which is why it wasn't caught by the original unit tests.

Fix: `completeOnboarding` now accepts a `startProfileStep` flag and sets `user` + `profileStepActive` in the same store update, eliminating the gap. `OnboardingGate` also now respects `profileStepActive` on `/new-password`, mirroring the existing `/onboarding` exception.

Closes #824

## Test plan

- [x] Added a `guards.test.tsx` case: `OnboardingGate` keeps a user on `/new-password` while `profileStepActive` is set, even with consent also pending
- [x] Added a `store.test.ts` case: `completeOnboarding({ startProfileStep: true })` sets `user` and `profileStepActive` in one update
- [x] Updated `NewPasswordScreen`/`OnboardingScreen` tests for the new `completeOnboarding` payload shape
- [x] Full frontend suite passes (782 tests), typecheck + lint clean
- [x] **Manually reproduced and verified live**, driving the real join-request → approval → magic-login → password-set flow in the browser against both fixture shapes (consent pending, and already consented) — confirmed "make it yours ✨" now shows before landing on consent/calendar in both cases
