### PR TITLE
fix(events): check phone before showing public rsvp form (Issue 881)

### DIFF
--- a/backend/community/_public_rsvp_submit.py
+++ b/backend/community/_public_rsvp_submit.py
@@ -1,4 +1,5 @@
 import logging
+from enum import StrEnum
 
 from config.audit import audit_log
 from config.ratelimit import client_ip, rate_limit
@@ -22,7 +23,7 @@ from community._public_rsvp_shared import (
     _log_email_failure,
 )
 from community._shared import ErrorOut, _validate_phone, validate_display_name
-from community._validation import Code, raise_validation
+from community._validation import Code, ValidationException, raise_validation
 from community.models import Event, RSVPStatus
 
 router = Router()
@@ -37,6 +38,21 @@ class PublicRsvpIn(BaseModel):
     has_plus_one: bool = False
     # Honeypot: hidden field humans never fill in. A non-empty value is spam.
     website: str = Field(default="", max_length=FieldLimit.DISPLAY_NAME)
+
+
+class PublicRsvpPhoneStatus(StrEnum):
+    MEMBER = "member"
+    ALREADY_RSVPD = "already_rsvpd"
+    NEW = "new"
+
+
+class PublicRsvpPhoneCheckIn(BaseModel):
+    phone_number: str = Field(max_length=FieldLimit.PHONE)
+
+
+class PublicRsvpPhoneCheckOut(BaseModel):
+    status: PublicRsvpPhoneStatus
+    rsvp_token: str = ""
 
 
 def _public_rsvp_decoy(event: Event, status: str, has_plus_one: bool) -> PublicRsvpOut:
