### PR TITLE
fix: 918 - stop leaking rsvp token via shareable event url

### DIFF
--- a/frontend/src/screens/events/PublicRsvpSection.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpSection.test.tsx
@@ -141,10 +141,7 @@ describe('PublicRsvpSection', () => {
     await user.type(screen.getByLabelText(/^email/i), 'sam@example.com');
     await user.click(screen.getByRole('button', { name: 'rsvp' }));
 
-    // issue 918: no url param — the event url is what people share, and a
-    // token there would leak the rsvp identity to whoever they share it with
     expect(mockNavigate).toHaveBeenCalledWith(0);
-    // persisted so the token survives navigation to another event (issue 873)
     expect(localStorage.getItem('pda-rsvp-token')).toBe('tok-abc');
   });
 

--- a/frontend/src/screens/events/PublicRsvpSection.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpSection.test.tsx
@@ -119,7 +119,7 @@ describe('PublicRsvpSection', () => {
     expect(screen.getByRole('heading', { name: 'rsvp' })).toBeInTheDocument();
   });
 
-  it('navigates to the event page with the rsvp token on success', async () => {
+  it('persists the rsvp token and refreshes without putting it in the url', async () => {
     mockCheckPhone.mockResolvedValue({ status: 'new', rsvp_token: '' });
     mockSubmit.mockResolvedValue({
       event: makeEvent(),
@@ -141,9 +141,9 @@ describe('PublicRsvpSection', () => {
     await user.type(screen.getByLabelText(/^email/i), 'sam@example.com');
     await user.click(screen.getByRole('button', { name: 'rsvp' }));
 
-    expect(mockNavigate).toHaveBeenCalledWith('/events/evt-1?rsvp_token=tok-abc', {
-      replace: true,
-    });
+    // issue 918: no url param — the event url is what people share, and a
+    // token there would leak the rsvp identity to whoever they share it with
+    expect(mockNavigate).toHaveBeenCalledWith(0);
     // persisted so the token survives navigation to another event (issue 873)
     expect(localStorage.getItem('pda-rsvp-token')).toBe('tok-abc');
   });
@@ -165,7 +165,7 @@ describe('PublicRsvpSection', () => {
     expect(screen.queryByLabelText(/first name/i)).not.toBeInTheDocument();
   });
 
-  it('navigates straight to the event page when already rsvpd, skipping the form', async () => {
+  it('unlocks the event page when already rsvpd, skipping the form', async () => {
     mockCheckPhone.mockResolvedValue({ status: 'already_rsvpd', rsvp_token: 'tok-returning' });
     const user = userEvent.setup();
     render(
@@ -178,9 +178,7 @@ describe('PublicRsvpSection', () => {
     await user.type(screen.getByLabelText(/phone number/i), '4155550123');
     await user.click(screen.getByRole('button', { name: 'continue' }));
 
-    expect(mockNavigate).toHaveBeenCalledWith('/events/evt-1?rsvp_token=tok-returning', {
-      replace: true,
-    });
+    expect(mockNavigate).toHaveBeenCalledWith(0);
     expect(mockSubmit).not.toHaveBeenCalled();
     expect(localStorage.getItem('pda-rsvp-token')).toBe('tok-returning');
   });

--- a/frontend/src/screens/events/PublicRsvpSection.tsx
+++ b/frontend/src/screens/events/PublicRsvpSection.tsx
@@ -15,11 +15,7 @@ export function PublicRsvpSection({ event }: Props) {
   const [isMember, setIsMember] = useState(false);
 
   function unlockWithToken(token: string) {
-    // Persist so the token survives navigation — a returning non-member
-    // reuses it across events instead of re-filling the form (issue #873).
-    // Kept out of the URL (issue #918) — this page's URL is what people
-    // copy/paste to share the event, and a token there would leak whoever
-    // clicks it into the sharer's RSVP identity.
+    // kept out of the url — this page's url is shared, and a token there would leak rsvp identity
     setStoredRsvpToken(token);
     void navigate(0);
   }

--- a/frontend/src/screens/events/PublicRsvpSection.tsx
+++ b/frontend/src/screens/events/PublicRsvpSection.tsx
@@ -17,10 +17,11 @@ export function PublicRsvpSection({ event }: Props) {
   function unlockWithToken(token: string) {
     // Persist so the token survives navigation — a returning non-member
     // reuses it across events instead of re-filling the form (issue #873).
+    // Kept out of the URL (issue #918) — this page's URL is what people
+    // copy/paste to share the event, and a token there would leak whoever
+    // clicks it into the sharer's RSVP identity.
     setStoredRsvpToken(token);
-    void navigate(`/events/${event.id}?rsvp_token=${encodeURIComponent(token)}`, {
-      replace: true,
-    });
+    void navigate(0);
   }
 
   if (isMember) return <MemberSignInPrompt />;


### PR DESCRIPTION
## Overview

Non-member RSVP confirmations were stamping the rsvp token onto the event detail page URL (`/events/:id?rsvp_token=...`) before navigating there. That URL is exactly what someone would copy and share (e.g. into a group chat) — so sharing an event link after RSVPing could hand the recipient the sharer's own RSVP identity (viewer unlock, RSVP status, member-only detail visibility).

The token was already persisted to `localStorage` for cross-event reuse (issue #873, "returning non-member" flow), so the fix drops the `?rsvp_token=` URL param entirely and just refreshes the current route — the stored token still unlocks the view for the original browser/device, but the shareable URL is now clean.

Closes #918

## Test plan

- [x] `npx vitest run src/screens/events/PublicRsvpSection.test.tsx src/screens/events/EventDetailScreen.test.tsx src/screens/events/PublicRsvpsScreen.test.tsx` — 40 passed
- [x] `make agent-frontend-typecheck` — clean
- [x] `make agent-frontend-lint` — clean
- [ ] TODO: manual smoke test — RSVP as a non-member, confirm the URL bar shows a clean `/events/:id` with no token, and that revisiting the same event in the same browser still shows the RSVP as unlocked
