### PR TITLE
refactor(events): extract host-action endpoints into _event_host_actions.py

### DIFF
--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -49,6 +49,15 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
 
+def load_event_with_stats_prefetch(event_id: UUID) -> Event | None:
+    return (
+        Event.objects.select_related("created_by")
+        .prefetch_related("co_hosts", "invited_users", "rsvps__user")
+        .filter(id=event_id)
+        .first()
+    )
+
+
 def broadcast_capacity_change(event_id: UUID, *, exclude_user_ids: set[str] | None = None) -> None:
     """Post-commit, silently refresh stakeholders' cached event so capacity shows live (no notification)."""
     excluded = exclude_user_ids or set()

--- a/backend/community/_event_host_actions.py
+++ b/backend/community/_event_host_actions.py
@@ -9,15 +9,30 @@ from django.db import transaction
 from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
+from users.models import User as UserModel
 
 from community._event_helpers import (
     _cancellations,
     _event_out,
+    broadcast_capacity_change,
     load_event_with_stats_prefetch,
+    promote_from_waitlist,
 )
-from community._event_schemas import AttendanceIn, EventOut, EventStatsOut, TextRecipientsOut
+from community._event_rsvps import (
+    _resolve_cancelled_at,
+    _resolve_rsvp_status,
+    _validate_rsvp_status,
+)
+from community._event_schemas import (
+    AttendanceIn,
+    EventOut,
+    EventStatsOut,
+    HostRSVPIn,
+    TextRecipientsOut,
+)
 from community._events import _can_edit_event
 from community._join_request_approval import _maybe_promote_tentative, send_join_approval
