### PR TITLE
fix(events): remove duplicate event card from public rsvp confirmation (Issue 854)

### DIFF
--- a/frontend/src/screens/events/PublicRsvpConfirmation.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpConfirmation.test.tsx
@@ -82,9 +82,13 @@ describe('PublicRsvpConfirmation', () => {
   it('shows the attending heading and event info', () => {
     renderCard('attending');
     expect(screen.getByText("you're in! 🌱")).toBeInTheDocument();
-    expect(screen.getByText('Community Potluck')).toBeInTheDocument();
     expect(screen.getByText('123 Main St')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /whatsapp/i })).toBeInTheDocument();
+  });
+
+  it('does not duplicate the event title or date already shown above it', () => {
+    renderCard('attending');
+    expect(screen.queryByText('Community Potluck')).not.toBeInTheDocument();
   });
 
   it('shows the waitlist heading', () => {

--- a/frontend/src/screens/events/PublicRsvpConfirmation.tsx
+++ b/frontend/src/screens/events/PublicRsvpConfirmation.tsx
@@ -3,7 +3,6 @@ import { Link } from 'react-router-dom';
 import type { PublicRsvpOut } from '@/api/publicRsvp';
 import type { Event } from '@/models/event';
 import { RsvpServerStatus } from '@/models/event';
-import { formatEventDateTime } from '@/utils/datetime';
 import { buildEventLinks } from '@/utils/eventLinks';
 
 interface Props {
@@ -21,6 +20,7 @@ const STATUS_HEADINGS: Record<string, string> = {
 export function PublicRsvpConfirmation({ event, result }: Props) {
   const heading = STATUS_HEADINGS[result.rsvp.status] ?? 'thanks for your rsvp';
   const links = buildEventLinks(event);
+  const hasExtraInfo = Boolean(event.location) || links.length > 0;
   return (
     <section
       aria-label="rsvp confirmation"
@@ -31,33 +31,29 @@ export function PublicRsvpConfirmation({ event, result }: Props) {
         we just emailed you a link to manage your rsvp — check your inbox
       </p>
 
-      <div className="border-border bg-background mb-4 rounded-md border p-4">
-        <p className="text-foreground font-medium">{event.title}</p>
-        {event.startDatetime ? (
-          <p className="text-foreground-secondary text-sm">
-            {formatEventDateTime(event.startDatetime, event.endDatetime, event.datetimeTbd)}
-          </p>
-        ) : null}
-        {event.location ? (
-          <p className="text-foreground-secondary text-sm">{event.location}</p>
-        ) : null}
-        {links.length > 0 ? (
-          <ul className="mt-2 flex flex-col gap-1">
-            {links.map((l) => (
-              <li key={l.url}>
-                <a
-                  href={l.url}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-info text-sm hover:underline"
-                >
-                  {l.label}
-                </a>
-              </li>
-            ))}
-          </ul>
-        ) : null}
-      </div>
+      {hasExtraInfo ? (
+        <div className="border-border bg-background mb-4 rounded-md border p-4">
+          {event.location ? (
+            <p className="text-foreground-secondary text-sm">{event.location}</p>
+          ) : null}
+          {links.length > 0 ? (
+            <ul className="mt-2 flex flex-col gap-1">
+              {links.map((l) => (
+                <li key={l.url}>
+                  <a
+                    href={l.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-info text-sm hover:underline"
+                  >
+                    {l.label}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
 
       <p className="text-foreground-tertiary mb-3 text-sm">want to be part of the community?</p>
       <Link


### PR DESCRIPTION
## Summary
- `PublicRsvpConfirmation` no longer re-renders the event title and date/time — `EventDetailScreen` already shows those (plus tags, actions, poll, and description) above the anonymous RSVP section for both authed and logged-out viewers, so the confirmation card was duplicating them.
- Kept `location` and any event links (whatsapp/partiful/etc.) in the confirmation card since those are genuinely not shown anywhere else for logged-out users; wrapped them in a conditional so no empty box renders when an event has neither.
- Success message and "want to be part of the community? request to join" CTA are unchanged.

Closes #854

## Flags for reviewer
- **Out of scope, needs a follow-up decision:** the issue also asks that after RSVPing, a logged-out user should see "the standard event details page with comments, rsvps, etc as if you were logged in." That requires accepting the public RSVP token as a secondary auth signal in the backend (`_event_out()` in `backend/community/_event_helpers.py` currently gates `rsvp_enabled`, links, and the guest list purely on JWT auth) — a materially larger backend change, not attempted here. Flagging so it can be scoped as its own issue if still wanted.
- This branch and #853's fix (`fix-853-public-rsvp-two-step-flow`) both touch the public RSVP flow but different files (`PublicRsvpConfirmation.tsx` here vs. `PublicRsvpForm.tsx`/`RsvpStatusPicker.tsx` there) — no overlap, but worth merging both before further public-RSVP work to avoid divergence.

## Test plan
- [x] `make agent-frontend-typecheck` — clean
- [x] `make agent-frontend-lint` — clean
- [x] `make agent-frontend-test` — 112 files, 825 passed, 1 pre-existing unrelated skip
- [x] `make agent-ci` — passes except 5 pre-existing SSE/`pg_notify` tests that fail under SQLite in every worktree (unrelated to this change, documented local-dev limitation)
- [ ] Manual: RSVP as a logged-out user to a public official event and confirm the confirmation screen no longer repeats the title/time/location already shown above