### PR TITLE
fix(staging): community events members-only, official/club public (Issue 916)

### DIFF
--- a/backend/community/management/commands/_seed_staging_data.py
+++ b/backend/community/management/commands/_seed_staging_data.py
@@ -2,7 +2,13 @@
 
 from dataclasses import dataclass
 
-from community.models.choices import AttendanceStatus, EventType, JoinRequestStatus, RSVPStatus
+from community.models.choices import (
+    AttendanceStatus,
+    EventType,
+    JoinRequestStatus,
+    PageVisibility,
+    RSVPStatus,
+)
 
 PASSWORD = "testPassword1@"
 
@@ -18,6 +24,13 @@ class SeedStagingEvent:
     rsvp_enabled: bool = False
     max_attendees: int | None = None
 
+    @property
+    def visibility(self) -> str:
+        """Official/club events are always public; matches the real event-form default."""
+        if self.event_type in (EventType.OFFICIAL, EventType.CLUB):
+            return PageVisibility.PUBLIC
+        return PageVisibility.MEMBERS_ONLY
+
 
 def perm_phone(index: int) -> str:
     return f"+170255501{index:02d}"
@@ -25,6 +38,10 @@ def perm_phone(index: int) -> str:
 
 def cond_phone(index: int) -> str:
     return f"+170255502{index:02d}"
+
+
+def privacy_phone(index: int) -> str:
+    return f"+170255505{index:02d}"
 
 
 def perm_email(key: str) -> str:
@@ -86,6 +103,36 @@ def is_seed_allowed(env_name: str | None, force: bool) -> bool:
     if not env_name or env_name == "staging":
         return True
     return force
