### PR TITLE
fix(events): tighten plus-one toggle label spacing

### DIFF
--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -145,7 +145,12 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
           <PhoneField label="phone" value={phone} onChange={setPhone} error={errors.phone} />
 
           {event.allowPlusOnes ? (
-            <Toggle label="bring a +1" checked={hasPlusOne} onChange={setHasPlusOne} />
+            <Toggle
+              label="bring a +1"
+              checked={hasPlusOne}
+              onChange={setHasPlusOne}
+              className="justify-start gap-2"
+            />
           ) : null}
 
           <Button type="submit" disabled={submit.isPending} fullWidth>


### PR DESCRIPTION
## Summary
- The public RSVP form's "bring a +1" toggle used the shared `Toggle` component's default `justify-between` layout, which spread the label to the far left of the full-width row instead of keeping it next to the switch on the right.
- Scoped the fix to this one usage via the existing `className` override prop (`justify-start gap-2`), rather than changing the shared `Toggle` component, since `Toggle` is used elsewhere (settings, admin, event forms) as a standard label-left/switch-right settings row.

Closes #869

## Test plan
- [x] `make agent-frontend-typecheck` — passes
- [x] `make agent-frontend-lint` — passes
- [x] `make agent-frontend-test` (PublicRsvpForm + ui component suites) — 18 passed
- [ ] Visual verification not performed in this environment (dev server/browser tooling wasn't practical to wire up against this worktree) — relying on the scoped Tailwind class change plus `twMerge` precedence (verified in `cn.ts`) for correctness