### PR TITLE
fix: 919 - live comments still not working

### DIFF
--- a/backend/community/_event_comments.py
+++ b/backend/community/_event_comments.py
@@ -9,7 +9,7 @@ from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
 from notifications.service import (
-    broadcast_event_update,
+    broadcast_event_comment_update,
     notify_comment_reply,
     notify_event_comment,
 )
@@ -221,7 +221,7 @@ def post_comment(request, event_id: UUID, payload: CommentBodyIn):
     with transaction.atomic():
         comment = EventComment.objects.create(event=event, author=user, body=payload.body)
         notify_event_comment(comment)
-    broadcast_event_update(event, exclude_user_ids={str(user.pk)})
+    broadcast_event_comment_update(event)
     return Status(201, _comment_out(comment, event, user))
 
 
@@ -262,7 +262,7 @@ def post_reply(request, event_id: UUID, comment_id: UUID, payload: CommentBodyIn
             event=event, author=user, body=payload.body, parent=parent
         )
         notify_comment_reply(reply)
-    broadcast_event_update(event, exclude_user_ids={str(user.pk)})
+    broadcast_event_comment_update(event)
     return Status(201, _comment_reply_out(reply, event, user))
 
 
@@ -293,7 +293,7 @@ def delete_comment(request, event_id: UUID, comment_id: UUID):
         with transaction.atomic():
             comment.deleted_at = timezone.now()
             comment.save(update_fields=["deleted_at", "updated_at"])
-        broadcast_event_update(event, exclude_user_ids={str(user.pk)})
+        broadcast_event_comment_update(event)
     return Status(204, None)
 
 

--- a/backend/notifications/service.py
+++ b/backend/notifications/service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from community.models import RSVPStatus
+from community.models import PageVisibility, RSVPStatus
 from django.db import DatabaseError, connection
 from users._helpers import visible_display_name
 from users.models import User
@@ -50,6 +50,20 @@ def _ping_event_update(user_ids: Iterable[str], event_id: str) -> None:
                 cursor.execute(f"SELECT pg_notify('{_EVENT_UPDATES_CHANNEL}', %s)", [payload])
     except DatabaseError:
         logging.getLogger(__name__).warning("event_update ping failed", exc_info=True)
