### PR TITLE
feat(events): add forget-my-rsvps control for non-members

### DIFF
--- a/frontend/src/screens/events/EventPublicRsvpSection.test.tsx
+++ b/frontend/src/screens/events/EventPublicRsvpSection.test.tsx
@@ -115,4 +115,14 @@ describe('EventPublicRsvpSection', () => {
       hasPlusOne: false,
     });
   });
+
+  it('clears the stored token when "not you?" is confirmed', () => {
+    localStorage.setItem('pda-rsvp-token', 'tok-123');
+    renderSection(baseEvent());
+
+    fireEvent.click(screen.getByRole('button', { name: 'not you?' }));
+    fireEvent.click(screen.getByRole('button', { name: 'forget me' }));
+
+    expect(localStorage.getItem('pda-rsvp-token')).toBeNull();
+  });
 });

--- a/frontend/src/screens/events/EventPublicRsvpSection.tsx
+++ b/frontend/src/screens/events/EventPublicRsvpSection.tsx
@@ -1,3 +1,8 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+import { clearStoredRsvpToken } from '@/api/rsvpTokenStorage';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import type { Event } from '@/models/event';
 
 import { EventCommentsCard } from './comments/EventCommentsCard';
@@ -10,7 +15,16 @@ interface Props {
 }
 
 export function EventPublicRsvpSection({ event, token }: Props) {
+  const navigate = useNavigate();
   const rsvpDisabled = !event.rsvpEnabled;
+  const [forgetOpen, setForgetOpen] = useState(false);
+
+  function handleForget() {
+    clearStoredRsvpToken();
+    setForgetOpen(false);
+    void navigate('/calendar');
+  }
+
   return (
     <div className="mt-8 flex flex-col gap-6">
       <LocationSection event={event} />
@@ -18,11 +32,35 @@ export function EventPublicRsvpSection({ event, token }: Props) {
       <CostSection event={event} />
       {event.isPast || rsvpDisabled ? null : (
         <section className="border-border bg-surface rounded-lg border p-4">
-          <h2 className="text-muted mb-3 text-xs font-medium tracking-wide">rsvp</h2>
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-muted text-xs font-medium tracking-wide">rsvp</h2>
+            <button
+              type="button"
+              onClick={() => {
+                setForgetOpen(true);
+              }}
+              className="text-foreground-secondary text-xs underline underline-offset-2"
+            >
+              not you?
+            </button>
+          </div>
           <RsvpSection event={event} canSeeInvited={false} token={token} />
         </section>
       )}
       {rsvpDisabled ? null : <EventCommentsCard eventId={event.id} token={token} />}
+
+      <ConfirmDialog
+        open={forgetOpen}
+        title="not you?"
+        message="this'll forget your rsvps on this device — you can always rsvp again to get a new link"
+        confirmLabel="forget me"
+        cancelLabel="cancel"
+        destructive={false}
+        onCancel={() => {
+          setForgetOpen(false);
+        }}
+        onConfirm={handleForget}
+      />
     </div>
   );
 }

--- a/frontend/src/screens/events/PublicRsvpsScreen.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpsScreen.test.tsx
@@ -175,6 +175,28 @@ describe('PublicRsvpsScreen', () => {
     });
   });
 
