### PR TITLE
ci(release): deploy staging from release.yml, not raw merge

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -1,8 +1,9 @@
 name: deploy railway (production)
 
-# Manual production deploys only — staging auto-deploys from main via Railway's
-# GitHub integration. Pick the ref from the "Run workflow" dropdown (main for
-# normal deploys; a tag or older commit for rollbacks).
+# Manual production deploys only — staging deploys automatically from
+# release.yml after a successful semantic-release run (see deploy-staging job
+# there). Pick the ref from the "Run workflow" dropdown (main for normal
+# deploys; a tag or older commit for rollbacks).
 # Pin matches image pulled 2026-04-20; bump intentionally when upgrading CLI.
 on:
   workflow_dispatch:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,9 @@ permissions:
   issues: write
   pull-requests: write
 
+env:
+  RAILWAY_CLI_IMAGE: ghcr.io/railwayapp/cli@sha256:10ff70f5b1d65e6eee8d8b7839b917bc88631efa5b5eddaa33a585a7891b254c
+
 jobs:
   release:
     name: Release
@@ -21,6 +24,8 @@ jobs:
     # only for pushes that create no commit (e.g. tag pushes), which this job
     # ignores anyway; semantic-release is also idempotent against existing tags.
     if: ${{ github.event.head_commit && !contains(github.event.head_commit.message, '[skip ci]') }}
+    outputs:
+      released: ${{ steps.check-release.outputs.released }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -44,6 +49,68 @@ jobs:
         run: npm ci --no-audit --no-fund
 
       - name: Run semantic-release
-        run: npx semantic-release
+        run: |
+          before=$(git rev-parse HEAD)
+          npx semantic-release
+          after=$(git rev-parse HEAD)
+          if [ "$before" != "$after" ]; then
+            echo "released=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "released=false" >> "$GITHUB_OUTPUT"
+          fi
+        id: check-release
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+
+  deploy-staging:
+    name: deploy to railway (staging)
+    needs: release
+    if: ${{ needs.release.outputs.released == 'true' }}
+    runs-on: ubuntu-latest
+    environment: railway-staging
+    concurrency:
+      group: railway-deploy-staging
+      cancel-in-progress: false
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: print deploy context (no token)
+        env:
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+          RAILWAY_ENVIRONMENT: ${{ vars.RAILWAY_ENVIRONMENT_STAGING }}
+          RAILWAY_SERVICE_NAME: ${{ vars.RAILWAY_SERVICE_NAME_STAGING }}
+        run: |
+          echo "railway deploy context (staging target)"
+          echo "  commit=$(git rev-parse --short=7 HEAD)"
+          echo "  railway_project_id=${RAILWAY_PROJECT_ID}"
+          echo "  railway_environment=${RAILWAY_ENVIRONMENT}"
+          echo "  railway_service=${RAILWAY_SERVICE_NAME}"
+
+      - name: railway up (staging token only in this job)
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_STAGING }}
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+          RAILWAY_ENVIRONMENT: ${{ vars.RAILWAY_ENVIRONMENT_STAGING }}
+          RAILWAY_SERVICE_NAME: ${{ vars.RAILWAY_SERVICE_NAME_STAGING }}
+        run: |
+          set -eu
+          test -n "${RAILWAY_TOKEN}"
+          test -n "${RAILWAY_PROJECT_ID}"
+          test -n "${RAILWAY_ENVIRONMENT}"
+          test -n "${RAILWAY_SERVICE_NAME}"
+          docker_run=(docker run --rm --platform linux/amd64
+            -v "${GITHUB_WORKSPACE}:/workspace"
+            -w /workspace
+            -e RAILWAY_TOKEN
+            "${RAILWAY_CLI_IMAGE}")
+          echo "railway cli version:"
+          "${docker_run[@]}" railway --version
+          echo "railway up (verbose) — 404 here often means wrong project id, environment id/name, or service slug for this token"
+          "${docker_run[@]}" railway up --ci --verbose \
+            --project "${RAILWAY_PROJECT_ID}" \
+            --environment "${RAILWAY_ENVIRONMENT}" \
+            --service "${RAILWAY_SERVICE_NAME}"


### PR DESCRIPTION
## Overview

Pushing to `main` currently triggers two Railway staging builds back to back: one for the raw merge commit (via Railway's GitHub auto-deploy integration watching `main`), and a second for the version-bump commit that `release.yml`'s semantic-release step pushes afterward.

This PR moves the staging deploy trigger from Railway's GitHub integration into `release.yml` itself, mirroring how `deploy-railway.yml` already drives production via `workflow_dispatch`:

- Adds a `deploy-staging` job to `release.yml` that runs `railway up --ci` against the staging project/environment/service, using the same shape as the production job in `deploy-railway.yml`.
- The job only runs when semantic-release actually published a new release — detected by diffing `git rev-parse HEAD` before/after the `npx semantic-release` step and exposing it as a job output, since the CLI is invoked directly (no action wrapper exposing `new_release_published`).
- Updates the stale comment in `deploy-railway.yml` that referenced the old auto-deploy behavior.
- No new secrets/vars needed — `RAILWAY_TOKEN_STAGING`, `RAILWAY_PROJECT_ID`, `RAILWAY_ENVIRONMENT_STAGING`, and `RAILWAY_SERVICE_NAME_STAGING` already exist in the repo, and the `railway-staging` GitHub environment is already configured.

**Manual follow-up required (not part of this PR):** once this merges, disable Railway's GitHub auto-deploy integration for the staging environment/service in the Railway dashboard — otherwise the raw merge commit will still trigger a duplicate build alongside the new `deploy-staging` job.

Closes #835

## Test plan

- [ ] YAML syntax validated locally (`yaml.safe_load`)
- [ ] TODO: merge a small PR to `main` and confirm exactly one Railway staging deploy fires, triggered by the version-bump commit
- [ ] TODO: confirm a `release.yml` run with no releasable commits does not trigger `deploy-staging`
- [ ] TODO: disable Railway's GitHub auto-deploy integration on staging in the Railway dashboard
