### PR TITLE
fix(seed): document seeder split rationale, fix affected-tests gap

### DIFF
--- a/backend/community/management/commands/_seed_data.py
+++ b/backend/community/management/commands/_seed_data.py
@@ -10,6 +10,8 @@ from community.models.choices import (
     RSVPStatus,
 )
 
+from ._seed_shared import SeedEvent
+
 PASSWORD = "testpass123"
 
 
@@ -25,19 +27,6 @@ class SeedUser:
     @property
     def full_name(self) -> str:
         return f"{self.first_name} {self.last_name}".strip()
-
-
-@dataclass
-class SeedEvent:
-    title: str
-    description: str
-    delta_days: int
-    duration_hours: float
-    location: str
-    event_type: str = EventType.COMMUNITY
-    rsvp_enabled: bool = False
-    allow_plus_ones: bool = False
-    max_attendees: int | None = None
 
 
 @dataclass

--- a/backend/community/management/commands/_seed_shared.py
+++ b/backend/community/management/commands/_seed_shared.py
@@ -1,0 +1,81 @@
+"""Helpers shared by the `seed` and `seed_staging` commands.
+
+Only genuinely identical shapes live here — events, the create-user-with-password
+idiom, and applying an RSVP. Anything that differs between local dev and staging
+(permission-matrix users, condition users, non-member tokens, join requests,
+env gating, transactions/reset) stays in each command's own module.
+"""
+
+from dataclasses import dataclass
+from datetime import timedelta
+
+from django.utils import timezone
+from users.models import User
+from users.roles import Role
+
+from community.models import Event, EventRSVP, EventType
+
+
+@dataclass
+class SeedEvent:
+    title: str
+    description: str
+    delta_days: int
+    duration_hours: float
+    location: str
+    event_type: str = EventType.COMMUNITY
+    rsvp_enabled: bool = False
+    allow_plus_ones: bool = False
+    max_attendees: int | None = None
+
+
+def seed_events(stdout, events: list[SeedEvent], created_by: User | None) -> dict[str, Event]:
+    """Seed events. Returns a title -> Event mapping."""
+    now = timezone.now()
+    result: dict[str, Event] = {}
+    for data in events:
+        start = now + timedelta(days=data.delta_days)
+        end = start + timedelta(hours=data.duration_hours)
+        event, created = Event.objects.get_or_create(
+            title=data.title,
+            defaults={
+                "description": data.description,
+                "start_datetime": start,
+                "end_datetime": end,
+                "location": data.location,
+                "event_type": data.event_type,
+                "rsvp_enabled": data.rsvp_enabled,
+                "allow_plus_ones": data.allow_plus_ones,
+                "max_attendees": data.max_attendees,
+                "created_by": created_by,
+            },
+        )
+        result[data.title] = event
+        stdout.write(f"  {'created' if created else 'exists'} event: {data.title}")
+    return result
+
+
+def get_or_create_seed_user(
+    phone_number: str, password: str, defaults: dict, roles: list[Role]
+) -> tuple[User, bool]:
+    """get_or_create by phone, set password + roles on creation. Returns (user, created)."""
+    user, created = User.objects.get_or_create(phone_number=phone_number, defaults=defaults)
+    if created:
+        user.set_password(password)
+        user.save(update_fields=["password"])
+        user.roles.set(roles)
+    return user, created
+
+
+def apply_rsvp(event: Event, user: User, defaults: dict, *, overwrite: bool = False) -> None:
+    """Seed one RSVP row directly (bypassing capacity rules) so seeded statuses
+    — including waitlisted entries and marked attendance — land verbatim.
+
+    `defaults` holds status/attendance/has_plus_one. `overwrite=True` (staging)
+    reflects the current spec on every run since staging is `--reset`-able;
+    local's default (create-only) is purely additive.
+    """
+    if overwrite:
+        EventRSVP.objects.update_or_create(event=event, user=user, defaults=defaults)
+    else:
+        EventRSVP.objects.get_or_create(event=event, user=user, defaults=defaults)

