### PR TITLE
feat(events): recognize returning non-member rsvps by phone (Issue 894)

### DIFF
--- a/backend/community/_public_rsvp_submit.py
+++ b/backend/community/_public_rsvp_submit.py
@@ -3,10 +3,11 @@ from enum import StrEnum
 
 from config.audit import audit_log
 from config.ratelimit import client_ip, rate_limit
+from django.conf import settings
 from django.db import IntegrityError, transaction
 from ninja import Router
 from ninja.responses import Status
-from notifications._email_helpers import send_rsvp_confirmation_email
+from notifications._email_helpers import send_rsvp_confirmation_email, send_rsvp_manage_link_email
 from notifications.email_sender import get_email_sender
 from pydantic import BaseModel, EmailStr, Field
 from users.models import NonMemberRsvpToken, User
@@ -43,6 +44,7 @@ class PublicRsvpIn(BaseModel):
 class PublicRsvpPhoneStatus(StrEnum):
     MEMBER = "member"
     ALREADY_RSVPD = "already_rsvpd"
+    RECOGNIZED = "recognized"
     NEW = "new"
 
 
@@ -154,6 +156,33 @@ def _send_confirmation_email(
         _log_email_failure(request, event, user, exc)
 
 
+def _send_recognized_login_link(request, user: User) -> None:
+    """Email a returning non-member their manage link instead of re-asking for contact info.
+
+    Best-effort — a send failure must not block the phone-check response.
+    """
+    token = NonMemberRsvpToken.issue_or_extend(user)
+    manage_url = f"{settings.FRONTEND_BASE_URL}/my-rsvps?token={token.token}"
+    try:
+        result = send_rsvp_manage_link_email(
+            sender=get_email_sender(),
+            to=user.email,
+            display_name=user.full_name,
+            manage_url=manage_url,
+        )
+        if not result.success:
+            raise RuntimeError(result.error or "send returned failure")
+    except Exception as exc:
+        audit_log(
+            logging.WARNING,
+            "public_rsvp_recognized_email_failed",
+            request,
+            target_type="user",
+            target_id=str(user.pk),
+            details={"error": str(exc)},
+        )
+
+
 @router.post(
     "/public/events/{event_id}/rsvp-phone-check/",
     response={200: PublicRsvpPhoneCheckOut, 404: ErrorOut, 429: ErrorOut},
@@ -181,6 +210,9 @@ def check_public_rsvp_phone(request, event_id, payload: PublicRsvpPhoneCheckIn):
                 status=PublicRsvpPhoneStatus.ALREADY_RSVPD, rsvp_token=token.token
             ),
         )
+    if user.email and user.event_rsvps.exists():
+        _send_recognized_login_link(request, user)
+        return Status(200, PublicRsvpPhoneCheckOut(status=PublicRsvpPhoneStatus.RECOGNIZED))
     return Status(200, PublicRsvpPhoneCheckOut(status=PublicRsvpPhoneStatus.NEW))
 
 

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -3978,6 +3978,7 @@
         "enum": [
           "member",
           "already_rsvpd",
+          "recognized",
           "new"
         ],
         "title": "PublicRsvpPhoneStatus",

--- a/backend/tests/test_public_rsvp_phone_check.py
+++ b/backend/tests/test_public_rsvp_phone_check.py
@@ -68,7 +68,9 @@ class TestPublicRsvpPhoneCheck:
         assert body["rsvp_token"] != ""
         assert NonMemberRsvpToken.resolve_user(body["rsvp_token"]) == guest
 
-    def test_already_rsvpd_on_other_event_is_new_for_this_one(self, api_client, official_event):
+    def test_already_rsvpd_on_other_event_is_recognized_for_this_one(
+        self, api_client, official_event, fake_email_sender
+    ):
         guest = make_non_member("+14155550199", "guest@example.com")
         other_event = make_official_event(title="Other Event", start_datetime=future_iso(days=45))
         EventRSVP.objects.create(event=other_event, user=guest, status=RSVPStatus.ATTENDING)
