### PR TITLE
refactor(tests): 734 - delegate makeEvent/makeGuest/makeUser fixtures to shared factories

### DIFF
--- a/frontend/src/api/eventWrites.test.ts
+++ b/frontend/src/api/eventWrites.test.ts
@@ -6,13 +6,8 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  type Event,
-  EventStatus,
-  EventType,
-  EventVisibility,
-  InvitePermission,
-} from '@/models/event';
+import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
+import { makeEvent } from '@/test/fixtures';
 
 vi.mock('@/api/client', () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
@@ -35,60 +30,6 @@ import {
   useUploadEventPhoto,
 } from './eventWrites';
 import { textRecipientsKeys } from './textRecipients';
-
-function makeEvent(overrides: Partial<Event> = {}): Event {
-  return {
-    id: 'e1',
-    title: 'potluck',
-    description: 'bring food',
-    startDatetime: new Date('2026-06-01T18:00:00Z'),
-    endDatetime: new Date('2026-06-01T20:00:00Z'),
-    location: 'the park',
-    latitude: null,
-    longitude: null,
-    whatsappLink: '',
-    partifulLink: '',
-    otherLink: '',
-    venmoLink: '',
-    cashappLink: '',
-    zelleInfo: '',
-    price: '',
-    rsvpEnabled: true,
-    allowPlusOnes: true,
-    maxAttendees: null,
-    attendingCount: 0,
-    waitlistedCount: 0,
-    invitedCount: 0,
-    datetimeTbd: false,
-    hasPoll: false,
-    datetimePollSlug: null,
-    createdById: null,
-    createdByName: null,
-    createdByPhotoUrl: '',
-    coHostIds: [],
-    coHostNames: [],
-    coHostPhotoUrls: [],
-    coHostInviteIds: [],
-    guests: [],
-    myRsvp: null,
-    viewerUserId: null,
-    surveySlugs: [],
-    invitedUserIds: [],
-    invitedUserNames: [],
-    invitedUserPhotoUrls: [],
-    invitePermission: InvitePermission.AllMembers,
-    pendingCohostInvites: [],
-    myPendingCohostInviteId: null,
-    eventType: EventType.Community,
-    visibility: EventVisibility.Public,
-    photoUrl: '',
-    photoUpdatedAt: null,
-    tags: [],
-    isPast: false,
-    status: EventStatus.Active,
-    ...overrides,
-  };
-}
 
 describe('eventToFormValues enum validation', () => {
   it('passes through known enum values', () => {

--- a/frontend/src/models/event.test.ts
+++ b/frontend/src/models/event.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
+import { makeEvent } from '@/test/fixtures';
+
 import {
-  type Event,
   eventClass,
   EventStatus,
   EventType,
@@ -10,60 +11,6 @@ import {
   RsvpServerStatus,
   spotsLeft,
 } from './event';
-
-function makeEvent(overrides: Partial<Event> = {}): Event {
-  return {
-    id: 'test-id',
-    title: 'Test Event',
-    description: '',
-    startDatetime: new Date('2026-04-15T18:00:00Z'),
-    endDatetime: null,
-    location: '',
-    latitude: null,
-    longitude: null,
-    whatsappLink: '',
-    partifulLink: '',
-    otherLink: '',
-    venmoLink: '',
-    cashappLink: '',
-    zelleInfo: '',
-    price: '',
-    rsvpEnabled: false,
-    allowPlusOnes: false,
-    maxAttendees: null,
-    attendingCount: 0,
-    waitlistedCount: 0,
-    invitedCount: 0,
-    datetimeTbd: false,
-    hasPoll: false,
-    datetimePollSlug: null,
-    createdById: null,
-    createdByName: null,
-    createdByPhotoUrl: '',
-    coHostIds: [],
-    coHostNames: [],
-    coHostPhotoUrls: [],
-    coHostInviteIds: [],
-    guests: [],
-    myRsvp: null,
-    viewerUserId: null,
-    surveySlugs: [],
-    invitedUserIds: [],
-    invitedUserNames: [],
-    invitedUserPhotoUrls: [],
-    invitePermission: 'all_members',
-    pendingCohostInvites: [],
-    myPendingCohostInviteId: null,
-    eventType: EventType.Community,
-    visibility: EventVisibility.Public,
-    photoUrl: '',
-    photoUpdatedAt: null,
-    tags: [],
-    isPast: false,
-    status: EventStatus.Active,
-    ...overrides,
-  };
-}
 
 describe('eventClass', () => {
   it('returns cancelled class for cancelled events (highest precedence)', () => {

--- a/frontend/src/screens/calendar/AgendaList.test.tsx
+++ b/frontend/src/screens/calendar/AgendaList.test.tsx
@@ -2,66 +2,10 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
-import type { Event } from '@/models/event';
-import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
+import { EventType } from '@/models/event';
+import { makeEvent } from '@/test/fixtures';
 
 import { AgendaList } from './AgendaList';
-
-function makeEvent(overrides: Partial<Event> = {}): Event {
-  const start = new Date();
-  start.setDate(start.getDate() + 7);
-  return {
-    id: 'ev1',
-    title: 'potluck',
-    description: '',
-    startDatetime: start,
-    endDatetime: null,
-    location: '',
-    latitude: null,
-    longitude: null,
-    whatsappLink: '',
-    partifulLink: '',
-    otherLink: '',
-    venmoLink: '',
-    cashappLink: '',
-    zelleInfo: '',
-    price: '',
-    rsvpEnabled: false,
-    allowPlusOnes: false,
-    maxAttendees: null,
-    attendingCount: 0,
-    waitlistedCount: 0,
-    invitedCount: 0,
-    datetimeTbd: false,
-    hasPoll: false,
-    datetimePollSlug: null,
-    createdById: 'u1',
-    createdByName: 'Host',
-    createdByPhotoUrl: '',
-    coHostIds: [],
-    coHostNames: [],
-    coHostPhotoUrls: [],
-    coHostInviteIds: [],
-    guests: [],
-    myRsvp: null,
-    viewerUserId: null,
-    surveySlugs: [],
-    invitedUserIds: [],
-    invitedUserNames: [],
-    invitedUserPhotoUrls: [],
-    invitePermission: InvitePermission.CoHostsOnly,
-    pendingCohostInvites: [],
-    myPendingCohostInviteId: null,
-    eventType: EventType.Community,
-    visibility: EventVisibility.Public,
-    photoUrl: '',
-    photoUpdatedAt: null,
-    tags: [],
-    isPast: false,
-    status: EventStatus.Active,
-    ...overrides,
-  };
-}
 
 describe('AgendaList type filter', () => {
   const events = [

--- a/frontend/src/screens/calendar/CalendarViews.a11y.test.tsx
+++ b/frontend/src/screens/calendar/CalendarViews.a11y.test.tsx
@@ -2,67 +2,10 @@ import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
 
-import type { Event } from '@/models/event';
-import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
+import { makeEvent } from '@/test/fixtures';
 
 import { AgendaList } from './AgendaList';
 import { DayEventList } from './DayEventList';
-
-function makeEvent(overrides: Partial<Event> = {}): Event {
-  const start = new Date();
-  start.setDate(start.getDate() + 7);
-  return {
-    id: 'ev1',
-    title: 'potluck in the park',
-    description: '',
-    startDatetime: start,
-    endDatetime: null,
-    location: '',
-    latitude: null,
-    longitude: null,
-    whatsappLink: '',
-    partifulLink: '',
-    otherLink: '',
-    venmoLink: '',
-    cashappLink: '',
-    zelleInfo: '',
-    price: '',
-    rsvpEnabled: false,
-    allowPlusOnes: false,
-    maxAttendees: null,
-    attendingCount: 0,
-    waitlistedCount: 0,
-    invitedCount: 0,
-    datetimeTbd: false,
-    hasPoll: false,
-    datetimePollSlug: null,
-    createdById: 'u1',
-    createdByName: 'Host',
-    createdByPhotoUrl: '',
-    coHostIds: [],
-    coHostNames: [],
-    coHostPhotoUrls: [],
-    coHostInviteIds: [],
-    guests: [],
-    myRsvp: null,
-    viewerUserId: null,
-    surveySlugs: [],
-    invitedUserIds: [],
-    invitedUserNames: [],
-    invitedUserPhotoUrls: [],
-    invitePermission: InvitePermission.CoHostsOnly,
-    pendingCohostInvites: [],
-    myPendingCohostInviteId: null,
-    eventType: EventType.Community,
-    visibility: EventVisibility.Public,
-    photoUrl: '',
-    photoUpdatedAt: null,
-    tags: [],
-    isPast: false,
-    status: EventStatus.Active,
-    ...overrides,
-  };
-}
 
 describe('calendar views accessibility', () => {
   it('AgendaList exposes each event as a button labelled with its title', () => {

--- a/frontend/src/screens/events/EmailBlastButton.test.tsx
+++ b/frontend/src/screens/events/EmailBlastButton.test.tsx
@@ -2,8 +2,8 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
-import type { Event, EventGuest } from '@/models/event';
-import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
+import { EventStatus } from '@/models/event';
+import { makeEvent } from '@/test/fixtures';
 
 vi.mock('./EmailBlastDialog', () => ({
   EmailBlastDialog: ({ open }: { open: boolean }) =>
@@ -11,73 +11,6 @@ vi.mock('./EmailBlastDialog', () => ({
 }));
 
 import { EmailBlastButton } from './EmailBlastButton';
-
-function guest(status: string): EventGuest {
-  return {
-    userId: 'g1',
-    name: 'Guest',
-    status,
-    phone: null,
-    photoUrl: '',
-    hasPlusOne: false,
-    attendance: 'unknown',
-    isMember: true,
-  };
-}
-
-function makeEvent(overrides: Partial<Event> = {}): Event {
-  return {
-    id: 'ev1',
-    title: 'Potluck',
-    description: '',
-    startDatetime: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
-    endDatetime: null,
-    location: '',
-    latitude: null,
-    longitude: null,
-    whatsappLink: '',
-    partifulLink: '',
-    otherLink: '',
-    venmoLink: '',
-    cashappLink: '',
-    zelleInfo: '',
-    price: '',
-    rsvpEnabled: true,
-    allowPlusOnes: false,
-    maxAttendees: null,
-    attendingCount: 1,
-    waitlistedCount: 0,
-    invitedCount: 0,
-    datetimeTbd: false,
-    hasPoll: false,
-    datetimePollSlug: null,
-    createdById: 'creator',
-    createdByName: 'Creator',
-    createdByPhotoUrl: '',
-    coHostIds: [],
-    coHostNames: [],
-    coHostPhotoUrls: [],
-    coHostInviteIds: [],
-    guests: [guest('attending')],
-    myRsvp: null,
-    viewerUserId: null,
-    surveySlugs: [],
-    invitedUserIds: [],
-    invitedUserNames: [],
-    invitedUserPhotoUrls: [],
-    invitePermission: InvitePermission.CoHostsOnly,
-    pendingCohostInvites: [],
-    myPendingCohostInviteId: null,
-    eventType: EventType.Community,
-    visibility: EventVisibility.Public,
-    photoUrl: '',
-    photoUpdatedAt: null,
-    tags: [],
-    isPast: false,
-    status: EventStatus.Active,
-    ...overrides,
-  };
-}
 
 describe('EmailBlastButton', () => {
   it('renders the email-blast button when the event has guests', () => {

--- a/frontend/src/screens/events/EmailBlastDialog.test.tsx
+++ b/frontend/src/screens/events/EmailBlastDialog.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Event, EventGuest } from '@/models/event';
-import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
+import { makeEvent as makeEventFixture } from '@/test/fixtures';
 
 const mutateAsyncMock = vi.fn();
 const toastSuccessMock = vi.fn();
@@ -41,56 +41,10 @@ function guest(status: string, i: number): EventGuest {
 }
 
 function makeEvent(guests: EventGuest[]): Event {
-  return {
-    id: 'ev1',
-    title: 'Potluck',
-    description: '',
-    startDatetime: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
-    endDatetime: null,
-    location: '',
-    latitude: null,
-    longitude: null,
-    whatsappLink: '',
-    partifulLink: '',
-    otherLink: '',
-    venmoLink: '',
-    cashappLink: '',
-    zelleInfo: '',
-    price: '',
-    rsvpEnabled: true,
-    allowPlusOnes: false,
-    maxAttendees: null,
-    attendingCount: guests.filter((g) => g.status === 'attending').length,
-    waitlistedCount: 0,
-    invitedCount: 0,
-    datetimeTbd: false,
-    hasPoll: false,
-    datetimePollSlug: null,
-    createdById: 'creator',
-    createdByName: 'Creator',
-    createdByPhotoUrl: '',
-    coHostIds: [],
-    coHostNames: [],
-    coHostPhotoUrls: [],
-    coHostInviteIds: [],
+  return makeEventFixture({
     guests,
-    myRsvp: null,
-    viewerUserId: null,
-    surveySlugs: [],
-    invitedUserIds: [],
-    invitedUserNames: [],
-    invitedUserPhotoUrls: [],
-    invitePermission: InvitePermission.CoHostsOnly,
-    pendingCohostInvites: [],
-    myPendingCohostInviteId: null,
-    eventType: EventType.Community,
-    visibility: EventVisibility.Public,
-    photoUrl: '',
-    photoUpdatedAt: null,
-    isPast: false,
-    status: EventStatus.Active,
-    tags: [],
-  };
+    attendingCount: guests.filter((g) => g.status === 'attending').length,
+  });
 }
 
 function renderDialog(event: Event) {

--- a/frontend/src/screens/events/EventAdminActions.test.tsx
+++ b/frontend/src/screens/events/EventAdminActions.test.tsx
@@ -7,6 +7,7 @@ import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
 import type { User } from '@/models/user';
+import { makeUser as makeBaseUser } from '@/test/fixtures';
 
 // Mock network-touching dependencies
 vi.mock('@/api/eventWrites', () => ({
@@ -24,34 +25,10 @@ const COHOST_ID = 'cohost-user';
 const REGULAR_ID = 'regular-user';
 
 function makeUser(id: string, permissions: string[] = []): User {
-  return {
+  return makeBaseUser({
     id,
-    phoneNumber: '+12125550001',
-    firstName: 'Test',
-    lastName: 'User',
-    fullName: 'Test User',
-    nickname: '',
-    email: '',
-    bio: '',
-    pronouns: '',
-    birthday: null,
-    isSuperuser: false,
-    isStaff: false,
-    needsOnboarding: false,
-    needsPasswordReset: false,
-    needsGuidelinesConsent: false,
-    needsSmsConsent: false,
-    needsContactPrivacyConsent: false,
-    showPhone: false,
-    showEmail: false,
-    showBirthday: false,
-    hideLastName: false,
-    weekStart: 'sunday',
-    calendarFeedScope: 'all',
-    profilePhotoUrl: '',
-    photoUpdatedAt: null,
     roles: permissions.length ? [{ id: 'r1', name: 'custom', isDefault: true, permissions }] : [],
-  };
+  });
 }
 
 const BASE_EVENT: Event = {

--- a/frontend/src/screens/events/EventBadge.test.tsx
+++ b/frontend/src/screens/events/EventBadge.test.tsx
@@ -1,69 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import {
-  type Event,
-  EventStatus,
-  EventType,
-  EventVisibility,
-  InvitePermission,
-} from '@/models/event';
+import { EventType } from '@/models/event';
+import { makeEvent } from '@/test/fixtures';
 
 import { EventBadge } from './EventBadge';
-
-function makeEvent(overrides: Partial<Event> = {}): Event {
-  return {
-    id: 'ev1',
-    title: 'potluck',
-    description: '',
-    startDatetime: new Date('2026-04-15T18:00:00Z'),
-    endDatetime: null,
-    location: '',
-    latitude: null,
-    longitude: null,
-    whatsappLink: '',
-    partifulLink: '',
-    otherLink: '',
-    venmoLink: '',
-    cashappLink: '',
-    zelleInfo: '',
-    price: '',
-    rsvpEnabled: false,
-    allowPlusOnes: false,
-    maxAttendees: null,
-    attendingCount: 0,
-    waitlistedCount: 0,
-    invitedCount: 0,
-    datetimeTbd: false,
-    hasPoll: false,
-    datetimePollSlug: null,
-    createdById: 'u1',
-    createdByName: 'Host',
-    createdByPhotoUrl: '',
-    coHostIds: [],
-    coHostNames: [],
-    coHostPhotoUrls: [],
-    coHostInviteIds: [],
-    guests: [],
-    myRsvp: null,
-    viewerUserId: null,
-    surveySlugs: [],
-    invitedUserIds: [],
-    invitedUserNames: [],
-    invitedUserPhotoUrls: [],
-    invitePermission: InvitePermission.CoHostsOnly,
-    pendingCohostInvites: [],
-    myPendingCohostInviteId: null,
-    eventType: EventType.Community,
-    visibility: EventVisibility.Public,
-    photoUrl: '',
-    photoUpdatedAt: null,
-    isPast: false,
-    status: EventStatus.Active,
-    tags: [],
-    ...overrides,
-  };
-}
 
 describe('EventBadge', () => {
   it('renders an official badge', () => {

--- a/frontend/src/screens/events/EventCardBadges.test.tsx
+++ b/frontend/src/screens/events/EventCardBadges.test.tsx
@@ -1,69 +1,10 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import {
-  type Event,
-  EventStatus,
-  EventType,
-  EventVisibility,
-  RsvpServerStatus,
-} from '@/models/event';
+import { RsvpServerStatus } from '@/models/event';
+import { makeEvent } from '@/test/fixtures';
 
 import { EventCardBadges } from './EventCardBadges';
-
-function makeEvent(overrides: Partial<Event> = {}): Event {
-  return {
-    id: 'ev1',
-    title: 'potluck',
-    description: '',
-    startDatetime: new Date('2026-04-15T18:00:00Z'),
-    endDatetime: null,
-    location: '',
-    latitude: null,
-    longitude: null,
-    whatsappLink: '',
-    partifulLink: '',
-    otherLink: '',
-    venmoLink: '',
-    cashappLink: '',
-    zelleInfo: '',
-    price: '',
-    rsvpEnabled: false,
-    allowPlusOnes: false,
-    maxAttendees: null,
-    attendingCount: 0,
-    waitlistedCount: 0,
-    invitedCount: 0,
-    datetimeTbd: false,
-    hasPoll: false,
-    datetimePollSlug: null,
-    createdById: null,
-    createdByName: null,
-    createdByPhotoUrl: '',
-    coHostIds: [],
-    coHostNames: [],
-    coHostPhotoUrls: [],
-    coHostInviteIds: [],
-    guests: [],
-    myRsvp: null,
-    viewerUserId: null,
-    surveySlugs: [],
-    invitedUserIds: [],
-    invitedUserNames: [],
-    invitedUserPhotoUrls: [],
-    invitePermission: 'all_members',
-    pendingCohostInvites: [],
-    myPendingCohostInviteId: null,
-    eventType: EventType.Community,
-    visibility: EventVisibility.Public,
-    photoUrl: '',
-    photoUpdatedAt: null,
-    isPast: false,
-    status: EventStatus.Active,
-    tags: [],
-    ...overrides,
-  };
-}
 
 describe('EventCardBadges', () => {
   it('renders nothing when there is no rsvp and capacity is unlimited', () => {

--- a/frontend/src/screens/events/PublicRsvp.a11y.test.tsx
+++ b/frontend/src/screens/events/PublicRsvp.a11y.test.tsx
@@ -3,13 +3,8 @@ import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
 
-import {
-  type Event,
-  EventStatus,
-  EventType,
-  EventVisibility,
-  InvitePermission,
-} from '@/models/event';
+import type { Event } from '@/models/event';
+import { makeEvent } from '@/test/fixtures';
 
 const checkPhoneMutate = vi.fn();
 vi.mock('@/api/publicRsvp', () => ({
@@ -30,60 +25,6 @@ function renderForm(event: Event) {
       />
     </MemoryRouter>,
   );
-}
-
-function makeEvent(overrides: Partial<Event> = {}): Event {
-  return {
-    id: 'ev1',
-    title: 'Potluck',
-    description: '',
-    startDatetime: new Date('2099-06-01T18:00:00Z'),
-    endDatetime: null,
-    location: '123 Main St',
-    latitude: null,
-    longitude: null,
-    whatsappLink: 'https://chat.whatsapp.com/abc123',
-    partifulLink: '',
-    otherLink: '',
-    venmoLink: '',
-    cashappLink: '',
-    zelleInfo: '',
-    price: '',
-    rsvpEnabled: true,
-    allowPlusOnes: true,
-    maxAttendees: null,
-    attendingCount: 0,
-    waitlistedCount: 0,
-    invitedCount: 0,
-    datetimeTbd: false,
-    hasPoll: false,
-    datetimePollSlug: null,
-    createdById: null,
-    createdByName: null,
-    createdByPhotoUrl: '',
-    coHostIds: [],
-    coHostNames: [],
-    coHostPhotoUrls: [],
-    coHostInviteIds: [],
-    guests: [],
-    myRsvp: null,
-    viewerUserId: null,
-    surveySlugs: [],
-    invitedUserIds: [],
-    invitedUserNames: [],
-    invitedUserPhotoUrls: [],
-    invitePermission: InvitePermission.AllMembers,
-    pendingCohostInvites: [],
-    myPendingCohostInviteId: null,
-    eventType: EventType.Official,
-    visibility: EventVisibility.Public,
-    photoUrl: '',
-    photoUpdatedAt: null,
-    tags: [],
-    isPast: false,
-    status: EventStatus.Active,
-    ...overrides,
-  };
 }
 
 describe('public rsvp a11y', () => {

--- a/frontend/src/screens/events/PublicRsvpCard.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpCard.test.tsx
@@ -3,14 +3,8 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 
-import {
-  type Event,
-  EventStatus,
-  EventType,
-  EventVisibility,
-  InvitePermission,
-  RsvpServerStatus,
-} from '@/models/event';
+import { type Event, RsvpServerStatus } from '@/models/event';
+import { makeEvent } from '@/test/fixtures';
 
 const updateMutate = vi.fn();
 const cancelMutate = vi.fn();
@@ -21,60 +15,6 @@ vi.mock('@/api/publicRsvp', () => ({
 
 import { PublicRsvpCard } from './PublicRsvpCard';
 
-function makeEvent(overrides: Partial<Event>): Event {
-  return {
-    id: 'ev1',
-    title: 'Potluck',
-    description: '',
-    startDatetime: new Date('2099-06-01T18:00:00Z'),
-    endDatetime: null,
-    location: '',
-    latitude: null,
-    longitude: null,
-    whatsappLink: '',
-    partifulLink: '',
-    otherLink: '',
-    venmoLink: '',
-    cashappLink: '',
-    zelleInfo: '',
-    price: '',
-    rsvpEnabled: true,
-    allowPlusOnes: true,
-    maxAttendees: null,
-    attendingCount: 0,
-    waitlistedCount: 0,
-    invitedCount: 0,
-    datetimeTbd: false,
-    hasPoll: false,
-    datetimePollSlug: null,
-    createdById: 'user-host',
-    createdByName: 'Host',
-    createdByPhotoUrl: '',
-    coHostIds: [],
-    coHostNames: [],
-    coHostPhotoUrls: [],
-    coHostInviteIds: [],
-    guests: [],
-    myRsvp: null,
-    viewerUserId: null,
-    surveySlugs: [],
-    invitedUserIds: [],
-    invitedUserNames: [],
-    invitedUserPhotoUrls: [],
-    invitePermission: InvitePermission.AllMembers,
-    pendingCohostInvites: [],
-    myPendingCohostInviteId: null,
-    eventType: EventType.Community,
-    visibility: EventVisibility.Public,
-    photoUrl: '',
-    photoUpdatedAt: null,
-    tags: [],
-    isPast: false,
-    status: EventStatus.Active,
-    ...overrides,
-  };
-}
-
 function renderCard(props: { status: string; hasPlusOne: boolean; event?: Partial<Event> }) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
@@ -82,7 +22,7 @@ function renderCard(props: { status: string; hasPlusOne: boolean; event?: Partia
       <MemoryRouter>
         <PublicRsvpCard
           token="tok123"
-          event={makeEvent(props.event ?? {})}
+          event={makeEvent({ allowPlusOnes: true, ...props.event })}
           status={props.status}
           hasPlusOne={props.hasPlusOne}
         />
@@ -93,7 +33,11 @@ function renderCard(props: { status: string; hasPlusOne: boolean; event?: Partia
 
 describe('PublicRsvpCard', () => {
   it('links the event title to the event detail page', () => {
-    renderCard({ status: RsvpServerStatus.Attending, hasPlusOne: false, event: { id: 'ev1' } });
+    renderCard({
+      status: RsvpServerStatus.Attending,
+      hasPlusOne: false,
+      event: { id: 'ev1', title: 'Potluck' },
+    });
     expect(screen.getByRole('link', { name: 'Potluck' })).toHaveAttribute('href', '/events/ev1');
   });
 

--- a/frontend/src/screens/events/PublicRsvpForm.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.test.tsx
@@ -2,13 +2,7 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  type Event,
-  EventStatus,
-  EventType,
-  EventVisibility,
-  InvitePermission,
-} from '@/models/event';
+import { makeEvent } from '@/test/fixtures';
 
 const submitMutate = vi.fn();
 const checkPhoneMutate = vi.fn();
@@ -18,60 +12,6 @@ vi.mock('@/api/publicRsvp', () => ({
 }));
 
 import { PublicRsvpForm } from './PublicRsvpForm';
-
-function makeEvent(overrides: Partial<Event> = {}): Event {
-  return {
-    id: 'ev1',
-    title: 'Potluck',
-    description: '',
-    startDatetime: new Date('2099-06-01T18:00:00Z'),
-    endDatetime: null,
-    location: '',
-    latitude: null,
-    longitude: null,
-    whatsappLink: '',
-    partifulLink: '',
-    otherLink: '',
-    venmoLink: '',
-    cashappLink: '',
-    zelleInfo: '',
-    price: '',
-    rsvpEnabled: true,
-    allowPlusOnes: true,
-    maxAttendees: null,
-    attendingCount: 0,
-    waitlistedCount: 0,
-    invitedCount: 0,
-    datetimeTbd: false,
-    hasPoll: false,
-    datetimePollSlug: null,
-    createdById: null,
-    createdByName: null,
-    createdByPhotoUrl: '',
-    coHostIds: [],
-    coHostNames: [],
-    coHostPhotoUrls: [],
-    coHostInviteIds: [],
-    guests: [],
-    myRsvp: null,
-    viewerUserId: null,
-    surveySlugs: [],
-    invitedUserIds: [],
-    invitedUserNames: [],
-    invitedUserPhotoUrls: [],
-    invitePermission: InvitePermission.AllMembers,
-    pendingCohostInvites: [],
-    myPendingCohostInviteId: null,
-    eventType: EventType.Official,
-    visibility: EventVisibility.Public,
-    photoUrl: '',
-    photoUpdatedAt: null,
-    tags: [],
-    isPast: false,
-    status: EventStatus.Active,
-    ...overrides,
-  };
-}
 
 function renderForm(
   event = makeEvent(),

--- a/frontend/src/screens/events/PublicRsvpSection.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpSection.test.tsx
@@ -4,14 +4,8 @@ import type * as RouterDom from 'react-router-dom';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  canPublicRsvp,
-  type Event,
-  EventStatus,
-  EventType,
-  EventVisibility,
-  InvitePermission,
-} from '@/models/event';
+import { canPublicRsvp, EventStatus, EventType, EventVisibility } from '@/models/event';
+import { makeEvent } from '@/test/fixtures';
 
 const mockNavigate = vi.fn();
 vi.mock('react-router-dom', async (importActual) => {
@@ -28,78 +22,32 @@ vi.mock('@/api/publicRsvp', () => ({
 
 import { PublicRsvpSection } from './PublicRsvpSection';
 
-function makeEvent(overrides: Partial<Event> = {}): Event {
-  return {
-    id: 'ev1',
-    title: 'Potluck',
-    description: '',
-    startDatetime: new Date('2099-06-01T18:00:00Z'),
-    endDatetime: null,
-    location: '',
-    latitude: null,
-    longitude: null,
-    whatsappLink: '',
-    partifulLink: '',
-    otherLink: '',
-    venmoLink: '',
-    cashappLink: '',
-    zelleInfo: '',
-    price: '',
-    rsvpEnabled: true,
-    allowPlusOnes: false,
-    maxAttendees: null,
-    attendingCount: 0,
-    waitlistedCount: 0,
-    invitedCount: 0,
-    datetimeTbd: false,
-    hasPoll: false,
-    datetimePollSlug: null,
-    createdById: null,
-    createdByName: null,
-    createdByPhotoUrl: '',
-    coHostIds: [],
-    coHostNames: [],
-    coHostPhotoUrls: [],
-    coHostInviteIds: [],
-    guests: [],
-    myRsvp: null,
-    viewerUserId: null,
-    surveySlugs: [],
-    invitedUserIds: [],
-    invitedUserNames: [],
-    invitedUserPhotoUrls: [],
-    invitePermission: InvitePermission.AllMembers,
-    pendingCohostInvites: [],
-    myPendingCohostInviteId: null,
+function officialEvent(overrides: Partial<Parameters<typeof makeEvent>[0]> = {}) {
+  return makeEvent({
     eventType: EventType.Official,
     visibility: EventVisibility.Public,
-    photoUrl: '',
-    photoUpdatedAt: null,
-    tags: [],
-    isPast: false,
-    status: EventStatus.Active,
     ...overrides,
-  };
+  });
 }
 
 describe('canPublicRsvp', () => {
   it('is true for official + public + rsvpEnabled + active + not-past', () => {
-    expect(canPublicRsvp(makeEvent())).toBe(true);
+    expect(canPublicRsvp(officialEvent())).toBe(true);
   });
   it('is false for community events', () => {
-    expect(canPublicRsvp(makeEvent({ eventType: EventType.Community }))).toBe(false);
+    expect(canPublicRsvp(officialEvent({ eventType: EventType.Community }))).toBe(false);
   });
   it('is false for members-only visibility', () => {
-    expect(canPublicRsvp(makeEvent({ visibility: EventVisibility.MembersOnly }))).toBe(false);
+    expect(canPublicRsvp(officialEvent({ visibility: EventVisibility.MembersOnly }))).toBe(false);
   });
   it('is false when rsvp disabled', () => {
-    expect(canPublicRsvp(makeEvent({ rsvpEnabled: false }))).toBe(false);
+    expect(canPublicRsvp(officialEvent({ rsvpEnabled: false }))).toBe(false);
   });
   it('is false when cancelled', () => {
-    expect(canPublicRsvp(makeEvent({ status: EventStatus.Cancelled }))).toBe(false);
+    expect(canPublicRsvp(officialEvent({ status: EventStatus.Cancelled }))).toBe(false);
   });
   it('is false when past', () => {
-    expect(canPublicRsvp(makeEvent({ isPast: true }))).toBe(false);
+    expect(canPublicRsvp(officialEvent({ isPast: true }))).toBe(false);
   });
 });
 
@@ -113,7 +61,7 @@ describe('PublicRsvpSection', () => {
   it('renders the form heading initially', () => {
     render(
       <MemoryRouter>
-        <PublicRsvpSection event={makeEvent()} />
+        <PublicRsvpSection event={officialEvent()} />
       </MemoryRouter>,
     );
     expect(screen.getByRole('heading', { name: 'rsvp' })).toBeInTheDocument();
@@ -122,14 +70,14 @@ describe('PublicRsvpSection', () => {
   it('persists the rsvp token and refreshes without putting it in the url', async () => {
     mockCheckPhone.mockResolvedValue({ status: 'new', rsvp_token: '' });
     mockSubmit.mockResolvedValue({
-      event: makeEvent(),
+      event: officialEvent(),
       rsvp: { status: 'attending', has_plus_one: false },
       rsvp_token: 'tok-abc',
     });
     const user = userEvent.setup();
     render(
       <MemoryRouter>
-        <PublicRsvpSection event={makeEvent({ id: 'evt-1' })} />
+        <PublicRsvpSection event={officialEvent({ id: 'evt-1' })} />
       </MemoryRouter>,
     );
 
@@ -150,7 +98,7 @@ describe('PublicRsvpSection', () => {
     const user = userEvent.setup();
     render(
       <MemoryRouter>
-        <PublicRsvpSection event={makeEvent({ id: 'evt-1' })} />
+        <PublicRsvpSection event={officialEvent({ id: 'evt-1' })} />
       </MemoryRouter>,
     );
 
@@ -167,7 +115,7 @@ describe('PublicRsvpSection', () => {
     const user = userEvent.setup();
     render(
       <MemoryRouter>
-        <PublicRsvpSection event={makeEvent({ id: 'evt-1' })} />
+        <PublicRsvpSection event={officialEvent({ id: 'evt-1' })} />
       </MemoryRouter>,
     );
 

--- a/frontend/src/screens/events/RsvpGuestList.test.tsx
+++ b/frontend/src/screens/events/RsvpGuestList.test.tsx
@@ -3,16 +3,8 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import {
-  AttendanceStatus,
-  type Event,
-  type EventGuest,
-  EventStatus,
-  EventType,
-  EventVisibility,
-  InvitePermission,
-  RsvpServerStatus,
-} from '@/models/event';
+import type { Event } from '@/models/event';
+import { makeEvent, makeGuest } from '@/test/fixtures';
 
 const setGuestRsvpMutate = vi.fn();
 vi.mock('@/api/eventStats', () => ({
@@ -20,74 +12,6 @@ vi.mock('@/api/eventStats', () => ({
 }));
 
 import { RsvpGuestList } from './RsvpGuestList';
-
-function makeGuest(overrides: Partial<EventGuest>): EventGuest {
-  return {
-    userId: 'user-other',
-    name: 'Other',
-    status: RsvpServerStatus.Attending,
-    phone: null,
-    photoUrl: '',
-    hasPlusOne: false,
-    attendance: AttendanceStatus.Unknown,
-    isMember: true,
-    ...overrides,
-  };
-}
-
-function makeEvent(overrides: Partial<Event>): Event {
-  return {
-    id: 'ev1',
-    title: 'Potluck',
-    description: '',
-    startDatetime: new Date('2099-06-01T18:00:00Z'),
-    endDatetime: null,
-    location: '',
-    latitude: null,
-    longitude: null,
-    whatsappLink: '',
-    partifulLink: '',
-    otherLink: '',
-    venmoLink: '',
-    cashappLink: '',
-    zelleInfo: '',
-    price: '',
-    rsvpEnabled: true,
-    allowPlusOnes: true,
-    maxAttendees: null,
-    attendingCount: 0,
-    waitlistedCount: 0,
-    invitedCount: 0,
-    datetimeTbd: false,
-    hasPoll: false,
-    datetimePollSlug: null,
-    createdById: 'user-host',
-    createdByName: 'Host',
-    createdByPhotoUrl: '',
-    coHostIds: [],
-    coHostNames: [],
-    coHostPhotoUrls: [],
-    coHostInviteIds: [],
-    guests: [makeGuest({})],
-    myRsvp: null,
-    surveySlugs: [],
-    invitedUserIds: [],
-    invitedUserNames: [],
-    invitedUserPhotoUrls: [],
-    invitePermission: InvitePermission.AllMembers,
-    pendingCohostInvites: [],
-    myPendingCohostInviteId: null,
-    eventType: EventType.Community,
-    visibility: EventVisibility.Public,
-    photoUrl: '',
-    photoUpdatedAt: null,
-    tags: [],
-    isPast: false,
-    status: EventStatus.Active,
-    viewerUserId: null,
-    ...overrides,
-  };
-}
 
 function renderList(event: Event, canManageRsvps = false) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
@@ -126,12 +50,12 @@ describe('RsvpGuestList', () => {
 
 describe('RsvpGuestList — host rsvp management (Issue 872)', () => {
   it('does not show an edit control when the viewer cannot manage rsvps', () => {
-    renderList(makeEvent({}), false);
+    renderList(makeEvent({ guests: [makeGuest({})] }), false);
     expect(screen.queryByRole('button', { name: /change other's rsvp/i })).not.toBeInTheDocument();
   });
 
   it('shows an edit control per guest when the viewer can manage rsvps', () => {
-    renderList(makeEvent({}), true);
+    renderList(makeEvent({ guests: [makeGuest({})] }), true);
     expect(screen.getByRole('button', { name: /change other's rsvp/i })).toBeInTheDocument();
   });
 
@@ -141,14 +65,14 @@ describe('RsvpGuestList — host rsvp management (Issue 872)', () => {
   });
 
   it('opens a dialog with status options when edit is tapped', () => {
-    renderList(makeEvent({}), true);
+    renderList(makeEvent({ guests: [makeGuest({})] }), true);
     fireEvent.click(screen.getByRole('button', { name: /change other's rsvp/i }));
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /^maybe$/i })).toBeInTheDocument();
   });
 
   it('calls the mutation with the selected status', () => {
-    renderList(makeEvent({}), true);
+    renderList(makeEvent({ guests: [makeGuest({})] }), true);
     fireEvent.click(screen.getByRole('button', { name: /change other's rsvp/i }));
     fireEvent.click(screen.getByRole('button', { name: /^maybe$/i }));
     expect(setGuestRsvpMutate).toHaveBeenCalledWith(

--- a/frontend/src/screens/events/RsvpSection.test.tsx
+++ b/frontend/src/screens/events/RsvpSection.test.tsx
@@ -4,17 +4,8 @@ import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAuthStore } from '@/auth/store';
-import {
-  AttendanceStatus,
-  type Event,
-  type EventGuest,
-  EventStatus,
-  EventType,
-  EventVisibility,
-  InvitePermission,
-  RsvpServerStatus,
-} from '@/models/event';
-import type { User } from '@/models/user';
+import { type Event, RsvpServerStatus } from '@/models/event';
+import { makeEvent as makeBaseEvent, makeGuest, makeUser } from '@/test/fixtures';
 
 const setRsvpMutate = vi.fn();
 const removeRsvpMutate = vi.fn();
@@ -42,101 +33,16 @@ vi.mock('./RsvpCommentField', () => ({
 
 import { RsvpSection } from './RsvpSection';
 
-const ME: User = {
-  id: 'user-me',
-  phoneNumber: '+12125550001',
-  firstName: 'Me',
-  lastName: '',
-  fullName: 'Me',
-  nickname: '',
-  email: '',
-  bio: '',
-  pronouns: '',
-  birthday: null,
-  isSuperuser: false,
-  isStaff: false,
-  needsOnboarding: false,
-  needsPasswordReset: false,
-  needsGuidelinesConsent: false,
-  needsSmsConsent: false,
-  needsContactPrivacyConsent: false,
-  showPhone: false,
-  showEmail: false,
-  showBirthday: false,
-  hideLastName: false,
-  weekStart: 'sunday',
-  calendarFeedScope: 'all',
-  profilePhotoUrl: '',
-  photoUpdatedAt: null,
-  roles: [],
-};
+const ME = makeUser({ id: 'user-me', firstName: 'Me', lastName: '', fullName: 'Me' });
 
-function makeGuest(overrides: Partial<EventGuest>): EventGuest {
-  return {
-    userId: 'user-other',
-    name: 'Other',
-    status: RsvpServerStatus.Attending,
-    phone: null,
-    photoUrl: '',
-    hasPlusOne: false,
-    attendance: AttendanceStatus.Unknown,
-    isMember: true,
-    ...overrides,
-  };
-}
-
-function makeEvent(overrides: Partial<Event>): Event {
-  return {
-    id: 'ev1',
-    title: 'Potluck',
-    description: '',
-    startDatetime: new Date('2099-06-01T18:00:00Z'),
-    endDatetime: null,
-    location: '',
-    latitude: null,
-    longitude: null,
-    whatsappLink: '',
-    partifulLink: '',
-    otherLink: '',
-    venmoLink: '',
-    cashappLink: '',
-    zelleInfo: '',
-    price: '',
-    rsvpEnabled: true,
-    allowPlusOnes: true,
-    maxAttendees: null,
-    attendingCount: 0,
-    waitlistedCount: 0,
-    invitedCount: 0,
-    datetimeTbd: false,
-    hasPoll: false,
-    datetimePollSlug: null,
+function makeEvent(overrides: Partial<Event> = {}): Event {
+  return makeBaseEvent({
     createdById: 'user-host',
     createdByName: 'Host',
-    createdByPhotoUrl: '',
-    coHostIds: [],
-    coHostNames: [],
-    coHostPhotoUrls: [],
-    coHostInviteIds: [],
+    allowPlusOnes: true,
     guests: [],
-    myRsvp: null,
-    surveySlugs: [],
-    invitedUserIds: [],
-    invitedUserNames: [],
-    invitedUserPhotoUrls: [],
-    invitePermission: InvitePermission.AllMembers,
-    pendingCohostInvites: [],
-    myPendingCohostInviteId: null,
-    eventType: EventType.Community,
-    visibility: EventVisibility.Public,
-    photoUrl: '',
-    photoUpdatedAt: null,
-    tags: [],
-    isPast: false,
-    status: EventStatus.Active,
-    viewerUserId: null,
     ...overrides,
-  };
+  });
 }
 
 function renderSection(event: Event, token?: string) {

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -1,7 +1,7 @@
 // Shared test fixtures. Factories return a complete, valid object with sensible
 // defaults; pass `overrides` to vary the fields a given test cares about.
 
-import type { Event } from '@/models/event';
+import type { Event, EventGuest } from '@/models/event';
 import {
   AttendanceStatus,
   EventStatus,
@@ -11,6 +11,20 @@ import {
   RsvpServerStatus,
 } from '@/models/event';
 import type { User } from '@/models/user';
+
+export function makeGuest(overrides: Partial<EventGuest> = {}): EventGuest {
+  return {
+    userId: 'user-other',
+    name: 'Other',
+    status: RsvpServerStatus.Attending,
+    phone: null,
+    photoUrl: '',
+    hasPlusOne: false,
+    attendance: AttendanceStatus.Unknown,
+    isMember: true,
+    ...overrides,
+  };
+}
 
 export function makeEvent(overrides: Partial<Event> = {}): Event {
   return {


### PR DESCRIPTION
## Summary
- Migrates the remaining fixture duplication called out in Issue 734's follow-ups after #740.
- 14 files with local `makeEvent` factories now delegate to the shared `makeEvent` in `frontend/src/test/fixtures.ts` (`EmailBlastDialog.test.tsx` and `RsvpSection.test.tsx` keep thin local wrappers for signature/default needs that don't fit the shared factory's shape).
- Added a shared `makeGuest` factory to `fixtures.ts` and wired `RsvpGuestList.test.tsx` and `RsvpSection.test.tsx` to it, replacing two duplicate local implementations.
- `EventAdminActions.test.tsx`'s custom `makeUser(id, permissions)` and `RsvpSection.test.tsx`'s inline `ME: User` literal now delegate to the shared `makeUser`.

Closes #734

## Test plan
- [x] `make agent-frontend-test` — 888 tests pass
- [x] `make agent-frontend-lint` — clean
- [x] `make agent-frontend-typecheck` — clean