### PR TITLE
feat(users): hide contact info from new members until first login

### DIFF
--- a/backend/tests/users/test_users_admin_extended.py
+++ b/backend/tests/users/test_users_admin_extended.py
@@ -231,6 +231,14 @@ class TestMemberProfile:
         response = api_client.get(f"/api/auth/users/{other_user.pk}/profile/", **auth_headers)
         assert response.status_code == 404
 
+    def test_member_profile_returns_404_for_onboarding_pending_user(
+        self, api_client, auth_headers, other_user
+    ):
+        other_user.needs_onboarding = True
+        other_user.save(update_fields=["needs_onboarding"])
+        response = api_client.get(f"/api/auth/users/{other_user.pk}/profile/", **auth_headers)
+        assert response.status_code == 404
+
     def test_member_profile_returns_pronouns(self, api_client, auth_headers, other_user):
         other_user.pronouns = "they/them"
         other_user.save(update_fields=["pronouns"])
@@ -294,6 +302,17 @@ class TestDeleteUser:
     def test_archived_user_excluded_from_search(self, api_client, manage_users_headers, other_user):
         other_user.archived_at = timezone.now()
         other_user.save(update_fields=["archived_at"])
+
+        response = api_client.get("/api/auth/users/search/?q=Other", **manage_users_headers)
+        assert response.status_code == 200
+        ids = [u["id"] for u in response.json()]
+        assert str(other_user.pk) not in ids
+
+    def test_onboarding_pending_user_excluded_from_search(
+        self, api_client, manage_users_headers, other_user
+    ):
+        other_user.needs_onboarding = True
+        other_user.save(update_fields=["needs_onboarding"])
 
         response = api_client.get("/api/auth/users/search/?q=Other", **manage_users_headers)
         assert response.status_code == 200

--- a/backend/tests/users/test_users_crud.py
+++ b/backend/tests/users/test_users_crud.py
@@ -66,7 +66,7 @@ class TestCreateUser:
         user = User.objects.get(phone_number="+12025550903")
         assert user.needs_onboarding is True
 
-    def test_create_user_hides_contact_info_by_default(self, api_client, manage_users_headers):
+    def test_create_user_keeps_contact_visibility_default(self, api_client, manage_users_headers):
         response = api_client.post(
             "/api/auth/create-user/",
             {"phone_number": "+12025550907", "first_name": "Newmember"},
@@ -75,8 +75,9 @@ class TestCreateUser:
         )
         assert response.status_code == 201
         user = User.objects.get(phone_number="+12025550907")