@@ -76,7 +78,35 @@ class TestPublicRsvpPhoneCheck:
         response = post(api_client, official_event, phone_number="+14155550199")
 
         assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "recognized"
+        assert body["rsvp_token"] == ""
+
+    def test_recognized_sends_login_link_email(self, api_client, official_event, fake_email_sender):
+        guest = make_non_member("+14155550199", "guest@example.com")
+        other_event = make_official_event(title="Other Event", start_datetime=future_iso(days=45))
+        EventRSVP.objects.create(event=other_event, user=guest, status=RSVPStatus.ATTENDING)
+
+        post(api_client, official_event, phone_number="+14155550199")
+
+        fake_email_sender.send.assert_called_once()
+        sent = fake_email_sender.send.call_args.kwargs
+        assert sent["to"] == "guest@example.com"
+        token = NonMemberRsvpToken.objects.get(user=guest)
+        assert token.token in sent["text"]
+
+    def test_recognized_without_email_falls_back_to_new(
+        self, api_client, official_event, fake_email_sender
+    ):
+        guest = make_non_member("+14155550199", "")
+        other_event = make_official_event(title="Other Event", start_datetime=future_iso(days=45))
+        EventRSVP.objects.create(event=other_event, user=guest, status=RSVPStatus.ATTENDING)
+
+        response = post(api_client, official_event, phone_number="+14155550199")
+
+        assert response.status_code == 200
         assert response.json()["status"] == "new"
