### PR TITLE
refactor(tests): bulk_create search-limit test users (Issue 933)

### DIFF
--- a/backend/tests/users/test_users_crud.py
+++ b/backend/tests/users/test_users_crud.py
@@ -266,12 +266,17 @@ class TestSearchUsers:
         assert response.status_code == 401
 
     def test_search_limits_to_ten_results(self, api_client, auth_headers, db):
-        for i in range(15):
-            User.objects.create_user(
+        users = [
+            User(
                 phone_number=f"+1555001{i:04d}",
-                password="pass",
                 first_name=f"Searchable User {i}",
+                is_member=True,
             )
+            for i in range(11)
+        ]
+        for user in users:
+            user.set_unusable_password()
+        User.objects.bulk_create(users)
         response = api_client.get("/api/auth/users/search/?q=Searchable", **auth_headers)
         assert response.status_code == 200
         assert len(response.json()) <= 10


### PR DESCRIPTION
## Summary
- Re-measured PR #757's Option C against the current suite (Option A's fast MD5 hasher is already in `backend/tests/conftest.py`): flagged files run in 4s total with nothing over 1.76s, full backend suite is 13.67s. Widening fixture scope carries shared-mutable-state risk for no measurable win, so most of Option C is not worth doing.
- One item did have an isolated, low-risk win: `test_search_limits_to_ten_results` looped `create_user` 15x (paying a real password hash each time pre-Option-A). Swapped to `bulk_create` + `set_unusable_password` over 11 users (one more than the cap being tested) — the test only asserts result count, never checks password.

Closes #933

## Test plan
- [x] `backend/tests/users/test_users_crud.py` — 26 passed
- [x] `make agent-lint`, `make agent-typecheck` — clean
- [x] `make agent-test` (full backend suite) — 1525 passed, 5 pre-existing SSE/pg_notify failures on SQLite (unrelated, documented as expected)