### PR TITLE
fix(events): add official-event hint to non-member sign-in prompt (Issue 877)

### DIFF
--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -235,6 +235,10 @@ function LoginOrJoinSection() {
           request to join
         </Link>
       </div>
+      <p className="text-foreground-tertiary mt-4 text-sm">
+        if you're not a member yet, look for the official events in blue on the calendar — once
+        you've come to one of those, you'll be able to sign up for all of the events on here!
+      </p>
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a hint below the sign-in/request-to-join prompt shown to non-members viewing an event they can't publicly RSVP to, pointing them toward official (blue) events on the calendar as the path to membership access.

Closes #877

## Test plan
- [x] `make agent-frontend-typecheck`
- [x] `make agent-frontend-lint`
- [x] `EventDetailScreen.test.tsx` (17/17 passing)
- [ ] manually view a non-official public event as a logged-out user and confirm the hint renders below the sign-in/join buttons