### PR TITLE
feat(onboarding): add pronouns, birthday, and privacy toggles (Issue 923)

### DIFF
--- a/frontend/src/screens/auth/OnboardingProfileStep.test.tsx
+++ b/frontend/src/screens/auth/OnboardingProfileStep.test.tsx
@@ -71,17 +71,38 @@ describe('OnboardingProfileStep', () => {
 
   it('saves a non-empty bio then finishes when "done" is clicked', async () => {
     render(<OnboardingProfileStep onDone={onDone} />);
-    await userEvent.type(screen.getByLabelText(/bio/i), 'i love tofu');
+    await userEvent.type(screen.getByLabelText(/^bio$/i), 'i love tofu');
     await userEvent.click(screen.getByRole('button', { name: /^done$/i }));
     expect(updateProfile).toHaveBeenCalledWith({ bio: 'i love tofu' });
     expect(onDone).toHaveBeenCalledTimes(1);
   });
 
-  it('finishes without calling updateProfile when bio is left empty', async () => {
+  it('finishes without calling updateProfile when bio and pronouns are left empty', async () => {
     render(<OnboardingProfileStep onDone={onDone} />);
     await userEvent.click(screen.getByRole('button', { name: /^done$/i }));
     expect(updateProfile).not.toHaveBeenCalled();
     expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it('saves non-empty pronouns then finishes when "done" is clicked', async () => {
+    render(<OnboardingProfileStep onDone={onDone} />);
+    await userEvent.type(screen.getByLabelText(/pronouns/i), 'they/them');
+    await userEvent.click(screen.getByRole('button', { name: /^done$/i }));
+    expect(updateProfile).toHaveBeenCalledWith({ pronouns: 'they/them' });
+    expect(onDone).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows privacy toggles including show birthday', () => {
+    render(<OnboardingProfileStep onDone={onDone} />);
+    expect(screen.getByText(/show birthday on my profile/i)).toBeInTheDocument();
+    expect(screen.getByText(/show phone on my profile/i)).toBeInTheDocument();
+    expect(screen.getByText(/show email on my profile/i)).toBeInTheDocument();
+  });
+
+  it('shows a birthday field with an edit control', () => {
+    render(<OnboardingProfileStep onDone={onDone} />);
+    expect(screen.getByText(/^birthday$/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /edit birthday/i })).toBeInTheDocument();
   });
 
   it('shows the "photo added" confirmation once a profile photo exists', () => {

--- a/frontend/src/screens/auth/OnboardingProfileStep.tsx
+++ b/frontend/src/screens/auth/OnboardingProfileStep.tsx
@@ -3,7 +3,10 @@ import { useState } from 'react';
 import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import { Textarea } from '@/components/ui/Textarea';
+import { TextField } from '@/components/ui/TextField';
 import { AvatarUpload } from '@/screens/settings/AvatarUpload';
+import { InlineBirthday } from '@/screens/settings/InlineBirthday';
+import { PrivacyToggles } from '@/screens/settings/PrivacyToggles';
 import { extractApiError } from '@/utils/errors';
 
 const MAX_BIO = 500;
@@ -16,28 +19,35 @@ export function OnboardingProfileStep({ onDone }: Props) {
   const user = useAuthStore((s) => s.user);
   const updateProfile = useAuthStore((s) => s.updateProfile);
   const [bio, setBio] = useState('');
+  const [pronouns, setPronouns] = useState('');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const hasPhoto = Boolean(user?.profilePhotoUrl);
 
   async function onFinish() {
-    const trimmed = bio.trim();
-    if (!trimmed) {
+    const trimmedBio = bio.trim();
+    const trimmedPronouns = pronouns.trim();
+    if (!trimmedBio && !trimmedPronouns) {
       onDone();
       return;
     }
     setError(null);
     setSaving(true);
     try {
-      await updateProfile({ bio: trimmed });
+      await updateProfile({
+        ...(trimmedBio ? { bio: trimmedBio } : {}),
+        ...(trimmedPronouns ? { pronouns: trimmedPronouns } : {}),
+      });
       onDone();
     } catch (err) {
-      setError(extractApiError(err, "couldn't save your bio — try again"));
+      setError(extractApiError(err, "couldn't save your profile — try again"));
     } finally {
       setSaving(false);
     }
   }
+
+  if (!user) return null;
 
   return (
     <div className="flex flex-col gap-5">
@@ -55,6 +65,24 @@ export function OnboardingProfileStep({ onDone }: Props) {
         rows={4}
         hint="optional — a sentence or two about you"
       />
+      <TextField
+        label="pronouns (optional)"
+        placeholder="e.g. she/her, they/them"
+        value={pronouns}
+        onChange={(e) => {
+          setPronouns(e.target.value);
+        }}
+      />
+      <InlineBirthday
+        label="birthday"
+        value={user.birthday}
+        onSave={(v) => updateProfile({ birthday: v })}
+        placeholder="add your birthday"
+      />
+      <div>
+        <p className="text-foreground-tertiary mb-2 text-sm">privacy</p>
+        <PrivacyToggles user={user} onChange={(patch) => void updateProfile(patch)} />
+      </div>
       {error ? (
         <p role="alert" className="text-destructive text-sm">
           {error}

--- a/frontend/src/screens/auth/OnboardingProfileStep.tsx
+++ b/frontend/src/screens/auth/OnboardingProfileStep.tsx
@@ -51,6 +51,9 @@ export function OnboardingProfileStep({ onDone }: Props) {
 
   return (
     <div className="flex flex-col gap-5">
+      <p className="text-foreground-tertiary text-sm">
+        totally optional — fill in what you want, skip the rest, change it later in settings
+      </p>
       <div className="flex flex-col items-center gap-2">
         <AvatarUpload size="lg" />
         {hasPhoto ? <p className="text-foreground-tertiary text-sm">✓ photo added</p> : null}

--- a/frontend/src/screens/settings/InlineBirthday.tsx
+++ b/frontend/src/screens/settings/InlineBirthday.tsx
@@ -1,0 +1,162 @@
+import { getDaysInMonth } from 'date-fns';
+import { useState } from 'react';
+
+import { extractApiErrorOr } from '@/api/apiErrors';
+import { Button } from '@/components/ui/Button';
+import { Select } from '@/components/ui/Select';
+import type { Birthday } from '@/models/user';
+import { formatBirthday } from '@/utils/datetime';
+
+const MONTH_OPTIONS = [
+  'january',
+  'february',
+  'march',
+  'april',
+  'may',
+  'june',
+  'july',
+  'august',
+  'september',
+  'october',
+  'november',
+  'december',
+].map((name, i) => ({ value: String(i + 1), label: name }));
+
+const NO_YEAR = '';
+const CURRENT_YEAR = new Date().getFullYear();
+const YEAR_OPTIONS = [
+  { value: NO_YEAR, label: 'prefer not to say' },
+  ...Array.from({ length: 120 }, (_, i) => {
+    const year = CURRENT_YEAR - i;
+    return { value: String(year), label: String(year) };
+  }),
+];
+
+function dayOptions(month: number | null) {
+  const count = month ? getDaysInMonth(new Date(2000, month - 1)) : 31;
+  return Array.from({ length: count }, (_, i) => ({ value: String(i + 1), label: String(i + 1) }));
+}
+
+export function InlineBirthday({
+  label,
+  value,
+  onSave,
+  placeholder,
+}: {
+  label: string;
+  value: Birthday | null;
+  onSave: (v: Birthday | null) => Promise<void>;
+  placeholder?: string;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [month, setMonth] = useState(value?.month ?? null);
+  const [day, setDay] = useState(value?.day ?? null);
+  const [year, setYear] = useState(value?.year ?? null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function startEditing() {
+    setMonth(value?.month ?? null);
+    setDay(value?.day ?? null);
+    setYear(value?.year ?? null);
+    setError(null);
+    setEditing(true);
+  }
+
+  async function save(next: Birthday | null) {
+    setSaving(true);
+    setError(null);
+    try {
+      await onSave(next);
+      setEditing(false);
+    } catch (err) {
+      setError(extractApiErrorOr(err, "couldn't save — try again"));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!editing) {
+    return (
+      <div className="flex items-center justify-between">
+        <div>
+          <div className="text-muted text-xs">{label}</div>
+          <div className="text-foreground text-sm">
+            {value ? formatBirthday(value) : placeholder}
+          </div>
+        </div>
+        <Button variant="ghost" onClick={startEditing} aria-label={`edit ${label}`}>
+          edit
+        </Button>
+      </div>
+    );
+  }
+
+  const canSave = month !== null && day !== null;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="grid grid-cols-3 gap-2">
+        <Select
+          label="month"
+          options={MONTH_OPTIONS}
+          value={month ? String(month) : ''}
+          placeholder="month"
+          onChange={(e) => {
+            const nextMonth = e.target.value ? Number(e.target.value) : null;
+            setMonth(nextMonth);
+            if (nextMonth && day && day > getDaysInMonth(new Date(2000, nextMonth - 1))) {
+              setDay(null);
+            }
+            if (error) setError(null);
+          }}
+        />
+        <Select
+          label="day"
+          options={dayOptions(month)}
+          value={day ? String(day) : ''}
+          placeholder="day"
+          onChange={(e) => {
+            setDay(e.target.value ? Number(e.target.value) : null);
+            if (error) setError(null);
+          }}
+        />
+        <Select
+          label="year"
+          options={YEAR_OPTIONS}
+          value={year ? String(year) : NO_YEAR}
+          onChange={(e) => {
+            setYear(e.target.value ? Number(e.target.value) : null);
+            if (error) setError(null);
+          }}
+        />
+      </div>
+      {error ? <p className="text-destructive text-xs">{error}</p> : null}
+      <div className="flex items-center justify-end gap-2">
+        {value ? (
+          <Button variant="ghost" onClick={() => void save(null)} disabled={saving}>
+            clear
+          </Button>
+        ) : null}
+        <Button
+          variant="ghost"
+          onClick={() => {
+            setError(null);
+            setEditing(false);
+          }}
+          disabled={saving}
+        >
+          cancel
+        </Button>
+        <Button
+          onClick={() => {
+            if (canSave) void save({ month, day, year });
+          }}
+          disabled={saving || !canSave}
+        >
+          save
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/screens/settings/SettingsScreen.tsx
+++ b/frontend/src/screens/settings/SettingsScreen.tsx
@@ -1,4 +1,3 @@
-import { getDaysInMonth } from 'date-fns';
 import type { ReactNode } from 'react';
 import { useState } from 'react';
 
@@ -7,16 +6,15 @@ import { extractApiErrorOr } from '@/api/apiErrors';
 import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import { SegmentedControl as SharedSegmentedControl } from '@/components/ui/SegmentedControl';
-import { Select } from '@/components/ui/Select';
 import { TextField } from '@/components/ui/TextField';
-import { type Birthday, CalendarFeedScope, type CalendarFeedScopeValue } from '@/models/user';
+import { CalendarFeedScope, type CalendarFeedScopeValue } from '@/models/user';
 import { ContentContainer } from '@/screens/public/ContentContainer';
-import { formatBirthday } from '@/utils/datetime';
 import { formatPhone } from '@/utils/formatPhone';
 
 import { AvatarUpload } from './AvatarUpload';
 import { CalendarFeedSubscription } from './CalendarFeedSubscription';
 import { ChangePasswordDialog } from './ChangePasswordDialog';
+import { InlineBirthday } from './InlineBirthday';
 import { PrivacyToggles } from './PrivacyToggles';
 
 export default function SettingsScreen() {
@@ -223,160 +221,6 @@ function InlineText({
       <Button onClick={() => void commit()} disabled={saving}>
         save
       </Button>
-    </div>
-  );
-}
-
-const MONTH_OPTIONS = [
-  'january',
-  'february',
-  'march',
-  'april',
-  'may',
-  'june',
-  'july',
-  'august',
-  'september',
-  'october',
-  'november',
-  'december',
-].map((name, i) => ({ value: String(i + 1), label: name }));
-
-const NO_YEAR = '';
-const CURRENT_YEAR = new Date().getFullYear();
-const YEAR_OPTIONS = [
-  { value: NO_YEAR, label: 'prefer not to say' },
-  ...Array.from({ length: 120 }, (_, i) => {
-    const year = CURRENT_YEAR - i;
-    return { value: String(year), label: String(year) };
-  }),
-];
-
-function dayOptions(month: number | null) {
-  const count = month ? getDaysInMonth(new Date(2000, month - 1)) : 31;
-  return Array.from({ length: count }, (_, i) => ({ value: String(i + 1), label: String(i + 1) }));
-}
-
-function InlineBirthday({
-  label,
-  value,
-  onSave,
-  placeholder,
-}: {
-  label: string;
-  value: Birthday | null;
-  onSave: (v: Birthday | null) => Promise<void>;
-  placeholder?: string;
-}) {
-  const [editing, setEditing] = useState(false);
-  const [month, setMonth] = useState(value?.month ?? null);
-  const [day, setDay] = useState(value?.day ?? null);
-  const [year, setYear] = useState(value?.year ?? null);
-  const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  function startEditing() {
-    setMonth(value?.month ?? null);
-    setDay(value?.day ?? null);
-    setYear(value?.year ?? null);
-    setError(null);
-    setEditing(true);
-  }
-
-  async function save(next: Birthday | null) {
-    setSaving(true);
-    setError(null);
-    try {
-      await onSave(next);
-      setEditing(false);
-    } catch (err) {
-      setError(extractApiErrorOr(err, "couldn't save — try again"));
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  if (!editing) {
-    return (
-      <div className="flex items-center justify-between">
-        <div>
-          <div className="text-muted text-xs">{label}</div>
-          <div className="text-foreground text-sm">
-            {value ? formatBirthday(value) : placeholder}
-          </div>
-        </div>
-        <Button variant="ghost" onClick={startEditing} aria-label={`edit ${label}`}>
-          edit
-        </Button>
-      </div>
-    );
-  }
-
-  const canSave = month !== null && day !== null;
-
-  return (
-    <div className="flex flex-col gap-2">
-      <div className="grid grid-cols-3 gap-2">
-        <Select
-          label="month"
-          options={MONTH_OPTIONS}
-          value={month ? String(month) : ''}
-          placeholder="month"
-          onChange={(e) => {
-            const nextMonth = e.target.value ? Number(e.target.value) : null;
-            setMonth(nextMonth);
-            if (nextMonth && day && day > getDaysInMonth(new Date(2000, nextMonth - 1))) {
-              setDay(null);
-            }
-            if (error) setError(null);
-          }}
-        />
-        <Select
-          label="day"
-          options={dayOptions(month)}
-          value={day ? String(day) : ''}
-          placeholder="day"
-          onChange={(e) => {
-            setDay(e.target.value ? Number(e.target.value) : null);
-            if (error) setError(null);
-          }}
-        />
-        <Select
-          label="year"
-          options={YEAR_OPTIONS}
-          value={year ? String(year) : NO_YEAR}
-          onChange={(e) => {
-            setYear(e.target.value ? Number(e.target.value) : null);
-            if (error) setError(null);
-          }}
-        />
-      </div>
-      {error ? <p className="text-destructive text-xs">{error}</p> : null}
-      <div className="flex items-center justify-end gap-2">
-        {value ? (
-          <Button variant="ghost" onClick={() => void save(null)} disabled={saving}>
-            clear
-          </Button>
-        ) : null}
-        <Button
-          variant="ghost"
-          onClick={() => {
-            setError(null);
-            setEditing(false);
-          }}
-          disabled={saving}
-        >
-          cancel
-        </Button>
-        <Button
-          onClick={() => {
-            if (canSave) void save({ month, day, year });
-          }}
-          disabled={saving || !canSave}
-        >
-          save
-        </Button>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- the "make it yours ✨" onboarding profile step (shown on first login) only had a photo + bio field, missing pronouns, birthday, and the privacy toggles that already exist in settings
- backend/API already supported all of these fields — this was a frontend-only gap
- added pronouns text field and reused the existing `PrivacyToggles` and a newly-extracted `InlineBirthday` component (pulled out of `SettingsScreen.tsx`, which was near the 500-line file cap, into a shared `frontend/src/screens/settings/InlineBirthday.tsx`) so onboarding and settings share the same edit UI

Closes #923

## Test plan
- [x] `pnpm exec vitest run src/screens/auth/OnboardingProfileStep.test.tsx src/screens/settings/SettingsScreen.test.tsx` — 18/18 passed
- [x] `make agent-frontend-typecheck` — clean
- [x] `make agent-frontend-lint` — clean
- [ ] manually click through onboarding as a new/legacy user to confirm the profile step shows pronouns, birthday, and privacy toggles