### PR TITLE
fix(events): persist non-member rsvp token across events (Issue 873)

### DIFF
--- a/backend/community/_event_viewer.py
+++ b/backend/community/_event_viewer.py
@@ -4,16 +4,19 @@ from django.http import HttpRequest
 from users.models import NonMemberRsvpToken, User
 
 from community._shared import _authenticated_user
-from community.models import Event, EventRSVP
+from community.models import Event
 
 
 def resolve_event_viewer(request: HttpRequest, event_id: UUID) -> "User | None":
     """Resolve the effective viewer for one event: real member, or a non-member
-    RSVP-token holder scoped to this event, or None.
+    RSVP-token holder on any public-RSVP-eligible event, or None.
 
-    A token only unlocks fields already gated purely on "is there a user
-    object" (see _event_out/_build_list_out) — it must never satisfy
-    permission checks that require real member/creator/co-host identity.
+    A valid token unlocks every event that already accepts public RSVPs — the
+    same events an anonymous visitor could unlock by submitting the form — so a
+    returning non-member reuses one token across events (issue #873). The token
+    only unlocks fields gated purely on "is there a user object" (see
+    _event_out/_build_list_out); it never satisfies member/creator/co-host
+    checks, and posting still requires an actual RSVP (see _can_post_comments).
     """
     auth_user = _authenticated_user(getattr(request, "auth", None))
     if auth_user is not None:
@@ -25,13 +28,9 @@ def resolve_event_viewer(request: HttpRequest, event_id: UUID) -> "User | None":
     user = NonMemberRsvpToken.resolve_user(token)
     if user is None:
         return None
-    rsvp = EventRSVP.objects.filter(event_id=event_id, user=user).select_related("event").first()
-    if rsvp is None:
-        return None
-    # Re-derive eligibility on every request — else an event that turns
-    # MEMBERS_ONLY (or otherwise drops out) after the RSVP keeps leaking its
-    # member-only fields to the token holder (mirrors _eligible_event_rsvps).
-    event: Event = rsvp.event
-    if not event.is_public_rsvp_eligible:
+    # Re-derive eligibility per request so an event that drops out of public-RSVP
+    # eligibility (MEMBERS_ONLY, cancelled, past, …) stops unlocking immediately.
+    event = Event.objects.filter(id=event_id).first()
+    if event is None or not event.is_public_rsvp_eligible:
         return None
     return user

--- a/backend/tests/test_event_viewer.py
+++ b/backend/tests/test_event_viewer.py
@@ -19,18 +19,6 @@ def event(db, test_user):
 
 
 @pytest.fixture
