### PR TITLE
feat(events): hint that rsvp unlocks more event detail (Issue 917)

### DIFF
--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -227,7 +227,10 @@ export function PublicRsvpForm({ event, onSuccess, onMember, onAlreadyRsvpd }: P
 
   return (
     <section aria-label="rsvp" className="border-border bg-surface mt-8 rounded-lg border p-6">
-      <h2 className="mb-4 text-base font-medium">rsvp</h2>
+      <h2 className="mb-2 text-base font-medium">rsvp</h2>
+      <p className="text-foreground-tertiary mb-4 text-sm">
+        rsvp to see the location and more details
+      </p>
       {renderStep()}
     </section>
   );


### PR DESCRIPTION
## Summary
- Investigated the public-RSVP "see more after rsvp" flow end-to-end (backend `NonMemberRsvpToken` issuance/resolution, frontend token storage, TanStack Query key wiring, `EventMemberSection` gating). The unlock mechanism itself works correctly — confirmed by manual reproduction with a real token (location, rsvp status, and guest list all render once unlocked) and by the existing test suite.
- The actual gap: the public-RSVP form (`PublicRsvpForm.tsx`) never told anonymous visitors that submitting an RSVP would unlock more detail — unlike the login-gated path (`LoginOrJoinSection`), which explicitly says "want to see more? ... shown once you sign in." Issue 917 ("say rsvp to see more") is about that missing promise, not a broken unlock.
- Added a one-line teaser under the "rsvp" heading: "rsvp to see the location and more details."

Closes #917

## Test plan
- [x] `npx vitest run src/screens/events/PublicRsvpForm.test.tsx src/screens/events/PublicRsvpSection.test.tsx src/screens/events/PublicRsvp.a11y.test.tsx src/screens/events/EventDetailScreen.test.tsx` — 46 passed
- [x] `make agent-frontend-typecheck` — clean
- [x] `make agent-frontend-lint` — clean
- [x] Manual E2E: seeded a public-rsvp-eligible event, submitted an RSVP via the backend, confirmed the issued `NonMemberRsvpToken` unlocks location/rsvp/guests on `GET /api/community/events/{id}/?token=...` and in the rendered `/events/{id}?rsvp_token=...` page.