### PR TITLE
feat(events): email notification for co-host invites

### DIFF
--- a/backend/community/_cohost_invite_helpers.py
+++ b/backend/community/_cohost_invite_helpers.py
@@ -4,10 +4,16 @@ plus lazy-on-read expiration of pending invites past the event end.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
+from django.conf import settings
 from django.db import transaction
 from django.utils import timezone
+from notifications._email_helpers import CohostInviteEmailDetails, send_cohost_invite_email
+from notifications.email_sender import get_email_sender
+from users._helpers import visible_display_name
+from users.models import User
 
 from community._validation import Code, raise_validation
 from community.models import CoHostInviteStatus, Event, EventCoHostInvite
@@ -16,6 +22,8 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from users.models import User as UserModel
+
+logger = logging.getLogger("pda.community.cohost_invite_helpers")
 
 
 def expire_stale_cohost_invites(event: Event) -> None:
@@ -153,6 +161,42 @@ def _check_past_event_guard(
         existing = existing_by_user.get(user_id)
         if existing is None or existing.status not in _ACTIVE_OR_PENDING:
             raise_validation(Code.CoHostInvite.EVENT_IS_PAST, status_code=400)
+
+
+def send_cohost_invite_emails(
+    event: Event,
+    new_user_ids: Iterable[str],
+    inviter: UserModel,
+) -> None:
+    """Email newly-invited co-hosts, complementing the in-app notification.
+
+    Legacy users may have no email on file — skip silently rather than crash
+    the invite flow. One bad send must not block the others.
+    """
+    inviter_id = str(inviter.pk)
+    invited_by_name = visible_display_name(inviter, None)
+    recipients = User.objects.filter(pk__in=[uid for uid in new_user_ids if str(uid) != inviter_id])
+    sender = get_email_sender()
+    event_url = f"{settings.FRONTEND_BASE_URL}/events/{event.pk}"
+    for user in recipients:
+        if not user.email:
+            continue
+        try:
+            result = send_cohost_invite_email(
+                sender=sender,
+                details=CohostInviteEmailDetails(
+                    to=user.email,
+                    display_name=user.full_name or "",
+                    inviter_name=invited_by_name,
+                    event_title=event.title,
+                    event_url=event_url,
+                ),
+            )
+        except Exception:  # noqa: BLE001 — one bad send must not abort the batch
+            logger.warning("cohost_invite_email_send_exception", exc_info=True)
+            continue
+        if not result.success:
+            logger.warning("cohost_invite_email_failed", extra={"error": result.error})
 
 
 def get_pending_invites_for_event(event: Event) -> list[EventCoHostInvite]:

--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -20,6 +20,7 @@ from community._cohost_invite_helpers import (
     diff_cohost_invites,
     get_my_pending_invite,
     get_pending_invites_for_event,
+    send_cohost_invite_emails,
 )
 from community._event_schemas import (
     CancellationOut,
@@ -379,6 +380,7 @@ def _update_co_hosts(
     newly_invited, removed_accepted_ids = diff_cohost_invites(event, next_ids, updater)
     if newly_invited:
         create_cohost_invite_notifications(event, newly_invited, updater)
+        send_cohost_invite_emails(event, newly_invited, updater)
 
     if newly_invited or removed_accepted_ids:
         broadcast_cohost_change(

--- a/backend/community/_event_transitions.py
+++ b/backend/community/_event_transitions.py
@@ -12,7 +12,7 @@ from notifications.service import (
 )
 from users.permissions import PermissionKey
 
-from community._cohost_invite_helpers import diff_cohost_invites
+from community._cohost_invite_helpers import diff_cohost_invites, send_cohost_invite_emails
 from community._event_helpers import _event_out, _has_attendees
 from community._validation import Code, raise_validation
 from community.models import Event, EventStatus
@@ -84,6 +84,7 @@ def _set_event_participants(request, event: Event, co_host_ids: list) -> None:
         newly_invited, _ = diff_cohost_invites(event, co_host_ids, request.auth)
         if newly_invited:
             create_cohost_invite_notifications(event, newly_invited, request.auth)
+            send_cohost_invite_emails(event, newly_invited, request.auth)
 
 
 def _publish_draft(request, event: Event) -> None:

--- a/backend/notifications/_email_helpers.py
+++ b/backend/notifications/_email_helpers.py
@@ -197,6 +197,39 @@ def send_event_invite_email(
     )
 
 
+@dataclass(frozen=True)
+class CohostInviteEmailDetails:
+    """Recipient + event details for the co-host invite email."""
+
+    to: str
+    display_name: str
+    inviter_name: str
+    event_title: str
+    event_url: str
+
+
+def send_cohost_invite_email(
+    *,
+    sender: EmailSender,
+    details: CohostInviteEmailDetails,
+) -> SendResult:
+    """Render and send the "you've been invited to co-host" email."""
+    context = {
+        "display_name": details.display_name or "",
+        "inviter_name": details.inviter_name,
+        "event_title": details.event_title,
+        "event_url": details.event_url,
+    }
+    html = render_to_string("emails/cohost_invite.html", context)
+    text = render_to_string("emails/cohost_invite.txt", context)
+    return sender.send(
+        to=details.to,
+        subject=f"you've been invited to co-host {details.event_title.lower()}",
+        html=html,
+        text=text,
+    )
+
+
 def send_event_blast_email(
     *,
     sender: EmailSender,

--- a/backend/templates/emails/cohost_invite.html
+++ b/backend/templates/emails/cohost_invite.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+<body style="margin: 0; padding: 24px; background: #f5f5f3; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #222;">
+  <div style="max-width: 480px; margin: 0 auto; background: #ffffff; border-radius: 8px; padding: 32px;">
+    <p style="margin: 0 0 16px;">hi{% if display_name %} {{ display_name|lower }}{% endif %} —</p>
+    <p style="margin: 0 0 24px;">{{ inviter_name|lower }} invited you to co-host <strong>{{ event_title|lower }}</strong> on pda.</p>
+    <p style="margin: 0 0 24px;">
+      <a href="{{ event_url }}" style="display: inline-block; background: #3c6939; color: #ffffff; text-decoration: none; padding: 12px 24px; border-radius: 6px; font-weight: 500;">view invite</a>
+    </p>
+    <p style="margin: 0 0 8px; font-size: 13px; color: #666;">or paste this into your browser:</p>
+    <p style="margin: 0; font-size: 13px; word-break: break-all;"><a href="{{ event_url }}" style="color: #3c6939;">{{ event_url }}</a></p>
+  </div>
+  <p style="text-align: center; margin: 16px 0 0; font-size: 12px; color: #888;">— pda</p>
+  {% include "emails/_no_reply_footer.html" %}
+</body>
+</html>

--- a/backend/templates/emails/cohost_invite.txt
+++ b/backend/templates/emails/cohost_invite.txt
@@ -1,0 +1,11 @@
+hi{% if display_name %} {{ display_name|lower }}{% endif %} —
+
+{{ inviter_name|lower }} invited you to co-host {{ event_title|lower }} on pda.
+
+view the invite here:
+
+{{ event_url }}
+
+— pda
+
+{% include "emails/_no_reply_footer.txt" %}

--- a/backend/tests/test_cohost_invite_email.py
+++ b/backend/tests/test_cohost_invite_email.py
@@ -1,0 +1,128 @@
+import json
+
+import pytest
+from community.models import Event, EventStatus
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
+
+from tests.conftest import future_iso
+
+CREATE_EVENT_URL = "/api/community/events/"
+
+
+def _make_user(phone: str, name: str = "Member", email: str | None = "") -> User:
+    return User.objects.create_user(
+        phone_number=phone,
+        password="testpass123",
+        first_name=name,
+        email=email,
+    )
+
+
+def _auth_headers(user: User) -> dict:
+    refresh = RefreshToken.for_user(user)
+    return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
+
+
+def _create_event_via_api(api_client, creator: User, co_host_ids: list[str]) -> dict:
+    payload = {
+        "title": "Community Potluck",
+        "start_datetime": future_iso(days=30),
+        "end_datetime": future_iso(days=30, hours=2),
+        "status": EventStatus.ACTIVE,
+        "co_host_ids": co_host_ids,
+    }
+    response = api_client.post(
+        CREATE_EVENT_URL,
+        data=json.dumps(payload),
+        content_type="application/json",
+        **_auth_headers(creator),
+    )
+    assert response.status_code == 201, response.content
+    return response.json()
+
+
+@pytest.fixture
+def creator(db) -> User:
+    return _make_user("+12025550111", "Creator", email="creator@example.com")
+
+
+@pytest.mark.django_db
+class TestCohostInviteEmail:
+    def test_sends_email_when_invitee_has_email(self, api_client, creator, fake_email_sender):
+        invitee = _make_user("+12025550112", "Invitee", email="invitee@example.com")
+
+        _create_event_via_api(api_client, creator, co_host_ids=[str(invitee.pk)])
+
+        fake_email_sender.send.assert_called_once()
+        call_kwargs = fake_email_sender.send.call_args.kwargs
+        assert call_kwargs["to"] == "invitee@example.com"
+        assert "co-host" in call_kwargs["subject"]
+        assert call_kwargs["subject"] == call_kwargs["subject"].lower()
+        assert "community potluck" in call_kwargs["text"].lower()
+        assert "creator" in call_kwargs["text"].lower()
+
+    def test_no_email_attempted_when_invitee_has_no_email(
+        self, api_client, creator, fake_email_sender
+    ):
+        invitee = _make_user("+12025550113", "Invitee", email="")
+
+        response_data = _create_event_via_api(api_client, creator, co_host_ids=[str(invitee.pk)])
+
+        fake_email_sender.send.assert_not_called()
+        # Invite flow itself still succeeds — email is best-effort, not required.
+        assert response_data["id"]
+
+    def test_does_not_crash_when_send_fails(self, api_client, creator, fake_email_sender):
+        from notifications.email_sender import SendResult
+
+        fake_email_sender.send.side_effect = Exception("smtp exploded")
+        invitee = _make_user("+12025550114", "Invitee", email="invitee2@example.com")
+
+        response = api_client.post(
+            CREATE_EVENT_URL,
+            data=json.dumps(
+                {
+                    "title": "Community Potluck",
+                    "start_datetime": future_iso(days=30),
+                    "end_datetime": future_iso(days=30, hours=2),
+                    "status": EventStatus.ACTIVE,
+                    "co_host_ids": [str(invitee.pk)],
+                }
+            ),
+            content_type="application/json",
+            **_auth_headers(creator),
+        )
+
+        assert response.status_code == 201, response.content
+        fake_email_sender.send.side_effect = None
+        fake_email_sender.send.return_value = SendResult(success=True)
+
+    def test_no_email_sent_to_inviter_for_self_invite(self, api_client, creator, fake_email_sender):
+        _create_event_via_api(api_client, creator, co_host_ids=[str(creator.pk)])
+        fake_email_sender.send.assert_not_called()
+
+    def test_email_via_patch_adds_new_cohost(self, api_client, creator, fake_email_sender):
+        data = _create_event_via_api(api_client, creator, co_host_ids=[])
+        event_id = data["id"]
+        invitee = _make_user("+12025550115", "Invitee", email="patched@example.com")
+
+        response = api_client.patch(
+            f"/api/community/events/{event_id}/",
+            data=json.dumps({"co_host_ids": [str(invitee.pk)]}),
+            content_type="application/json",
+            **_auth_headers(creator),
+        )
+
+        assert response.status_code == 200, response.content
+        fake_email_sender.send.assert_called_once()
+        assert fake_email_sender.send.call_args.kwargs["to"] == "patched@example.com"
+
+    def test_event_url_points_to_event_detail_page(self, api_client, creator, fake_email_sender):
+        invitee = _make_user("+12025550116", "Invitee", email="invitee3@example.com")
+        data = _create_event_via_api(api_client, creator, co_host_ids=[str(invitee.pk)])
+        event = Event.objects.get(id=data["id"])
+
+        call_kwargs = fake_email_sender.send.call_args.kwargs
+        assert f"/events/{event.pk}" in call_kwargs["text"]
+        assert f"/events/{event.pk}" in call_kwargs["html"]


### PR DESCRIPTION
## Summary
- Sends an email to newly-invited co-hosts, complementing the existing in-app `COHOST_INVITE` notification (Issue 856)
- Follows the existing email pattern in the codebase: `EmailSender` protocol, `templates/emails/cohost_invite.{html,txt}`, `_no_reply_footer` include, lowercase subject/body copy
- Skips sending silently when the invitee has no email on file (legacy users may lack one) — mirrors the defensive check used elsewhere (e.g. magic-login email flow)
- A failed/erroring send is logged and does not abort the invite flow — one bad send never blocks the invite itself or other recipients
- Wired into both places that create new co-host invites: event create/update (`_event_helpers.py::_update_co_hosts`) and draft publish (`_event_transitions.py::_set_event_participants`)

## Changes
- `backend/notifications/_email_helpers.py`: `send_cohost_invite_email()` + `CohostInviteEmailDetails` dataclass (kept under the 5-arg ruff limit, same pattern as `RsvpEmailDetails`)
- `backend/templates/emails/cohost_invite.{html,txt}`: new templates, styled like `join_approval`/`magic_login`
- `backend/community/_cohost_invite_helpers.py`: new `send_cohost_invite_emails()` — resolves recipients, skips missing emails, calls the sender per-recipient with a try/except guard
- `backend/community/_event_helpers.py`, `backend/community/_event_transitions.py`: call `send_cohost_invite_emails()` alongside the existing `create_cohost_invite_notifications()` call
- `backend/tests/test_cohost_invite_email.py`: new tests — email sent when invitee has email, no email attempted when missing, send failure doesn't crash the invite, no email to inviter on self-invite, email sent on PATCH-added co-host, email body/text link to the event detail page

## Test plan
- [x] `uv run ruff check` + `uv run ruff format --check` on all changed/new files — clean
- [x] `uv run ty check` on all changed files — clean
- [x] `pytest backend/tests/test_cohost_invite_email.py -q` — 6/6 passed
- [x] `pytest backend/tests/test_event_cohost_invites.py backend/tests/test_event_management.py -q` (existing coverage, unaffected) — 55/55 passed
- Not run: full `make agent-ci` / full test suite, per explicit instruction for this task

🤖 Generated with [Claude Code](https://claude.com/claude-code)