### PR TITLE
feat(events): split public rsvp into status-then-details steps (Issue 853)

### DIFF
--- a/frontend/src/components/ui/RsvpStatusPicker.test.tsx
+++ b/frontend/src/components/ui/RsvpStatusPicker.test.tsx
@@ -50,4 +50,11 @@ describe('RsvpStatusPicker', () => {
     );
     expect(screen.getByRole('button', { name: 'join the waitlist' })).toBeInTheDocument();
   });
+
+  it('filters to only the given statuses', () => {
+    render(<RsvpStatusPicker value={null} onSelect={vi.fn()} statuses={['attending', 'maybe']} />);
+    expect(screen.getByRole('button', { name: "i'm going" })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'maybe' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: "can't go" })).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/components/ui/RsvpStatusPicker.tsx
+++ b/frontend/src/components/ui/RsvpStatusPicker.tsx
@@ -7,12 +7,16 @@ interface Props {
   onSelect: (status: RsvpInputStatus) => void;
   disabled?: boolean;
   labelFor?: (status: RsvpInputStatus, defaultLabel: string) => string;
+  statuses?: RsvpInputStatus[];
 }
 
-export function RsvpStatusPicker({ value, onSelect, disabled = false, labelFor }: Props) {
+export function RsvpStatusPicker({ value, onSelect, disabled = false, labelFor, statuses }: Props) {
+  const options = statuses
+    ? RSVP_STATUS_LABELS.filter((p) => statuses.includes(p.status))
+    : RSVP_STATUS_LABELS;
   return (
     <div className="-mx-1 flex justify-center-safe gap-2 overflow-x-auto px-1 py-1">
-      {RSVP_STATUS_LABELS.map((p) => {
+      {options.map((p) => {
         const label = labelFor ? labelFor(p.status, p.label) : p.label;
         const active = value === p.status;
         return (

--- a/frontend/src/screens/events/PublicRsvp.a11y.test.tsx
+++ b/frontend/src/screens/events/PublicRsvp.a11y.test.tsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
@@ -73,12 +73,23 @@ function makeEvent(overrides: Partial<Event> = {}): Event {
 }
 
 describe('public rsvp a11y', () => {
-  it('form has no axe violations', async () => {
+  it('form step one has no axe violations', async () => {
     const { container } = render(
       <MemoryRouter>
         <PublicRsvpForm event={makeEvent()} onSuccess={vi.fn()} />
       </MemoryRouter>,
     );
+    const results = await axe(container, { rules: { 'color-contrast': { enabled: false } } });
+    expect(results).toHaveNoViolations();
+  }, 15000);
+
+  it('form step two has no axe violations', async () => {
+    const { container } = render(
+      <MemoryRouter>
+        <PublicRsvpForm event={makeEvent()} onSuccess={vi.fn()} />
+      </MemoryRouter>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: "i'm going" }));
     const results = await axe(container, { rules: { 'color-contrast': { enabled: false } } });
     expect(results).toHaveNoViolations();
   }, 15000);

--- a/frontend/src/screens/events/PublicRsvpForm.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.test.tsx
@@ -79,10 +79,10 @@ function renderForm(event = makeEvent(), onSuccess = vi.fn()) {
 }
 
 function fillRequired() {
+  fireEvent.click(screen.getByRole('button', { name: "i'm going" }));
   fireEvent.change(screen.getByLabelText('first name'), { target: { value: 'Ada' } });
   fireEvent.change(screen.getByLabelText('email'), { target: { value: 'ada@example.com' } });
   fireEvent.change(screen.getByLabelText('phone'), { target: { value: '+15550001111' } });
-  fireEvent.click(screen.getByRole('button', { name: "i'm going" }));
 }
 
 describe('PublicRsvpForm', () => {
@@ -116,6 +116,7 @@ describe('PublicRsvpForm', () => {
 
   it('renders the plus-one toggle only when allowPlusOnes', () => {
     const { rerender } = renderForm(makeEvent({ allowPlusOnes: true }));
+    fireEvent.click(screen.getByRole('button', { name: "i'm going" }));
     expect(screen.getByRole('switch')).toBeInTheDocument();
     rerender(
       <MemoryRouter>
@@ -123,6 +124,44 @@ describe('PublicRsvpForm', () => {
       </MemoryRouter>,
     );
     expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+  });
+
+  it('shows only going/maybe status options in step one', () => {
+    renderForm();
+    expect(screen.getByRole('button', { name: "i'm going" })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'maybe' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: "can't go" })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('first name')).not.toBeInTheDocument();
+  });
+
+  it('advances to the contact-details step after picking a status', () => {
+    renderForm();
+    fireEvent.click(screen.getByRole('button', { name: 'maybe' }));
+    expect(screen.getByLabelText('first name')).toBeInTheDocument();
+    expect(screen.getByText('maybe')).toBeInTheDocument();
+  });
+
+  it('lets you change the status and go back to step one', () => {
+    renderForm();
+    fireEvent.click(screen.getByRole('button', { name: 'maybe' }));
+    fireEvent.click(screen.getByRole('button', { name: 'change' }));
+    expect(screen.getByRole('button', { name: "i'm going" })).toBeInTheDocument();
+    expect(screen.queryByLabelText('first name')).not.toBeInTheDocument();
+  });
+
+  it('submits maybe status chosen in step one', async () => {
+    const onSuccess = vi.fn();
+    renderForm(makeEvent(), onSuccess);
+    fireEvent.click(screen.getByRole('button', { name: 'maybe' }));
+    fireEvent.change(screen.getByLabelText('first name'), { target: { value: 'Ada' } });
+    fireEvent.change(screen.getByLabelText('email'), { target: { value: 'ada@example.com' } });
+    fireEvent.change(screen.getByLabelText('phone'), { target: { value: '+15550001111' } });
+    fireEvent.click(screen.getByRole('button', { name: 'rsvp' }));
+    await waitFor(() => expect(submitMutate).toHaveBeenCalled());
+    expect(submitMutate).toHaveBeenCalledWith({
+      eventId: 'ev1',
+      payload: expect.objectContaining({ status: 'maybe' }),
+    });
   });
 
   it('shows a 409 inline error with a sign-in link', async () => {
@@ -144,6 +183,7 @@ describe('PublicRsvpForm', () => {
 
   it('renders the hidden honeypot field', () => {
     renderForm();
+    fireEvent.click(screen.getByRole('button', { name: "i'm going" }));
     const hp = screen.getByLabelText('website (leave blank)');
     expect(hp).toHaveAttribute('name', 'website');
     expect(hp).toHaveAttribute('tabindex', '-1');

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -9,10 +9,11 @@ import { PhoneField } from '@/components/ui/PhoneField';
 import { RsvpStatusPicker } from '@/components/ui/RsvpStatusPicker';
 import { TextField } from '@/components/ui/TextField';
 import { Toggle } from '@/components/ui/Toggle';
-import { type Event, type RsvpInputStatus } from '@/models/event';
+import { type Event, RSVP_STATUS_LABELS, type RsvpInputStatus, RsvpStatus } from '@/models/event';
 import { optionalEmail } from '@/utils/validators';
 
 const MAX_NAME = 100;
+const PUBLIC_RSVP_STATUSES: RsvpInputStatus[] = [RsvpStatus.Attending, RsvpStatus.Maybe];
 
 interface Props {
   event: Event;
@@ -37,13 +38,17 @@ function messageForStatus(status: number | null): SubmitError {
   return { text: 'something went wrong — try again', showSignIn: false };
 }
 
+function statusLabel(status: RsvpInputStatus): string {
+  return RSVP_STATUS_LABELS.find((s) => s.status === status)?.label ?? status;
+}
+
 export function PublicRsvpForm({ event, onSuccess }: Props) {
   const submit = useSubmitPublicRsvp();
+  const [status, setStatus] = useState<RsvpInputStatus | null>(null);
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [email, setEmail] = useState('');
   const [phone, setPhone] = useState('');
-  const [status, setStatus] = useState<RsvpInputStatus | null>(null);
   const [hasPlusOne, setHasPlusOne] = useState(false);
   const [website, setWebsite] = useState('');
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -55,7 +60,6 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
     if (!email.trim()) next.email = 'email required';
     else if (optionalEmail(email)) next.email = 'not a valid email';
     if (!phone.trim()) next.phone = 'phone required';
-    if (!status) next.status = 'pick a status';
     setErrors(next);
     return Object.keys(next).length === 0;
   }
@@ -63,7 +67,7 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
   async function onSubmit(e: SyntheticEvent) {
     e.preventDefault();
     setSubmitError(null);
-    if (!validate() || !status) return;
+    if (!status || !validate()) return;
     try {
       const result = await submit.mutateAsync({
         eventId: event.id,
@@ -86,73 +90,87 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
   return (
     <section aria-label="rsvp" className="border-border bg-surface mt-8 rounded-lg border p-6">
       <h2 className="mb-4 text-base font-medium">rsvp</h2>
-      <form onSubmit={(e) => void onSubmit(e)} className="flex flex-col gap-4" noValidate>
-        <Honeypot value={website} onChange={setWebsite} />
+      {status === null ? (
+        <RsvpStatusPicker value={status} onSelect={setStatus} statuses={PUBLIC_RSVP_STATUSES} />
+      ) : (
+        <form onSubmit={(e) => void onSubmit(e)} className="flex flex-col gap-4" noValidate>
+          <Honeypot value={website} onChange={setWebsite} />
 
-        <TextField
-          label="first name"
-          value={firstName}
-          onChange={(e) => {
-            setFirstName(e.target.value);
-          }}
-          maxLength={MAX_NAME}
-          autoComplete="given-name"
-          error={errors.firstName}
-          required
-        />
-        <TextField
-          label="last name"
-          value={lastName}
-          onChange={(e) => {
-            setLastName(e.target.value);
-          }}
-          maxLength={MAX_NAME}
-          autoComplete="family-name"
-        />
-        <TextField
-          label="email"
-          type="email"
-          value={email}
-          onChange={(e) => {
-            setEmail(e.target.value);
-          }}
-          autoComplete="email"
-          error={errors.email}
-          required
-        />
-        <PhoneField label="phone" value={phone} onChange={setPhone} error={errors.phone} />
-
-        <div className="flex flex-col gap-1">
-          <RsvpStatusPicker value={status} onSelect={setStatus} disabled={submit.isPending} />
-          {errors.status ? <p className="text-destructive text-xs">{errors.status}</p> : null}
-        </div>
-
-        {event.allowPlusOnes ? (
-          <Toggle label="bring a +1" checked={hasPlusOne} onChange={setHasPlusOne} />
-        ) : null}
-
-        <Button type="submit" disabled={submit.isPending} fullWidth>
-          rsvp
-        </Button>
-
-        {submitError ? (
-          <div role="alert" className="text-destructive text-sm">
-            <p>{submitError.text}</p>
-            {submitError.showSignIn ? (
-              <Link to="/login" className="text-info hover:underline">
-                sign in
-              </Link>
-            ) : null}
+          <div className="flex items-center justify-between">
+            <p className="text-foreground-secondary text-sm">
+              rsvping as <span className="text-foreground font-medium">{statusLabel(status)}</span>
+            </p>
+            <button
+              type="button"
+              onClick={() => {
+                setStatus(null);
+              }}
+              className="text-info text-sm hover:underline"
+            >
+              change
+            </button>
           </div>
-        ) : null}
 
-        <p className="text-foreground-tertiary text-xs">
-          rsvping doesn't make you a pda member —{' '}
-          <Link to="/join" className="text-info hover:underline">
-            request to join
-          </Link>
-        </p>
-      </form>
+          <TextField
+            label="first name"
+            value={firstName}
+            onChange={(e) => {
+              setFirstName(e.target.value);
+            }}
+            maxLength={MAX_NAME}
+            autoComplete="given-name"
+            error={errors.firstName}
+            required
+          />
+          <TextField
+            label="last name"
+            value={lastName}
+            onChange={(e) => {
+              setLastName(e.target.value);
+            }}
+            maxLength={MAX_NAME}
+            autoComplete="family-name"
+          />
+          <TextField
+            label="email"
+            type="email"
+            value={email}
+            onChange={(e) => {
+              setEmail(e.target.value);
+            }}
+            autoComplete="email"
+            error={errors.email}
+            required
+          />
+          <PhoneField label="phone" value={phone} onChange={setPhone} error={errors.phone} />
+
+          {event.allowPlusOnes ? (
+            <Toggle label="bring a +1" checked={hasPlusOne} onChange={setHasPlusOne} />
+          ) : null}
+
+          <Button type="submit" disabled={submit.isPending} fullWidth>
+            rsvp
+          </Button>
+
+          {submitError ? (
+            <div role="alert" className="text-destructive text-sm">
+              <p>{submitError.text}</p>
+              {submitError.showSignIn ? (
+                <Link to="/login" className="text-info hover:underline">
+                  sign in
+                </Link>
+              ) : null}
+            </div>
+          ) : null}
+
+          <p className="text-foreground-tertiary text-xs">
+            rsvping doesn't make you a pda member —{' '}
+            <Link to="/join" className="text-info hover:underline">
+              request to join
+            </Link>
+          </p>
+        </form>
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- Public (logged-out) RSVP now shows a status step first — "i'm going" / "maybe" only (no "can't go" for the anonymous flow) — then advances to a contact-details step (name, email, phone, +1 toggle) with the chosen status carried forward as a read-only label plus a "change" link back to step one.
- `RsvpStatusPicker` gains an optional `statuses` filter prop so the public flow can restrict options without affecting the shared member-facing picker (`RsvpBox`, `RsvpSection`, `PublicRsvpCard` are unchanged).
- Submission still uses the same `useSubmitPublicRsvp` mutation/payload shape as before — backend endpoint unchanged.

Closes #853

## Flags for reviewer
- Judgment call: "change status" is a small text link next to a read-only "rsvping as {status}" line in step two, rather than re-showing the picker inline — chosen for consistency with the app's minimal, lowercase UI conventions. Open to feedback if a different layout is preferred.
- This branch and #854's fix (`fix-854-public-rsvp-duplicate-confirmation`) both touch the public RSVP flow but different files (`PublicRsvpForm.tsx`/`RsvpStatusPicker.tsx` here vs. `PublicRsvpConfirmation.tsx` there) — no overlap, but worth merging both before further public-RSVP work to avoid divergence.

## Test plan
- [x] `make agent-frontend-typecheck` — clean
- [x] `make agent-frontend-lint` — clean
- [x] `make agent-frontend-test` — 112 files, 830 passed, 1 pre-existing unrelated skip
- [x] `make agent-ci` — passes except 5 pre-existing SSE/`pg_notify` tests that fail under SQLite in every worktree (unrelated to this change, documented local-dev limitation)
- [ ] Manual: RSVP as a logged-out user to a public official event and confirm the two-step flow (going/maybe → contact form → submit) works end to end