### PR TITLE
fix(events): prevent clicking non-member rsvp entries

### DIFF
--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -86,6 +86,7 @@ def _build_guest_list(rsvps, can_see_phones: bool, viewer=None) -> list[RSVPGues
             photo_url=media_path(r.user.profile_photo),
             attendance=r.attendance,
             checked_in_at=r.checked_in_at,
+            is_member=r.user.is_member,
         )
         for r in rsvps
     ]

--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -115,6 +115,7 @@ class RSVPGuestOut(BaseModel):
     photo_url: str = ""
     attendance: str = AttendanceStatus.UNKNOWN
     checked_in_at: datetime | None = None
+    is_member: bool = True
 
 
 class PendingCoHostInviteOut(BaseModel):

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -3985,6 +3985,11 @@
             "title": "Has Plus One",
             "type": "boolean"
           },
+          "is_member": {
+            "default": true,
+            "title": "Is Member",
+            "type": "boolean"
+          },
           "name": {
             "title": "Name",
             "type": "string"

--- a/backend/tests/test_event_helpers.py
+++ b/backend/tests/test_event_helpers.py
@@ -51,6 +51,7 @@ class TestBuildGuestList:
                 show_phone=show_phone,
                 profile_photo=None,
                 hide_last_name=False,
+                is_member=True,
             ),
             status=status,
             has_plus_one=False,

--- a/backend/tests/test_rsvp.py
+++ b/backend/tests/test_rsvp.py
@@ -276,6 +276,20 @@ class TestRSVP:
         assert len(guests) == 1
         assert guests[0]["phone"] is None
 
+    def test_guest_list_flags_non_members(self, api_client, auth_headers, rsvp_event):
+        non_member = User.objects.create_user(
+            phone_number="+12025550199",
+            password="testpass123",
+            first_name="Guest",
+            is_member=False,
+        )
+        EventRSVP.objects.create(event=rsvp_event, user=non_member, status=RSVPStatus.ATTENDING)
+        response = api_client.get(f"/api/community/events/{rsvp_event.id}/", **auth_headers)
+        assert response.status_code == 200
+        guests = response.json()["guests"]
+        assert len(guests) == 1
+        assert guests[0]["is_member"] is False
+
 
 # ---------------------------------------------------------------------------
 # TestCreateEventWithCohosts

--- a/frontend/src/api/eventMapper.ts
+++ b/frontend/src/api/eventMapper.ts
@@ -15,6 +15,7 @@ interface WireGuest {
   photo_url?: string;
   has_plus_one?: boolean;
   attendance?: string;
+  is_member?: boolean;
 }
 
 export interface WireEvent {
@@ -107,6 +108,7 @@ function mapGuest(g: WireGuest): EventGuest {
     photoUrl: g.photo_url ?? '',
     hasPlusOne: g.has_plus_one ?? false,
     attendance: mapAttendance(g.attendance),
+    isMember: g.is_member ?? true,
   };
 }
 

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -3551,6 +3551,11 @@ export interface components {
              * @default false
              */
             has_plus_one: boolean;
+            /**
+             * Is Member
+             * @default true
+             */
+            is_member: boolean;
             /** Name */
             name: string;
             /** Phone */

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -70,6 +70,7 @@ export interface EventGuest {
   photoUrl: string;
   hasPlusOne: boolean;
   attendance: AttendanceStatusValue;
+  isMember: boolean;
 }
 
 export interface EventCancellation {

--- a/frontend/src/screens/events/EmailBlastButton.test.tsx
+++ b/frontend/src/screens/events/EmailBlastButton.test.tsx
@@ -21,6 +21,7 @@ function guest(status: string): EventGuest {
     photoUrl: '',
     hasPlusOne: false,
     attendance: 'unknown',
+    isMember: true,
   };
 }
 

--- a/frontend/src/screens/events/EmailBlastDialog.test.tsx
+++ b/frontend/src/screens/events/EmailBlastDialog.test.tsx
@@ -36,6 +36,7 @@ function guest(status: string, i: number): EventGuest {
     photoUrl: '',
     hasPlusOne: false,
     attendance: 'unknown',
+    isMember: true,
   };
 }
 