+
+
+def broadcast_event_comment_update(event: Event) -> None:
+    """Live-update ping for anyone who can view this event's comments.
+
+    Comments are readable by any member who can see the event, not just
+    RSVP'd/invited stakeholders, so this pings every connected viewer for
+    public/members-only events. Invite-only events stay scoped to the people
+    who can actually see them, matching `broadcast_event_update`.
+    """
+    if event.visibility == PageVisibility.INVITE_ONLY:
+        broadcast_event_update(event)
+        return
+    _ping_event_update(["*"], str(event.pk))
 
 
 def broadcast_cohost_change(

--- a/backend/notifications/sse.py
+++ b/backend/notifications/sse.py
@@ -60,9 +60,10 @@ def _format_notify_for_user(channel: str, payload: str, user_id: str) -> str | N
             return f"event: notification\ndata: {json.dumps({'type': 'notification'})}\n\n"
         return None
     if channel == _EVENT_UPDATES_CHANNEL:
-        # Payload format: "<user_id>:<event_id>"
+        # Payload format: "<user_id-or-*>:<event_id>". "*" broadcasts to every
+        # connected viewer (used for changes visible to any member, e.g. comments).
         target_user, _, event_id = payload.partition(":")
-        if target_user == user_id and event_id:
+        if target_user in (user_id, "*") and event_id:
             return f"event: event_updated\ndata: {json.dumps({'event_id': event_id})}\n\n"
         return None
     return None

--- a/backend/tests/test_event_comments.py
+++ b/backend/tests/test_event_comments.py
@@ -138,7 +138,7 @@ class TestPostComment:
         assert response.status_code == 422
 
     def test_post_broadcasts_event_update(self, api_client, rsvp_headers, event_with_rsvp):
-        with patch("community._event_comments.broadcast_event_update") as mock_broadcast:
+        with patch("community._event_comments.broadcast_event_comment_update") as mock_broadcast:
             response = api_client.post(
                 f"/api/community/events/{event_with_rsvp.id}/comments/",
                 data=json.dumps({"body": "first comment"}),
@@ -184,7 +184,7 @@ class TestPostReply:
         self, api_client, rsvp_headers, event_with_rsvp, rsvp_user
     ):
         parent = EventComment.objects.create(event=event_with_rsvp, author=rsvp_user, body="parent")
-        with patch("community._event_comments.broadcast_event_update") as mock_broadcast:
+        with patch("community._event_comments.broadcast_event_comment_update") as mock_broadcast:
             response = api_client.post(
                 f"/api/community/events/{event_with_rsvp.id}/comments/{parent.id}/replies/",
                 data=json.dumps({"body": "reply"}),
@@ -313,7 +313,7 @@ class TestDeleteComment:
         self, api_client, rsvp_headers, event_with_rsvp, rsvp_user
     ):
         comment = EventComment.objects.create(event=event_with_rsvp, author=rsvp_user, body="mine")
-        with patch("community._event_comments.broadcast_event_update") as mock_broadcast:
+        with patch("community._event_comments.broadcast_event_comment_update") as mock_broadcast:
             response = api_client.delete(
                 f"/api/community/events/{event_with_rsvp.id}/comments/{comment.id}/",
                 **rsvp_headers,

--- a/backend/tests/test_sse.py
+++ b/backend/tests/test_sse.py
@@ -5,6 +5,22 @@ from datetime import timedelta
 import pytest
 from django.utils import timezone
 from ninja_jwt.tokens import RefreshToken
+from notifications.sse import _format_notify_for_user
+
+
+class TestFormatNotifyForUser:
+    def test_event_update_matches_target_user(self):
+        frame = _format_notify_for_user("event_updates", "user-1:event-1", "user-1")
+        assert frame is not None
+        assert "event: event_updated" in frame
+
+    def test_event_update_skips_other_user(self):
+        assert _format_notify_for_user("event_updates", "user-1:event-1", "user-2") is None
+
+    def test_event_update_wildcard_matches_any_user(self):
+        frame = _format_notify_for_user("event_updates", "*:event-1", "user-2")
+        assert frame is not None
+        assert "event: event_updated" in frame
 
 
 def _auth_headers(user) -> dict:


### PR DESCRIPTION
## Overview

The previous fix for live comments (Issue 870, PR #914) wired `broadcast_event_update()` into the comment create/reply/delete endpoints and had the frontend `NotificationBell` invalidate the `event-comments` query cache on `event_updated` SSE frames. That mechanism is sound, but `broadcast_event_update()` scopes its pg_notify recipients to the event's *stakeholders* (creator, co-hosts, invited users, and RSVP'd attendees/maybes) — not to everyone who can actually view the event.

Comments, however, are readable by any member who can view the event, regardless of RSVP status. A member just browsing an event page (without RSVPing) never appeared in the broadcast's recipient list, so they never received the `event_updated` ping and their comments feed never refreshed live — even though the backend broadcast call fired correctly on every mutation.

Fix: add `broadcast_event_comment_update()`, which pings **all** connected SSE viewers (via a wildcard `"*"` pg_notify payload) for public/members-only events, since anyone can view those. Invite-only events keep the existing stakeholder-scoped broadcast, since visibility there is already restricted to that same set. `_format_notify_for_user` in the SSE layer now treats `"*"` as a wildcard match for any connected user.

Comment create/reply/delete now call `broadcast_event_comment_update()` instead of the RSVP-scoped `broadcast_event_update()`.

Closes #919

## Test plan

- [x] `backend/tests/test_event_comments.py` — updated broadcast mocks to the new function name, all pass
- [x] `backend/tests/test_sse.py` — added `TestFormatNotifyForUser` covering the new wildcard-match branch, all pass
- [x] `backend/tests/test_rsvp.py::*broadcast*` — confirms the untouched RSVP-scoped `broadcast_event_update()` call site still behaves correctly
- [x] `make agent-lint` / `make agent-typecheck` — clean
- Note: `TestSseStreamAuth` in `test_sse.py` has 5 pre-existing failures on SQLite (503 — SSE requires Postgres for `pg_notify`/`LISTEN`); unrelated to this change and not something introduced here.
- [ ] TODO: manual verification against Postgres (two logged-in, non-RSVP'd members viewing the same event; post a comment from one, confirm it appears live for the other) — not run in this session (no local Postgres available).
