### PR TITLE
fix(notifications): cancel refetches before optimistic mark-all + mutation-error backstop

### DIFF
--- a/frontend/src/api/notifications.ts
+++ b/frontend/src/api/notifications.ts
@@ -128,7 +128,9 @@ export function useMarkAllNotificationsRead() {
     mutationFn: async () => {
       await apiClient.post('/api/notifications/read-all/');
     },
-    onMutate: () => {
+    onMutate: async () => {
+      // Cancel in-flight refetches so a late response can't clobber the optimistic write.
+      await qc.cancelQueries({ queryKey: notificationKeys.all });
       // Snapshot for onError rollback so a failed mark-all doesn't leave the badge stuck at 0.
       const prevUnread = qc.getQueryData<number>(notificationKeys.unread);
       const prevBell = qc.getQueryData<AppNotification[]>(notificationKeys.bell);

--- a/frontend/src/api/queryClient.ts
+++ b/frontend/src/api/queryClient.ts
@@ -1,10 +1,19 @@
-import { QueryClient } from '@tanstack/react-query';
+import { MutationCache, QueryClient } from '@tanstack/react-query';
+
+import { reportError } from '@/utils/errorReporter';
 
 // Defaults tuned for PDA's semantics:
 //   - 4xx errors are deterministic, don't retry them.
 //   - 30s staleTime means nav within the app feels instant; detailed mutations
 //     call invalidateQueries explicitly rather than relying on polling.
 export const queryClient = new QueryClient({
+  // Report-only backstop: log every mutation failure to the backend. No toast —
+  // components own user-facing messaging, so toasting here would double-notify.
+  mutationCache: new MutationCache({
+    onError: (error) => {
+      void reportError(error, 'mutation');
+    },
+  }),
   defaultOptions: {
     queries: {
       staleTime: 30_000,


### PR DESCRIPTION
## Overview

The two remaining #714 review findings that never landed on main. PR #726 (the original fix) has been overtaken — of its 5 findings, 3 landed on main independently over the past week (update_event atomicity, RsvpSection dedup, release-script scoping) and the notifications onError snapshot landed partially. This PR carries the two residuals so #726 can be closed.

## Changes

- **notifications race** — `useMarkAllNotificationsRead.onMutate` now `await qc.cancelQueries({ queryKey: notificationKeys.all })` before the optimistic write, matching the `eventComments`/`eventPolls` convention. Without it, a refetch in flight during the mutation can clobber the optimistic write or leave the `onError` rollback restoring a stale snapshot.
- **silent-failure backstop** — added a `MutationCache` `onError` to `queryClient` that `reportError`s every mutation failure to the backend. Report-only (no toast) so components keep owning user-facing messaging and there's no double-notify — catches the silent-failure class at the root rather than one call site at a time.

## Verification

- tsc ✓, eslint ✓
- `notifications.test.ts` — 8/8 ✓ (covers `useMarkAllNotificationsRead`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