+  it('clears the stored token when "not you?" is confirmed', () => {
+    localStorage.setItem('pda-rsvp-token', 'good-token');
+    usePublicMyRsvps.mockReturnValue({ data: successData(), isPending: false, isError: false });
+    renderAt('good-token');
+
+    fireEvent.click(screen.getByRole('button', { name: 'not you?' }));
+    fireEvent.click(screen.getByRole('button', { name: 'forget me' }));
+
+    expect(localStorage.getItem('pda-rsvp-token')).toBeNull();
+  });
+
+  it('keeps the stored token when "not you?" is cancelled', () => {
+    localStorage.setItem('pda-rsvp-token', 'good-token');
+    usePublicMyRsvps.mockReturnValue({ data: successData(), isPending: false, isError: false });
+    renderAt('good-token');
+
+    fireEvent.click(screen.getByRole('button', { name: 'not you?' }));
+    fireEvent.click(screen.getByRole('button', { name: 'cancel' }));
+
+    expect(localStorage.getItem('pda-rsvp-token')).toBe('good-token');
+  });
+
   it('has no axe violations', async () => {
     usePublicMyRsvps.mockReturnValue({ data: successData(), isPending: false, isError: false });
     const { container } = renderAt('good-token');

--- a/frontend/src/screens/events/PublicRsvpsScreen.tsx
+++ b/frontend/src/screens/events/PublicRsvpsScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { getApiStatus } from '@/api/apiErrors';
 import { usePublicMyRsvps } from '@/api/publicRsvp';
@@ -8,6 +8,7 @@ import {
   getStoredRsvpToken,
   setStoredRsvpToken,
 } from '@/api/rsvpTokenStorage';
+import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 
 import { PublicRsvpCard } from './PublicRsvpCard';
@@ -15,10 +16,12 @@ import { PublicRsvpCard } from './PublicRsvpCard';
 const INVALID_TOKEN_COPY = "this link's expired or invalid — rsvp again to get a new one";
 
 export default function PublicRsvpsScreen() {
+  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const urlToken = searchParams.get('token');
   const [storedToken] = useState(() => getStoredRsvpToken());
   const token = urlToken ?? storedToken ?? '';
+  const [forgetOpen, setForgetOpen] = useState(false);
 
   useEffect(() => {
     if (urlToken) setStoredRsvpToken(urlToken);
@@ -30,6 +33,12 @@ export default function PublicRsvpsScreen() {
   useEffect(() => {
     if (isInvalidToken) clearStoredRsvpToken();
   }, [isInvalidToken]);
+
+  function handleForget() {
+    clearStoredRsvpToken();
+    setForgetOpen(false);
+    void navigate('/calendar');
+  }
 
   // only a 404 means the link is bad; transient failures must not tell the holder to re-rsvp.
   if (!token || isInvalidToken) {
@@ -45,7 +54,18 @@ export default function PublicRsvpsScreen() {
   return (
     <ContentContainer>
       <h1 className="text-foreground mb-1 text-2xl font-semibold">your rsvps</h1>
-      <p className="text-foreground-secondary mb-6 text-sm">{data.user.name}</p>
+      <div className="mb-6 flex items-center justify-between gap-2">
+        <p className="text-foreground-secondary text-sm">{data.user.name}</p>
+        <button
+          type="button"
+          onClick={() => {
+            setForgetOpen(true);
+          }}
+          className="text-foreground-secondary text-sm underline underline-offset-2"
+        >
+          not you?
+        </button>
+      </div>
 
       {data.rsvps.length === 0 ? (
         <p className="text-foreground-secondary text-sm">
@@ -64,6 +84,19 @@ export default function PublicRsvpsScreen() {
           ))}
         </div>
       )}
+
+      <ConfirmDialog
+        open={forgetOpen}
+        title="not you?"
+        message="this'll forget your rsvps on this device — you can always rsvp again to get a new link"
+        confirmLabel="forget me"
+        cancelLabel="cancel"
+        destructive={false}
+        onCancel={() => {
+          setForgetOpen(false);
+        }}
+        onConfirm={handleForget}
+      />
     </ContentContainer>
   );
 }


### PR DESCRIPTION
## Summary
- Adds a lowercase "not you?" text control to `PublicRsvpsScreen` (`/my-rsvps`) and to the token-unlocked event detail rsvp section (`EventPublicRsvpSection`)
- Clicking it opens a lightweight `ConfirmDialog` ("not you? / this'll forget your rsvps on this device — you can always rsvp again to get a new link")
- Confirming calls `clearStoredRsvpToken()` and navigates to `/calendar`

Addresses Issue 896: non-members who publicly RSVP get a token persisted in localStorage with no way to clear it (e.g. on a shared device). This adds a small, reversible "forget me" control at both places a token holder's identity is surfaced.

## Test plan
- [x] `npx tsc --noEmit` — passes
- [x] `eslint` + `prettier --check` on touched files — clean
- [x] `vitest run` on `PublicRsvpsScreen.test.tsx` + `EventPublicRsvpSection.test.tsx` — 16/16 passing, including new tests for confirm/cancel of the "not you?" flow
- [ ] Manual click-through on staging once deployed