### PR TITLE
feat(events): host rsvp management UI (Issue 872)

### DIFF
--- a/frontend/src/api/eventStats.ts
+++ b/frontend/src/api/eventStats.ts
@@ -99,11 +99,7 @@ export function useSetAttendance(eventId: string) {
 export function useSetGuestRsvp(eventId: string) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: async (args: {
-      userId: string;
-      status: RsvpInputStatus;
-      hasPlusOne?: boolean;
-    }) => {
+    mutationFn: async (args: { userId: string; status: RsvpInputStatus; hasPlusOne?: boolean }) => {
       const { data } = await apiClient.post<WireEvent>(
         `/api/community/events/${eventId}/rsvps/${args.userId}/rsvp/`,
         { status: args.status, has_plus_one: args.hasPlusOne ?? false },

--- a/frontend/src/api/eventStats.ts
+++ b/frontend/src/api/eventStats.ts
@@ -5,7 +5,12 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
-import type { AttendanceStatusValue, EventCancellation, EventStats } from '@/models/event';
+import type {
+  AttendanceStatusValue,
+  EventCancellation,
+  EventStats,
+  RsvpInputStatus,
+} from '@/models/event';
 
 import { attendanceReportKey } from './attendanceReport';
 import { apiClient } from './client';
@@ -87,6 +92,27 @@ export function useSetAttendance(eventId: string) {
       // attendance marks feed the admin report + members-list last_attended.
       void qc.invalidateQueries({ queryKey: attendanceReportKey });
       void qc.invalidateQueries({ queryKey: USERS_KEY });
+    },
+  });
+}
+
+export function useSetGuestRsvp(eventId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (args: {
+      userId: string;
+      status: RsvpInputStatus;
+      hasPlusOne?: boolean;
+    }) => {
+      const { data } = await apiClient.post<WireEvent>(
+        `/api/community/events/${eventId}/rsvps/${args.userId}/rsvp/`,
+        { status: args.status, has_plus_one: args.hasPlusOne ?? false },
+      );
+      return mapEvent(data);
+    },
+    onSuccess: (event) => {
+      qc.setQueryData(eventKeys.detail(event.id, true), event);
+      void qc.invalidateQueries({ queryKey: eventStatsKeys.detail(eventId) });
     },
   });
 }

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -64,7 +64,12 @@ export function EventMemberSection({ event, token }: Props) {
       <CostSection event={event} />
       {showRsvp ? (
         <Card label="rsvp">
-          <RsvpSection event={event} canSeeInvited={canSeeInvited} {...(token ? { token } : {})} />
+          <RsvpSection
+            event={event}
+            canSeeInvited={canSeeInvited}
+            canManageRsvps={canSeeInvited}
+            {...(token ? { token } : {})}
+          />
           {canInvite || isCoHost ? (
             <div className="mt-4 flex flex-wrap justify-end gap-2">
               {canInvite ? <InviteSection event={event} /> : null}

--- a/frontend/src/screens/events/RsvpGuestList.test.tsx
+++ b/frontend/src/screens/events/RsvpGuestList.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   AttendanceStatus,
@@ -13,12 +14,17 @@ import {
   RsvpServerStatus,
 } from '@/models/event';
 
+const setGuestRsvpMutate = vi.fn();
+vi.mock('@/api/eventStats', () => ({
+  useSetGuestRsvp: () => ({ mutate: setGuestRsvpMutate, isPending: false }),
+}));
+
 import { RsvpGuestList } from './RsvpGuestList';
 
 function makeGuest(overrides: Partial<EventGuest>): EventGuest {
   return {
-    userId: 'user-1',
-    name: 'Alex',
+    userId: 'user-other',
+    name: 'Other',
     status: RsvpServerStatus.Attending,
     phone: null,
     photoUrl: '',
@@ -29,7 +35,7 @@ function makeGuest(overrides: Partial<EventGuest>): EventGuest {
   };
 }
 
-function makeEvent(guests: EventGuest[]): Event {
+function makeEvent(overrides: Partial<Event>): Event {
   return {
     id: 'ev1',
     title: 'Potluck',
@@ -49,7 +55,7 @@ function makeEvent(guests: EventGuest[]): Event {
     rsvpEnabled: true,
     allowPlusOnes: true,
     maxAttendees: null,
-    attendingCount: guests.length,
+    attendingCount: 0,
     waitlistedCount: 0,
     invitedCount: 0,
     datetimeTbd: false,
@@ -62,9 +68,8 @@ function makeEvent(guests: EventGuest[]): Event {
     coHostNames: [],
     coHostPhotoUrls: [],
     coHostInviteIds: [],
-    guests,
+    guests: [makeGuest({})],
     myRsvp: null,
-    viewerUserId: null,
     surveySlugs: [],
     invitedUserIds: [],
     invitedUserNames: [],
@@ -79,31 +84,76 @@ function makeEvent(guests: EventGuest[]): Event {
     tags: [],
     isPast: false,
     status: EventStatus.Active,
+    viewerUserId: null,
+    ...overrides,
   };
 }
 
+function renderList(event: Event, canManageRsvps = false) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <RsvpGuestList event={event} canSeeInvited={false} canManageRsvps={canManageRsvps} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  setGuestRsvpMutate.mockReset();
+});
+
 describe('RsvpGuestList', () => {
   it('links member guests to their profile', () => {
-    const event = makeEvent([makeGuest({ userId: 'user-1', name: 'Alex', isMember: true })]);
-    render(
-      <MemoryRouter>
-        <RsvpGuestList event={event} canSeeInvited={false} />
-      </MemoryRouter>,
-    );
+    const event = makeEvent({
+      guests: [makeGuest({ userId: 'user-1', name: 'Alex', isMember: true })],
+    });
+    renderList(event);
     const link = screen.getByRole('link', { name: /alex/i });
     expect(link).toHaveAttribute('href', '/members/user-1');
   });
 
   it('renders non-member guests without a profile link', () => {
-    const event = makeEvent([
-      makeGuest({ userId: 'guest-1', name: 'Sam', isMember: false, hasPlusOne: true }),
-    ]);
-    render(
-      <MemoryRouter>
-        <RsvpGuestList event={event} canSeeInvited={false} />
-      </MemoryRouter>,
-    );
+    const event = makeEvent({
+      guests: [makeGuest({ userId: 'guest-1', name: 'Sam', isMember: false, hasPlusOne: true })],
+    });
+    renderList(event);
     expect(screen.queryByRole('link', { name: /sam/i })).not.toBeInTheDocument();
     expect(screen.getByText('Sam')).toBeInTheDocument();
+  });
+});
+
+describe('RsvpGuestList — host rsvp management (Issue 872)', () => {
+  it('does not show an edit control when the viewer cannot manage rsvps', () => {
+    renderList(makeEvent({}), false);
+    expect(screen.queryByRole('button', { name: /change other's rsvp/i })).not.toBeInTheDocument();
+  });
+
+  it('shows an edit control per guest when the viewer can manage rsvps', () => {
+    renderList(makeEvent({}), true);
+    expect(screen.getByRole('button', { name: /change other's rsvp/i })).toBeInTheDocument();
+  });
+
+  it('does not show an edit control for non-member guests', () => {
+    renderList(makeEvent({ guests: [makeGuest({ isMember: false })] }), true);
+    expect(screen.queryByRole('button', { name: /change other's rsvp/i })).not.toBeInTheDocument();
+  });
+
+  it('opens a dialog with status options when edit is tapped', () => {
+    renderList(makeEvent({}), true);
+    fireEvent.click(screen.getByRole('button', { name: /change other's rsvp/i }));
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^maybe$/i })).toBeInTheDocument();
+  });
+
+  it('calls the mutation with the selected status', () => {
+    renderList(makeEvent({}), true);
+    fireEvent.click(screen.getByRole('button', { name: /change other's rsvp/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^maybe$/i }));
+    expect(setGuestRsvpMutate).toHaveBeenCalledWith(
+      { userId: 'user-other', status: 'maybe', hasPlusOne: false },
+      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+    );
   });
 });

--- a/frontend/src/screens/events/RsvpGuestList.tsx
+++ b/frontend/src/screens/events/RsvpGuestList.tsx
@@ -3,9 +3,14 @@
 
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { toast } from 'sonner';
 
-import type { Event, EventGuest } from '@/models/event';
-import { AttendanceStatus, RsvpServerStatus } from '@/models/event';
+import { extractApiErrorOr } from '@/api/apiErrors';
+import { useSetGuestRsvp } from '@/api/eventStats';
+import { Dialog } from '@/components/ui/Dialog';
+import { RsvpStatusPicker } from '@/components/ui/RsvpStatusPicker';
+import type { Event, EventGuest, RsvpInputStatus } from '@/models/event';
+import { AttendanceStatus, isRsvpInputStatus, RsvpServerStatus } from '@/models/event';
 import { cn } from '@/utils/cn';
 
 type Tab = 'going' | 'maybe' | 'cant' | 'waitlist' | 'invited';
@@ -27,9 +32,10 @@ function bucket(guests: EventGuest[]): Record<Tab, EventGuest[]> {
 interface Props {
   event: Event;
   canSeeInvited: boolean;
+  canManageRsvps?: boolean;
 }
 
-export function RsvpGuestList({ event, canSeeInvited }: Props) {
+export function RsvpGuestList({ event, canSeeInvited, canManageRsvps = false }: Props) {
   const buckets = useMemo(() => bucket(event.guests), [event.guests]);
   const counts: Record<Tab, number> = {
     going: countWithPlusOnes(buckets.going),
@@ -88,7 +94,12 @@ export function RsvpGuestList({ event, canSeeInvited }: Props) {
       ) : (
         <div className="flex flex-wrap gap-2">
           {visible.map((g) => (
-            <GuestChip key={g.userId} guest={g} />
+            <GuestChip
+              key={g.userId}
+              guest={g}
+              eventId={event.id}
+              canEdit={canManageRsvps}
+            />
           ))}
         </div>
       )}
@@ -96,7 +107,17 @@ export function RsvpGuestList({ event, canSeeInvited }: Props) {
   );
 }
 
-function GuestChip({ guest }: { guest: EventGuest }) {
+function GuestChip({
+  guest,
+  eventId,
+  canEdit = false,
+}: {
+  guest: EventGuest;
+  eventId?: string;
+  canEdit?: boolean;
+}) {
+  const [editOpen, setEditOpen] = useState(false);
+
   const content = (
     <>
       {guest.photoUrl ? (
@@ -132,13 +153,74 @@ function GuestChip({ guest }: { guest: EventGuest }) {
   }
 
   return (
-    <Link
-      to={`/members/${guest.userId}`}
-      className="bg-surface-dim hover:bg-surface-dim/70 inline-flex items-center gap-1.5 rounded-full px-2 py-1 text-xs"
-      title={guest.name}
-    >
-      {content}
-    </Link>
+    <span className="bg-surface-dim hover:bg-surface-dim/70 inline-flex items-center gap-1 rounded-full pr-1 text-xs">
+      <Link
+        to={`/members/${guest.userId}`}
+        className="inline-flex items-center gap-1.5 py-1 pl-2"
+        title={guest.name}
+      >
+        {content}
+      </Link>
+      {canEdit && eventId ? (
+        <>
+          <button
+            type="button"
+            aria-label={`change ${guest.name}'s rsvp`}
+            onClick={() => {
+              setEditOpen(true);
+            }}
+            className="text-muted hover:text-foreground px-1"
+          >
+            edit
+          </button>
+          <EditGuestRsvpDialog
+            eventId={eventId}
+            guest={guest}
+            open={editOpen}
+            onClose={() => {
+              setEditOpen(false);
+            }}
+          />
+        </>
+      ) : null}
+    </span>
+  );
+}
+
+function EditGuestRsvpDialog({
+  eventId,
+  guest,
+  open,
+  onClose,
+}: {
+  eventId: string;
+  guest: EventGuest;
+  open: boolean;
+  onClose: () => void;
+}) {
+  const setGuestRsvp = useSetGuestRsvp(eventId);
+  const currentStatus = isRsvpInputStatus(guest.status) ? guest.status : null;
+
+  function changeStatus(status: RsvpInputStatus) {
+    setGuestRsvp.mutate(
+      { userId: guest.userId, status, hasPlusOne: guest.hasPlusOne },
+      {
+        onSuccess: onClose,
+        onError: (err) => {
+          toast.error(extractApiErrorOr(err, "couldn't update their rsvp — try again"));
+        },
+      },
+    );
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} title={`${guest.name}'s rsvp`}>
+      <RsvpStatusPicker
+        value={currentStatus}
+        disabled={setGuestRsvp.isPending}
+        onSelect={changeStatus}
+      />
+    </Dialog>
   );
 }
 

--- a/frontend/src/screens/events/RsvpGuestList.tsx
+++ b/frontend/src/screens/events/RsvpGuestList.tsx
@@ -94,12 +94,7 @@ export function RsvpGuestList({ event, canSeeInvited, canManageRsvps = false }: 
       ) : (
         <div className="flex flex-wrap gap-2">
           {visible.map((g) => (
-            <GuestChip
-              key={g.userId}
-              guest={g}
-              eventId={event.id}
-              canEdit={canManageRsvps}
-            />
+            <GuestChip key={g.userId} guest={g} eventId={event.id} canEdit={canManageRsvps} />
           ))}
         </div>
       )}

--- a/frontend/src/screens/events/RsvpSection.tsx
+++ b/frontend/src/screens/events/RsvpSection.tsx
@@ -21,6 +21,7 @@ import { RsvpGuestList } from './RsvpGuestList';
 interface Props {
   event: Event;
   canSeeInvited: boolean;
+  canManageRsvps?: boolean;
   token?: string;
 }
 
@@ -35,7 +36,7 @@ interface BoxState {
   initialStatus: RsvpInputStatus;
 }
 
-export function RsvpSection({ event, canSeeInvited, token }: Props) {
+export function RsvpSection({ event, canSeeInvited, canManageRsvps = false, token }: Props) {
   const setRsvp = useSetRsvp();
   const removeRsvp = useRemoveRsvp();
   const updatePublicRsvp = useUpdatePublicMyRsvp(token ?? '');
@@ -145,7 +146,11 @@ export function RsvpSection({ event, canSeeInvited, token }: Props) {
       ) : null}
 
       <div className="mt-2">
-        <RsvpGuestList event={event} canSeeInvited={canSeeInvited} />
+        <RsvpGuestList
+          event={event}
+          canSeeInvited={canSeeInvited}
+          canManageRsvps={canManageRsvps}
+        />
       </div>
 
       {box ? (


### PR DESCRIPTION
## Summary
- Split out of #893 to keep PRs under 500 lines. Stacked on #906 (the backend endpoint) and #905.
- Adds an edit control to each member `GuestChip` in `RsvpGuestList` — a host/co-host/manager can open a dialog and change a guest's rsvp status directly, using the endpoint from #906.
- Wires `canManageRsvps` through `EventMemberSection` → `RsvpSection` → `RsvpGuestList`.
- Adds `useSetGuestRsvp` hook.
- Non-member guests keep the existing grayed-out, no-edit treatment — editing is member-only since non-members have no account-linked rsvp status to change via this flow.
- Includes the merged version of `RsvpGuestList.tsx`/`.test.tsx` that also resolved the conflict with #892's non-member rendering treatment.

## Test plan
- [x] `make agent-frontend-typecheck`
- [x] `make agent-frontend-lint`
- [x] `RsvpGuestList.test.tsx`, `RsvpSection.test.tsx`, `EventMemberSection.test.tsx` — 53 passed