+from community._public_rsvp_shared import _email_promoted_non_members
 from community._rsvp_counts import (
     _attended_count,
     _attending_headcount,
@@ -168,4 +183,97 @@ def set_attendance(request, event_id: UUID, user_id: UUID, payload: AttendanceIn
     event = load_event_with_stats_prefetch(event_id)
     if event is None:
         raise_validation(Code.Event.NOT_FOUND, status_code=404)
+    return Status(200, _event_out(event, request.auth))
+
+
+def _apply_host_rsvp_in_transaction(
+    event_id, target_user, status: str, has_plus_one: bool
+) -> tuple[str, list[str]]:
+    """Execute a host-driven RSVP upsert for another user inside a locked transaction.
+
+    Unlike _apply_rsvp_in_transaction, access is already gated on the acting
+    host (_can_edit_event) by the caller — this only enforces that the event
+    still accepts RSVPs, not the target user's own read-visibility.
+
+    Returns (final_status, promoted_user_ids). Raises ValidationException on failure.
+    """
+    event = (
+        Event.objects.select_for_update()
+        .prefetch_related("co_hosts", "invited_users")
+        .get(id=event_id)
+    )
+
+    if not event.rsvp_enabled:
+        raise_validation(Code.Event.RSVPS_NOT_ENABLED, status_code=400)
+    if event.is_cancelled:
+        raise_validation(Code.Event.RSVPS_CLOSED_CANCELLED, status_code=400)
+
+    final_status, final_plus_one = _resolve_rsvp_status(event, target_user, status, has_plus_one)
+
+    existing = EventRSVP.objects.filter(event=event, user=target_user).first()
+    was_attending = existing is not None and existing.status == RSVPStatus.ATTENDING
+    had_plus_one = existing is not None and existing.has_plus_one
+
+    EventRSVP.objects.update_or_create(
+        event=event,
+        user=target_user,
+        defaults={
+            "status": final_status,
+            "has_plus_one": final_plus_one,
+            "cancelled_at": _resolve_cancelled_at(existing, final_status),
+        },
+    )
+
+    spot_freed = (was_attending and final_status != RSVPStatus.ATTENDING) or (
+        was_attending and had_plus_one and not final_plus_one
+    )
+    promoted_user_ids = promote_from_waitlist(event) if spot_freed else []
+
+    return final_status, promoted_user_ids
+
+
+@router.post(
+    "/events/{event_id}/rsvps/{user_id}/rsvp/",
+    response={200: EventOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut, 429: ErrorOut},
+    auth=gated_jwt,
+)
+@rate_limit(key_func=lambda r: str(r.auth.pk), rate="30/m")
+def set_guest_rsvp(request, event_id: UUID, user_id: UUID, payload: HostRSVPIn):
+    """Let an event host/co-host/manager change another user's rsvp on their behalf (Issue 872)."""
+    event = (
+        Event.objects.select_related("created_by")
+        .prefetch_related("co_hosts", "invited_users", "rsvps__user")
+        .filter(id=event_id)
+        .first()
+    )
+    if event is None:
+        raise_validation(Code.Event.NOT_FOUND, status_code=404)
+    if not _can_edit_event(request.auth, event):
+        raise_validation(Code.Perm.DENIED, status_code=403, action="set_guest_rsvp")
+
+    _validate_rsvp_status(payload.status)
+
+    try:
+        target_user = UserModel.objects.get(id=user_id)
+    except UserModel.DoesNotExist:
+        raise_validation(Code.User.NOT_FOUND, status_code=404)
+
+    with transaction.atomic():
+        final_status, promoted_user_ids = _apply_host_rsvp_in_transaction(
+            event_id, target_user, payload.status, payload.has_plus_one
+        )
+
+    audit_log(
+        logging.INFO,
+        "guest_rsvp_changed",
+        request,
+        target_type="event",
+        target_id=str(event_id),
+        details={"user_id": str(user_id), "status": final_status},
+    )
+    event = load_event_with_stats_prefetch(event_id)
+    if event is None:
+        raise_validation(Code.Event.NOT_FOUND, status_code=404)
+    broadcast_capacity_change(event_id, exclude_user_ids={str(request.auth.pk)})
+    _email_promoted_non_members(request, event, promoted_user_ids)
     return Status(200, _event_out(event, request.auth))

--- a/backend/community/_event_host_actions.py
+++ b/backend/community/_event_host_actions.py
@@ -1,0 +1,171 @@
+import logging
+from datetime import timedelta
+from uuid import UUID
+
+from config.audit import audit_log
+from config.auth import gated_jwt
+from config.ratelimit import rate_limit
+from django.db import transaction
+from django.utils import timezone
+from ninja import Router
+from ninja.responses import Status
+
+from community._event_helpers import (
+    _cancellations,
+    _event_out,
+    load_event_with_stats_prefetch,
+)
+from community._event_schemas import AttendanceIn, EventOut, EventStatsOut, TextRecipientsOut
+from community._events import _can_edit_event
+from community._join_request_approval import _maybe_promote_tentative, send_join_approval
+from community._rsvp_counts import (
+    _attended_count,
+    _attending_headcount,
+    _cant_go_count,
+    _maybe_count,
+    _no_response_count,
+    _no_show_count,
+    _not_marked_count,
+    _waitlisted_count,
+)
+from community._shared import ErrorOut
+from community._validation import Code, raise_validation
+from community.models import AttendanceStatus, Event, EventRSVP, RSVPStatus
+
+router = Router()
+
+CHECK_IN_OPENS_BEFORE_START = timedelta(hours=1)
+
+
+def _check_in_open(event: Event) -> bool:
+    """Check-in opens 1 hour before start and never closes."""
+    if event.start_datetime is None:
+        return False
+    return timezone.now() >= event.start_datetime - CHECK_IN_OPENS_BEFORE_START
+
+
+@router.get(
+    "/events/{event_id}/stats/",
+    response={200: EventStatsOut, 403: ErrorOut, 404: ErrorOut},
+    auth=gated_jwt,
+)
+def get_event_stats(request, event_id: UUID):
+    event = load_event_with_stats_prefetch(event_id)
+    if event is None:
+        raise_validation(Code.Event.NOT_FOUND, status_code=404)
+    if not _can_edit_event(request.auth, event):
+        raise_validation(Code.Perm.DENIED, status_code=403, action="get_event_stats")
+    return Status(
+        200,
+        EventStatsOut(
+            going_count=_attending_headcount(event),
+            maybe_count=_maybe_count(event),
+            cant_go_count=_cant_go_count(event),
+            no_response_count=_no_response_count(event),
+            waitlisted_count=_waitlisted_count(event),
+            attended_count=_attended_count(event),
+            no_show_count=_no_show_count(event),
+            not_marked_count=_not_marked_count(event),
+            cancellations=_cancellations(event, request.auth),
+        ),
+    )
+
+
+def _build_text_recipients(event: Event) -> TextRecipientsOut:
+    by_status: dict[str, list[str]] = {
+        RSVPStatus.ATTENDING: [],
+        RSVPStatus.MAYBE: [],
+        RSVPStatus.CANT_GO: [],
+        RSVPStatus.WAITLISTED: [],
+    }
+    for rsvp in event.rsvps.all():
+        phone = rsvp.user.phone_number
+        if phone and rsvp.status in by_status:
+            by_status[rsvp.status].append(phone)
+    invited = [u.phone_number for u in event.invited_users.all() if u.phone_number]
+    return TextRecipientsOut(
+        attending=by_status[RSVPStatus.ATTENDING],
+        maybe=by_status[RSVPStatus.MAYBE],
+        cant_go=by_status[RSVPStatus.CANT_GO],
+        waitlisted=by_status[RSVPStatus.WAITLISTED],
+        invited=invited,
+    )
+
+
+@router.get(
+    "/events/{event_id}/text-recipients/",
+    response={200: TextRecipientsOut, 403: ErrorOut, 404: ErrorOut},
+    auth=gated_jwt,
+)
+def get_text_recipients(request, event_id: UUID):
+    event = load_event_with_stats_prefetch(event_id)
+    if event is None:
+        raise_validation(Code.Event.NOT_FOUND, status_code=404)
+    if not _can_edit_event(request.auth, event):
+        raise_validation(Code.Perm.DENIED, status_code=403, action="get_text_recipients")
+    return Status(200, _build_text_recipients(event))
+
+
+@router.post(
+    "/events/{event_id}/rsvps/{user_id}/attendance/",
+    response={200: EventOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut, 429: ErrorOut},
+    auth=gated_jwt,
+)
+@rate_limit(key_func=lambda r: str(r.auth.pk), rate="60/m")
+def set_attendance(request, event_id: UUID, user_id: UUID, payload: AttendanceIn):
+    event = (
+        Event.objects.select_related("created_by")
+        .prefetch_related("co_hosts", "invited_users", "rsvps__user")
+        .filter(id=event_id)
+        .first()
+    )
+    if event is None:
+        raise_validation(Code.Event.NOT_FOUND, status_code=404)
+    if not _can_edit_event(request.auth, event):
+        raise_validation(Code.Perm.DENIED, status_code=403, action="set_attendance")
+    if not _check_in_open(event):
+        raise_validation(Code.Event.ATTENDANCE_OPENS_LATER, status_code=400)
+
+    rsvp = EventRSVP.objects.filter(event=event, user_id=user_id).first()
+    if rsvp is None:
+        raise_validation(Code.Event.RSVP_NOT_FOUND, status_code=404)
+    if rsvp.status != RSVPStatus.ATTENDING:
+        raise_validation(Code.Event.ATTENDANCE_ONLY_FOR_GOING_RSVPS, status_code=400)
+
+    # The mark and any tentative promotion it triggers commit as a unit, so a
+    # mid-promotion failure can't leave a member flagged without their request
+    # stamped approved.
+    with transaction.atomic():
+        rsvp.attendance = payload.attendance
+        # Stamp the first time a guest is marked ATTENDED; keep the original
+        # check-in time if attendance is later flipped and re-marked.
+        if payload.attendance == AttendanceStatus.ATTENDED and rsvp.checked_in_at is None:
+            rsvp.checked_in_at = timezone.now()
+        rsvp.save(update_fields=["attendance", "checked_in_at", "updated_at"])
+        magic_token = (
+            _maybe_promote_tentative(rsvp.user, event, request.auth)
+            if payload.attendance == AttendanceStatus.ATTENDED
+            else None
+        )
+
+    if magic_token:
+        send_join_approval(
+            to=rsvp.user.email,
+            display_name=rsvp.user.full_name,
+            first_name=rsvp.user.first_name,
+            magic_token=magic_token,
+        )
+
+    audit_log(
+        logging.INFO,
+        "attendance_marked",
+        request,
+        target_type="event",
+        target_id=str(event_id),
+        details={"user_id": str(user_id), "attendance": payload.attendance},
+    )
+
+    event = load_event_with_stats_prefetch(event_id)
+    if event is None:
+        raise_validation(Code.Event.NOT_FOUND, status_code=404)
+    return Status(200, _event_out(event, request.auth))

--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -1,5 +1,4 @@
 import logging
-from datetime import timedelta
 from uuid import UUID
 
 from config.audit import audit_log
@@ -12,52 +11,20 @@ from ninja.responses import Status
 from notifications.service import notify_event_comment, notify_rsvp_declined_note
 
 from community._event_helpers import (
-    _cancellations,
     _event_out,
     broadcast_capacity_change,
+    load_event_with_stats_prefetch,
     promote_from_waitlist,
 )
-from community._event_schemas import (
-    AttendanceIn,
-    EventOut,
-    EventStatsOut,
-    RSVPIn,
-    TextRecipientsOut,
-)
+from community._event_schemas import EventOut, RSVPIn
 from community._events import _can_edit_event, _enforce_event_read_visibility
-from community._join_request_approval import _maybe_promote_tentative, send_join_approval
 from community._public_rsvp_shared import _email_promoted_non_members
-from community._rsvp_counts import (
-    _attended_count,
-    _attending_headcount,
-    _attending_headcount_db,
-    _cant_go_count,
-    _maybe_count,
-    _no_response_count,
-    _no_show_count,
-    _not_marked_count,
-    _waitlisted_count,
-)
+from community._rsvp_counts import _attending_headcount_db
 from community._shared import ErrorOut
 from community._validation import Code, raise_validation
-from community.models import (
-    AttendanceStatus,
-    Event,
-    EventComment,
-    EventRSVP,
-    RSVPStatus,
-)
+from community.models import Event, EventComment, EventRSVP, RSVPStatus
 
 router = Router()
-
-CHECK_IN_OPENS_BEFORE_START = timedelta(hours=1)
-
-
-def _check_in_open(event: Event) -> bool:
-    """Check-in opens 1 hour before start and never closes."""
-    if event.start_datetime is None:
-        return False
-    return timezone.now() >= event.start_datetime - CHECK_IN_OPENS_BEFORE_START
 
 
 def _validate_rsvp_access(user, event) -> None:
@@ -232,148 +199,12 @@ def upsert_rsvp(request, event_id: UUID, payload: RSVPIn):
         target_id=str(event_id),
         details={"status": final_status},
     )
-    event = _load_event_with_stats_prefetch(event_id)
+    event = load_event_with_stats_prefetch(event_id)
     if event is None:
         raise_validation(Code.Event.NOT_FOUND, status_code=404)
     # Actor already has the fresh event in this response, so exclude them.
     broadcast_capacity_change(event_id, exclude_user_ids={str(request.auth.pk)})
     _email_promoted_non_members(request, event, promoted_user_ids)
-    return Status(200, _event_out(event, request.auth))
-
-
-def _load_event_with_stats_prefetch(event_id: UUID) -> Event | None:
-    return (
-        Event.objects.select_related("created_by")
-        .prefetch_related("co_hosts", "invited_users", "rsvps__user")
-        .filter(id=event_id)
-        .first()
-    )
-
-
-@router.get(
-    "/events/{event_id}/stats/",
-    response={200: EventStatsOut, 403: ErrorOut, 404: ErrorOut},
-    auth=gated_jwt,
-)
-def get_event_stats(request, event_id: UUID):
-    event = _load_event_with_stats_prefetch(event_id)
-    if event is None:
-        raise_validation(Code.Event.NOT_FOUND, status_code=404)
-    if not _can_edit_event(request.auth, event):
-        raise_validation(Code.Perm.DENIED, status_code=403, action="get_event_stats")
-    return Status(
-        200,
-        EventStatsOut(
-            going_count=_attending_headcount(event),
-            maybe_count=_maybe_count(event),
-            cant_go_count=_cant_go_count(event),
-            no_response_count=_no_response_count(event),
-            waitlisted_count=_waitlisted_count(event),
-            attended_count=_attended_count(event),
-            no_show_count=_no_show_count(event),
-            not_marked_count=_not_marked_count(event),
-            cancellations=_cancellations(event, request.auth),
-        ),
-    )
-
-
-def _build_text_recipients(event: Event) -> TextRecipientsOut:
-    by_status: dict[str, list[str]] = {
-        RSVPStatus.ATTENDING: [],
-        RSVPStatus.MAYBE: [],
-        RSVPStatus.CANT_GO: [],
-        RSVPStatus.WAITLISTED: [],
-    }
-    for rsvp in event.rsvps.all():
-        phone = rsvp.user.phone_number
-        if phone and rsvp.status in by_status:
-            by_status[rsvp.status].append(phone)
-    invited = [u.phone_number for u in event.invited_users.all() if u.phone_number]
-    return TextRecipientsOut(
-        attending=by_status[RSVPStatus.ATTENDING],
-        maybe=by_status[RSVPStatus.MAYBE],
-        cant_go=by_status[RSVPStatus.CANT_GO],
-        waitlisted=by_status[RSVPStatus.WAITLISTED],
-        invited=invited,
-    )
-
-
-@router.get(
-    "/events/{event_id}/text-recipients/",
-    response={200: TextRecipientsOut, 403: ErrorOut, 404: ErrorOut},
-    auth=gated_jwt,
-)
-def get_text_recipients(request, event_id: UUID):
-    event = _load_event_with_stats_prefetch(event_id)
-    if event is None:
-        raise_validation(Code.Event.NOT_FOUND, status_code=404)
-    if not _can_edit_event(request.auth, event):
-        raise_validation(Code.Perm.DENIED, status_code=403, action="get_text_recipients")
-    return Status(200, _build_text_recipients(event))
-
-
-@router.post(
-    "/events/{event_id}/rsvps/{user_id}/attendance/",
-    response={200: EventOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut, 429: ErrorOut},
-    auth=gated_jwt,
-)
-@rate_limit(key_func=lambda r: str(r.auth.pk), rate="60/m")
-def set_attendance(request, event_id: UUID, user_id: UUID, payload: AttendanceIn):
-    event = (
-        Event.objects.select_related("created_by")
-        .prefetch_related("co_hosts", "invited_users", "rsvps__user")
-        .filter(id=event_id)
-        .first()
-    )
-    if event is None:
-        raise_validation(Code.Event.NOT_FOUND, status_code=404)
-    if not _can_edit_event(request.auth, event):
-        raise_validation(Code.Perm.DENIED, status_code=403, action="set_attendance")
-    if not _check_in_open(event):
-        raise_validation(Code.Event.ATTENDANCE_OPENS_LATER, status_code=400)
-
-    rsvp = EventRSVP.objects.filter(event=event, user_id=user_id).first()
-    if rsvp is None:
-        raise_validation(Code.Event.RSVP_NOT_FOUND, status_code=404)
-    if rsvp.status != RSVPStatus.ATTENDING:
-        raise_validation(Code.Event.ATTENDANCE_ONLY_FOR_GOING_RSVPS, status_code=400)
-
-    # The mark and any tentative promotion it triggers commit as a unit, so a
-    # mid-promotion failure can't leave a member flagged without their request
-    # stamped approved.
-    with transaction.atomic():
-        rsvp.attendance = payload.attendance
-        # Stamp the first time a guest is marked ATTENDED; keep the original
-        # check-in time if attendance is later flipped and re-marked.
-        if payload.attendance == AttendanceStatus.ATTENDED and rsvp.checked_in_at is None:
-            rsvp.checked_in_at = timezone.now()
-        rsvp.save(update_fields=["attendance", "checked_in_at", "updated_at"])
-        magic_token = (
-            _maybe_promote_tentative(rsvp.user, event, request.auth)
-            if payload.attendance == AttendanceStatus.ATTENDED
-            else None
-        )
-
-    if magic_token:
-        send_join_approval(
-            to=rsvp.user.email,
-            display_name=rsvp.user.full_name,
-            first_name=rsvp.user.first_name,
-            magic_token=magic_token,
-        )
-
-    audit_log(
-        logging.INFO,
-        "attendance_marked",
-        request,
-        target_type="event",
-        target_id=str(event_id),
-        details={"user_id": str(user_id), "attendance": payload.attendance},
-    )
-
-    event = _load_event_with_stats_prefetch(event_id)
-    if event is None:
-        raise_validation(Code.Event.NOT_FOUND, status_code=404)
     return Status(200, _event_out(event, request.auth))
 
 

--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -233,6 +233,11 @@ class RSVPIn(BaseModel):
     comment: str | None = Field(default=None, max_length=FieldLimit.SHORT_TEXT)
 
 
+class HostRSVPIn(BaseModel):
+    status: RSVPStatus
+    has_plus_one: bool = False
+
+
 class TextRecipientsOut(BaseModel):
     attending: list[str] = []
     maybe: list[str] = []

--- a/backend/community/api.py
+++ b/backend/community/api.py
@@ -16,6 +16,7 @@ from community._event_helpers import (  # noqa: F401
     _can_see_phones,
     _find_my_rsvp,
 )
+from community._event_host_actions import router as event_host_actions_router
 from community._event_invitations import router as event_invitations_router
 from community._event_rsvps import router as event_rsvps_router
 from community._event_schemas import EventPatchIn  # noqa: F401
@@ -64,6 +65,7 @@ router.add_router("", attendance_report_router)
 router.add_router("", events_router)
 router.add_router("", event_tags_router)
 router.add_router("", event_rsvps_router)
+router.add_router("", event_host_actions_router)
 router.add_router("", public_rsvp_submit_router)
 # Mount resend before manage so the literal `/public/my-rsvps/resend/` route
 # resolves before that router's `/public/my-rsvps/{event_id}/` parameterized route.

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -2792,6 +2792,23 @@
         "title": "HomePagePatchIn",
         "type": "object"
       },