@@ -136,6 +152,36 @@ def _send_confirmation_email(
             raise RuntimeError(result.error or "send returned failure")
     except Exception as exc:
         _log_email_failure(request, event, user, exc)
+
+
+@router.post(
+    "/public/events/{event_id}/rsvp-phone-check/",
+    response={200: PublicRsvpPhoneCheckOut, 404: ErrorOut, 429: ErrorOut},
+    auth=None,
+)
+@rate_limit(key_func=client_ip, rate="20/h")
+def check_public_rsvp_phone(request, event_id, payload: PublicRsvpPhoneCheckIn):
+    """Resolve a phone number's state for this event, before the full rsvp form is shown."""
+    event = _load_public_rsvp_event(event_id)
+    try:
+        phone = _validate_phone(payload.phone_number)
+    except ValidationException:
+        return Status(200, PublicRsvpPhoneCheckOut(status=PublicRsvpPhoneStatus.NEW))
+
+    user = User.objects.filter(phone_number=phone, archived_at__isnull=True).first()
+    if user is None:
+        return Status(200, PublicRsvpPhoneCheckOut(status=PublicRsvpPhoneStatus.NEW))
+    if user.is_member:
+        return Status(200, PublicRsvpPhoneCheckOut(status=PublicRsvpPhoneStatus.MEMBER))
+    if event.rsvps.filter(user=user).exists():
+        token = NonMemberRsvpToken.issue_or_extend(user)
+        return Status(
+            200,
+            PublicRsvpPhoneCheckOut(
+                status=PublicRsvpPhoneStatus.ALREADY_RSVPD, rsvp_token=token.token
+            ),
+        )
+    return Status(200, PublicRsvpPhoneCheckOut(status=PublicRsvpPhoneStatus.NEW))
 
 
 @router.post(

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -3943,6 +3943,46 @@
         "title": "PublicRsvpOut",
         "type": "object"
       },
+      "PublicRsvpPhoneCheckIn": {
+        "properties": {
+          "phone_number": {
+            "maxLength": 20,
+            "title": "Phone Number",
+            "type": "string"
+          }
+        },
+        "required": [
+          "phone_number"
+        ],
+        "title": "PublicRsvpPhoneCheckIn",
+        "type": "object"
+      },
+      "PublicRsvpPhoneCheckOut": {
+        "properties": {
+          "rsvp_token": {
+            "default": "",
+            "title": "Rsvp Token",
+            "type": "string"
+          },
+          "status": {
+            "$ref": "#/components/schemas/PublicRsvpPhoneStatus"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "PublicRsvpPhoneCheckOut",
+        "type": "object"
+      },
+      "PublicRsvpPhoneStatus": {
+        "enum": [
+          "member",
+          "already_rsvpd",
+          "new"
+        ],
+        "title": "PublicRsvpPhoneStatus",
+        "type": "string"
+      },
       "PublicRsvpStateOut": {
         "properties": {
           "has_plus_one": {
@@ -11279,6 +11319,69 @@
           }
         ],
         "summary": "Update Page",
+        "tags": [
+          "community"
+        ]
+      }
+    },
+    "/api/community/public/events/{event_id}/rsvp-phone-check/": {
+      "post": {
+        "description": "Resolve a phone number's state for this event, before the full rsvp form is shown.",
+        "operationId": "community__public_rsvp_submit_check_public_rsvp_phone",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "event_id",
+            "required": true,
+            "schema": {
+              "title": "Event Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/PublicRsvpPhoneCheckIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicRsvpPhoneCheckOut"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          }
+        },
+        "summary": "Check Public Rsvp Phone",
         "tags": [
           "community"
         ]

--- a/backend/tests/test_public_rsvp_phone_check.py
+++ b/backend/tests/test_public_rsvp_phone_check.py
@@ -1,0 +1,94 @@
+"""Tests for the public rsvp phone-check endpoint.
+
+POST /api/community/public/events/{event_id}/rsvp-phone-check/ — no auth. Lets
+the frontend ask "what should happen for this phone number" before showing the
+full rsvp form (Issue 881).
+"""
+
+import pytest
+from community.models import EventRSVP, RSVPStatus
+from users.models import NonMemberRsvpToken
+
+from tests._public_rsvp_helpers import make_non_member, make_official_event
+from tests.conftest import future_iso
+
+URL_TEMPLATE = "/api/community/public/events/{event_id}/rsvp-phone-check/"
+
+
+def url(event):
+    return URL_TEMPLATE.format(event_id=event.id)
+
+
+def post(api_client, event, phone_number="+14155550123"):
+    return api_client.post(
+        url(event), {"phone_number": phone_number}, content_type="application/json"
+    )
+
+
+@pytest.fixture
+def official_event(db):
+    return make_official_event()
+
+
+@pytest.mark.django_db
+class TestPublicRsvpPhoneCheck:
+    def test_unknown_phone_is_new(self, api_client, official_event):
+        response = post(api_client, official_event)
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "new"
+        assert body["rsvp_token"] == ""
+
+    def test_member_phone_returns_member(self, api_client, official_event, test_user):
+        response = post(api_client, official_event, phone_number=test_user.phone_number)
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "member"
+
+    def test_non_member_without_rsvp_is_new(self, api_client, official_event):
+        make_non_member("+14155550199", "guest@example.com")
+
+        response = post(api_client, official_event, phone_number="+14155550199")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "new"
+        assert body["rsvp_token"] == ""
+
+    def test_non_member_already_rsvpd_returns_token(self, api_client, official_event):
+        guest = make_non_member("+14155550199", "guest@example.com")
+        EventRSVP.objects.create(event=official_event, user=guest, status=RSVPStatus.ATTENDING)
+
+        response = post(api_client, official_event, phone_number="+14155550199")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "already_rsvpd"
+        assert body["rsvp_token"] != ""
+        assert NonMemberRsvpToken.resolve_user(body["rsvp_token"]) == guest
+
+    def test_already_rsvpd_on_other_event_is_new_for_this_one(self, api_client, official_event):
+        guest = make_non_member("+14155550199", "guest@example.com")
+        other_event = make_official_event(title="Other Event", start_datetime=future_iso(days=45))
+        EventRSVP.objects.create(event=other_event, user=guest, status=RSVPStatus.ATTENDING)
+
+        response = post(api_client, official_event, phone_number="+14155550199")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "new"
+
+    def test_invalid_phone_is_new(self, api_client, official_event):
+        response = post(api_client, official_event, phone_number="not-a-phone")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "new"
+
+    def test_nonexistent_event_returns_404(self, api_client):
+        response = api_client.post(
+            "/api/community/public/events/00000000-0000-0000-0000-000000000000/rsvp-phone-check/",
+            {"phone_number": "+14155550123"},
+            content_type="application/json",
+        )
+
+        assert response.status_code == 404

--- a/frontend/src/api/publicRsvp.ts
+++ b/frontend/src/api/publicRsvp.ts
@@ -8,6 +8,8 @@ import { apiClient } from './client';
 
 export type PublicRsvpIn = components['schemas']['PublicRsvpIn'];
 export type PublicRsvpOut = components['schemas']['PublicRsvpOut'];
+export type PublicRsvpPhoneStatus = components['schemas']['PublicRsvpPhoneStatus'];
+export type PublicRsvpPhoneCheckOut = components['schemas']['PublicRsvpPhoneCheckOut'];
 type PublicRsvpManageIn = components['schemas']['PublicRsvpManageIn'];
 
 interface SubmitArgs {
@@ -21,6 +23,23 @@ export function useSubmitPublicRsvp() {
       const { data } = await apiClient.post<PublicRsvpOut>(
         `/api/community/public/events/${eventId}/rsvp/`,
         payload,
+      );
+      return data;
+    },
+  });
+}
+
+interface PhoneCheckArgs {
+  eventId: string;
+  phoneNumber: string;
+}
+
+export function useCheckPublicRsvpPhone() {
+  return useMutation({
+    mutationFn: async ({ eventId, phoneNumber }: PhoneCheckArgs) => {
+      const { data } = await apiClient.post<PublicRsvpPhoneCheckOut>(
+        `/api/community/public/events/${eventId}/rsvp-phone-check/`,
+        { phone_number: phoneNumber },
       );
       return data;
     },

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -1345,6 +1345,26 @@ export interface paths {
         patch: operations["community__pages_update_page"];
         trace?: never;
     };
+    "/api/community/public/events/{event_id}/rsvp-phone-check/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Check Public Rsvp Phone
+         * @description Resolve a phone number's state for this event, before the full rsvp form is shown.
+         */
+        post: operations["community__public_rsvp_submit_check_public_rsvp_phone"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/community/public/events/{event_id}/rsvp/": {
         parameters: {
             query?: never;
@@ -3530,6 +3550,25 @@ export interface components {
             /** Rsvp Token */
             rsvp_token: string;
         };
+        /** PublicRsvpPhoneCheckIn */
+        PublicRsvpPhoneCheckIn: {
+            /** Phone Number */
+            phone_number: string;
+        };
+        /** PublicRsvpPhoneCheckOut */
+        PublicRsvpPhoneCheckOut: {
+            /**
+             * Rsvp Token
+             * @default
+             */
+            rsvp_token: string;
+            status: components["schemas"]["PublicRsvpPhoneStatus"];
+        };
+        /**
+         * PublicRsvpPhoneStatus
+         * @enum {string}
+         */
+        PublicRsvpPhoneStatus: "member" | "already_rsvpd" | "new";
         /** PublicRsvpStateOut */
         PublicRsvpStateOut: {
             /** Has Plus One */
@@ -8338,6 +8377,50 @@ export interface operations {
             };
             /** @description Forbidden */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
+    community__public_rsvp_submit_check_public_rsvp_phone: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                event_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["PublicRsvpPhoneCheckIn"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PublicRsvpPhoneCheckOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/screens/events/PublicRsvp.a11y.test.tsx
+++ b/frontend/src/screens/events/PublicRsvp.a11y.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
@@ -11,11 +11,26 @@ import {
   InvitePermission,
 } from '@/models/event';
 
+const checkPhoneMutate = vi.fn();
 vi.mock('@/api/publicRsvp', () => ({
   useSubmitPublicRsvp: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  useCheckPublicRsvpPhone: () => ({ mutateAsync: checkPhoneMutate, isPending: false }),
 }));
 
 import { PublicRsvpForm } from './PublicRsvpForm';
+
+function renderForm(event: Event) {
+  return render(
+    <MemoryRouter>
+      <PublicRsvpForm
+        event={event}
+        onSuccess={vi.fn()}
+        onMember={vi.fn()}
+        onAlreadyRsvpd={vi.fn()}
+      />
+    </MemoryRouter>,
+  );
+}
 
 function makeEvent(overrides: Partial<Event> = {}): Event {
   return {
@@ -73,22 +88,25 @@ function makeEvent(overrides: Partial<Event> = {}): Event {
 
 describe('public rsvp a11y', () => {
   it('form step one has no axe violations', async () => {
-    const { container } = render(
-      <MemoryRouter>
-        <PublicRsvpForm event={makeEvent()} onSuccess={vi.fn()} />
-      </MemoryRouter>,
-    );
+    const { container } = renderForm(makeEvent());
     const results = await axe(container, { rules: { 'color-contrast': { enabled: false } } });
     expect(results).toHaveNoViolations();
   }, 15000);
 
-  it('form step two has no axe violations', async () => {
-    const { container } = render(
-      <MemoryRouter>
-        <PublicRsvpForm event={makeEvent()} onSuccess={vi.fn()} />
-      </MemoryRouter>,
-    );
+  it('form step two (phone) has no axe violations', async () => {
+    const { container } = renderForm(makeEvent());
     fireEvent.click(screen.getByRole('button', { name: "i'm going" }));
+    const results = await axe(container, { rules: { 'color-contrast': { enabled: false } } });
+    expect(results).toHaveNoViolations();
+  }, 15000);
+
+  it('form step three (contact details) has no axe violations', async () => {
+    checkPhoneMutate.mockResolvedValue({ status: 'new', rsvp_token: '' });
+    const { container } = renderForm(makeEvent());
+    fireEvent.click(screen.getByRole('button', { name: "i'm going" }));
+    fireEvent.change(screen.getByLabelText(/phone number/i), { target: { value: '+14155550123' } });
+    fireEvent.click(screen.getByRole('button', { name: 'continue' }));
+    await waitFor(() => expect(screen.getByLabelText('first name')).toBeInTheDocument());
     const results = await axe(container, { rules: { 'color-contrast': { enabled: false } } });
     expect(results).toHaveNoViolations();
   }, 15000);

--- a/frontend/src/screens/events/PublicRsvpForm.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.test.tsx
@@ -11,8 +11,10 @@ import {
 } from '@/models/event';
 
 const submitMutate = vi.fn();
+const checkPhoneMutate = vi.fn();
 vi.mock('@/api/publicRsvp', () => ({
   useSubmitPublicRsvp: () => ({ mutateAsync: submitMutate, isPending: false }),
+  useCheckPublicRsvpPhone: () => ({ mutateAsync: checkPhoneMutate, isPending: false }),
 }));
 
 import { PublicRsvpForm } from './PublicRsvpForm';
@@ -71,19 +73,36 @@ function makeEvent(overrides: Partial<Event> = {}): Event {
   };
 }
 
-function renderForm(event = makeEvent(), onSuccess = vi.fn()) {
+function renderForm(
+  event = makeEvent(),
+  onSuccess = vi.fn(),
+  onMember = vi.fn(),
+  onAlreadyRsvpd = vi.fn(),
+) {
   return render(
     <MemoryRouter>
-      <PublicRsvpForm event={event} onSuccess={onSuccess} />
+      <PublicRsvpForm
+        event={event}
+        onSuccess={onSuccess}
+        onMember={onMember}
+        onAlreadyRsvpd={onAlreadyRsvpd}
+      />
     </MemoryRouter>,
   );
 }
 
-function fillRequired() {
+function fillPhoneStep(phone = '4155550123') {
   fireEvent.click(screen.getByRole('button', { name: "i'm going" }));
+  fireEvent.change(screen.getByLabelText(/phone number/i), { target: { value: phone } });
+  fireEvent.click(screen.getByRole('button', { name: 'continue' }));
+}
+
+async function fillRequired() {
+  checkPhoneMutate.mockResolvedValue({ status: 'new', rsvp_token: '' });
+  fillPhoneStep();
+  await waitFor(() => expect(screen.getByLabelText('first name')).toBeInTheDocument());
   fireEvent.change(screen.getByLabelText('first name'), { target: { value: 'Ada' } });
   fireEvent.change(screen.getByLabelText('email'), { target: { value: 'ada@example.com' } });
-  fireEvent.change(screen.getByLabelText('phone'), { target: { value: '+15550001111' } });
 }
 
 describe('PublicRsvpForm', () => {
@@ -93,12 +112,13 @@ describe('PublicRsvpForm', () => {
       event: { id: 'ev1' },
       rsvp: { status: 'attending', has_plus_one: false },
     });
+    checkPhoneMutate.mockReset();
   });
 
   it('submits the correct payload shape', async () => {
     const onSuccess = vi.fn();
     renderForm(makeEvent(), onSuccess);
-    fillRequired();
+    await fillRequired();
     fireEvent.click(screen.getByRole('button', { name: 'rsvp' }));
     await waitFor(() => expect(submitMutate).toHaveBeenCalled());
     expect(submitMutate).toHaveBeenCalledWith({
@@ -106,7 +126,7 @@ describe('PublicRsvpForm', () => {
       payload: expect.objectContaining({
         first_name: 'Ada',
         email: 'ada@example.com',
-        phone_number: '+15550001111',
+        phone_number: '+14155550123',
         status: 'attending',
         has_plus_one: false,
         website: '',
@@ -115,13 +135,19 @@ describe('PublicRsvpForm', () => {
     await waitFor(() => expect(onSuccess).toHaveBeenCalled());
   });
 
-  it('renders the plus-one toggle only when allowPlusOnes', () => {
+  it('renders the plus-one toggle only when allowPlusOnes', async () => {
+    checkPhoneMutate.mockResolvedValue({ status: 'new', rsvp_token: '' });
     const { rerender } = renderForm(makeEvent({ allowPlusOnes: true }));
-    fireEvent.click(screen.getByRole('button', { name: "i'm going" }));
-    expect(screen.getByRole('switch')).toBeInTheDocument();
+    fillPhoneStep();
+    await waitFor(() => expect(screen.getByRole('switch')).toBeInTheDocument());
     rerender(
       <MemoryRouter>
-        <PublicRsvpForm event={makeEvent({ allowPlusOnes: false })} onSuccess={vi.fn()} />
+        <PublicRsvpForm
+          event={makeEvent({ allowPlusOnes: false })}
+          onSuccess={vi.fn()}
+          onMember={vi.fn()}
+          onAlreadyRsvpd={vi.fn()}
+        />
       </MemoryRouter>,
     );
     expect(screen.queryByRole('switch')).not.toBeInTheDocument();
@@ -132,31 +158,69 @@ describe('PublicRsvpForm', () => {
     expect(screen.getByRole('button', { name: "i'm going" })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'maybe' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: "can't go" })).not.toBeInTheDocument();
-    expect(screen.queryByLabelText('first name')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText(/phone number/i)).not.toBeInTheDocument();
   });
 
-  it('advances to the contact-details step after picking a status', () => {
+  it('advances to the phone step after picking a status', () => {
     renderForm();
     fireEvent.click(screen.getByRole('button', { name: 'maybe' }));
-    expect(screen.getByLabelText('first name')).toBeInTheDocument();
+    expect(screen.getByLabelText(/phone number/i)).toBeInTheDocument();
+  });
+
+  it('advances to the contact-details step after the phone check resolves new', async () => {
+    checkPhoneMutate.mockResolvedValue({ status: 'new', rsvp_token: '' });
+    renderForm();
+    fireEvent.click(screen.getByRole('button', { name: 'maybe' }));
+    fireEvent.change(screen.getByLabelText(/phone number/i), {
+      target: { value: '+14155550123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'continue' }));
+    await waitFor(() => expect(screen.getByLabelText('first name')).toBeInTheDocument());
     expect(screen.getByText('maybe')).toBeInTheDocument();
   });
 
-  it('lets you change the status and go back to step one', () => {
+  it('calls onMember when the phone belongs to a member', async () => {
+    checkPhoneMutate.mockResolvedValue({ status: 'member', rsvp_token: '' });
+    const onMember = vi.fn();
+    renderForm(makeEvent(), vi.fn(), onMember);
+    fillPhoneStep();
+    await waitFor(() => expect(onMember).toHaveBeenCalled());
+  });
+
+  it('calls onAlreadyRsvpd with the refreshed token when already rsvpd', async () => {
+    checkPhoneMutate.mockResolvedValue({ status: 'already_rsvpd', rsvp_token: 'tok-xyz' });
+    const onAlreadyRsvpd = vi.fn();
+    renderForm(makeEvent(), vi.fn(), vi.fn(), onAlreadyRsvpd);
+    fillPhoneStep();
+    await waitFor(() => expect(onAlreadyRsvpd).toHaveBeenCalledWith({ rsvpToken: 'tok-xyz' }));
+  });
+
+  it('lets you change the status and go back to step one from the details step', async () => {
+    checkPhoneMutate.mockResolvedValue({ status: 'new', rsvp_token: '' });
     renderForm();
     fireEvent.click(screen.getByRole('button', { name: 'maybe' }));
+    fireEvent.change(screen.getByLabelText(/phone number/i), {
+      target: { value: '+14155550123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'continue' }));
+    await waitFor(() => expect(screen.getByLabelText('first name')).toBeInTheDocument());
     fireEvent.click(screen.getByRole('button', { name: 'change' }));
     expect(screen.getByRole('button', { name: "i'm going" })).toBeInTheDocument();
     expect(screen.queryByLabelText('first name')).not.toBeInTheDocument();
   });
 
   it('submits maybe status chosen in step one', async () => {
+    checkPhoneMutate.mockResolvedValue({ status: 'new', rsvp_token: '' });
     const onSuccess = vi.fn();
     renderForm(makeEvent(), onSuccess);
     fireEvent.click(screen.getByRole('button', { name: 'maybe' }));
+    fireEvent.change(screen.getByLabelText(/phone number/i), {
+      target: { value: '+14155550123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'continue' }));
+    await waitFor(() => expect(screen.getByLabelText('first name')).toBeInTheDocument());
     fireEvent.change(screen.getByLabelText('first name'), { target: { value: 'Ada' } });
     fireEvent.change(screen.getByLabelText('email'), { target: { value: 'ada@example.com' } });
-    fireEvent.change(screen.getByLabelText('phone'), { target: { value: '+15550001111' } });
     fireEvent.click(screen.getByRole('button', { name: 'rsvp' }));
     await waitFor(() => expect(submitMutate).toHaveBeenCalled());
     expect(submitMutate).toHaveBeenCalledWith({
@@ -168,7 +232,7 @@ describe('PublicRsvpForm', () => {
   it('shows a 409 inline error with a sign-in link', async () => {
     submitMutate.mockRejectedValue({ isAxiosError: true, response: { status: 409 } });
     renderForm();
-    fillRequired();
+    await fillRequired();
     fireEvent.click(screen.getByRole('button', { name: 'rsvp' }));
     await screen.findByText('looks like you already have an account — sign in to rsvp');
     expect(screen.getByRole('link', { name: 'sign in' })).toHaveAttribute('href', '/login');
@@ -177,14 +241,16 @@ describe('PublicRsvpForm', () => {
   it('shows a 429 rate-limit error', async () => {
     submitMutate.mockRejectedValue({ isAxiosError: true, response: { status: 429 } });
     renderForm();
-    fillRequired();
+    await fillRequired();
     fireEvent.click(screen.getByRole('button', { name: 'rsvp' }));
     await screen.findByText("you're rsvping too fast — try again in a few minutes");
   });
 
-  it('renders the hidden honeypot field', () => {
+  it('renders the hidden honeypot field', async () => {
+    checkPhoneMutate.mockResolvedValue({ status: 'new', rsvp_token: '' });
     renderForm();
-    fireEvent.click(screen.getByRole('button', { name: "i'm going" }));
+    fillPhoneStep();
+    await waitFor(() => expect(screen.getByLabelText('first name')).toBeInTheDocument());
     const hp = screen.getByLabelText('website (leave blank)');
     expect(hp).toHaveAttribute('name', 'website');
     expect(hp).toHaveAttribute('tabindex', '-1');

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -12,12 +12,16 @@ import { Toggle } from '@/components/ui/Toggle';
 import { type Event, RSVP_STATUS_LABELS, type RsvpInputStatus, RsvpStatus } from '@/models/event';
 import { optionalEmail } from '@/utils/validators';
 
+import { type AlreadyRsvpdResult, PublicRsvpPhoneStep } from './PublicRsvpPhoneStep';
+
 const MAX_NAME = 100;
 const PUBLIC_RSVP_STATUSES: RsvpInputStatus[] = [RsvpStatus.Attending, RsvpStatus.Maybe];
 
 interface Props {
   event: Event;
   onSuccess: (result: PublicRsvpOut) => void;
+  onMember: () => void;
+  onAlreadyRsvpd: (result: AlreadyRsvpdResult) => void;
 }
 
 interface SubmitError {
@@ -42,9 +46,10 @@ function statusLabel(status: RsvpInputStatus): string {
   return RSVP_STATUS_LABELS.find((s) => s.status === status)?.label ?? status;
 }
 
-export function PublicRsvpForm({ event, onSuccess }: Props) {
+export function PublicRsvpForm({ event, onSuccess, onMember, onAlreadyRsvpd }: Props) {
   const submit = useSubmitPublicRsvp();
   const [status, setStatus] = useState<RsvpInputStatus | null>(null);
+  const [phoneConfirmed, setPhoneConfirmed] = useState(false);
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [email, setEmail] = useState('');
@@ -87,95 +92,116 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
     }
   }
 
+  function renderStep() {
+    if (status === null) {
+      return (
+        <RsvpStatusPicker value={status} onSelect={setStatus} statuses={PUBLIC_RSVP_STATUSES} />
+      );
+    }
+    if (!phoneConfirmed) {
+      return (
+        <PublicRsvpPhoneStep
+          eventId={event.id}
+          onMember={onMember}
+          onAlreadyRsvpd={onAlreadyRsvpd}
+          onNew={(result) => {
+            setPhone(result.phone);
+            setPhoneConfirmed(true);
+          }}
+        />
+      );
+    }
+    return (
+      <form onSubmit={(e) => void onSubmit(e)} className="flex flex-col gap-4" noValidate>
+        <Honeypot value={website} onChange={setWebsite} />
+
+        <div className="flex items-center justify-between">
+          <p className="text-foreground-secondary text-sm">
+            rsvping as <span className="text-foreground font-medium">{statusLabel(status)}</span>
+          </p>
+          <button
+            type="button"
+            onClick={() => {
+              setStatus(null);
+              setPhoneConfirmed(false);
+            }}
+            className="text-info text-sm hover:underline"
+          >
+            change
+          </button>
+        </div>
+
+        <TextField
+          label="first name"
+          value={firstName}
+          onChange={(e) => {
+            setFirstName(e.target.value);
+          }}
+          maxLength={MAX_NAME}
+          autoComplete="given-name"
+          error={errors.firstName}
+          required
+        />
+        <TextField
+          label="last name"
+          value={lastName}
+          onChange={(e) => {
+            setLastName(e.target.value);
+          }}
+          maxLength={MAX_NAME}
+          autoComplete="family-name"
+        />
+        <TextField
+          label="email"
+          type="email"
+          value={email}
+          onChange={(e) => {
+            setEmail(e.target.value);
+          }}
+          autoComplete="email"
+          error={errors.email}
+          required
+        />
+        <PhoneField label="phone" value={phone} onChange={setPhone} error={errors.phone} />
+
+        {event.allowPlusOnes ? (
+          <Toggle
+            label="bring a +1"
+            checked={hasPlusOne}
+            onChange={setHasPlusOne}
+            className="justify-start gap-2"
+          />
+        ) : null}
+
+        <Button type="submit" disabled={submit.isPending} fullWidth>
+          rsvp
+        </Button>
+
+        {submitError ? (
+          <div role="alert" className="text-destructive text-sm">
+            <p>{submitError.text}</p>
+            {submitError.showSignIn ? (
+              <Link to="/login" className="text-info hover:underline">
+                sign in
+              </Link>
+            ) : null}
+          </div>
+        ) : null}
+
+        <p className="text-foreground-tertiary text-xs">
+          rsvping doesn't make you a pda member —{' '}
+          <Link to="/join" className="text-info hover:underline">
+            request to join
+          </Link>
+        </p>
+      </form>
+    );
+  }
+
   return (
     <section aria-label="rsvp" className="border-border bg-surface mt-8 rounded-lg border p-6">
       <h2 className="mb-4 text-base font-medium">rsvp</h2>
-      {status === null ? (
-        <RsvpStatusPicker value={status} onSelect={setStatus} statuses={PUBLIC_RSVP_STATUSES} />
-      ) : (
-        <form onSubmit={(e) => void onSubmit(e)} className="flex flex-col gap-4" noValidate>
-          <Honeypot value={website} onChange={setWebsite} />
-
-          <div className="flex items-center justify-between">
-            <p className="text-foreground-secondary text-sm">
-              rsvping as <span className="text-foreground font-medium">{statusLabel(status)}</span>
-            </p>
-            <button
-              type="button"
-              onClick={() => {
-                setStatus(null);
-              }}
-              className="text-info text-sm hover:underline"
-            >
-              change
-            </button>
-          </div>
-
-          <TextField
-            label="first name"
-            value={firstName}
-            onChange={(e) => {
-              setFirstName(e.target.value);
-            }}
-            maxLength={MAX_NAME}
-            autoComplete="given-name"
-            error={errors.firstName}
-            required
-          />
-          <TextField
-            label="last name"
-            value={lastName}
-            onChange={(e) => {
-              setLastName(e.target.value);
-            }}
-            maxLength={MAX_NAME}
-            autoComplete="family-name"
-          />
-          <TextField
-            label="email"
-            type="email"
-            value={email}
-            onChange={(e) => {
-              setEmail(e.target.value);
-            }}
-            autoComplete="email"
-            error={errors.email}
-            required
-          />
-          <PhoneField label="phone" value={phone} onChange={setPhone} error={errors.phone} />
-
-          {event.allowPlusOnes ? (
-            <Toggle
-              label="bring a +1"
-              checked={hasPlusOne}
-              onChange={setHasPlusOne}
-              className="justify-start gap-2"
-            />
-          ) : null}
-
-          <Button type="submit" disabled={submit.isPending} fullWidth>
-            rsvp
-          </Button>
-
-          {submitError ? (
-            <div role="alert" className="text-destructive text-sm">
-              <p>{submitError.text}</p>
-              {submitError.showSignIn ? (
-                <Link to="/login" className="text-info hover:underline">
-                  sign in
-                </Link>
-              ) : null}
-            </div>
-          ) : null}
-
-          <p className="text-foreground-tertiary text-xs">
-            rsvping doesn't make you a pda member —{' '}
-            <Link to="/join" className="text-info hover:underline">
-              request to join
-            </Link>
-          </p>
-        </form>
-      )}
+      {renderStep()}
     </section>
   );
 }

--- a/frontend/src/screens/events/PublicRsvpPhoneStep.tsx
+++ b/frontend/src/screens/events/PublicRsvpPhoneStep.tsx
@@ -1,0 +1,62 @@
+import { type SyntheticEvent, useState } from 'react';
+import { isValidPhoneNumber } from 'react-phone-number-input';
+
+import { useCheckPublicRsvpPhone } from '@/api/publicRsvp';
+import { Button } from '@/components/ui/Button';
+import { PhoneField } from '@/components/ui/PhoneField';
+import { extractApiError } from '@/utils/errors';
+
+export interface PhoneStepResult {
+  phone: string;
+  status: 'new';
+}
+
+export interface AlreadyRsvpdResult {
+  rsvpToken: string;
+}
+
+interface Props {
+  onNew: (result: PhoneStepResult) => void;
+  onMember: () => void;
+  onAlreadyRsvpd: (result: AlreadyRsvpdResult) => void;
+  eventId: string;
+}
+
+export function PublicRsvpPhoneStep({ onNew, onMember, onAlreadyRsvpd, eventId }: Props) {
+  const check = useCheckPublicRsvpPhone();
+  const [phone, setPhone] = useState('');
+  const [error, setError] = useState<string | undefined>(undefined);
+
+  async function onSubmit(e: SyntheticEvent) {
+    e.preventDefault();
+    setError(undefined);
+    if (!phone || !isValidPhoneNumber(phone)) {
+      setError('enter a valid phone number');
+      return;
+    }
+    try {
+      const result = await check.mutateAsync({ eventId, phoneNumber: phone });
+      if (result.status === 'member') {
+        onMember();
+        return;
+      }
+      if (result.status === 'already_rsvpd') {
+        onAlreadyRsvpd({ rsvpToken: result.rsvp_token });
+        return;
+      }
+      onNew({ phone, status: 'new' });
+    } catch (err) {
+      setError(extractApiError(err, "couldn't check your number — try again"));
+    }
+  }
+
+  return (
+    <form onSubmit={(e) => void onSubmit(e)} className="flex flex-col gap-4" noValidate>
+      <p className="text-foreground-secondary text-sm">enter your phone number to continue</p>
+      <PhoneField label="phone number" value={phone} onChange={setPhone} error={error} />
+      <Button type="submit" disabled={check.isPending} fullWidth>
+        {check.isPending ? 'checking…' : 'continue'}
+      </Button>
+    </form>
+  );
+}

--- a/frontend/src/screens/events/PublicRsvpSection.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpSection.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type * as RouterDom from 'react-router-dom';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   canPublicRsvp,
@@ -20,8 +20,10 @@ vi.mock('react-router-dom', async (importActual) => {
 });
 
 const mockSubmit = vi.fn();
+const mockCheckPhone = vi.fn();
 vi.mock('@/api/publicRsvp', () => ({
   useSubmitPublicRsvp: () => ({ mutateAsync: mockSubmit, isPending: false }),
+  useCheckPublicRsvpPhone: () => ({ mutateAsync: mockCheckPhone, isPending: false }),
 }));
 
 import { PublicRsvpSection } from './PublicRsvpSection';
@@ -102,6 +104,12 @@ describe('canPublicRsvp', () => {
 });
 
 describe('PublicRsvpSection', () => {
+  beforeEach(() => {
+    mockSubmit.mockReset();
+    mockCheckPhone.mockReset();
+    localStorage.clear();
+  });
+
   it('renders the form heading initially', () => {
     render(
       <MemoryRouter>
@@ -112,6 +120,7 @@ describe('PublicRsvpSection', () => {
   });
 
   it('navigates to the event page with the rsvp token on success', async () => {
+    mockCheckPhone.mockResolvedValue({ status: 'new', rsvp_token: '' });
     mockSubmit.mockResolvedValue({
       event: makeEvent(),
       rsvp: { status: 'attending', has_plus_one: false },
@@ -125,9 +134,11 @@ describe('PublicRsvpSection', () => {
     );
 
     await user.click(screen.getByRole('button', { name: "i'm going" }));
+    await user.type(screen.getByLabelText(/phone number/i), '4155550123');
+    await user.click(screen.getByRole('button', { name: 'continue' }));
+    await screen.findByLabelText(/first name/i);
     await user.type(screen.getByLabelText(/first name/i), 'Sam');
     await user.type(screen.getByLabelText(/^email/i), 'sam@example.com');
-    await user.type(screen.getByLabelText(/phone/i), '4155550123');
     await user.click(screen.getByRole('button', { name: 'rsvp' }));
 
     expect(mockNavigate).toHaveBeenCalledWith('/events/evt-1?rsvp_token=tok-abc', {
@@ -135,5 +146,42 @@ describe('PublicRsvpSection', () => {
     });
     // persisted so the token survives navigation to another event (issue 873)
     expect(localStorage.getItem('pda-rsvp-token')).toBe('tok-abc');
+  });
+
+  it('prompts sign-in when the phone belongs to a member, without showing the form', async () => {
+    mockCheckPhone.mockResolvedValue({ status: 'member', rsvp_token: '' });
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <PublicRsvpSection event={makeEvent({ id: 'evt-1' })} />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByRole('button', { name: "i'm going" }));
+    await user.type(screen.getByLabelText(/phone number/i), '4155550123');
+    await user.click(screen.getByRole('button', { name: 'continue' }));
+
+    expect(await screen.findByRole('link', { name: 'sign in' })).toHaveAttribute('href', '/login');
+    expect(screen.queryByLabelText(/first name/i)).not.toBeInTheDocument();
+  });
+
+  it('navigates straight to the event page when already rsvpd, skipping the form', async () => {
+    mockCheckPhone.mockResolvedValue({ status: 'already_rsvpd', rsvp_token: 'tok-returning' });
+    const user = userEvent.setup();
+    render(
+      <MemoryRouter>
+        <PublicRsvpSection event={makeEvent({ id: 'evt-1' })} />
+      </MemoryRouter>,
+    );
+
+    await user.click(screen.getByRole('button', { name: "i'm going" }));
+    await user.type(screen.getByLabelText(/phone number/i), '4155550123');
+    await user.click(screen.getByRole('button', { name: 'continue' }));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/events/evt-1?rsvp_token=tok-returning', {
+      replace: true,
+    });
+    expect(mockSubmit).not.toHaveBeenCalled();
+    expect(localStorage.getItem('pda-rsvp-token')).toBe('tok-returning');
   });
 });

--- a/frontend/src/screens/events/PublicRsvpSection.tsx
+++ b/frontend/src/screens/events/PublicRsvpSection.tsx
@@ -1,4 +1,5 @@
-import { useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 
 import { setStoredRsvpToken } from '@/api/rsvpTokenStorage';
 import type { Event } from '@/models/event';
@@ -11,17 +12,46 @@ interface Props {
 
 export function PublicRsvpSection({ event }: Props) {
   const navigate = useNavigate();
+  const [isMember, setIsMember] = useState(false);
+
+  function unlockWithToken(token: string) {
+    // Persist so the token survives navigation — a returning non-member
+    // reuses it across events instead of re-filling the form (issue #873).
+    setStoredRsvpToken(token);
+    void navigate(`/events/${event.id}?rsvp_token=${encodeURIComponent(token)}`, {
+      replace: true,
+    });
+  }
+
+  if (isMember) return <MemberSignInPrompt />;
+
   return (
     <PublicRsvpForm
       event={event}
       onSuccess={(result) => {
-        // Persist so the token survives navigation — a returning non-member
-        // reuses it across events instead of re-filling the form (issue #873).
-        setStoredRsvpToken(result.rsvp_token);
-        void navigate(`/events/${event.id}?rsvp_token=${encodeURIComponent(result.rsvp_token)}`, {
-          replace: true,
-        });
+        unlockWithToken(result.rsvp_token);
+      }}
+      onMember={() => {
+        setIsMember(true);
+      }}
+      onAlreadyRsvpd={(result) => {
+        unlockWithToken(result.rsvpToken);
       }}
     />
+  );
+}
+
+function MemberSignInPrompt() {
+  return (
+    <section aria-label="rsvp" className="border-border bg-surface mt-8 rounded-lg border p-6">
+      <h2 className="mb-2 text-base font-medium">looks like you already have an account</h2>
+      <p className="text-foreground-tertiary mb-4 text-sm">sign in to rsvp to this event</p>
+      <Link
+        to="/login"
+        className="bg-brand-600 text-brand-on hover:bg-brand-700 inline-flex h-10 items-center rounded-md px-4 text-sm font-medium"
+      >
+        sign in
+      </Link>
+    </section>
   );
 }


### PR DESCRIPTION
## Summary

Closes #881

The public rsvp flow (anonymous "i'm going" on an official/public event, reached from `/calendar` -> event detail) showed the full name/email/phone form immediately after picking a status. Per the issue's spec, phone number should be collected and checked *first*, before the form appears, branching into three flows:

- **member phone** -> prompt sign-in inline (no rsvp form shown)
- **non-member phone that already rsvp'd to this event** -> refresh their `NonMemberRsvpToken` and take them straight to the (now-unlocked) event detail page, skipping the form entirely
- **non-member phone, no rsvp yet** -> show the contact-details form as before

### Backend

- New endpoint: `POST /api/community/public/events/{event_id}/rsvp-phone-check/` (`backend/community/_public_rsvp_submit.py`) — resolves a phone number against this event's member/RSVP state and returns `{ status: "member" | "already_rsvpd" | "new", rsvp_token }`.
- Reuses existing infrastructure rather than adding anything new: `NonMemberRsvpToken.issue_or_extend` (built for Issue 854) mints the refreshed token for the `already_rsvpd` case, and `_validate_phone` / `User.is_member` mirror the member-detection logic already used in `_resolve_non_member`.
- New tests: `backend/tests/test_public_rsvp_phone_check.py` (7 cases — unknown phone, member phone, non-member without rsvp, non-member with rsvp on this event, non-member with rsvp on a *different* event, invalid phone, nonexistent event).

### Frontend

- New `PublicRsvpPhoneStep` component (mirrors the login screen's phone-first pattern: `PhoneField` + `isValidPhoneNumber` validation) inserted into `PublicRsvpForm` between the status picker and the contact-details step.
- `PublicRsvpSection` now branches on the phone-check result: shows an inline sign-in prompt for members, or unlocks the event detail page directly (same token-unlock mechanism from Issue 854) for a returning non-member guest — without ever rendering the form for either case.
- New API hook `useCheckPublicRsvpPhone` in `frontend/src/api/publicRsvp.ts`.
- Updated/extended tests in `PublicRsvpForm.test.tsx`, `PublicRsvpSection.test.tsx`, `PublicRsvp.a11y.test.tsx` to cover the new step and all three branches.

## Overlap with Issue 854

This significantly reuses Issue 854's infrastructure (`NonMemberRsvpToken`, `resolve_event_viewer`, the `?rsvp_token=` unlock flow, `rsvpTokenStorage`) rather than duplicating it — no new token/session mechanism was introduced. The only new pieces are the phone-check endpoint and the frontend phone-first step.

## Design notes / open questions

- The new phone-check endpoint is intentionally **event-scoped** (not a generic phone lookup) since "already rsvp'd" is inherently per-event — this differs from the existing generic `POST /api/community/check-phone/` used by the login screen, which only reports member/pending/unknown.
- Rate limit set to `20/h` per IP on the new endpoint, matching the generic check-phone endpoint (more permissive than the `5/h` on the actual rsvp submit, since this is a lighter read-only lookup users may retry while getting their number right).
- The "member" branch shows an inline sign-in prompt (with a link to `/login`) rather than auto-redirecting, per the issue text ("prompt login").

## Test plan

- [x] `make agent-typecheck` / `make agent-lint` / backend test suite (1479 passed, 5 pre-existing unrelated SQLite/pg_notify SSE failures)
- [x] `make agent-frontend-typecheck` / `make agent-frontend-lint` / `make agent-frontend-test` (862 passed)
- [x] `make frontend-types` regenerated after backend endpoint changes
- [ ] Manual click-through in a running dev environment (not done in this pass — reviewer may want to verify the phone-first UX manually)
