### PR TITLE
fix(notifications): add no-reply note to member-facing emails (Issue 883)

### DIFF
--- a/backend/templates/emails/_no_reply_footer.html
+++ b/backend/templates/emails/_no_reply_footer.html
@@ -1,0 +1,1 @@
+<p style="margin: 8px 0 0; font-size: 12px; color: #999;">this is an automated email — please don't reply, this inbox isn't monitored.</p>

--- a/backend/templates/emails/_no_reply_footer.txt
+++ b/backend/templates/emails/_no_reply_footer.txt
@@ -1,0 +1,1 @@
+this is an automated email — please don't reply, this inbox isn't monitored.

--- a/backend/templates/emails/event_blast.html
+++ b/backend/templates/emails/event_blast.html
@@ -7,5 +7,6 @@
     <p style="margin: 0; font-size: 13px; color: #666;">you're receiving this because you rsvp'd to this event on pda.</p>
   </div>
   <p style="text-align: center; margin: 16px 0 0; font-size: 12px; color: #888;">— pda</p>
+  {% include "emails/_no_reply_footer.html" %}
 </body>
 </html>

--- a/backend/templates/emails/event_blast.txt
+++ b/backend/templates/emails/event_blast.txt
@@ -5,3 +5,5 @@ an update about {{ event_title|lower }}
 you're receiving this because you rsvp'd to this event on pda.
 
 — pda
+
+{% include "emails/_no_reply_footer.txt" %}

--- a/backend/templates/emails/join_approval.html
+++ b/backend/templates/emails/join_approval.html
@@ -7,5 +7,6 @@
     <div style="margin: 0 0 8px; font-size: 13px; color: #666;">{{ message_body|linebreaks }}</div>
   </div>
   <p style="text-align: center; margin: 16px 0 0; font-size: 12px; color: #888;">— pda</p>
+  {% include "emails/_no_reply_footer.html" %}
 </body>
 </html>

--- a/backend/templates/emails/join_approval.txt
+++ b/backend/templates/emails/join_approval.txt
@@ -5,3 +5,5 @@ you're fully approved — welcome to pda!
 {% autoescape off %}{{ message_body }}{% endautoescape %}
 
 — pda
+
+{% include "emails/_no_reply_footer.txt" %}

--- a/backend/templates/emails/magic_login.html
+++ b/backend/templates/emails/magic_login.html
@@ -13,5 +13,6 @@
     <p style="margin: 0; font-size: 13px; color: #666;">if you didn't request it, you can ignore this email.</p>
   </div>
   <p style="text-align: center; margin: 16px 0 0; font-size: 12px; color: #888;">— pda</p>
+  {% include "emails/_no_reply_footer.html" %}
 </body>
 </html>

--- a/backend/templates/emails/magic_login.txt
+++ b/backend/templates/emails/magic_login.txt
@@ -7,3 +7,5 @@ here's your one-time login link for pda:
 this link expires in 7 days. if you didn't request it, you can ignore this email.
 
 — pda
+
+{% include "emails/_no_reply_footer.txt" %}

--- a/backend/templates/emails/rsvp_confirmation.html
+++ b/backend/templates/emails/rsvp_confirmation.html
@@ -20,5 +20,6 @@
     <p style="margin: 0; font-size: 13px; color: #666;">when you join pda you get access to club events and our whatsapp community. <a href="{{ join_url }}" style="color: #3c6939;">click here to join</a>.</p>
   </div>
   <p style="text-align: center; margin: 16px 0 0; font-size: 12px; color: #888;">— pda</p>
+  {% include "emails/_no_reply_footer.html" %}
 </body>
 </html>

--- a/backend/templates/emails/rsvp_confirmation.txt
+++ b/backend/templates/emails/rsvp_confirmation.txt
@@ -13,3 +13,5 @@ manage or change your rsvp anytime:
 when you join pda you get access to club events and our whatsapp community. click here to join: {{ join_url }}
 
 — pda
