### PR TITLE
fix(rsvp): keep +1 checkbox visible and editable on maybe/can't go (Issue 849)

### DIFF
--- a/frontend/src/screens/events/PublicRsvpCard.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpCard.test.tsx
@@ -1,0 +1,133 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  type Event,
+  EventStatus,
+  EventType,
+  EventVisibility,
+  InvitePermission,
+  RsvpServerStatus,
+} from '@/models/event';
+
+const updateMutate = vi.fn();
+const cancelMutate = vi.fn();
+vi.mock('@/api/publicRsvp', () => ({
+  useUpdatePublicMyRsvp: () => ({ mutateAsync: updateMutate, isPending: false }),
+  useCancelPublicMyRsvp: () => ({ mutateAsync: cancelMutate, isPending: false }),
+}));
+
+import { PublicRsvpCard } from './PublicRsvpCard';
+
+function makeEvent(overrides: Partial<Event>): Event {
+  return {
+    id: 'ev1',
+    title: 'Potluck',
+    description: '',
+    startDatetime: new Date('2099-06-01T18:00:00Z'),
+    endDatetime: null,
+    location: '',
+    latitude: null,
+    longitude: null,
+    whatsappLink: '',
+    partifulLink: '',
+    otherLink: '',
+    venmoLink: '',
+    cashappLink: '',
+    zelleInfo: '',
+    price: '',
+    rsvpEnabled: true,
+    allowPlusOnes: true,
+    maxAttendees: null,
+    attendingCount: 0,
+    waitlistedCount: 0,
+    invitedCount: 0,
+    datetimeTbd: false,
+    hasPoll: false,
+    datetimePollSlug: null,
+    createdById: 'user-host',
+    createdByName: 'Host',
+    createdByPhotoUrl: '',
+    coHostIds: [],
+    coHostNames: [],
+    coHostPhotoUrls: [],
+    coHostInviteIds: [],
+    guests: [],
+    myRsvp: null,
+    surveySlugs: [],
+    invitedUserIds: [],
+    invitedUserNames: [],
+    invitedUserPhotoUrls: [],
+    invitePermission: InvitePermission.AllMembers,
+    pendingCohostInvites: [],
+    myPendingCohostInviteId: null,
+    eventType: EventType.Community,
+    visibility: EventVisibility.Public,
+    photoUrl: '',
+    photoUpdatedAt: null,
+    tags: [],
+    isPast: false,
+    status: EventStatus.Active,
+    ...overrides,
+  };
+}
+
+function renderCard(props: { status: string; hasPlusOne: boolean; event?: Partial<Event> }) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <PublicRsvpCard
+        token="tok123"
+        event={makeEvent(props.event ?? {})}
+        status={props.status}
+        hasPlusOne={props.hasPlusOne}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe('PublicRsvpCard', () => {
+  it('shows the +1 toggle when attending', () => {
+    renderCard({ status: RsvpServerStatus.Attending, hasPlusOne: false });
+    expect(screen.getByRole('switch', { name: /bring a \+1/i })).toBeInTheDocument();
+  });
+
+  it('keeps the +1 toggle visible and checked after switching to maybe', () => {
+    renderCard({ status: RsvpServerStatus.Attending, hasPlusOne: true });
+    fireEvent.click(screen.getByRole('button', { name: /^maybe$/i }));
+    expect(updateMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: RsvpServerStatus.Maybe, hasPlusOne: true }),
+    );
+  });
+
+  it('preserves the +1 flag when switching to can’t go', () => {
+    renderCard({ status: RsvpServerStatus.Attending, hasPlusOne: true });
+    fireEvent.click(screen.getByRole('button', { name: /can't go/i }));
+    expect(updateMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: RsvpServerStatus.CantGo, hasPlusOne: true }),
+    );
+  });
+
+  it('allows toggling +1 while on maybe', () => {
+    renderCard({ status: RsvpServerStatus.Maybe, hasPlusOne: false });
+    fireEvent.click(screen.getByRole('switch', { name: /bring a \+1/i }));
+    expect(updateMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: RsvpServerStatus.Maybe, hasPlusOne: true }),
+    );
+  });
+
+  it('hides the +1 toggle when waitlisted', () => {
+    renderCard({ status: RsvpServerStatus.Waitlisted, hasPlusOne: false });
+    expect(screen.queryByRole('switch', { name: /bring a \+1/i })).not.toBeInTheDocument();
+  });
+
+  it('hides the +1 toggle when the event does not allow plus ones', () => {
+    renderCard({
+      status: RsvpServerStatus.Attending,
+      hasPlusOne: false,
+      event: { allowPlusOnes: false },
+    });
+    expect(screen.queryByRole('switch', { name: /bring a \+1/i })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/events/PublicRsvpCard.tsx
+++ b/frontend/src/screens/events/PublicRsvpCard.tsx
@@ -6,7 +6,7 @@ import { useCancelPublicMyRsvp, useUpdatePublicMyRsvp } from '@/api/publicRsvp';
 import { Button } from '@/components/ui/Button';
 import { RsvpStatusPicker } from '@/components/ui/RsvpStatusPicker';
 import { Toggle } from '@/components/ui/Toggle';
-import { type Event, type RsvpInputStatus, RsvpServerStatus, RsvpStatus } from '@/models/event';
+import { type Event, type RsvpInputStatus, RsvpServerStatus } from '@/models/event';
 import { formatEventDateTime } from '@/utils/datetime';
 import { buildEventLinks } from '@/utils/eventLinks';
 
@@ -40,8 +40,8 @@ export function PublicRsvpCard({ token, event, status, hasPlusOne }: Props) {
   const [error, setError] = useState<string | null>(null);
   const links = buildEventLinks(event);
   const busy = update.isPending || cancel.isPending;
-  // only attending holders can carry a +1; the backend discards a waitlisted +1.
-  const canPlusOne = event.allowPlusOnes && status === RsvpServerStatus.Attending;
+  // the backend discards a waitlisted +1; every other status can carry one.
+  const canPlusOne = event.allowPlusOnes && status !== RsvpServerStatus.Waitlisted;
 
   async function applyRsvp(next: RsvpInputStatus, plusOne: boolean) {
     setError(null);
@@ -55,11 +55,11 @@ export function PublicRsvpCard({ token, event, status, hasPlusOne }: Props) {
 
   function changeStatus(next: RsvpInputStatus) {
     if (next === status) return;
-    void applyRsvp(next, next === RsvpStatus.Attending ? hasPlusOne : false);
+    void applyRsvp(next, hasPlusOne);
   }
 
   function togglePlusOne(next: boolean) {
-    void applyRsvp(RsvpStatus.Attending, next);
+    void applyRsvp(status as RsvpInputStatus, next);
   }
 
   async function cancelRsvp() {

--- a/frontend/src/screens/events/RsvpBox.test.tsx
+++ b/frontend/src/screens/events/RsvpBox.test.tsx
@@ -80,4 +80,48 @@ describe('RsvpBox', () => {
       expect.objectContaining({ status: RsvpStatus.Attending, hasPlusOne: true }),
     );
   });
+
+  it('keeps the +1 checkbox visible and checked after switching to maybe', () => {
+    const onConfirm = vi.fn();
+    render(
+      <RsvpBox
+        {...base}
+        mode="edit"
+        initialStatus={RsvpStatus.Attending}
+        initialHasPlusOne
+        onConfirm={onConfirm}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /^maybe$/i }));
+    const checkbox = screen.getByRole('checkbox', { name: /bringing a \+1/i });
+    expect(checkbox).toBeChecked();
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ status: RsvpStatus.Maybe, hasPlusOne: true }),
+    );
+  });
+
+  it('allows unchecking the +1 checkbox after switching to can’t go', () => {
+    const onConfirm = vi.fn();
+    render(
+      <RsvpBox
+        {...base}
+        mode="edit"
+        initialStatus={RsvpStatus.Attending}
+        initialHasPlusOne
+        onConfirm={onConfirm}
+      />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /can't go/i }));
+    fireEvent.click(screen.getByRole('checkbox', { name: /bringing a \+1/i }));
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ status: RsvpStatus.CantGo, hasPlusOne: false }),
+    );
+  });
+
+  it('hides the +1 checkbox when the event does not allow plus ones', () => {
+    render(<RsvpBox {...base} mode="edit" allowPlusOnes={false} onConfirm={() => {}} />);
+    expect(screen.queryByRole('checkbox', { name: /bringing a \+1/i })).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/screens/events/RsvpBox.tsx
+++ b/frontend/src/screens/events/RsvpBox.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import { RsvpStatusPicker } from '@/components/ui/RsvpStatusPicker';
-import { type RsvpInputStatus, RsvpStatus } from '@/models/event';
+import { type RsvpInputStatus } from '@/models/event';
 
 import { RsvpCommentField } from './RsvpCommentField';
 
@@ -41,7 +41,7 @@ export function RsvpBox({
   const [hasPlusOne, setHasPlusOne] = useState(initialHasPlusOne);
 
   const showComment = mode === 'create';
-  const showPlusOne = allowPlusOnes && status === RsvpStatus.Attending;
+  const showPlusOne = allowPlusOnes;
 
   function confirm() {
     const trimmed = comment.trim();


### PR DESCRIPTION
## Summary
- The +1 checkbox in the RSVP dialog was only shown while status was "attending", but its value was still submitted on save regardless of visibility — switching from attending(+1) to maybe silently kept `has_plus_one=true` with no way to see or clear it.
- Broadened the +1 control to show (and stay editable) for all non-waitlisted statuses in both the member RSVP dialog (`RsvpBox.tsx`) and the public RSVP management card (`PublicRsvpCard.tsx`).
- Stopped `PublicRsvpCard` from force-clearing the +1 flag on non-attending status changes, matching the member flow.

Closes #849

## Test plan
- [x] `make agent-frontend-typecheck` passes
- [x] `make agent-frontend-lint` passes
- [x] `make agent-frontend-test` — all 823 tests pass, including new coverage in `RsvpBox.test.tsx` and new `PublicRsvpCard.test.tsx`
- [x] `make agent-ci` — backend lint/typecheck/complexity clean; pytest passes except 5 pre-existing SSE tests that fail on SQLite (unrelated, `pg_notify`-based)
- [ ] Manually verify: RSVP going with +1, edit to maybe, confirm +1 checkbox stays visible and checked, toggle it off, save, confirm it stays off