+
+
+@dataclass
+class PrivacySpec:
+    """Members covering the pronouns/birthday/contact-privacy fields (Issue 923)."""
+
+    label: str
+    pronouns: str
+    birthday_month: int | None
+    birthday_day: int | None
+    show_phone: bool = True
+    show_email: bool = True
+    show_birthday: bool = True
+    hide_last_name: bool = False
+
+
+PRIVACY_SPECS = [
+    PrivacySpec("privacy: fully public", "they/them", 6, 15),
+    PrivacySpec(
+        "privacy: hides everything",
+        "she/her",
+        11,
+        3,
+        show_phone=False,
+        show_email=False,
+        show_birthday=False,
+        hide_last_name=True,
+    ),
+    PrivacySpec("privacy: no pronouns or birthday set", "", None, None),
+]
 
 
 STAGING_EVENTS = [

--- a/backend/community/management/commands/seed_staging.py
+++ b/backend/community/management/commands/seed_staging.py
@@ -20,6 +20,7 @@ from ._seed_staging_data import (
     NON_MEMBER_EVENT_TITLE,
     NON_MEMBER_SPECS,
     PASSWORD,
+    PRIVACY_SPECS,
     STAGING_EVENTS,
     TOKEN_EXPIRED,
     TOKEN_NONE,
@@ -32,6 +33,7 @@ from ._seed_staging_data import (
     nonmember_phone,
     perm_email,
     perm_phone,
+    privacy_phone,
 )
 
 
@@ -60,6 +62,7 @@ class Command(BaseCommand):
             roles = self._seed_perm_roles()
             perm_users = self._seed_perm_users(roles)
             cond_users = self._seed_condition_users()
+            self._seed_privacy_users()
             admin = perm_users[0] if perm_users else None
             events = self._seed_events(admin)
             self._seed_member_rsvps(cond_users, events)
@@ -82,6 +85,7 @@ class Command(BaseCommand):
         User.objects.filter(phone_number__startswith="+170255501").delete()
         User.objects.filter(phone_number__startswith="+170255502").delete()
         User.objects.filter(phone_number__startswith="+170255503").delete()
+        User.objects.filter(phone_number__startswith="+170255505").delete()
         Role.objects.filter(name__startswith="perm: ").delete()
         reset_join_requests()
         self.stdout.write("  reset: removed staging-scoped rows")
@@ -168,6 +172,34 @@ class Command(BaseCommand):
             self.stdout.write(f"  {'created' if created else 'exists'} user: {user.full_name}")
         return users
 
+    def _seed_privacy_users(self) -> list[User]:
+        member_role = self._member_role()
+        now = timezone.now()
+        users: list[User] = []
+        for index, spec in enumerate(PRIVACY_SPECS):
+            user, created = User.objects.get_or_create(
+                phone_number=privacy_phone(index), defaults={"is_member": True}
+            )
+            user.first_name = spec.label
+            user.last_name = ""
+            user.pronouns = spec.pronouns
+            user.birthday_month = spec.birthday_month
+            user.birthday_day = spec.birthday_day
+            user.show_phone = spec.show_phone
+            user.show_email = spec.show_email
+            user.show_birthday = spec.show_birthday
+            user.hide_last_name = spec.hide_last_name
+            user.needs_onboarding = False
+            user.onboarded_at = now
+            user.save()
+            if created:
+                user.set_password(PASSWORD)
+                user.save(update_fields=["password"])
+            user.roles.set([member_role])
+            users.append(user)
+            self.stdout.write(f"  {'created' if created else 'exists'} user: {user.full_name}")
+        return users
+
     def _seed_events(self, created_by) -> list[Event]:
         now = timezone.now()
         events: list[Event] = []
@@ -182,6 +214,7 @@ class Command(BaseCommand):
                     "end_datetime": end,
                     "location": data.location,
                     "event_type": data.event_type,
+                    "visibility": data.visibility,
                     "rsvp_enabled": data.rsvp_enabled,
                     "max_attendees": data.max_attendees,
                     "created_by": created_by,

--- a/backend/tests/test_seed_staging.py
+++ b/backend/tests/test_seed_staging.py
@@ -9,6 +9,7 @@ from community.management.commands._seed_staging_data import (
     OFFICIAL_PAST_TITLE,
     OFFICIAL_TODAY_TITLE,
     PASSWORD,
+    PRIVACY_SPECS,
     STAGING_EVENTS,
     TOKEN_EXPIRED,
     TOKEN_NONE,
@@ -21,6 +22,7 @@ from community.management.commands._seed_staging_data import (
     joinreq_phone,
     perm_email,
     perm_phone,
+    privacy_phone,
 )
 from community.models import (
     AttendanceStatus,
@@ -29,6 +31,7 @@ from community.models import (
     EventType,
     JoinRequest,
     JoinRequestStatus,
+    PageVisibility,
     RSVPStatus,
 )
 from django.contrib.auth.hashers import check_password
@@ -273,6 +276,16 @@ def test_official_events_span_past_today_future_with_capacity_variety():
 
 
 @pytest.mark.django_db
+def test_seed_staging_official_and_club_events_are_public():
+    call_command("seed_staging")
+    for event in Event.objects.filter(title__startswith="[staging] "):
+        if event.event_type in (EventType.OFFICIAL, EventType.CLUB):
+            assert event.visibility == PageVisibility.PUBLIC
+        else:
+            assert event.visibility == PageVisibility.MEMBERS_ONLY
+
+
+@pytest.mark.django_db
 def test_seed_staging_official_events_are_rsvp_enabled():
     call_command("seed_staging")
     for title in (OFFICIAL_PAST_TITLE, OFFICIAL_TODAY_TITLE, OFFICIAL_FULL_TITLE):
@@ -370,6 +383,29 @@ def test_seed_staging_join_requests_idempotent():
     assert JoinRequest.objects.filter(phone_number__startswith="+170255504").count() == len(
         JOIN_REQUEST_SPECS
     )
+
+
+@pytest.mark.django_db
+def test_seed_staging_privacy_users_match_specs():
+    call_command("seed_staging")
+    assert User.objects.filter(phone_number__startswith="+170255505").count() == len(PRIVACY_SPECS)
+    for index, spec in enumerate(PRIVACY_SPECS):
+        user = User.objects.get(phone_number=privacy_phone(index))
+        assert user.is_member is True
+        assert user.pronouns == spec.pronouns
+        assert user.birthday_month == spec.birthday_month
+        assert user.birthday_day == spec.birthday_day
+        assert user.show_phone is spec.show_phone
+        assert user.show_email is spec.show_email
+        assert user.show_birthday is spec.show_birthday
+        assert user.hide_last_name is spec.hide_last_name
+
+
+@pytest.mark.django_db
+def test_seed_staging_privacy_users_idempotent():
+    call_command("seed_staging")
+    call_command("seed_staging")
+    assert User.objects.filter(phone_number__startswith="+170255505").count() == len(PRIVACY_SPECS)
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- `seed_staging` events now set `visibility` explicitly: official/club events are public, all other (community) events are members-only — matching the real event-form default introduced in Issue 895.
- Added `PRIVACY_SPECS`: 3 new staging members covering pronouns, birthday, and contact-privacy toggles added in Issue 923.
- Clearing currently-seeded staging events is an operational step (`railway run --environment staging python backend/manage.py seed_staging --reset`), not a code change — flagging here so it can be run against staging once this merges.

Closes #916

## Test plan
- [x] `pytest backend/tests/test_seed_staging.py` — 33 passed (includes 3 new tests: official/club visibility, privacy user specs, privacy idempotency)
- [x] ruff check + format on changed files
- [ ] run `seed_staging --reset` against staging after merge to clear stale events and reseed