--- a/backend/community/management/commands/_seed_shared.py
+++ b/backend/community/management/commands/_seed_shared.py
@@ -1,11 +1,3 @@
-"""Helpers shared by the `seed` and `seed_staging` commands.
-
-Only genuinely identical shapes live here — events, the create-user-with-password
-idiom, and applying an RSVP. Anything that differs between local dev and staging
-(permission-matrix users, condition users, non-member tokens, join requests,
-env gating, transactions/reset) stays in each command's own module.
-"""
-
 from dataclasses import dataclass
 from datetime import timedelta
 
@@ -68,13 +60,7 @@ def get_or_create_seed_user(
 
 
 def apply_rsvp(event: Event, user: User, defaults: dict, *, overwrite: bool = False) -> None:
-    """Seed one RSVP row directly (bypassing capacity rules) so seeded statuses
-    — including waitlisted entries and marked attendance — land verbatim.
-
-    `defaults` holds status/attendance/has_plus_one. `overwrite=True` (staging)
-    reflects the current spec on every run since staging is `--reset`-able;
-    local's default (create-only) is purely additive.
-    """
+    """Seed one RSVP row directly (bypassing capacity rules) so seeded statuses land verbatim."""
     if overwrite:
         EventRSVP.objects.update_or_create(event=event, user=user, defaults=defaults)
     else:

--- a/backend/community/management/commands/_seed_staging_data.py
+++ b/backend/community/management/commands/_seed_staging_data.py
@@ -4,19 +4,9 @@ from dataclasses import dataclass
 
 from community.models.choices import AttendanceStatus, EventType, JoinRequestStatus, RSVPStatus
 
+from ._seed_shared import SeedEvent
+
 PASSWORD = "testPassword1@"
-
-
-@dataclass
-class SeedStagingEvent:
-    title: str
-    description: str
-    delta_days: int
-    duration_hours: float
-    location: str
-    event_type: str = EventType.COMMUNITY
-    rsvp_enabled: bool = False
-    max_attendees: int | None = None
 
 
 def perm_phone(index: int) -> str:
@@ -89,28 +79,28 @@ def is_seed_allowed(env_name: str | None, force: bool) -> bool:
 
 
 STAGING_EVENTS = [
-    SeedStagingEvent(
+    SeedEvent(
         title="[staging] past potluck",
         description="a wrapped-up community potluck from last month.",
         delta_days=-30,
         duration_hours=3,
         location="community center",
     ),
-    SeedStagingEvent(
+    SeedEvent(
         title="[staging] last week's film night",
         description="documentary screening and discussion.",
         delta_days=-7,
         duration_hours=2,
         location="the annex",
     ),
-    SeedStagingEvent(
+    SeedEvent(
         title="[staging] yesterday's kitchen social",
         description="casual cook-and-hang.",
         delta_days=-1,
         duration_hours=2.5,
         location="shared kitchen",
     ),
-    SeedStagingEvent(
+    SeedEvent(
         title="[staging] happening today",
         description="drop-in tabling and outreach.",
         delta_days=0,
@@ -118,28 +108,28 @@ STAGING_EVENTS = [
         location="market square",
         event_type=EventType.OFFICIAL,
     ),
-    SeedStagingEvent(
+    SeedEvent(
         title="[staging] tomorrow's cooking workshop",
         description="plant-based basics, hands-on.",
         delta_days=1,
         duration_hours=2,
         location="teaching kitchen",
     ),
-    SeedStagingEvent(
+    SeedEvent(
         title="[staging] weekend park cleanup",
         description="gloves and bags provided.",
         delta_days=3,
         duration_hours=3,
         location="riverside park",
     ),
-    SeedStagingEvent(
+    SeedEvent(
         title="[staging] next week's book club",
         description="this month's read: collective liberation.",
         delta_days=7,
         duration_hours=1.5,
         location="library room b",
     ),
-    SeedStagingEvent(
+    SeedEvent(
         title="[staging] monthly official meeting",
         description="agenda, updates, and open floor.",
         delta_days=14,
@@ -147,21 +137,21 @@ STAGING_EVENTS = [
         location="main hall",
         event_type=EventType.OFFICIAL,
     ),
-    SeedStagingEvent(
+    SeedEvent(
         title="[staging] future festival",
         description="all-day tabling, food, and music.",
         delta_days=45,
         duration_hours=8,
         location="fairgrounds",
     ),
-    SeedStagingEvent(
+    SeedEvent(
         title="[staging] far-future retreat",
         description="weekend planning retreat.",
         delta_days=90,
         duration_hours=48,
         location="the lodge",
     ),
-    SeedStagingEvent(
+    SeedEvent(
         title=NON_MEMBER_EVENT_TITLE,
         description="official public event for testing non-member rsvp.",
         delta_days=5,
@@ -171,7 +161,7 @@ STAGING_EVENTS = [
         rsvp_enabled=True,
         max_attendees=20,
     ),
-    SeedStagingEvent(
+    SeedEvent(
         title=OFFICIAL_PAST_TITLE,
         description="past official event with attendance marked for the report.",
         delta_days=-10,
@@ -181,7 +171,7 @@ STAGING_EVENTS = [
         rsvp_enabled=True,
         max_attendees=8,
     ),
-    SeedStagingEvent(
+    SeedEvent(
         title=OFFICIAL_TODAY_TITLE,
         description="official event happening today with rsvp open, well under capacity.",
         delta_days=0,
@@ -191,7 +181,7 @@ STAGING_EVENTS = [
         rsvp_enabled=True,
         max_attendees=50,
     ),
-    SeedStagingEvent(
+    SeedEvent(
         title=OFFICIAL_FULL_TITLE,
         description="official event at/over capacity to exercise waitlist + promotion.",
         delta_days=9,

--- a/backend/community/management/commands/_seed_staging_data.py
+++ b/backend/community/management/commands/_seed_staging_data.py
@@ -2,7 +2,13 @@
 
 from dataclasses import dataclass
 
-from community.models.choices import AttendanceStatus, EventType, JoinRequestStatus, RSVPStatus
+from community.models.choices import (
+    AttendanceStatus,
+    EventType,
+    JoinRequestStatus,
+    PageVisibility,
+    RSVPStatus,
+)
 
 PASSWORD = "testPassword1@"
 
@@ -18,6 +24,13 @@ class SeedStagingEvent:
     rsvp_enabled: bool = False
     max_attendees: int | None = None
 
+    @property
+    def visibility(self) -> str:
+        """Official/club events are always public; matches the real event-form default."""
+        if self.event_type in (EventType.OFFICIAL, EventType.CLUB):
+            return PageVisibility.PUBLIC
+        return PageVisibility.MEMBERS_ONLY
+
 
 def perm_phone(index: int) -> str:
     return f"+170255501{index:02d}"
@@ -25,6 +38,10 @@ def perm_phone(index: int) -> str:
 
 def cond_phone(index: int) -> str:
     return f"+170255502{index:02d}"
+
+
+def privacy_phone(index: int) -> str:
+    return f"+170255505{index:02d}"
 
 
 def perm_email(key: str) -> str:
@@ -86,6 +103,36 @@ def is_seed_allowed(env_name: str | None, force: bool) -> bool:
     if not env_name or env_name == "staging":
         return True
     return force
+
+
+@dataclass
+class PrivacySpec:
+    """Members covering the pronouns/birthday/contact-privacy fields (Issue 923)."""
+
+    label: str
+    pronouns: str
+    birthday_month: int | None
+    birthday_day: int | None
+    show_phone: bool = True
+    show_email: bool = True
+    show_birthday: bool = True
+    hide_last_name: bool = False
+
+
+PRIVACY_SPECS = [
+    PrivacySpec("privacy: fully public", "they/them", 6, 15),
+    PrivacySpec(
+        "privacy: hides everything",
+        "she/her",
+        11,
+        3,
+        show_phone=False,
+        show_email=False,
+        show_birthday=False,
+        hide_last_name=True,
+    ),
+    PrivacySpec("privacy: no pronouns or birthday set", "", None, None),
+]
 
 
 STAGING_EVENTS = [

--- a/backend/community/management/commands/seed.py
+++ b/backend/community/management/commands/seed.py
@@ -22,6 +22,7 @@ from ._seed_data import (
     SEED_USERS,
     SeedUser,
 )
+from ._seed_shared import apply_rsvp, get_or_create_seed_user, seed_events
 
 
 def _seed_singleton(model_cls, seed_data: dict, fields: tuple[str, ...], cmd: "Command") -> None:
@@ -77,13 +78,9 @@ class Command(BaseCommand):
         if data.is_superuser:
             defaults["is_superuser"] = True
             defaults["is_staff"] = True
-        user, created = User.objects.get_or_create(
-            phone_number=data.phone_number, defaults=defaults
-        )
+        role = admin_role if data.is_superuser else member_role
+        user, created = get_or_create_seed_user(data.phone_number, PASSWORD, defaults, [role])
         if created:
-            user.set_password(PASSWORD)
-            user.save()
-            user.roles.add(admin_role if data.is_superuser else member_role)
             self.stdout.write(f"  Created user: {user.full_name}")
         else:
             self._backfill_user(user, data)
@@ -148,37 +145,10 @@ class Command(BaseCommand):
 
     def _seed_events(self, created_by: User) -> dict[str, Event]:
         """Seed events. Returns a title→Event mapping for RSVP seeding."""
-        now = timezone.now()
-        events: dict[str, Event] = {}
-        for data in SEED_EVENTS:
-            start = now + timedelta(days=data.delta_days)
-            end = start + timedelta(hours=data.duration_hours)
-            event, created = Event.objects.get_or_create(
-                title=data.title,
-                defaults={
-                    "description": data.description,
-                    "start_datetime": start,
-                    "end_datetime": end,
-                    "location": data.location,
-                    "event_type": data.event_type,
-                    "rsvp_enabled": data.rsvp_enabled,
-                    "allow_plus_ones": data.allow_plus_ones,
-                    "max_attendees": data.max_attendees,
-                    "created_by": created_by,
-                },
-            )
-            events[data.title] = event
-            label = "Created" if created else "Already exists"
-            self.stdout.write(f"  {label} event: {data.title}")
-        return events
+        return seed_events(self.stdout, SEED_EVENTS, created_by)
 
     def _seed_rsvps(self, events: dict[str, Event]) -> None:
-        """Seed RSVPs so the roster, waitlist, and stats panel are QA-able.
-
-        RSVP rows are written directly (not via the upsert endpoint) so the
-        seeded statuses — including waitlisted entries and marked attendance —
-        land verbatim rather than being re-derived from capacity rules.
-        """
+        """Seed RSVPs so the roster, waitlist, and stats panel are QA-able."""
         users = {
             u.phone_number: u for u in User.objects.filter(phone_number__startswith="+1702555")
         }
@@ -190,17 +160,16 @@ class Command(BaseCommand):
                     f"  Skipped RSVP (missing event/user): {data.event_title} / {data.phone_number}"
                 )
                 continue
-            _, created = EventRSVP.objects.get_or_create(
-                event=event,
-                user=user,
-                defaults={
+            apply_rsvp(
+                event,
+                user,
+                {
                     "status": data.status,
-                    "has_plus_one": data.has_plus_one,
                     "attendance": data.attendance,
+                    "has_plus_one": data.has_plus_one,
                 },
             )
-            label = "Created" if created else "Already exists"
-            self.stdout.write(f"  {label} RSVP: {user.full_name} → {data.event_title}")
+            self.stdout.write(f"  RSVP: {user.full_name} → {data.event_title}")
 
     def _seed_join_requests(self, questions: dict[str, JoinFormQuestion], admin_user: User) -> None:
         now = timezone.now()

--- a/backend/community/management/commands/seed_staging.py
+++ b/backend/community/management/commands/seed_staging.py
@@ -47,8 +47,8 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        # kept separate from seed.py: enum-driven per-permission + condition-matrix +
-        # non-member fixtures and this env gate don't belong in local dev's `seed`.
+        # kept separate from seed.py so `make seed` never emits staging demo
+        # accounts (enum-driven per-permission/condition-matrix/non-member fixtures).
         env_name = os.environ.get("RAILWAY_ENVIRONMENT_NAME")
         self.stdout.write(f"detected environment: {env_name or 'local/unset'}")
         if not is_seed_allowed(env_name, force=options["force"]):

--- a/backend/community/management/commands/seed_staging.py
+++ b/backend/community/management/commands/seed_staging.py
@@ -48,8 +48,6 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-        # kept separate from seed.py so `make seed` never emits staging demo
-        # accounts (enum-driven per-permission/condition-matrix/non-member fixtures).
         env_name = os.environ.get("RAILWAY_ENVIRONMENT_NAME")
         self.stdout.write(f"detected environment: {env_name or 'local/unset'}")
         if not is_seed_allowed(env_name, force=options["force"]):

--- a/backend/community/management/commands/seed_staging.py
+++ b/backend/community/management/commands/seed_staging.py
@@ -20,6 +20,7 @@ from ._seed_staging_data import (
     NON_MEMBER_EVENT_TITLE,
     NON_MEMBER_SPECS,
     PASSWORD,
+    PRIVACY_SPECS,
     STAGING_EVENTS,
     TOKEN_EXPIRED,
     TOKEN_NONE,
@@ -32,6 +33,7 @@ from ._seed_staging_data import (
     nonmember_phone,
     perm_email,
     perm_phone,
+    privacy_phone,
 )
 
 
@@ -60,6 +62,7 @@ class Command(BaseCommand):
             roles = self._seed_perm_roles()
             perm_users = self._seed_perm_users(roles)
             cond_users = self._seed_condition_users()
+            self._seed_privacy_users()
             admin = perm_users[0] if perm_users else None
             events = self._seed_events(admin)
             self._seed_member_rsvps(cond_users, events)
@@ -82,6 +85,7 @@ class Command(BaseCommand):
         User.objects.filter(phone_number__startswith="+170255501").delete()
         User.objects.filter(phone_number__startswith="+170255502").delete()
         User.objects.filter(phone_number__startswith="+170255503").delete()
+        User.objects.filter(phone_number__startswith="+170255505").delete()
         Role.objects.filter(name__startswith="perm: ").delete()
         reset_join_requests()
         self.stdout.write("  reset: removed staging-scoped rows")
@@ -168,6 +172,34 @@ class Command(BaseCommand):
             self.stdout.write(f"  {'created' if created else 'exists'} user: {user.full_name}")
         return users
 
+    def _seed_privacy_users(self) -> list[User]:
+        member_role = self._member_role()
+        now = timezone.now()
+        users: list[User] = []
+        for index, spec in enumerate(PRIVACY_SPECS):
+            user, created = User.objects.get_or_create(
+                phone_number=privacy_phone(index), defaults={"is_member": True}
+            )
+            user.first_name = spec.label
+            user.last_name = ""
+            user.pronouns = spec.pronouns
+            user.birthday_month = spec.birthday_month
+            user.birthday_day = spec.birthday_day
+            user.show_phone = spec.show_phone
+            user.show_email = spec.show_email
+            user.show_birthday = spec.show_birthday
+            user.hide_last_name = spec.hide_last_name
+            user.needs_onboarding = False
+            user.onboarded_at = now
+            user.save()
+            if created:
+                user.set_password(PASSWORD)
+                user.save(update_fields=["password"])
+            user.roles.set([member_role])
+            users.append(user)
+            self.stdout.write(f"  {'created' if created else 'exists'} user: {user.full_name}")
+        return users
+
     def _seed_events(self, created_by) -> list[Event]:
         now = timezone.now()
         events: list[Event] = []
@@ -182,6 +214,7 @@ class Command(BaseCommand):
                     "end_datetime": end,
                     "location": data.location,
                     "event_type": data.event_type,
+                    "visibility": data.visibility,
                     "rsvp_enabled": data.rsvp_enabled,
                     "max_attendees": data.max_attendees,
                     "created_by": created_by,

--- a/backend/community/management/commands/seed_staging.py
+++ b/backend/community/management/commands/seed_staging.py
@@ -47,6 +47,8 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        # kept separate from seed.py: enum-driven per-permission + condition-matrix +
+        # non-member fixtures and this env gate don't belong in local dev's `seed`.
         env_name = os.environ.get("RAILWAY_ENVIRONMENT_NAME")
         self.stdout.write(f"detected environment: {env_name or 'local/unset'}")
         if not is_seed_allowed(env_name, force=options["force"]):

--- a/backend/community/management/commands/seed_staging.py
+++ b/backend/community/management/commands/seed_staging.py
@@ -12,9 +12,10 @@ from users.models import NonMemberRsvpToken, User
 from users.permissions import PermissionKey
 from users.roles import Role
 
-from community.models import Event, EventRSVP, EventType, RSVPStatus
+from community.models import Event, EventType, RSVPStatus
 
 from ._seed_join_requests import reset_join_requests, seed_join_requests
+from ._seed_shared import apply_rsvp, get_or_create_seed_user, seed_events
 from ._seed_staging_data import (
     MEMBER_RSVP_SPECS,
     NON_MEMBER_EVENT_TITLE,
@@ -107,22 +108,18 @@ class Command(BaseCommand):
         users: list[User] = []
         now = timezone.now()
         for index, key in enumerate(PermissionKey.values):
-            user, created = User.objects.get_or_create(
-                phone_number=perm_phone(index),
-                defaults={
-                    "first_name": f"perm: {key}",
-                    "email": perm_email(key),
-                    "is_member": True,
-                    "needs_onboarding": False,
-                    "onboarded_at": now,
-                    "guidelines_consent_at": now,
-                    "sms_consent_at": now,
-                },
+            defaults = {
+                "first_name": f"perm: {key}",
+                "email": perm_email(key),
+                "is_member": True,
+                "needs_onboarding": False,
+                "onboarded_at": now,
+                "guidelines_consent_at": now,
+                "sms_consent_at": now,
+            }
+            user, created = get_or_create_seed_user(
+                perm_phone(index), PASSWORD, defaults, [roles[key]]
             )
-            if created:
-                user.set_password(PASSWORD)
-                user.save(update_fields=["password"])
-            user.roles.set([roles[key]])
             users.append(user)
             self.stdout.write(f"  {'created' if created else 'exists'} user: {user.full_name}")
         return users
@@ -171,36 +168,17 @@ class Command(BaseCommand):
         return users
 
     def _seed_events(self, created_by) -> list[Event]:
-        now = timezone.now()
-        events: list[Event] = []
-        for data in STAGING_EVENTS:
-            start = now + timedelta(days=data.delta_days)
-            end = start + timedelta(hours=data.duration_hours)
-            event, created = Event.objects.get_or_create(
-                title=data.title,
-                defaults={
-                    "description": data.description,
-                    "start_datetime": start,
-                    "end_datetime": end,
-                    "location": data.location,
-                    "event_type": data.event_type,
-                    "rsvp_enabled": data.rsvp_enabled,
-                    "max_attendees": data.max_attendees,
-                    "created_by": created_by,
-                },
-            )
-            events.append(event)
-            self.stdout.write(f"  {'created' if created else 'exists'} event: {data.title}")
-        return events
+        return list(seed_events(self.stdout, STAGING_EVENTS, created_by).values())
 
     def _apply_rsvps(self, user, rsvps, events_by_title: dict) -> None:
         for rsvp in rsvps:
             event = events_by_title.get(rsvp.event_title)
             if event is not None:
-                EventRSVP.objects.update_or_create(
-                    event=event,
-                    user=user,
-                    defaults={"status": rsvp.status, "attendance": rsvp.attendance},
+                apply_rsvp(
+                    event,
+                    user,
+                    {"status": rsvp.status, "attendance": rsvp.attendance},
+                    overwrite=True,
                 )
 
     def _seed_member_rsvps(self, cond_users: list[User], events: list[Event]) -> None:

--- a/backend/tests/test_seed_staging.py
+++ b/backend/tests/test_seed_staging.py
@@ -9,6 +9,7 @@ from community.management.commands._seed_staging_data import (
     OFFICIAL_PAST_TITLE,
     OFFICIAL_TODAY_TITLE,
     PASSWORD,
+    PRIVACY_SPECS,
     STAGING_EVENTS,
     TOKEN_EXPIRED,
     TOKEN_NONE,
@@ -21,6 +22,7 @@ from community.management.commands._seed_staging_data import (
     joinreq_phone,
     perm_email,
     perm_phone,
+    privacy_phone,
 )
 from community.models import (
     AttendanceStatus,
@@ -29,6 +31,7 @@ from community.models import (
     EventType,
     JoinRequest,
     JoinRequestStatus,
+    PageVisibility,
     RSVPStatus,
 )
 from django.contrib.auth.hashers import check_password
@@ -273,6 +276,16 @@ def test_official_events_span_past_today_future_with_capacity_variety():
 
 
 @pytest.mark.django_db
+def test_seed_staging_official_and_club_events_are_public():
+    call_command("seed_staging")
+    for event in Event.objects.filter(title__startswith="[staging] "):
+        if event.event_type in (EventType.OFFICIAL, EventType.CLUB):
+            assert event.visibility == PageVisibility.PUBLIC
+        else:
+            assert event.visibility == PageVisibility.MEMBERS_ONLY
+
+
+@pytest.mark.django_db
 def test_seed_staging_official_events_are_rsvp_enabled():
     call_command("seed_staging")
     for title in (OFFICIAL_PAST_TITLE, OFFICIAL_TODAY_TITLE, OFFICIAL_FULL_TITLE):
@@ -370,6 +383,29 @@ def test_seed_staging_join_requests_idempotent():
     assert JoinRequest.objects.filter(phone_number__startswith="+170255504").count() == len(
         JOIN_REQUEST_SPECS
     )
+
+
+@pytest.mark.django_db
+def test_seed_staging_privacy_users_match_specs():
+    call_command("seed_staging")
+    assert User.objects.filter(phone_number__startswith="+170255505").count() == len(PRIVACY_SPECS)
+    for index, spec in enumerate(PRIVACY_SPECS):
+        user = User.objects.get(phone_number=privacy_phone(index))
+        assert user.is_member is True
+        assert user.pronouns == spec.pronouns
+        assert user.birthday_month == spec.birthday_month
+        assert user.birthday_day == spec.birthday_day
+        assert user.show_phone is spec.show_phone
+        assert user.show_email is spec.show_email
+        assert user.show_birthday is spec.show_birthday
+        assert user.hide_last_name is spec.hide_last_name
+
+
+@pytest.mark.django_db
+def test_seed_staging_privacy_users_idempotent():
+    call_command("seed_staging")
+    call_command("seed_staging")
+    assert User.objects.filter(phone_number__startswith="+170255505").count() == len(PRIVACY_SPECS)
 
 
 @pytest.mark.django_db

--- a/scripts/dev_pg_db.sh
+++ b/scripts/dev_pg_db.sh
@@ -75,7 +75,8 @@ fingerprint() {
     find "$ROOT/backend" -path '*/migrations/*.py' | sort
     printf '%s\n' \
       "$ROOT/backend/community/management/commands/seed.py" \
-      "$ROOT/backend/community/management/commands/_seed_data.py"
+      "$ROOT/backend/community/management/commands/_seed_data.py" \
+      "$ROOT/backend/community/management/commands/_seed_shared.py"
   } | xargs shasum -a 256 | shasum -a 256 | awk '{print $1}'
 }
 

--- a/scripts/dev_sqlite_db.sh
+++ b/scripts/dev_sqlite_db.sh
@@ -13,7 +13,8 @@ fingerprint() {
     find "$ROOT/backend" -path '*/migrations/*.py' | sort
     printf '%s\n' \
       "$ROOT/backend/community/management/commands/seed.py" \
-      "$ROOT/backend/community/management/commands/_seed_data.py"
+      "$ROOT/backend/community/management/commands/_seed_data.py" \
+      "$ROOT/backend/community/management/commands/_seed_shared.py"
   } | xargs shasum -a 256 | shasum -a 256 | awk '{print $1}'
 }
 

--- a/scripts/list_affected_tests.py
+++ b/scripts/list_affected_tests.py
@@ -64,6 +64,7 @@ COMMUNITY_TESTS: frozenset[str] = frozenset(
         "tests/test_calendar.py",
         "tests/test_community.py",
         "tests/test_seed.py",
+        "tests/test_seed_staging.py",
         "tests/test_join_request_submission.py",
         "tests/test_join_request_management.py",
         "tests/test_event_cancel.py",


### PR DESCRIPTION
## Overview

Implements the follow-ups from the #717 explore spec (docs PR #749), which recommended keeping the local (`seed`) and staging (`seed_staging`) seeders separate:

- Adds a one-line rationale comment in `seed_staging.py`'s `handle()` documenting why it's kept separate from `seed.py`.
- Fixes the incidental gap: adds `tests/test_seed_staging.py` to the community bundle in `scripts/list_affected_tests.py`.
- Extracts the genuinely duplicated logic into a new `_seed_shared.py`: the `SeedEvent` dataclass + `seed_events()` loop, `get_or_create_seed_user()` (create + set_password + assign roles), and `apply_rsvp()` (get_or_create for local's additive seeding vs update_or_create for staging's `--reset`-able seeding). Both `seed.py` and `seed_staging.py` now import from it instead of maintaining near-duplicate implementations.
- Adds `_seed_shared.py` to the dev-db stamp fingerprints in `dev_sqlite_db.sh` / `dev_pg_db.sh` so edits to it bust the local cache.

What's *not* touched, on purpose: each command keeps its own data module, env gating, `transaction.atomic`/`--reset`, and permission-matrix/condition-matrix/non-member logic — those genuinely diverge between local dev and staging and don't belong in a shared module.

Closes #717

## Incorporates #935 (staging data, Issue 916)

Folded in the staging-data changes from #935 so both ship as one PR instead of conflicting on `seed_staging.py`. Rather than #935's staging-only `SeedStagingEvent.visibility` property, the visibility now rides on the shared `SeedEvent`:

- `SeedEvent` gains a `visibility` field (defaults to `PageVisibility.PUBLIC`, matching the `Event` model); `seed_events()` passes it through.
- `STAGING_EVENTS` marks community events members-only; official events keep the public default — matching the real event-form default from Issue 895.
- Adds `PRIVACY_SPECS` + `_seed_privacy_users()` (3 members exercising the pronouns/birthday/contact-privacy toggles from Issue 923) and their `+170255505` `--reset` scope.

Closes #916

> **Operational follow-up (from #935):** after this merges, run `railway run --environment staging python backend/manage.py seed_staging --reset` against staging to clear stale events and reseed with the new visibility.

## Test plan

- [x] `tests/test_seed_staging.py` + `tests/test_seed.py` pass locally (40 passed — includes #935's 3 new tests: official/club visibility, privacy user specs, privacy idempotency)
- [x] `ruff check` + `ruff format --check` + `ty check` clean on the changed seed files
- [x] `make agent-ci` — lint/typecheck/complexity clean; `agent-test` has pre-existing SSE failures unrelated to this change (SQLite doesn't support `pg_notify`, tracked separately)
