### PR TITLE
fix(events): default visibility to members-only except official/club (Issue 895)

### DIFF
--- a/frontend/src/api/eventWrites.ts
+++ b/frontend/src/api/eventWrites.ts
@@ -308,7 +308,7 @@ export function emptyEventFormValues(): EventFormValues {
     endDatetime: null,
     datetimeTbd: false,
     eventType: 'community',
-    visibility: 'public',
+    visibility: 'members_only',
     invitePermission: 'all_members',
     rsvpEnabled: true,
     allowPlusOnes: true,

--- a/frontend/src/screens/events/form/EventFormType.test.tsx
+++ b/frontend/src/screens/events/form/EventFormType.test.tsx
@@ -59,7 +59,7 @@ describe('EventFormType', () => {
     expect(onChange).toHaveBeenCalledWith({ eventType: 'club', visibility: 'public' });
   });
 
-  it('turning a type off reverts to community (still public)', async () => {
+  it('turning a type off reverts to community without forcing visibility', async () => {
     const onChange = vi.fn();
     render(
       <EventFormType
@@ -70,7 +70,7 @@ describe('EventFormType', () => {
       />,
     );
     await userEvent.click(screen.getByRole('switch'));
-    expect(onChange).toHaveBeenCalledWith({ eventType: 'community', visibility: 'public' });
+    expect(onChange).toHaveBeenCalledWith({ eventType: 'community' });
   });
 
   it('with both permissions, the club toggle is off while official is selected', () => {

--- a/frontend/src/screens/events/form/EventFormType.tsx
+++ b/frontend/src/screens/events/form/EventFormType.tsx
@@ -9,12 +9,16 @@ interface Props {
   canTagClub: boolean;
 }
 
-// Single-valued event_type makes the toggles mutually exclusive; both force public.
+// Single-valued event_type makes the toggles mutually exclusive; only official/club force public.
 export function EventFormType({ values, onChange, canTagOfficial, canTagClub }: Props) {
   if (!canTagOfficial && !canTagClub) return null;
 
   const setType = (type: EventFormValues['eventType']) => {
-    onChange({ eventType: type, visibility: EventVisibility.Public });
+    const isPublicOnly = type === EventType.Official || type === EventType.Club;
+    onChange({
+      eventType: type,
+      ...(isPublicOnly ? { visibility: EventVisibility.Public } : {}),
+    });
   };
 
   return (


### PR DESCRIPTION
## Summary
- `emptyEventFormValues` now defaults `visibility` to `members_only` instead of `public` (new events start as `community` type, which has no public-visibility requirement)
- `EventFormType`'s `setType` now only forces/locks `visibility` to `public` when switching to `official` or `club` — switching to `community` no longer resets visibility
- Updated `EventFormType.test.tsx` to reflect that toggling off official/club (reverting to community) no longer forces public visibility

Closes #895

## Test plan
- [x] `npx vitest run src/screens/events/form/EventFormType.test.tsx src/screens/events/form/EventFormDetails.test.tsx src/api/eventWrites.test.ts` — 21 passed
- [x] `make agent-frontend-typecheck` — clean
- [ ] manual: create a new event, confirm it defaults to "members only"; toggle official/club on, confirm visibility locks to public; toggle back to community, confirm visibility is not reset to public