### PR TITLE
feat: 867 - persist non-member rsvp token so /my-rsvps auto-restores

### DIFF
--- a/frontend/src/api/rsvpTokenStorage.ts
+++ b/frontend/src/api/rsvpTokenStorage.ts
@@ -1,0 +1,13 @@
+const STORAGE_KEY = 'pda-rsvp-token';
+
+export function getStoredRsvpToken(): string | null {
+  return localStorage.getItem(STORAGE_KEY);
+}
+
+export function setStoredRsvpToken(token: string): void {
+  localStorage.setItem(STORAGE_KEY, token);
+}
+
+export function clearStoredRsvpToken(): void {
+  localStorage.removeItem(STORAGE_KEY);
+}

--- a/frontend/src/screens/events/PublicRsvpsScreen.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpsScreen.test.tsx
@@ -27,6 +27,28 @@ vi.mock('@/api/publicRsvp', () => ({
   useCancelPublicMyRsvp: () => ({ mutateAsync: cancelAsync, isPending: false }),
 }));
 
+// jsdom's default Storage isn't wired up for get/set round-trips — stub a real one.
+const storageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string): string | null => store[key] ?? null,
+    setItem: (key: string, value: string): void => {
+      store[key] = value;
+    },
+    removeItem: (key: string): void => {
+      delete store[key];
+    },
+    clear: (): void => {
+      store = {};
+    },
+    get length(): number {
+      return Object.keys(store).length;
+    },
+    key: (index: number): string | null => Object.keys(store)[index] ?? null,
+  };
+})();
+Object.defineProperty(window, 'localStorage', { value: storageMock, writable: true });
+
 import PublicRsvpsScreen from './PublicRsvpsScreen';
 
 function renderAt(token: string | null) {
@@ -54,6 +76,7 @@ function successData(overrides: Partial<ManageRsvps> = {}): ManageRsvps {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  localStorage.clear();
   updateAsync.mockResolvedValue({});
   cancelAsync.mockResolvedValue(undefined);
 });
@@ -71,6 +94,33 @@ describe('PublicRsvpsScreen', () => {
     usePublicMyRsvps.mockReturnValue({ data: undefined, isPending: false, isError: false });
     renderAt(null);
     expect(screen.getByText(/this link's expired or invalid/)).toBeInTheDocument();
+  });
+
+  it('persists the token from the url so a later visit can reuse it', () => {
+    usePublicMyRsvps.mockReturnValue({ data: successData(), isPending: false, isError: false });
+    renderAt('good-token');
+    expect(localStorage.getItem('pda-rsvp-token')).toBe('good-token');
+  });
+
+  it('restores the persisted token when the url has none', () => {
+    localStorage.setItem('pda-rsvp-token', 'stored-token');
+    usePublicMyRsvps.mockReturnValue({ data: successData(), isPending: false, isError: false });
+    renderAt(null);
+    expect(usePublicMyRsvps).toHaveBeenCalledWith('stored-token');
+    expect(screen.getByRole('heading', { name: 'your rsvps' })).toBeInTheDocument();
+  });
+
+  it('clears the persisted token and shows the invalid-token state on a 404', () => {
+    localStorage.setItem('pda-rsvp-token', 'stale-token');
+    usePublicMyRsvps.mockReturnValue({
+      data: undefined,
+      isPending: false,
+      isError: true,
+      error: { isAxiosError: true, response: { status: 404 } },
+    });
+    renderAt(null);
+    expect(screen.getByText(/this link's expired or invalid/)).toBeInTheDocument();
+    expect(localStorage.getItem('pda-rsvp-token')).toBeNull();
   });
 
   it('shows the invalid-token empty state on a 404 (expired or revoked)', () => {

--- a/frontend/src/screens/events/PublicRsvpsScreen.tsx
+++ b/frontend/src/screens/events/PublicRsvpsScreen.tsx
@@ -1,7 +1,13 @@
+import { useEffect, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
 
 import { getApiStatus } from '@/api/apiErrors';
 import { usePublicMyRsvps } from '@/api/publicRsvp';
+import {
+  clearStoredRsvpToken,
+  getStoredRsvpToken,
+  setStoredRsvpToken,
+} from '@/api/rsvpTokenStorage';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 
 import { PublicRsvpCard } from './PublicRsvpCard';
@@ -10,11 +16,23 @@ const INVALID_TOKEN_COPY = "this link's expired or invalid — rsvp again to get
 
 export default function PublicRsvpsScreen() {
   const [searchParams] = useSearchParams();
-  const token = searchParams.get('token') ?? '';
+  const urlToken = searchParams.get('token');
+  const [storedToken] = useState(() => getStoredRsvpToken());
+  const token = urlToken ?? storedToken ?? '';
+
+  useEffect(() => {
+    if (urlToken) setStoredRsvpToken(urlToken);
+  }, [urlToken]);
+
   const { data, isPending, isError, error } = usePublicMyRsvps(token);
+  const isInvalidToken = isError && getApiStatus(error) === 404;
+
+  useEffect(() => {
+    if (isInvalidToken) clearStoredRsvpToken();
+  }, [isInvalidToken]);
 
   // only a 404 means the link is bad; transient failures must not tell the holder to re-rsvp.
-  if (!token || (isError && getApiStatus(error) === 404)) {
+  if (!token || isInvalidToken) {
     return (
       <ContentContainer>
         <p className="text-foreground text-base">{INVALID_TOKEN_COPY}</p>


### PR DESCRIPTION
## Overview

Persists the non-member RSVP token client-side so `/my-rsvps` auto-restores on return visits instead of requiring the emailed link every time. `PublicRsvpsScreen` previously read the `NonMemberRsvpToken` purely from the `?token=` URL query param — arriving via a bookmark or a re-visit without the param showed "this link's expired or invalid" even though the token (durable, 90-day, auto-extended) was still valid.

Now: arriving with `?token=` persists it to `localStorage`; a later visit with no `token` param falls back to the stored one. A confirmed-invalid (404) response clears the stored token so a revoked/expired one doesn't loop. No backend changes — `NonMemberRsvpToken`, its endpoints, and `guards.tsx` are untouched.

Closes #867. Follows the investigation in #864.

## Test plan

- [x] Added tests: persists token from URL, restores from storage when URL has none, clears storage + shows invalid-link state on 404
- [x] `make agent-frontend-lint`, `make agent-frontend-typecheck` pass
- [x] Full frontend suite passes (115 files, 847 passed / 1 skipped)
- [ ] TODO: manual check in browser (RSVP → close tab → reopen `/my-rsvps` with no token → confirm auto-restore)
