### PR TITLE
fix: 920 - comment reply bug for non-member rsvp viewers

### DIFF
--- a/frontend/src/screens/events/comments/CommentItem.test.tsx
+++ b/frontend/src/screens/events/comments/CommentItem.test.tsx
@@ -1,12 +1,15 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
+
+const { mockPost } = vi.hoisted(() => ({ mockPost: vi.fn().mockResolvedValue({ data: {} }) }));
 
 vi.mock('@/api/client', () => ({
   apiClient: {
     get: vi.fn(),
-    post: vi.fn(),
+    post: mockPost,
     delete: vi.fn(),
   },
 }));
@@ -67,5 +70,20 @@ describe('CommentItem', () => {
       />,
     );
     expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
+  });
+
+  it('includes the rsvp token when a non-member posts a reply', async () => {
+    mockPost.mockClear();
+    const user = userEvent.setup();
+    wrap(<CommentItem comment={baseComment} eventId="evt" token="rsvp-token" canReact canReply />);
+    await user.click(screen.getByRole('button', { name: 'reply' }));
+    await user.type(screen.getByPlaceholderText('reply…'), 'hi there');
+    await user.click(screen.getByRole('button', { name: 'post' }));
+
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/community/events/evt/comments/c1/replies/',
+      { body: 'hi there' },
+      { params: { token: 'rsvp-token' } },
+    );
   });
 });

--- a/frontend/src/screens/events/comments/CommentItem.tsx
+++ b/frontend/src/screens/events/comments/CommentItem.tsx
@@ -14,15 +14,23 @@ import { formatRelative } from './utils';
 interface Props {
   comment: EventComment;
   eventId: string;
+  token?: string;
   canReact: boolean;
   canReply: boolean;
   reactDisabledReason?: string | undefined;
 }
 
-export function CommentItem({ comment, eventId, canReact, canReply, reactDisabledReason }: Props) {
-  const toggleReaction = useToggleReaction(eventId);
-  const deleteComment = useDeleteComment(eventId);
-  const postReply = usePostReply(eventId);
+export function CommentItem({
+  comment,
+  eventId,
+  token,
+  canReact,
+  canReply,
+  reactDisabledReason,
+}: Props) {
+  const toggleReaction = useToggleReaction(eventId, token);
+  const deleteComment = useDeleteComment(eventId, token);
+  const postReply = usePostReply(eventId, token);
   const [replyOpen, setReplyOpen] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
 
@@ -119,6 +127,7 @@ export function CommentItem({ comment, eventId, canReact, canReply, reactDisable
               key={reply.id}
               reply={reply}
               eventId={eventId}
+              {...(token ? { token } : {})}
               canReact={canReact}
               reactDisabledReason={reactDisabledReason}
             />

--- a/frontend/src/screens/events/comments/CommentThread.tsx
+++ b/frontend/src/screens/events/comments/CommentThread.tsx
@@ -5,6 +5,7 @@ import { CommentItem } from './CommentItem';
 interface Props {
   comments: EventComment[];
   eventId: string;
+  token?: string;
   canReact: boolean;
   canReply: boolean;
   reactDisabledReason?: string | undefined;
@@ -13,6 +14,7 @@ interface Props {
 export function CommentThread({
   comments,
   eventId,
+  token,
   canReact,
   canReply,
   reactDisabledReason,
@@ -27,6 +29,7 @@ export function CommentThread({
           key={c.id}
           comment={c}
           eventId={eventId}
+          {...(token ? { token } : {})}
           canReact={canReact}
           canReply={canReply}
           reactDisabledReason={reactDisabledReason}

--- a/frontend/src/screens/events/comments/EventCommentsCard.tsx
+++ b/frontend/src/screens/events/comments/EventCommentsCard.tsx
@@ -84,6 +84,7 @@ export function EventCommentsCard({ eventId, token }: Props) {
       <CommentThread
         comments={data.items}
         eventId={eventId}
+        {...(token ? { token } : {})}
         canReact={canReact}
         canReply={data.canPost}
         reactDisabledReason={reactDisabledReason}

--- a/frontend/src/screens/events/comments/ReplyItem.tsx
+++ b/frontend/src/screens/events/comments/ReplyItem.tsx
@@ -10,13 +10,14 @@ import { formatRelative } from './utils';
 interface Props {
   reply: EventCommentReply;
   eventId: string;
+  token?: string;
   canReact: boolean;
   reactDisabledReason?: string | undefined;
 }
 
-export function ReplyItem({ reply, eventId, canReact, reactDisabledReason }: Props) {
-  const toggleReaction = useToggleReaction(eventId);
-  const deleteComment = useDeleteComment(eventId);
+export function ReplyItem({ reply, eventId, token, canReact, reactDisabledReason }: Props) {
+  const toggleReaction = useToggleReaction(eventId, token);
+  const deleteComment = useDeleteComment(eventId, token);
   const [confirmOpen, setConfirmOpen] = useState(false);
 
   const handleToggle = (emoji: ReactionEmojiValue) => {


### PR DESCRIPTION
## Overview

Non-member RSVP-token viewers could post top-level comments on an event but got a 403 when replying to an existing comment (or reacting/deleting).

Root cause: `usePostReply`, `useToggleReaction`, and `useDeleteComment` all accept an optional `token` param that gets forwarded as a `?token=` query param to the backend (where `resolve_event_viewer` uses it to resolve a non-member viewer). `EventCommentsCard` received the `token` prop and passed it to `usePostComment` correctly, but never threaded it down through `CommentThread` -> `CommentItem` -> `ReplyItem`, so those three hooks were always called without a token. For an RSVP-token-authenticated non-member, that meant the reply/react/delete requests resolved to no viewer at all, and `_require_rsvp_for_post` / `_can_delete_comment` rejected them.

Fix: thread `token` as a prop through `CommentThread`, `CommentItem`, and `ReplyItem`, mirroring how `EventCommentsCard` already passes it to `usePostComment`.

Closes #920

## Test plan

- [x] `npx vitest run src/screens/events/comments/CommentItem.test.tsx src/screens/events/comments/EventCommentsCard.test.tsx src/screens/events/EventMemberSection.test.tsx` — added a regression test verifying the rsvp token is included when a non-member posts a reply
- [x] `make agent-frontend-typecheck`
- [x] `make agent-frontend-lint`