+      "HostRSVPIn": {
+        "properties": {
+          "has_plus_one": {
+            "default": false,
+            "title": "Has Plus One",
+            "type": "boolean"
+          },
+          "status": {
+            "$ref": "#/components/schemas/RSVPStatus"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "title": "HostRSVPIn",
+        "type": "object"
+      },
       "InviteIn": {
         "properties": {
           "user_ids": {
@@ -10117,6 +10134,105 @@
           }
         ],
         "summary": "Set Attendance",
+        "tags": [
+          "community"
+        ]
+      }
+    },
+    "/api/community/events/{event_id}/rsvps/{user_id}/rsvp/": {
+      "post": {
+        "description": "Let an event host/co-host/manager change another user's rsvp on their behalf (Issue 872).",
+        "operationId": "community__event_host_actions_set_guest_rsvp",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "event_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Event Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HostRSVPIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventOut"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          }
+        },
+        "security": [
+          {
+            "GatedJWTAuth": []
+          }
+        ],
+        "summary": "Set Guest Rsvp",
         "tags": [
           "community"
         ]

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -10026,7 +10026,7 @@
     },
     "/api/community/events/{event_id}/rsvps/{user_id}/attendance/": {
       "post": {
-        "operationId": "community__event_rsvps_set_attendance",
+        "operationId": "community__event_host_actions_set_attendance",
         "parameters": [
           {
             "in": "path",
@@ -10124,7 +10124,7 @@
     },
     "/api/community/events/{event_id}/stats/": {
       "get": {
-        "operationId": "community__event_rsvps_get_event_stats",
+        "operationId": "community__event_host_actions_get_event_stats",
         "parameters": [
           {
             "in": "path",
@@ -10182,7 +10182,7 @@
     },
     "/api/community/events/{event_id}/text-recipients/": {
       "get": {
-        "operationId": "community__event_rsvps_get_text_recipients",
+        "operationId": "community__event_host_actions_get_text_recipients",
         "parameters": [
           {
             "in": "path",

--- a/backend/tests/test_host_rsvp.py
+++ b/backend/tests/test_host_rsvp.py
@@ -1,0 +1,240 @@
+"""Tests for the host-driven guest RSVP endpoint (Issue 872)."""
+
+from unittest.mock import patch
+
+import pytest
+from community.models import Event, EventRSVP, EventStatus, RSVPStatus
+from django.utils import timezone
+from ninja_jwt.tokens import RefreshToken
+from users.models import Role, User
+from users.permissions import PermissionKey
+
+from tests._asserts import assert_error_code
+from tests.conftest import future_iso
+
+
+def _auth(user):
+    refresh = RefreshToken.for_user(user)
+    return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # ty: ignore[unresolved-attribute]
+
+
+@pytest.fixture
+def host_user(db):
+    return User.objects.create_user(phone_number="+12025559100", password="x", first_name="Host")
+
+
+@pytest.fixture
+def cohost_user(db):
+    return User.objects.create_user(phone_number="+12025559101", password="x", first_name="Co-host")
+
+
+@pytest.fixture
+def admin_user(db):
+    admin = User.objects.create_user(phone_number="+12025559102", password="x", first_name="Admin")
+    role = Role.objects.create(name="rsvp_admin", permissions=[PermissionKey.MANAGE_EVENTS])
+    admin.roles.add(role)
+    return admin
+
+
+@pytest.fixture
+def guest(db):
+    return User.objects.create_user(phone_number="+12025559103", password="x", first_name="Guest")
+
+
+@pytest.fixture
+def other_member(db):
+    return User.objects.create_user(phone_number="+12025559104", password="x", first_name="Other")
+
+
+@pytest.fixture
+def host_rsvp_event(db, host_user, cohost_user):
+    event = Event.objects.create(
+        title="Host RSVP Event",
+        start_datetime=future_iso(days=14),
+        end_datetime=future_iso(days=14, hours=2),
+        rsvp_enabled=True,
+        created_by=host_user,
+    )
+    event.co_hosts.add(cohost_user)
+    return event
+
+
+@pytest.mark.django_db
+class TestSetGuestRsvp:
+    def test_host_changes_guest_rsvp(self, api_client, host_rsvp_event, host_user, guest):
+        EventRSVP.objects.create(event=host_rsvp_event, user=guest, status=RSVPStatus.MAYBE)
+        response = api_client.post(
+            f"/api/community/events/{host_rsvp_event.id}/rsvps/{guest.pk}/rsvp/",
+            {"status": RSVPStatus.ATTENDING},
+            content_type="application/json",
+            **_auth(host_user),
+        )
+        assert response.status_code == 200
+        rsvp = EventRSVP.objects.get(event=host_rsvp_event, user=guest)
+        assert rsvp.status == RSVPStatus.ATTENDING
+
+    def test_host_creates_rsvp_for_guest_with_none(
+        self, api_client, host_rsvp_event, host_user, guest
+    ):
+        response = api_client.post(
+            f"/api/community/events/{host_rsvp_event.id}/rsvps/{guest.pk}/rsvp/",
+            {"status": RSVPStatus.ATTENDING},
+            content_type="application/json",
+            **_auth(host_user),
+        )
+        assert response.status_code == 200
+        assert EventRSVP.objects.filter(
+            event=host_rsvp_event, user=guest, status=RSVPStatus.ATTENDING
+        ).exists()
+
+    def test_cohost_can_change_guest_rsvp(self, api_client, host_rsvp_event, cohost_user, guest):
+        EventRSVP.objects.create(event=host_rsvp_event, user=guest, status=RSVPStatus.ATTENDING)
+        response = api_client.post(
+            f"/api/community/events/{host_rsvp_event.id}/rsvps/{guest.pk}/rsvp/",
+            {"status": RSVPStatus.CANT_GO},
+            content_type="application/json",
+            **_auth(cohost_user),
+        )
+        assert response.status_code == 200
+
+    def test_manage_events_admin_can_change_guest_rsvp(
+        self, api_client, host_rsvp_event, admin_user, guest
+    ):
+        EventRSVP.objects.create(event=host_rsvp_event, user=guest, status=RSVPStatus.MAYBE)
+        response = api_client.post(
+            f"/api/community/events/{host_rsvp_event.id}/rsvps/{guest.pk}/rsvp/",
+            {"status": RSVPStatus.ATTENDING},
+            content_type="application/json",
+            **_auth(admin_user),
+        )
+        assert response.status_code == 200
+
+    def test_rejects_non_host(self, api_client, host_rsvp_event, other_member, guest):
+        EventRSVP.objects.create(event=host_rsvp_event, user=guest, status=RSVPStatus.MAYBE)
+        response = api_client.post(
+            f"/api/community/events/{host_rsvp_event.id}/rsvps/{guest.pk}/rsvp/",
+            {"status": RSVPStatus.ATTENDING},
+            content_type="application/json",
+            **_auth(other_member),
+        )
+        assert response.status_code == 403
+        assert_error_code(response, "perm.denied")
+
+    def test_rejects_unauthenticated(self, api_client, host_rsvp_event, guest):
+        response = api_client.post(
+            f"/api/community/events/{host_rsvp_event.id}/rsvps/{guest.pk}/rsvp/",
+            {"status": RSVPStatus.ATTENDING},
+            content_type="application/json",
+        )
+        assert response.status_code == 401
+
+    def test_event_not_found(self, api_client, host_user, guest):
+        response = api_client.post(
+            f"/api/community/events/00000000-0000-0000-0000-000000000000/rsvps/{guest.pk}/rsvp/",
+            {"status": RSVPStatus.ATTENDING},
+            content_type="application/json",
+            **_auth(host_user),
+        )
+        assert response.status_code == 404
+
+    def test_target_user_not_found(self, api_client, host_rsvp_event, host_user):
+        response = api_client.post(
+            f"/api/community/events/{host_rsvp_event.id}"
+            "/rsvps/00000000-0000-0000-0000-000000000000/rsvp/",
+            {"status": RSVPStatus.ATTENDING},
+            content_type="application/json",
+            **_auth(host_user),
+        )
+        assert response.status_code == 404
+        assert_error_code(response, "user.not_found")
+
+    def test_rejects_waitlisted_as_input_status(
+        self, api_client, host_rsvp_event, host_user, guest
+    ):
+        response = api_client.post(
+            f"/api/community/events/{host_rsvp_event.id}/rsvps/{guest.pk}/rsvp/",
+            {"status": RSVPStatus.WAITLISTED},
+            content_type="application/json",
+            **_auth(host_user),
+        )
+        assert response.status_code == 400
+        assert_error_code(response, "event.rsvp_invalid_status")
+
+    def test_rejects_when_event_cancelled(self, api_client, host_rsvp_event, host_user, guest):
+        host_rsvp_event.status = EventStatus.CANCELLED
+        host_rsvp_event.save(update_fields=["status"])
+        response = api_client.post(
+            f"/api/community/events/{host_rsvp_event.id}/rsvps/{guest.pk}/rsvp/",
+            {"status": RSVPStatus.ATTENDING},
+            content_type="application/json",
+            **_auth(host_user),
+        )
+        assert response.status_code == 400
+        assert_error_code(response, "event.rsvps_closed_cancelled")
+
+    def test_over_capacity_auto_waitlists(
+        self, api_client, host_rsvp_event, host_user, guest, other_member
+    ):
+        host_rsvp_event.max_attendees = 1
+        host_rsvp_event.save(update_fields=["max_attendees"])
+        EventRSVP.objects.create(
+            event=host_rsvp_event, user=other_member, status=RSVPStatus.ATTENDING
+        )
+        response = api_client.post(
+            f"/api/community/events/{host_rsvp_event.id}/rsvps/{guest.pk}/rsvp/",
+            {"status": RSVPStatus.ATTENDING},
+            content_type="application/json",
+            **_auth(host_user),
+        )
+        assert response.status_code == 200
+        rsvp = EventRSVP.objects.get(event=host_rsvp_event, user=guest)
+        assert rsvp.status == RSVPStatus.WAITLISTED
+
+    def test_freeing_spot_promotes_waitlisted_guest(
+        self, api_client, host_rsvp_event, host_user, guest, other_member
+    ):
+        host_rsvp_event.max_attendees = 1
+        host_rsvp_event.save(update_fields=["max_attendees"])
+        EventRSVP.objects.create(event=host_rsvp_event, user=guest, status=RSVPStatus.ATTENDING)
+        waitlisted = EventRSVP.objects.create(
+            event=host_rsvp_event, user=other_member, status=RSVPStatus.WAITLISTED
+        )
+        response = api_client.post(
+            f"/api/community/events/{host_rsvp_event.id}/rsvps/{guest.pk}/rsvp/",
+            {"status": RSVPStatus.CANT_GO},
+            content_type="application/json",
+            **_auth(host_user),
+        )
+        assert response.status_code == 200
+        waitlisted.refresh_from_db()
+        assert waitlisted.status == RSVPStatus.ATTENDING
+
+    def test_stamps_cancelled_at_on_transition_to_cant_go(
+        self, api_client, host_rsvp_event, host_user, guest
+    ):
+        EventRSVP.objects.create(event=host_rsvp_event, user=guest, status=RSVPStatus.ATTENDING)
+        before = timezone.now()
+        response = api_client.post(
+            f"/api/community/events/{host_rsvp_event.id}/rsvps/{guest.pk}/rsvp/",
+            {"status": RSVPStatus.CANT_GO},
+            content_type="application/json",
+            **_auth(host_user),
+        )
+        assert response.status_code == 200
+        rsvp = EventRSVP.objects.get(event=host_rsvp_event, user=guest)
+        assert rsvp.cancelled_at is not None
+        assert rsvp.cancelled_at >= before
+
+    def test_broadcasts_capacity_change_excluding_actor(
+        self, api_client, host_rsvp_event, host_user, guest
+    ):
+        with patch("community._event_host_actions.broadcast_capacity_change") as mock_broadcast:
+            api_client.post(
+                f"/api/community/events/{host_rsvp_event.id}/rsvps/{guest.pk}/rsvp/",
+                {"status": RSVPStatus.ATTENDING},
+                content_type="application/json",
+                **_auth(host_user),
+            )
+        mock_broadcast.assert_called_once()
+        assert mock_broadcast.call_args.args[0] == host_rsvp_event.id
+        assert mock_broadcast.call_args.kwargs["exclude_user_ids"] == {str(host_user.pk)}

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -1016,7 +1016,7 @@ export interface paths {
         get?: never;
         put?: never;
         /** Set Attendance */
-        post: operations["community__event_rsvps_set_attendance"];
+        post: operations["community__event_host_actions_set_attendance"];
         delete?: never;
         options?: never;
         head?: never;
@@ -1031,7 +1031,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get Event Stats */
-        get: operations["community__event_rsvps_get_event_stats"];
+        get: operations["community__event_host_actions_get_event_stats"];
         put?: never;
         post?: never;
         delete?: never;
@@ -1048,7 +1048,7 @@ export interface paths {
             cookie?: never;
         };
         /** Get Text Recipients */
-        get: operations["community__event_rsvps_get_text_recipients"];
+        get: operations["community__event_host_actions_get_text_recipients"];
         put?: never;
         post?: never;
         delete?: never;
@@ -7461,7 +7461,7 @@ export interface operations {
             };
         };
     };
-    community__event_rsvps_set_attendance: {
+    community__event_host_actions_set_attendance: {
         parameters: {
             query?: never;
             header?: never;
@@ -7524,7 +7524,7 @@ export interface operations {
             };
         };
     };
-    community__event_rsvps_get_event_stats: {
+    community__event_host_actions_get_event_stats: {
         parameters: {
             query?: never;
             header?: never;
@@ -7564,7 +7564,7 @@ export interface operations {
             };
         };
     };
-    community__event_rsvps_get_text_recipients: {
+    community__event_host_actions_get_text_recipients: {
         parameters: {
             query?: never;
             header?: never;

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -1023,6 +1023,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/community/events/{event_id}/rsvps/{user_id}/rsvp/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Set Guest Rsvp
+         * @description Let an event host/co-host/manager change another user's rsvp on their behalf (Issue 872).
+         */
+        post: operations["community__event_host_actions_set_guest_rsvp"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/community/events/{event_id}/stats/": {
         parameters: {
             query?: never;
@@ -3042,6 +3062,15 @@ export interface components {
         HomePagePatchIn: {
             /** Content Pm */
             content_pm?: string | null;
+        };
+        /** HostRSVPIn */
+        HostRSVPIn: {
+            /**
+             * Has Plus One
+             * @default false
+             */
+            has_plus_one: boolean;
+            status: components["schemas"]["RSVPStatus"];
         };
         /** InviteIn */
         InviteIn: {
@@ -7474,6 +7503,69 @@ export interface operations {
         requestBody: {
             content: {
                 "application/json": components["schemas"]["AttendanceIn"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EventOut"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
+    community__event_host_actions_set_guest_rsvp: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                event_id: string;
+                user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["HostRSVPIn"];
             };
         };
         responses: {


### PR DESCRIPTION
## Summary
- Pure code-move refactor, split out of #893 to keep PRs under 500 lines.
- Moves `get_event_stats`, `get_text_recipients`, and `set_attendance` (plus their private helpers `_check_in_open`, `_build_text_recipients`, `_load_event_with_stats_prefetch`) out of `_event_rsvps.py` into a new `_event_host_actions.py`.
- `_load_event_with_stats_prefetch` becomes `load_event_with_stats_prefetch`, promoted to `_event_helpers.py` as a shared helper (both `_event_rsvps.py` and `_event_host_actions.py` use it).
- No behavior change — same endpoints, same responses. Regenerated `openapi_schema.json`/`types.gen.ts` only rename `operationId`s to reflect the new module path (not referenced by name anywhere in the frontend).
- Ahead of PR2 which adds the actual new host rsvp-management feature (Issue 872) into this new file.

## Test plan
- [x] `make agent-lint`
- [x] `make agent-typecheck`
- [x] `make agent-test` — 1480 passed; 5 pre-existing SQLite/pg_notify SSE failures unrelated to this change
- [x] frontend typecheck clean