+        fake_email_sender.send.assert_not_called()
 
     def test_invalid_phone_is_new(self, api_client, official_event):
         response = post(api_client, official_event, phone_number="not-a-phone")

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -3568,7 +3568,7 @@ export interface components {
          * PublicRsvpPhoneStatus
          * @enum {string}
          */
-        PublicRsvpPhoneStatus: "member" | "already_rsvpd" | "new";
+        PublicRsvpPhoneStatus: "member" | "already_rsvpd" | "recognized" | "new";
         /** PublicRsvpStateOut */
         PublicRsvpStateOut: {
             /** Has Plus One */

--- a/frontend/src/screens/events/PublicRsvpForm.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.test.tsx
@@ -195,6 +195,16 @@ describe('PublicRsvpForm', () => {
     await waitFor(() => expect(onAlreadyRsvpd).toHaveBeenCalledWith({ rsvpToken: 'tok-xyz' }));
   });
 
+  it('shows a check-your-email message instead of the contact form when recognized', async () => {
+    checkPhoneMutate.mockResolvedValue({ status: 'recognized', rsvp_token: '' });
+    renderForm();
+    fillPhoneStep();
+    await screen.findByText(
+      'we recognized your number — check your email for a link to confirm your rsvp',
+    );
+    expect(screen.queryByLabelText('first name')).not.toBeInTheDocument();
+  });
+
   it('lets you change the status and go back to step one from the details step', async () => {
     checkPhoneMutate.mockResolvedValue({ status: 'new', rsvp_token: '' });
     renderForm();

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -50,6 +50,7 @@ export function PublicRsvpForm({ event, onSuccess, onMember, onAlreadyRsvpd }: P
   const submit = useSubmitPublicRsvp();
   const [status, setStatus] = useState<RsvpInputStatus | null>(null);
   const [phoneConfirmed, setPhoneConfirmed] = useState(false);
+  const [recognized, setRecognized] = useState(false);
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [email, setEmail] = useState('');
@@ -98,12 +99,22 @@ export function PublicRsvpForm({ event, onSuccess, onMember, onAlreadyRsvpd }: P
         <RsvpStatusPicker value={status} onSelect={setStatus} statuses={PUBLIC_RSVP_STATUSES} />
       );
     }
+    if (recognized) {
+      return (
+        <p className="text-foreground-secondary text-sm">
+          we recognized your number — check your email for a link to confirm your rsvp
+        </p>
+      );
+    }
     if (!phoneConfirmed) {
       return (
         <PublicRsvpPhoneStep
           eventId={event.id}
           onMember={onMember}
           onAlreadyRsvpd={onAlreadyRsvpd}
+          onRecognized={() => {
+            setRecognized(true);
+          }}
           onNew={(result) => {
             setPhone(result.phone);
             setPhoneConfirmed(true);

--- a/frontend/src/screens/events/PublicRsvpPhoneStep.tsx
+++ b/frontend/src/screens/events/PublicRsvpPhoneStep.tsx
@@ -19,10 +19,17 @@ interface Props {
   onNew: (result: PhoneStepResult) => void;
   onMember: () => void;
   onAlreadyRsvpd: (result: AlreadyRsvpdResult) => void;
+  onRecognized: () => void;
   eventId: string;
 }
 
-export function PublicRsvpPhoneStep({ onNew, onMember, onAlreadyRsvpd, eventId }: Props) {
+export function PublicRsvpPhoneStep({
+  onNew,
+  onMember,
+  onAlreadyRsvpd,
+  onRecognized,
+  eventId,
+}: Props) {
   const check = useCheckPublicRsvpPhone();
   const [phone, setPhone] = useState('');
   const [error, setError] = useState<string | undefined>(undefined);
@@ -42,6 +49,10 @@ export function PublicRsvpPhoneStep({ onNew, onMember, onAlreadyRsvpd, eventId }
       }
       if (result.status === 'already_rsvpd') {
         onAlreadyRsvpd({ rsvpToken: result.rsvp_token });
+        return;
+      }
+      if (result.status === 'recognized') {
+        onRecognized();
         return;
       }
       onNew({ phone, status: 'new' });


### PR DESCRIPTION
## Summary

Closes Issue 894. Non-members rsvping publicly were only recognized as "already rsvpd" when they'd previously rsvp'd to the **same** event — a returning guest rsvping to a *different* event still had to refill the entire contact form. This extends the phone-check endpoint to recognize a non-member with **any** prior rsvp and an email on file, and emails them their existing manage-rsvp login link instead of re-asking for contact info.

## Changes

- **Backend** (`backend/community/_public_rsvp_submit.py`): `check_public_rsvp_phone` now checks `user.event_rsvps.exists()` (any prior event) in addition to the existing same-event check. Added a new `recognized` status to `PublicRsvpPhoneStatus` and `_send_recognized_login_link`, which reuses `send_rsvp_manage_link_email` (the same email helper already used by the manage-link resend/recovery flow) to email the non-member's existing `NonMemberRsvpToken` manage link. If the matched user has no email on file, falls back to `new` since there's nowhere to send a link.
- **Frontend**: `PublicRsvpPhoneStep` gained an `onRecognized` callback fired on the new `recognized` status. `PublicRsvpForm` shows a "check your email" message in place of the contact-info form when recognized.
- Regenerated `frontend/src/api/types.gen.ts` and `backend/openapi_schema.json` for the new `recognized` enum value.

## Acceptance criteria

- [x] Entering a phone number that matches a previous non-member rsvp (any event) does not re-prompt for full contact info
- [x] The recognized-contact flow sends an email with a login link (reusing the existing manage-link email) instead of asking to refill the form
- [x] First-time rsvps (unrecognized phone number) still go through the full contact info flow unchanged — same-event "already rsvpd" instant-unlock behavior (Issue 854/#866) is also unchanged

## Test plan

- [x] Backend: `uv run ruff check` / `uv run ruff format --check` on changed files
- [x] Backend: `pytest tests/test_public_rsvp_phone_check.py` (9 passed, incl. 3 new tests for the recognized path) and regression run of `test_public_rsvp.py`, `test_public_rsvp_resend.py`, `test_public_rsvp_capacity.py` (50 passed)
- [x] Frontend: eslint + prettier on touched files
- [x] Frontend: `npx tsc --noEmit` (whole project, clean)
- [x] Frontend: `vitest run` on `PublicRsvpForm.test.tsx`, `PublicRsvpSection.test.tsx`, `PublicRsvp.a11y.test.tsx` (26 passed, incl. 1 new test for the recognized state)
- [ ] Full `make agent-ci` / full test suite intentionally not run per task instructions