### PR TITLE
fix: style and reposition feedback toast action button (Issue 811)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -12,7 +12,18 @@ export default function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <RouterProvider router={router} />
-      <Toaster position="top-center" richColors closeButton />
+      <Toaster
+        position="top-center"
+        richColors
+        closeButton
+        toastOptions={{
+          classNames: {
+            toast: 'flex-wrap!',
+            actionButton:
+              'bg-brand-600! text-brand-on! hover:bg-brand-700! mt-2! ml-0! h-9! w-full! basis-full! rounded-md! px-3! text-sm! font-medium! transition-colors!',
+          },
+        }}
+      />
     </QueryClientProvider>
   );
 }


### PR DESCRIPTION
## Summary
- Restyle the "view your issue" action button on the feedback-submitted toast to match brand button styling instead of sonner's default
- Wrap the toast and move the action button onto its own full-width line below the message text

Closes #811

## Test plan
- [ ] Submit feedback via the feedback button, confirm the success toast shows the action button styled with brand colors, wrapped below the message text