### PR TITLE
feat(events): let non-members reach my-rsvps from bottom nav (Issue 878)

### DIFF
--- a/frontend/src/layout/BottomNav.test.tsx
+++ b/frontend/src/layout/BottomNav.test.tsx
@@ -1,11 +1,15 @@
-// Unit tests for the bottom nav. Covers all five destinations rendering,
-// the add-event button navigating to /events/add, and the nav always
-// mounting (no permission gate on the FAB).
+// Unit tests for the bottom nav. Covers the fixed destinations rendering,
+// the auth-dependent my-rsvps tab, the add-event button navigating to
+// /events/add, and the nav always mounting (no permission gate on the FAB).
 
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { setStoredRsvpToken } from '@/api/rsvpTokenStorage';
+import { useAuthStore } from '@/auth/store';
+import type { User } from '@/models/user';
 
 import { BottomNav } from './BottomNav';
 
@@ -33,20 +37,43 @@ function renderNav(initialPath = '/') {
 }
 
 describe('BottomNav', () => {
-  it('renders all five destinations: calendar, my events, add event, members, profile', () => {
+  afterEach(() => {
+    useAuthStore.setState({ status: 'idle', user: null, accessToken: null });
+  });
+
+  it('renders calendar, add event, members, profile regardless of auth state', () => {
     renderNav('/');
 
     expect(screen.getByRole('link', { name: /^calendar$/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /^my events$/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /^add event$/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /^members$/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /^profile$/i })).toBeInTheDocument();
   });
 
-  it('my events link points at /events/mine', () => {
+  it('authed users get a my rsvps link pointing at /events/mine', () => {
+    useAuthStore.setState({
+      status: 'authed',
+      user: { profilePhotoUrl: '', photoUpdatedAt: null } as User,
+      accessToken: 'token',
+    });
     renderNav('/');
-    const link = screen.getByRole('link', { name: /^my events$/i });
+
+    const link = screen.getByRole('link', { name: /^my rsvps$/i });
     expect(link).toHaveAttribute('href', '/events/mine');
+  });
+
+  it('logged-out users with a stored rsvp token get a my rsvps link pointing at /my-rsvps', () => {
+    setStoredRsvpToken('abc123');
+    renderNav('/');
+
+    const link = screen.getByRole('link', { name: /^my rsvps$/i });
+    expect(link).toHaveAttribute('href', '/my-rsvps');
+  });
+
+  it('logged-out users with no stored rsvp token get no my rsvps tab', () => {
+    renderNav('/');
+
+    expect(screen.queryByRole('link', { name: /^my rsvps$/i })).not.toBeInTheDocument();
   });
 
   it('members link points at /members', () => {

--- a/frontend/src/layout/BottomNav.tsx
+++ b/frontend/src/layout/BottomNav.tsx
@@ -1,4 +1,4 @@
-// Fixed bottom nav — calendar / my events / +event / members / profile.
+// Fixed bottom nav — calendar / my rsvps / +event / members / profile.
 //
 // Mirrors Flutter's NavigationBar with labelBehavior=alwaysHide: labels are
 // visually hidden but present in the accessible name so screen readers can
@@ -8,6 +8,7 @@
 import type { ReactNode } from 'react';
 import { NavLink, useLocation, useNavigate } from 'react-router-dom';
 
+import { getStoredRsvpToken } from '@/api/rsvpTokenStorage';
 import { useAuthStore } from '@/auth/store';
 import { cn } from '@/utils/cn';
 
@@ -15,12 +16,14 @@ export function BottomNav() {
   const navigate = useNavigate();
   const location = useLocation();
   const onEventsAdd = location.pathname === '/events/add';
+  const isAuthed = useAuthStore((s) => s.status === 'authed');
   const user = useAuthStore((s) => s.user);
   const photoUrl = user?.profilePhotoUrl
     ? user.photoUpdatedAt
       ? `${user.profilePhotoUrl}?v=${encodeURIComponent(user.photoUpdatedAt)}`
       : user.profilePhotoUrl
     : '';
+  const myEventsTo = isAuthed ? '/events/mine' : getStoredRsvpToken() ? '/my-rsvps' : null;
 
   return (
     <nav
@@ -32,9 +35,13 @@ export function BottomNav() {
           {({ active }) => <CalendarIcon filled={active} />}
         </NavItem>
 
-        <NavItem to="/events/mine" label="my events">
-          {({ active }) => <StarIcon filled={active} />}
-        </NavItem>
+        {myEventsTo ? (
+          <NavItem to={myEventsTo} label="my rsvps">
+            {({ active }) => <StarIcon filled={active} />}
+          </NavItem>
+        ) : (
+          <div />
+        )}
 
         <div className="flex items-center justify-center">
           <button


### PR DESCRIPTION
## Summary
- Repurposes the bottom nav's "my events" star tab based on auth state: authed users still go to `/events/mine`; non-members holding a persisted RSVP token now go to `/my-rsvps` (relabeled "my rsvps") instead of being bounced to login; non-members with no stored token get the tab hidden entirely rather than a dead-end login redirect.

Closes #878

## Test plan
- [x] `make agent-frontend-typecheck`
- [x] `make agent-frontend-lint`
- [x] `make agent-frontend-test` (855 passed / 1 pre-existing skip, no regressions)
- [ ] manually RSVP to a public event as a logged-out user, then confirm the bottom nav tab shows "my rsvps" and lands on the correct screen
- [ ] manually confirm the tab is hidden for a logged-out user with no stored RSVP token