--- a/frontend/src/screens/events/EventAttendancePanel.test.tsx
+++ b/frontend/src/screens/events/EventAttendancePanel.test.tsx
@@ -77,6 +77,7 @@ const BASE_EVENT: Event = {
       photoUrl: '',
       hasPlusOne: false,
       attendance: AttendanceStatus.Unknown,
+      isMember: true,
     },
   ],
   myRsvp: null,

--- a/frontend/src/screens/events/RsvpGuestList.test.tsx
+++ b/frontend/src/screens/events/RsvpGuestList.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import {
+  AttendanceStatus,
+  type Event,
+  type EventGuest,
+  EventStatus,
+  EventType,
+  EventVisibility,
+  InvitePermission,
+  RsvpServerStatus,
+} from '@/models/event';
+
+import { RsvpGuestList } from './RsvpGuestList';
+
+function makeGuest(overrides: Partial<EventGuest>): EventGuest {
+  return {
+    userId: 'user-1',
+    name: 'Alex',
+    status: RsvpServerStatus.Attending,
+    phone: null,
+    photoUrl: '',
+    hasPlusOne: false,
+    attendance: AttendanceStatus.Unknown,
+    isMember: true,
+    ...overrides,
+  };
+}
+
+function makeEvent(guests: EventGuest[]): Event {
+  return {
+    id: 'ev1',
+    title: 'Potluck',
+    description: '',
+    startDatetime: new Date('2099-06-01T18:00:00Z'),
+    endDatetime: null,
+    location: '',
+    latitude: null,
+    longitude: null,
+    whatsappLink: '',
+    partifulLink: '',
+    otherLink: '',
+    venmoLink: '',
+    cashappLink: '',
+    zelleInfo: '',
+    price: '',
+    rsvpEnabled: true,
+    allowPlusOnes: true,
+    maxAttendees: null,
+    attendingCount: guests.length,
+    waitlistedCount: 0,
+    invitedCount: 0,
+    datetimeTbd: false,
+    hasPoll: false,
+    datetimePollSlug: null,
+    createdById: 'user-host',
+    createdByName: 'Host',
+    createdByPhotoUrl: '',
+    coHostIds: [],
+    coHostNames: [],
+    coHostPhotoUrls: [],
+    coHostInviteIds: [],
+    guests,
+    myRsvp: null,
+    viewerUserId: null,
+    surveySlugs: [],
+    invitedUserIds: [],
+    invitedUserNames: [],
+    invitedUserPhotoUrls: [],
+    invitePermission: InvitePermission.AllMembers,
+    pendingCohostInvites: [],
+    myPendingCohostInviteId: null,
+    eventType: EventType.Community,
+    visibility: EventVisibility.Public,
+    photoUrl: '',
+    photoUpdatedAt: null,
+    tags: [],
+    isPast: false,
+    status: EventStatus.Active,
+  };
+}
+
+describe('RsvpGuestList', () => {
+  it('links member guests to their profile', () => {
+    const event = makeEvent([makeGuest({ userId: 'user-1', name: 'Alex', isMember: true })]);
+    render(
+      <MemoryRouter>
+        <RsvpGuestList event={event} canSeeInvited={false} />
+      </MemoryRouter>,
+    );
+    const link = screen.getByRole('link', { name: /alex/i });
+    expect(link).toHaveAttribute('href', '/members/user-1');
+  });
+
+  it('renders non-member guests without a profile link', () => {
+    const event = makeEvent([
+      makeGuest({ userId: 'guest-1', name: 'Sam', isMember: false, hasPlusOne: true }),
+    ]);
+    render(
+      <MemoryRouter>
+        <RsvpGuestList event={event} canSeeInvited={false} />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByRole('link', { name: /sam/i })).not.toBeInTheDocument();
+    expect(screen.getByText('Sam')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/events/RsvpGuestList.tsx
+++ b/frontend/src/screens/events/RsvpGuestList.tsx
@@ -97,12 +97,8 @@ export function RsvpGuestList({ event, canSeeInvited }: Props) {
 }
 
 function GuestChip({ guest }: { guest: EventGuest }) {
-  return (
-    <Link
-      to={`/members/${guest.userId}`}
-      className="bg-surface-dim hover:bg-surface-dim/70 inline-flex items-center gap-1.5 rounded-full px-2 py-1 text-xs"
-      title={guest.name}
-    >
+  const content = (
+    <>
       {guest.photoUrl ? (
         <img
           src={guest.photoUrl}
@@ -120,6 +116,28 @@ function GuestChip({ guest }: { guest: EventGuest }) {
       )}
       {guest.name}
       {guest.hasPlusOne ? <span className="text-muted">+1</span> : null}
+    </>
+  );
+
+  if (!guest.isMember) {
+    return (
+      <span
+        className="bg-surface-dim/60 text-foreground-secondary inline-flex items-center gap-1.5 rounded-full px-2 py-1 text-xs opacity-60 grayscale"
+        title={`${guest.name} (not a member)`}
+        aria-label={`${guest.name} (not a member)`}
+      >
+        {content}
+      </span>
+    );
+  }
+
+  return (
+    <Link
+      to={`/members/${guest.userId}`}
+      className="bg-surface-dim hover:bg-surface-dim/70 inline-flex items-center gap-1.5 rounded-full px-2 py-1 text-xs"
+      title={guest.name}
+    >
+      {content}
     </Link>
   );
 }
@@ -144,6 +162,7 @@ export function InvitedList({ event }: { event: Event }) {
               photoUrl,
               hasPlusOne: false,
               attendance: AttendanceStatus.Unknown,
+              isMember: true,
             }}
           />
         );

--- a/frontend/src/screens/events/RsvpSection.test.tsx
+++ b/frontend/src/screens/events/RsvpSection.test.tsx
@@ -79,6 +79,7 @@ function makeGuest(overrides: Partial<EventGuest>): EventGuest {
     photoUrl: '',
     hasPlusOne: false,
     attendance: AttendanceStatus.Unknown,
+    isMember: true,
     ...overrides,
   };
 }

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -54,6 +54,7 @@ export function makeEvent(overrides: Partial<Event> = {}): Event {
         photoUrl: '',
         hasPlusOne: false,
         attendance: AttendanceStatus.Unknown,
+        isMember: true,
       },
       {
         userId: 'b',
@@ -62,6 +63,7 @@ export function makeEvent(overrides: Partial<Event> = {}): Event {
         phone: '+15553334444',
         photoUrl: '',
         hasPlusOne: false,
+        isMember: true,
         attendance: AttendanceStatus.Unknown,
       },
     ],


### PR DESCRIPTION
## Summary

Closes #876

Non-member attendees on an event's rsvp/attendee list (public rsvp guests, or a member's +1 without their own account) were rendered as clickable profile links identical to real members. Clicking one navigated to `/members/{userId}`, which 404s against `GET /api/users/{user_id}/profile/` (that endpoint only resolves `is_member=True` users) — surfacing a broken "couldn't load this profile" error.

## Changes

- **Backend**: added `is_member: bool` to `RSVPGuestOut` (`backend/community/_event_schemas.py`), populated from `r.user.is_member` in `_build_guest_list` (`backend/community/_event_helpers.py`).
- **Frontend**: added `isMember` to the `EventGuest` model and its wire mapper (`frontend/src/api/eventMapper.ts`). In `RsvpGuestList.tsx`, `GuestChip` now renders non-member guests as a plain non-interactive `<span>` (no `<Link>`, no hover affordance, `opacity-60 grayscale`, `title`/`aria-label` noting "not a member") instead of a clickable profile link — following the existing `PendingHostChip` pattern in `EventMemberSection.tsx`.
- Regenerated `frontend/src/api/types.gen.ts` / `backend/openapi_schema.json` via `make frontend-types`.
- Added `frontend/src/screens/events/RsvpGuestList.test.tsx` (new) asserting member guests still link to their profile and non-member guests render without a link. Added a backend integration test (`test_guest_list_flags_non_members` in `test_rsvp.py`) asserting the API returns `is_member: false` for a non-member rsvp.
- Updated existing test fixtures (`frontend/src/test/fixtures.ts`, and a few other `.test.tsx` files) to include the new required `isMember` field.

## Test plan

- [x] `make agent-frontend-typecheck` — passes
- [x] `make agent-frontend-lint` — passes
- [x] `make agent-frontend-test` — 858 passed, 1 skipped
- [x] `make agent-typecheck` — passes
- [x] `make agent-lint` — passes
- [x] `make agent-test` — 1473 passed (5 pre-existing `test_sse.py` failures unrelated to this change — SQLite doesn't support `pg_notify`, documented as expected-to-fail locally)
- [x] `make agent-complexity` — passes