-def other_event(db, test_user):
-    return Event.objects.create(
-        title="Other Event",
-        start_datetime=future_iso(days=11),
-        event_type=EventType.OFFICIAL,
-        visibility=PageVisibility.PUBLIC,
-        rsvp_enabled=True,
-        created_by=test_user,
-    )
-
-
-@pytest.fixture
 def non_member(db):
     user = User.objects.create_user(
         phone_number="+12025550199",
@@ -67,14 +55,13 @@ class TestResolveEventViewer:
         request.auth = None
         assert resolve_event_viewer(request, event.id) == non_member
 
-    def test_valid_token_without_rsvp_on_this_event_stays_locked(
-        self, rf, event, other_event, non_member
-    ):
-        EventRSVP.objects.create(event=other_event, user=non_member, status=RSVPStatus.ATTENDING)
+    def test_valid_token_without_rsvp_unlocks_eligible_event(self, rf, event, non_member):
+        # Reusing one token across events: no RSVP on THIS event, but the token
+        # is valid and the event still accepts public RSVPs (issue #873).
         token = NonMemberRsvpToken.issue(non_member)
         request = _request(rf, query=f"token={token.token}")
         request.auth = None
-        assert resolve_event_viewer(request, event.id) is None
+        assert resolve_event_viewer(request, event.id) == non_member
 
     def test_invalid_token_stays_locked(self, rf, event):
         request = _request(rf, query="token=not-a-real-token")
@@ -94,10 +81,9 @@ class TestResolveEventViewer:
         request.auth = None
         assert resolve_event_viewer(request, event.id) is None
 
-    def test_valid_token_locks_out_once_event_turns_members_only(self, rf, event, non_member):
-        # Event was public-RSVP-eligible when the non-member RSVP'd, but a host
-        # later flipped visibility — the token must not keep unlocking it.
-        EventRSVP.objects.create(event=event, user=non_member, status=RSVPStatus.ATTENDING)
+    def test_valid_token_stays_locked_on_members_only_event(self, rf, event, non_member):
+        # The token only unlocks public-RSVP-eligible events — a members-only
+        # event never accepts public RSVPs, so it must stay locked.
         token = NonMemberRsvpToken.issue(non_member)
         event.visibility = PageVisibility.MEMBERS_ONLY
         event.save(update_fields=["visibility"])

--- a/backend/tests/test_public_rsvp_event_detail.py
+++ b/backend/tests/test_public_rsvp_event_detail.py
@@ -1,5 +1,5 @@
 """GET /events/{id}/ with a non-member RSVP token — unlocks member-only fields
-scoped to the one event the token holder RSVP'd to."""
+on any public-RSVP-eligible event for a valid token holder (issue #873)."""
 
 import pytest
 from community.models import Event, EventRSVP, EventType, PageVisibility, RSVPStatus
@@ -63,16 +63,28 @@ class TestGetEventWithToken:
         assert response.status_code == 200, response.content
         assert response.json()["whatsapp_link"] == "https://chat.whatsapp.com/abc123"
 
-    def test_token_scoped_to_other_event_does_not_unlock(
+    def test_token_from_other_event_unlocks_eligible_event(
         self, api_client, official_event, other_event, non_member
     ):
+        # One token, reused across events: RSVP'd to other_event, no RSVP on
+        # official_event, but the token still unlocks it (issue #873).
         EventRSVP.objects.create(event=other_event, user=non_member, status=RSVPStatus.ATTENDING)
         token = NonMemberRsvpToken.issue(non_member)
         response = api_client.get(
             f"/api/community/events/{official_event.id}/", {"token": token.token}
         )
         assert response.status_code == 200, response.content
-        assert response.json()["whatsapp_link"] == ""
+        assert response.json()["whatsapp_link"] == "https://chat.whatsapp.com/abc123"
+
+    def test_token_does_not_unlock_members_only_event(self, api_client, official_event, non_member):
+        official_event.visibility = PageVisibility.MEMBERS_ONLY
+        official_event.save(update_fields=["visibility"])
+        token = NonMemberRsvpToken.issue(non_member)
+        response = api_client.get(
+            f"/api/community/events/{official_event.id}/", {"token": token.token}
+        )
+        # Members-only events never accept public RSVPs — a token can't unlock them.
+        assert response.status_code == 404, response.content
 
     def test_token_never_unlocks_invited_list(self, api_client, official_event, non_member):
         invited = User.objects.create_user(

--- a/frontend/src/screens/events/EventDetailScreen.test.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.test.tsx
@@ -238,7 +238,7 @@ describe('EventDetailScreen', () => {
     it('renders the public-rsvp section when rsvp_token is present and the event comes back unlocked', () => {
       useAuthStore.setState({ status: 'unauthed', user: null, accessToken: null });
       mockUseEvent.mockReturnValue({
-        data: { ...BASE_EVENT, myRsvp: 'attending' },
+        data: { ...BASE_EVENT, viewerUserId: 'nm-1' },
         isPending: false,
         isError: false,
       } as ReturnType<typeof useEvent>);
@@ -249,17 +249,24 @@ describe('EventDetailScreen', () => {
       expect(screen.queryByText('want to see more?')).not.toBeInTheDocument();
     });
 
-    it('falls back to the login wall when the token did not unlock the event', () => {
+    it('falls back to the public rsvp form when the token did not unlock the event', () => {
       useAuthStore.setState({ status: 'unauthed', user: null, accessToken: null });
       mockUseEvent.mockReturnValue({
-        data: { ...BASE_EVENT, myRsvp: null, whatsappLink: '', location: '' },
+        data: {
+          ...BASE_EVENT,
+          eventType: EventType.Official,
+          viewerUserId: null,
+          whatsappLink: '',
+          location: '',
+        },
         isPending: false,
         isError: false,
       } as ReturnType<typeof useEvent>);
 
       renderScreen('ev1', '?rsvp_token=expired-or-wrong-scope');
 
-      expect(screen.getByText('want to see more?')).toBeInTheDocument();
+      // public-rsvp-eligible event with a rejected token → the rsvp form, not the login wall
+      expect(screen.getByRole('heading', { name: 'rsvp' })).toBeInTheDocument();
     });
 
     it('passes the rsvp_token through to useEvent', () => {
@@ -267,6 +274,43 @@ describe('EventDetailScreen', () => {
       renderScreen('ev1', '?rsvp_token=tok-abc');
 
       expect(mockUseEvent).toHaveBeenCalledWith('ev1', undefined, 'tok-abc');
+    });
+
+    it('reuses a persisted token when the url has none (issue 873)', () => {
+      useAuthStore.setState({ status: 'unauthed', user: null, accessToken: null });
+      localStorage.setItem('pda-rsvp-token', 'stored-tok');
+      mockUseEvent.mockReturnValue({
+        data: { ...BASE_EVENT, viewerUserId: 'nm-1' },
+        isPending: false,
+        isError: false,
+      } as ReturnType<typeof useEvent>);
+
+      renderScreen('ev1');
+
+      expect(mockUseEvent).toHaveBeenCalledWith('ev1', undefined, 'stored-tok');
+      expect(screen.getByRole('link', { name: /123 Main St/i })).toBeInTheDocument();
+    });
+
+    it('drops a stored token the backend rejected', () => {
+      useAuthStore.setState({ status: 'unauthed', user: null, accessToken: null });
+      localStorage.setItem('pda-rsvp-token', 'stale-tok');
+      mockUseEvent.mockReturnValue({
+        data: { ...BASE_EVENT, viewerUserId: null },
+        isPending: false,
+        isError: false,
+      } as ReturnType<typeof useEvent>);
+
+      renderScreen('ev1');
+
+      expect(localStorage.getItem('pda-rsvp-token')).toBeNull();
+    });
+
+    it('ignores a stored token for an authed member', () => {
+      useAuthStore.setState({ status: 'authed', user: AUTHED_USER, accessToken: 'tok' });
+      localStorage.setItem('pda-rsvp-token', 'stored-tok');
+      renderScreen('ev1');
+
+      expect(mockUseEvent).toHaveBeenCalledWith('ev1', undefined, undefined);
     });
   });
 });

--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -1,8 +1,10 @@
 import type { ReactNode } from 'react';
+import { useEffect } from 'react';
 import { Link, useParams, useSearchParams } from 'react-router-dom';
 
 import { extractApiError, getApiStatus } from '@/api/apiErrors';
 import { useEvent } from '@/api/events';
+import { clearStoredRsvpToken, getStoredRsvpToken } from '@/api/rsvpTokenStorage';
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
 import {
@@ -33,10 +35,21 @@ function photoSrc(url: string, updatedAt: string | null): string {
 export default function EventDetailScreen() {
   const { id } = useParams<{ id: string }>();
   const [searchParams] = useSearchParams();
-  const rsvpToken = searchParams.get('rsvp_token') ?? undefined;
   const isAuthed = useAuthStore((s) => s.status === 'authed');
   const user = useAuthStore((s) => s.user);
+  // The emailed link carries ?rsvp_token=…; a returning non-member arrives with
+  // none, so fall back to the token persisted on their last rsvp (issue #873).
+  const urlToken = searchParams.get('rsvp_token') ?? undefined;
+  const rsvpToken = isAuthed ? undefined : (urlToken ?? getStoredRsvpToken() ?? undefined);
   const { data: event, isPending, isError, error } = useEvent(id, undefined, rsvpToken);
+
+  // A supplied token that didn't unlock the event is expired/invalid — drop it
+  // so a stale stored token doesn't keep re-attaching on every navigation.
+  const tokenRejected =
+    !isPending && !isError && Boolean(rsvpToken) && !isAuthed && event.viewerUserId === null;
+  useEffect(() => {
+    if (tokenRejected) clearStoredRsvpToken();
+  }, [tokenRejected]);
 
   if (isPending) return <ContentLoading />;
   if (isError) {
@@ -48,11 +61,11 @@ export default function EventDetailScreen() {
   }
 
   const showKebab = isAuthed && event.rsvpEnabled && canManageEvent(event, user);
-  // myRsvp is populated by the backend's rsvp resolver only when the caller
-  // was resolved as "authed" (real member or a token scoped to THIS event) —
-  // an invalid/expired/wrong-scope token gets the same locked shape as no
-  // token at all, so this is an exact backend-verified signal, not a guess.
-  const hasTokenUnlock = Boolean(rsvpToken) && !isAuthed && event.myRsvp !== null;
+  // viewerUserId is set by the backend's viewer resolver only when the caller
+  // resolved to a real identity (member, or a valid token on an eligible event);
+  // an invalid/expired token gets the same locked shape as no token at all, so
+  // this is an exact backend-verified signal, not a guess.
+  const hasTokenUnlock = Boolean(rsvpToken) && !isAuthed && event.viewerUserId !== null;
 
   return (
     <ContentContainer>

--- a/frontend/src/screens/events/PublicRsvpSection.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpSection.test.tsx
@@ -133,5 +133,7 @@ describe('PublicRsvpSection', () => {
     expect(mockNavigate).toHaveBeenCalledWith('/events/evt-1?rsvp_token=tok-abc', {
       replace: true,
     });
+    // persisted so the token survives navigation to another event (issue 873)
+    expect(localStorage.getItem('pda-rsvp-token')).toBe('tok-abc');
   });
 });

--- a/frontend/src/screens/events/PublicRsvpSection.tsx
+++ b/frontend/src/screens/events/PublicRsvpSection.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 
+import { setStoredRsvpToken } from '@/api/rsvpTokenStorage';
 import type { Event } from '@/models/event';
 
 import { PublicRsvpForm } from './PublicRsvpForm';
@@ -14,6 +15,9 @@ export function PublicRsvpSection({ event }: Props) {
     <PublicRsvpForm
       event={event}
       onSuccess={(result) => {
+        // Persist so the token survives navigation — a returning non-member
+        // reuses it across events instead of re-filling the form (issue #873).
+        setStoredRsvpToken(result.rsvp_token);
         void navigate(`/events/${event.id}?rsvp_token=${encodeURIComponent(result.rsvp_token)}`, {
           replace: true,
         });

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -11,8 +11,31 @@ expect.extend(axeMatchers);
 
 setPhoneCountriesForTesting(['US', 'CA', 'GB', 'AU']);
 
+// jsdom's default Storage isn't wired up for get/set round-trips — stub a real one.
+const storageMock = (() => {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string): string | null => store[key] ?? null,
+    setItem: (key: string, value: string): void => {
+      store[key] = value;
+    },
+    removeItem: (key: string): void => {
+      delete store[key];
+    },
+    clear: (): void => {
+      store = {};
+    },
+    get length(): number {
+      return Object.keys(store).length;
+    },
+    key: (index: number): string | null => Object.keys(store)[index] ?? null,
+  };
+})();
+Object.defineProperty(window, 'localStorage', { value: storageMock, writable: true });
+
 afterEach(() => {
   cleanup();
+  localStorage.clear();
 });
 
 // jsdom doesn't implement ResizeObserver — provide a no-op stub so components


### PR DESCRIPTION
## Summary
- Grant and persist a non-member's rsvp token immediately, so rsvping to a second event doesn't force them to re-fill the public rsvp form.
- `resolve_event_viewer` now unlocks any public-rsvp-eligible event for a valid token holder (previously scoped to only the one event they'd already rsvp'd to) — the same events an anonymous visitor could already unlock by submitting the form, so this doesn't widen what's reachable, just removes the re-fill friction. Posting comments still requires an actual rsvp.
- `PublicRsvpSection` persists the token to `localStorage` on success; `EventDetailScreen` falls back to the stored token when the url has none, and clears it if the backend rejects it (expired/invalid).

Closes #873

## Test plan
- [x] Backend: `test_event_viewer.py`, `test_public_rsvp_event_detail.py`, `test_event_comments.py` (40 passed)
- [x] Frontend: full vitest suite (853 passed), typecheck, lint, prettier clean
- [x] Manually drove the flow end-to-end in the browser: rsvp'd as a non-member to event A via the form → visited event B with no token in the url → event B rendered unlocked (location, links, member-style rsvp controls) purely from the persisted token, no form re-fill → confirmed the token-based rsvp actually created an `attending` row for event B server-side
- [x] Probed a stale/invalid stored token → correctly falls back to the locked anon form and clears the bad token from storage