### PR TITLE
fix(feedback): show feedback button to token-holding non-members (Issue 879)

### DIFF
--- a/frontend/src/components/FeedbackButton.test.tsx
+++ b/frontend/src/components/FeedbackButton.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { clearStoredRsvpToken, setStoredRsvpToken } from '@/api/rsvpTokenStorage';
 import { useAuthStore } from '@/auth/store';
 import type { User } from '@/models/user';
 import { makeUser as makeSharedUser } from '@/test/fixtures';
@@ -54,6 +55,7 @@ function renderButton(initialPath = '/calendar') {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  clearStoredRsvpToken();
   useAuthStore.setState({ status: 'authed', user: makeUser(), accessToken: 'tok' });
   submitFeedbackMock.mockResolvedValue({ html_url: 'https://example.com/1' });
   mockedUseSubmitFeedback.mockReturnValue({
@@ -70,10 +72,17 @@ describe('FeedbackButton', () => {
     expect(btn).toHaveTextContent('?');
   });
 
-  it('is hidden when the user is not authenticated', () => {
+  it('is hidden when the user is not authenticated and has no rsvp token', () => {
     useAuthStore.setState({ status: 'unauthed', user: null, accessToken: null });
     renderButton();
     expect(screen.queryByRole('button', { name: /send feedback/i })).not.toBeInTheDocument();
+  });
+
+  it('renders for an unauthenticated non-member holding a stored rsvp token', () => {
+    useAuthStore.setState({ status: 'unauthed', user: null, accessToken: null });
+    setStoredRsvpToken('rsvp-token-123');
+    renderButton();
+    expect(screen.getByRole('button', { name: /send feedback/i })).toBeInTheDocument();
   });
 
   it('opens the form dialog when the button is tapped', async () => {

--- a/frontend/src/components/FeedbackButton.tsx
+++ b/frontend/src/components/FeedbackButton.tsx
@@ -1,8 +1,9 @@
 // Floating feedback button — bottom-right FAB that opens a card form.
 //
 // Submits to /api/community/feedback/, which creates a GitHub issue. Shown
-// only to authed users; route-aware via useLocation. Copy is all lowercase
-// per .claude/rules/ui-copy-tone.md. maxLength caps match the frontend
+// to authed users and to non-members holding a persisted public-RSVP token
+// (Issue 879). Route-aware via useLocation. Copy is all lowercase per
+// .claude/rules/ui-copy-tone.md. maxLength caps match the frontend
 // input-validation guidance (title 150, description 2000) and stay under
 // the backend FieldLimit on FeedbackIn (200 / 10000).
 import type { SyntheticEvent } from 'react';
@@ -11,6 +12,7 @@ import { useLocation } from 'react-router-dom';
 import { toast } from 'sonner';
 
 import { type FeedbackType, useSubmitFeedback } from '@/api/feedback';
+import { getStoredRsvpToken } from '@/api/rsvpTokenStorage';
 import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import { Textarea } from '@/components/ui/Textarea';
@@ -21,6 +23,8 @@ const DESCRIPTION_MAX = 2000;
 
 export function FeedbackButton() {
   const isAuthed = useAuthStore((s) => s.status === 'authed');
+  const hasRsvpToken = !!getStoredRsvpToken();
+  const canShowFeedback = isAuthed || hasRsvpToken;
   const location = useLocation();
   const { mutateAsync, isPending } = useSubmitFeedback();
 
@@ -43,7 +47,7 @@ export function FeedbackButton() {
     };
   }, [open]);
 
-  if (!isAuthed) return null;
+  if (!canShowFeedback) return null;
 
   function close() {
     setOpen(false);


### PR DESCRIPTION
## Summary
- The floating "?" feedback button was gated on `isAuthed` only, so non-members who publicly RSVP'd to an official event never saw it. Now also shows when a valid RSVP token is persisted in localStorage (`getStoredRsvpToken()`), which is only set after a successful public RSVP or via an emailed return link — never on a bare page visit.

Closes #879

## Test plan
- [x] `make agent-frontend-typecheck`
- [x] `make agent-frontend-lint`
- [x] `FeedbackButton.test.tsx` + `FeedbackButton.a11y.test.tsx` (16/16 passing, including new token-present case)
- [x] `make agent-frontend-test` full suite (854 passed, 1 pre-existing skip, no regressions)
- [ ] manually RSVP to a public event as a logged-out user and confirm the "?" button appears