+
+{% include "emails/_no_reply_footer.txt" %}

--- a/backend/templates/emails/rsvp_manage_link.html
+++ b/backend/templates/emails/rsvp_manage_link.html
@@ -12,5 +12,6 @@
     <p style="margin: 0; font-size: 13px; color: #666;">if you didn't request it, you can ignore this email.</p>
   </div>
   <p style="text-align: center; margin: 16px 0 0; font-size: 12px; color: #888;">— pda</p>
+  {% include "emails/_no_reply_footer.html" %}
 </body>
 </html>

--- a/backend/templates/emails/rsvp_manage_link.txt
+++ b/backend/templates/emails/rsvp_manage_link.txt
@@ -7,3 +7,5 @@ here's your link to manage your rsvps:
 if you didn't request it, you can ignore this email.
 
 — pda
+
+{% include "emails/_no_reply_footer.txt" %}

--- a/backend/templates/emails/rsvp_updated.html
+++ b/backend/templates/emails/rsvp_updated.html
@@ -16,5 +16,6 @@
     <p style="margin: 0; font-size: 13px; color: #666;">when you join pda you get access to club events and our whatsapp community. <a href="{{ join_url }}" style="color: #3c6939;">click here to join</a>.</p>
   </div>
   <p style="text-align: center; margin: 16px 0 0; font-size: 12px; color: #888;">— pda</p>
+  {% include "emails/_no_reply_footer.html" %}
 </body>
 </html>

--- a/backend/templates/emails/rsvp_updated.txt
+++ b/backend/templates/emails/rsvp_updated.txt
@@ -13,3 +13,5 @@ manage or change your rsvp anytime:
 when you join pda you get access to club events and our whatsapp community. click here to join: {{ join_url }}
 
 — pda
+
+{% include "emails/_no_reply_footer.txt" %}

--- a/backend/templates/emails/rsvp_waitlist_promoted.html
+++ b/backend/templates/emails/rsvp_waitlist_promoted.html
@@ -16,5 +16,6 @@
     <p style="margin: 0; font-size: 13px; color: #666;">when you join pda you get access to club events and our whatsapp community. <a href="{{ join_url }}" style="color: #3c6939;">click here to join</a>.</p>
   </div>
   <p style="text-align: center; margin: 16px 0 0; font-size: 12px; color: #888;">— pda</p>
+  {% include "emails/_no_reply_footer.html" %}
 </body>
 </html>

--- a/backend/templates/emails/rsvp_waitlist_promoted.txt
+++ b/backend/templates/emails/rsvp_waitlist_promoted.txt
@@ -13,3 +13,5 @@ manage or change your rsvp anytime:
 when you join pda you get access to club events and our whatsapp community. click here to join: {{ join_url }}
 
 — pda
+
+{% include "emails/_no_reply_footer.txt" %}


### PR DESCRIPTION
## Summary
- Adds a short no-reply note ("this is an automated email — please don't reply, this inbox isn't monitored.") to every member-facing email, since the sending address can't receive replies (Issue 883).
- Introduces a shared partial pair, `backend/templates/emails/_no_reply_footer.html` / `.txt`, included via `{% include %}` at the bottom of each of the 7 member-facing templates (14 files total): rsvp confirmation, rsvp updated, rsvp waitlist promoted, rsvp manage link, magic login, join approval, event blast.
- Left internal admin-facing emails untouched — `_join_request_submit.py`'s vetting email goes to `settings.VETTING_EMAIL` (an internal group inbox, not an end user), so a no-reply note doesn't apply there.

## Test plan
- [x] `make agent-test` — all backend tests pass except 5 pre-existing `test_sse.py` failures (pg_notify/SSE requires Postgres, not exercised under the SQLite dev DB — unrelated to this change)
- [x] `make agent-typecheck` — clean
- [x] `make agent-lint` — clean
- [x] Manually rendered `rsvp_confirmation.html`/`.txt` via `render_to_string` to confirm the include resolves and renders the footer correctly in both formats