### PR TITLE
fix(events): live-update comments via sse event_updates channel (Issue 870)

### DIFF
--- a/backend/community/_event_comments.py
+++ b/backend/community/_event_comments.py
@@ -8,7 +8,11 @@ from django.db import transaction
 from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
-from notifications.service import notify_comment_reply, notify_event_comment
+from notifications.service import (
+    broadcast_event_update,
+    notify_comment_reply,
+    notify_event_comment,
+)
 from users._helpers import visible_display_name
 from users.permissions import PermissionKey
 
@@ -217,6 +221,7 @@ def post_comment(request, event_id: UUID, payload: CommentBodyIn):
     with transaction.atomic():
         comment = EventComment.objects.create(event=event, author=user, body=payload.body)
         notify_event_comment(comment)
+    broadcast_event_update(event, exclude_user_ids={str(user.pk)})
     return Status(201, _comment_out(comment, event, user))
 
 
@@ -257,6 +262,7 @@ def post_reply(request, event_id: UUID, comment_id: UUID, payload: CommentBodyIn
             event=event, author=user, body=payload.body, parent=parent
         )
         notify_comment_reply(reply)
+    broadcast_event_update(event, exclude_user_ids={str(user.pk)})
     return Status(201, _comment_reply_out(reply, event, user))
 
 
@@ -287,6 +293,7 @@ def delete_comment(request, event_id: UUID, comment_id: UUID):
         with transaction.atomic():
             comment.deleted_at = timezone.now()
             comment.save(update_fields=["deleted_at", "updated_at"])
+        broadcast_event_update(event, exclude_user_ids={str(user.pk)})
     return Status(204, None)
 
 

--- a/backend/tests/test_event_comments.py
+++ b/backend/tests/test_event_comments.py
@@ -1,6 +1,7 @@
 """End-to-end tests for the event comments API."""
 
 import json
+from unittest.mock import patch
 
 import pytest
 from community.models import (
@@ -136,6 +137,18 @@ class TestPostComment:
         )
         assert response.status_code == 422
 
+    def test_post_broadcasts_event_update(self, api_client, rsvp_headers, event_with_rsvp):
+        with patch("community._event_comments.broadcast_event_update") as mock_broadcast:
+            response = api_client.post(
+                f"/api/community/events/{event_with_rsvp.id}/comments/",
+                data=json.dumps({"body": "first comment"}),
+                content_type="application/json",
+                **rsvp_headers,
+            )
+        assert response.status_code == 201, response.content
+        mock_broadcast.assert_called_once()
+        assert mock_broadcast.call_args.args[0].id == event_with_rsvp.id
+
 
 @pytest.mark.django_db
 class TestPostReply:
@@ -166,6 +179,21 @@ class TestPostReply:
         )
         assert response.status_code == 422
         assert response.json()["detail"][0]["code"] == "comment.reply_depth_exceeded"
+
+    def test_reply_broadcasts_event_update(
+        self, api_client, rsvp_headers, event_with_rsvp, rsvp_user
+    ):
+        parent = EventComment.objects.create(event=event_with_rsvp, author=rsvp_user, body="parent")
+        with patch("community._event_comments.broadcast_event_update") as mock_broadcast:
+            response = api_client.post(
+                f"/api/community/events/{event_with_rsvp.id}/comments/{parent.id}/replies/",
+                data=json.dumps({"body": "reply"}),
+                content_type="application/json",
+                **rsvp_headers,
+            )
+        assert response.status_code == 201, response.content
+        mock_broadcast.assert_called_once()
+        assert mock_broadcast.call_args.args[0].id == event_with_rsvp.id
 
     def test_reply_to_deleted_parent_404(
         self, api_client, rsvp_headers, event_with_rsvp, rsvp_user
@@ -280,6 +308,19 @@ class TestDeleteComment:
         )
         assert first.status_code == 204
         assert second.status_code == 204
+
+    def test_delete_broadcasts_event_update(
+        self, api_client, rsvp_headers, event_with_rsvp, rsvp_user
+    ):
+        comment = EventComment.objects.create(event=event_with_rsvp, author=rsvp_user, body="mine")
+        with patch("community._event_comments.broadcast_event_update") as mock_broadcast:
+            response = api_client.delete(
+                f"/api/community/events/{event_with_rsvp.id}/comments/{comment.id}/",
+                **rsvp_headers,
+            )
+        assert response.status_code == 204
+        mock_broadcast.assert_called_once()
+        assert mock_broadcast.call_args.args[0].id == event_with_rsvp.id
 
 
 @pytest.mark.django_db

--- a/frontend/src/layout/NotificationBell.tsx
+++ b/frontend/src/layout/NotificationBell.tsx
@@ -45,6 +45,7 @@ export function NotificationBell() {
       // for anyone who happens to be looking at the event right now.
       event_updated: () => {
         void qc.invalidateQueries({ queryKey: ['events'] });
+        void qc.invalidateQueries({ queryKey: ['event-comments'] });
       },
     },
   });


### PR DESCRIPTION
## Summary
- Comment create/reply/delete never called `broadcast_event_update()`, so other viewers watching the same event never got an SSE ping telling them to refetch comments — hence "you need to refresh to see new comments from other people" (Issue 870).
- The frontend's `event_updated` SSE handler in `NotificationBell.tsx` also only invalidated the `['events']` query key, not `['event-comments']`, so even a broadcast wouldn't have refreshed the comments list.
- Wired `post_comment`, `post_reply`, and `delete_comment` in `backend/community/_event_comments.py` into the existing `broadcast_event_update()` helper — the same mechanism RSVP/cohost changes already use — excluding the acting user (they already have the fresh state from the response).
- Added `event-comments` invalidation to the `event_updated` handler in `frontend/src/layout/NotificationBell.tsx`.

Closes #870

## Test plan
- [x] `uv run pytest tests/test_event_comments.py tests/test_rsvp_comment.py tests/test_comment_notifications.py tests/test_event_comments_nonmember_token.py -q` — 53 passed, including new assertions that `broadcast_event_update` is called on post/reply/delete
- [x] `npx vitest run src/layout/NotificationBell.test.tsx` — 12 passed
- [x] `npx tsc --noEmit` — clean
- [ ] Manual end-to-end SSE verification wasn't possible in this worktree (SQLite dev db; `pg_notify`/SSE returns 503 outside Postgres) — relied on reading the existing broadcast wiring pattern (RSVP/cohost) and the unit tests above.