### PR TITLE
fix(events): show waitlist option on public rsvp form at capacity

### DIFF
--- a/frontend/src/screens/events/PublicRsvpForm.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.test.tsx
@@ -229,6 +229,39 @@ describe('PublicRsvpForm', () => {
     });
   });
 
+  it('shows join the waitlist instead of going when the event is at capacity', () => {
+    renderForm(makeEvent({ maxAttendees: 2, attendingCount: 2 }));
+    expect(screen.getByRole('button', { name: 'join the waitlist' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: "i'm going" })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'maybe' })).toBeInTheDocument();
+  });
+
+  it('submits attending status and shows join the waitlist copy when at capacity', async () => {
+    checkPhoneMutate.mockResolvedValue({ status: 'new', rsvp_token: '' });
+    submitMutate.mockResolvedValue({
+      event: { id: 'ev1' },
+      rsvp: { status: 'waitlisted', has_plus_one: false },
+    });
+    const onSuccess = vi.fn();
+    renderForm(makeEvent({ maxAttendees: 2, attendingCount: 2 }), onSuccess);
+    fireEvent.click(screen.getByRole('button', { name: 'join the waitlist' }));
+    fireEvent.change(screen.getByLabelText(/phone number/i), {
+      target: { value: '+14155550123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'continue' }));
+    await waitFor(() => expect(screen.getByLabelText('first name')).toBeInTheDocument());
+    expect(screen.getByText('join the waitlist')).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText('first name'), { target: { value: 'Ada' } });
+    fireEvent.change(screen.getByLabelText('email'), { target: { value: 'ada@example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: 'rsvp' }));
+    await waitFor(() => expect(submitMutate).toHaveBeenCalled());
+    expect(submitMutate).toHaveBeenCalledWith({
+      eventId: 'ev1',
+      payload: expect.objectContaining({ status: 'attending' }),
+    });
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+  });
+
   it('shows a 409 inline error with a sign-in link', async () => {
     submitMutate.mockRejectedValue({ isAxiosError: true, response: { status: 409 } });
     renderForm();

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -9,7 +9,13 @@ import { PhoneField } from '@/components/ui/PhoneField';
 import { RsvpStatusPicker } from '@/components/ui/RsvpStatusPicker';
 import { TextField } from '@/components/ui/TextField';
 import { Toggle } from '@/components/ui/Toggle';
-import { type Event, RSVP_STATUS_LABELS, type RsvpInputStatus, RsvpStatus } from '@/models/event';
+import {
+  type Event,
+  RSVP_STATUS_LABELS,
+  type RsvpInputStatus,
+  RsvpStatus,
+  spotsLeft,
+} from '@/models/event';
 import { optionalEmail } from '@/utils/validators';
 
 import { type AlreadyRsvpdResult, PublicRsvpPhoneStep } from './PublicRsvpPhoneStep';
@@ -42,12 +48,14 @@ function messageForStatus(status: number | null): SubmitError {
   return { text: 'something went wrong — try again', showSignIn: false };
 }
 
-function statusLabel(status: RsvpInputStatus): string {
+function statusLabel(status: RsvpInputStatus, atCapacity: boolean): string {
+  if (status === RsvpStatus.Attending && atCapacity) return 'join the waitlist';
   return RSVP_STATUS_LABELS.find((s) => s.status === status)?.label ?? status;
 }
 
 export function PublicRsvpForm({ event, onSuccess, onMember, onAlreadyRsvpd }: Props) {
   const submit = useSubmitPublicRsvp();
+  const atCapacity = spotsLeft(event) === 0;
   const [status, setStatus] = useState<RsvpInputStatus | null>(null);
   const [phoneConfirmed, setPhoneConfirmed] = useState(false);
   const [firstName, setFirstName] = useState('');
@@ -95,7 +103,14 @@ export function PublicRsvpForm({ event, onSuccess, onMember, onAlreadyRsvpd }: P
   function renderStep() {
     if (status === null) {
       return (
-        <RsvpStatusPicker value={status} onSelect={setStatus} statuses={PUBLIC_RSVP_STATUSES} />
+        <RsvpStatusPicker
+          value={status}
+          onSelect={setStatus}
+          statuses={PUBLIC_RSVP_STATUSES}
+          labelFor={(s, defaultLabel) =>
+            s === RsvpStatus.Attending && atCapacity ? 'join the waitlist' : defaultLabel
+          }
+        />
       );
     }
     if (!phoneConfirmed) {
@@ -117,7 +132,10 @@ export function PublicRsvpForm({ event, onSuccess, onMember, onAlreadyRsvpd }: P
 
         <div className="flex items-center justify-between">
           <p className="text-foreground-secondary text-sm">
-            rsvping as <span className="text-foreground font-medium">{statusLabel(status)}</span>
+            rsvping as{' '}
+            <span className="text-foreground font-medium">
+              {statusLabel(status, atCapacity)}
+            </span>
           </p>
           <button
             type="button"

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -133,9 +133,7 @@ export function PublicRsvpForm({ event, onSuccess, onMember, onAlreadyRsvpd }: P
         <div className="flex items-center justify-between">
           <p className="text-foreground-secondary text-sm">
             rsvping as{' '}
-            <span className="text-foreground font-medium">
-              {statusLabel(status, atCapacity)}
-            </span>
+            <span className="text-foreground font-medium">{statusLabel(status, atCapacity)}</span>
           </p>
           <button
             type="button"


### PR DESCRIPTION
## Summary

- The public (non-member) RSVP form hardcoded "i'm going" / "maybe" as the only status options and never relabeled to "join the waitlist" when an event was at capacity — unlike the member-facing `RsvpSection`, which already handles this via a `labelFor` prop on `RsvpStatusPicker`.
- Mirrors `RsvpSection.tsx`'s pattern: detects capacity with `spotsLeft(event) === 0` and relabels the attending option to "join the waitlist" in both the status picker and the "rsvping as ..." confirmation line.
- Backend already auto-waitlists correctly when at capacity — no backend changes needed.

Closes Issue 871.

## Test plan

- [x] Added a test asserting "join the waitlist" (not "i'm going") is shown when `maxAttendees === attendingCount`
- [x] Added a test covering full submission flow at capacity — submits `status: 'attending'`, backend returns `waitlisted`, waitlist copy shown
- [x] `make agent-frontend-test` — all 869 tests pass
- [x] `make agent-frontend-typecheck` — clean
- [x] `make agent-frontend-lint` — clean