-        assert user.show_phone is False
-        assert user.show_email is False
+        assert user.needs_onboarding is True
+        assert user.show_phone is True
+        assert user.show_email is True
 
     def test_create_user_unauthenticated(self, api_client):
         response = api_client.post(
@@ -207,7 +208,7 @@ class TestBulkCreateUsers:
         assert data["created"] == 2
         assert all(r.get("magic_link_token") for r in data["results"] if r["success"])
 
-    def test_bulk_create_users_hides_contact_info_by_default(
+    def test_bulk_create_users_keeps_contact_visibility_default(
         self, api_client, manage_users_headers
     ):
         response = api_client.post(
@@ -218,8 +219,9 @@ class TestBulkCreateUsers:
         )
         assert response.status_code == 200
         user = User.objects.get(phone_number="+12025551501")
-        assert user.show_phone is False
-        assert user.show_email is False
+        assert user.needs_onboarding is True
+        assert user.show_phone is True
+        assert user.show_email is True
 
     def test_bulk_create_users_empty_list(self, api_client, manage_users_headers):
         response = api_client.post(

--- a/backend/tests/users/test_users_crud.py
+++ b/backend/tests/users/test_users_crud.py
@@ -66,6 +66,18 @@ class TestCreateUser:
         user = User.objects.get(phone_number="+12025550903")
         assert user.needs_onboarding is True
 
+    def test_create_user_hides_contact_info_by_default(self, api_client, manage_users_headers):
+        response = api_client.post(
+            "/api/auth/create-user/",
+            {"phone_number": "+12025550907", "first_name": "Newmember"},
+            content_type="application/json",
+            **manage_users_headers,
+        )
+        assert response.status_code == 201
+        user = User.objects.get(phone_number="+12025550907")
+        assert user.show_phone is False
+        assert user.show_email is False
+
     def test_create_user_unauthenticated(self, api_client):
         response = api_client.post(
             "/api/auth/create-user/",
@@ -194,6 +206,20 @@ class TestBulkCreateUsers:
         data = response.json()
         assert data["created"] == 2
         assert all(r.get("magic_link_token") for r in data["results"] if r["success"])
+
+    def test_bulk_create_users_hides_contact_info_by_default(
+        self, api_client, manage_users_headers
+    ):
+        response = api_client.post(
+            "/api/auth/bulk-create-users/",
+            {"phone_numbers": ["+12025551501"]},
+            content_type="application/json",
+            **manage_users_headers,
+        )
+        assert response.status_code == 200
+        user = User.objects.get(phone_number="+12025551501")
+        assert user.show_phone is False
+        assert user.show_email is False
 
     def test_bulk_create_users_empty_list(self, api_client, manage_users_headers):
         response = api_client.post(

--- a/backend/users/_helpers.py
+++ b/backend/users/_helpers.py
@@ -228,6 +228,8 @@ def _create_user_with_role(  # noqa: PLR0913
         email=normalized_email,
         is_member=True,
         needs_onboarding=True,
+        show_phone=False,
+        show_email=False,
         guidelines_consent_at=consent.guidelines_consent_at if consent else None,
         sms_consent_at=consent.sms_consent_at if consent else None,
     )

--- a/backend/users/_helpers.py
+++ b/backend/users/_helpers.py
@@ -228,8 +228,6 @@ def _create_user_with_role(  # noqa: PLR0913
         email=normalized_email,
         is_member=True,
         needs_onboarding=True,
-        show_phone=False,
-        show_email=False,
         guidelines_consent_at=consent.guidelines_consent_at if consent else None,
         sms_consent_at=consent.sms_consent_at if consent else None,
     )

--- a/backend/users/_management.py
+++ b/backend/users/_management.py
@@ -152,8 +152,6 @@ def bulk_create_users(request, payload: BulkUserCreateIn):
             phone_number=validated_phone,
             is_member=True,
             needs_onboarding=True,
-            show_phone=False,
-            show_email=False,
         )
         user.set_unusable_password()
         user.save(update_fields=["password"])
@@ -200,7 +198,7 @@ def _matches_for_non_admin(u: User, q: str, digits: str) -> bool:
 
 @router.get("/users/search/", response={200: list[UserSearchOut]}, auth=gated_jwt)
 def search_users(request, q: str = ""):
-    qs = User.objects.active_members().exclude(pk=request.auth.pk)
+    qs = User.objects.active_members().filter(needs_onboarding=False).exclude(pk=request.auth.pk)
     q = q.strip()
     digits = re.sub(r"\D", "", q)
     if q:

--- a/backend/users/_management.py
+++ b/backend/users/_management.py
@@ -152,6 +152,8 @@ def bulk_create_users(request, payload: BulkUserCreateIn):
             phone_number=validated_phone,
             is_member=True,
             needs_onboarding=True,
+            show_phone=False,
+            show_email=False,
         )
         user.set_unusable_password()
         user.save(update_fields=["password"])

--- a/backend/users/_members.py
+++ b/backend/users/_members.py
@@ -53,7 +53,7 @@ def list_member_directory(request):
 )
 def get_member_profile(request, user_id: str):
     try:
-        user = User.objects.active_members().get(pk=user_id)
+        user = User.objects.active_members().filter(needs_onboarding=False).get(pk=user_id)
     except User.DoesNotExist:
         raise_validation(Code.Member.NOT_FOUND, status_code=404)
     is_own_profile = str(request.auth.pk) == user_id

--- a/frontend/src/screens/auth/OnboardingScreen.test.tsx
+++ b/frontend/src/screens/auth/OnboardingScreen.test.tsx
@@ -77,14 +77,16 @@ describe('OnboardingScreen', () => {
     expect(completeOnboarding).not.toHaveBeenCalled();
   });
 
-  it('explains that contact info stays private by default', () => {
+  it('explains that contact info is shared with other members after onboarding', () => {
     setupMock(makeUser({ needsGuidelinesConsent: false, needsSmsConsent: false }));
     render(
       <MemoryRouter>
         <OnboardingScreen />
       </MemoryRouter>,
     );
-    expect(screen.getByText(/stay private from other members by default/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/your name and contact info are shared with other members/i),
+    ).toBeInTheDocument();
   });
 
   it('submits with required email (no consent checkboxes for already-consented user)', async () => {

--- a/frontend/src/screens/auth/OnboardingScreen.test.tsx
+++ b/frontend/src/screens/auth/OnboardingScreen.test.tsx
@@ -77,6 +77,16 @@ describe('OnboardingScreen', () => {
     expect(completeOnboarding).not.toHaveBeenCalled();
   });
 
+  it('explains that contact info stays private by default', () => {
+    setupMock(makeUser({ needsGuidelinesConsent: false, needsSmsConsent: false }));
+    render(
+      <MemoryRouter>
+        <OnboardingScreen />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText(/stay private from other members by default/i)).toBeInTheDocument();
+  });
+
   it('submits with required email (no consent checkboxes for already-consented user)', async () => {
     completeOnboarding.mockResolvedValue(undefined);
     setupMock(makeUser({ needsGuidelinesConsent: false, needsSmsConsent: false }));

--- a/frontend/src/screens/auth/OnboardingScreen.tsx
+++ b/frontend/src/screens/auth/OnboardingScreen.tsx
@@ -115,6 +115,10 @@ export default function OnboardingScreen() {
           {...register('email')}
           error={errors.email?.message}
         />
+        <p className="text-muted-foreground text-sm">
+          your phone number and email stay private from other members by default — you can choose
+          to share them anytime in settings
+        </p>
         <TextField
           label="pronouns (optional)"
           placeholder="e.g. she/her, they/them"

--- a/frontend/src/screens/auth/OnboardingScreen.tsx
+++ b/frontend/src/screens/auth/OnboardingScreen.tsx
@@ -116,8 +116,8 @@ export default function OnboardingScreen() {
           error={errors.email?.message}
         />
         <p className="text-muted-foreground text-sm">
-          your phone number and email stay private from other members by default — you can choose
-          to share them anytime in settings
+          once you finish here, your name and contact info are shared with other members — you can
+          hide your phone number or email anytime in settings
         </p>
         <TextField
           label="pronouns (optional)"


### PR DESCRIPTION
## Summary
- Onboarding-pending members (created but not yet logged in) are now hidden from other members everywhere, not just field-blanked: `search_users` and `get_member_profile` now filter `needs_onboarding=False`, mirroring the existing `list_member_directory` behavior.
- Reverted the `show_phone=False`/`show_email=False` defaults at creation from the original approach — those changed the *post-login* default to private, requiring members to manually opt in, which was the opposite of the intended behavior (contact info should be visible to other members once a member has logged in, per the existing product default).
- Updated the onboarding-screen note so it accurately explains that a member's name and contact info become visible to other members once they finish onboarding, and that they can hide phone/email anytime in settings.

Addresses Issue 884.

## Test plan
- [x] `backend/tests/users/test_users_crud.py`: creation tests now assert `show_phone`/`show_email` stay `True` (the pre-existing default) and `needs_onboarding` is `True` at creation.
- [x] `backend/tests/users/test_users_admin_extended.py`: new tests assert onboarding-pending members are excluded from search (`test_onboarding_pending_user_excluded_from_search`) and from profile lookups by other members (`test_member_profile_returns_404_for_onboarding_pending_user`).
- [x] `frontend/src/screens/auth/OnboardingScreen.test.tsx`: updated to assert the corrected copy.
- [x] Ran the affected backend test files locally (111 tests, all passing) and `ruff check` on changed files (clean).
- [ ] CI (backend/frontend test, typecheck, lint) — pending on this PR.