### PR TITLE
refactor(tests): delegate remaining test factories to shared fixtures

### DIFF
--- a/frontend/src/screens/admin/AttendanceReportScreen.test.tsx
+++ b/frontend/src/screens/admin/AttendanceReportScreen.test.tsx
@@ -3,13 +3,12 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { EventAttendanceRow } from '@/api/attendanceReport';
-
 vi.mock('@/api/attendanceReport', () => ({
   useAttendanceReport: vi.fn(),
 }));
 
 import { useAttendanceReport } from '@/api/attendanceReport';
+import { makeRow } from '@/test/fixtures';
 
 import AttendanceReportScreen from './AttendanceReportScreen';
 
@@ -22,18 +21,6 @@ function mockResult(overrides: Partial<ReturnType<typeof useAttendanceReport>>) 
     data: [],
     ...overrides,
   } as ReturnType<typeof useAttendanceReport>);
-}
-
-function makeRow(overrides: Partial<EventAttendanceRow> = {}): EventAttendanceRow {
-  return {
-    eventId: 'e1',
-    title: 'Potluck',
-    startDatetime: new Date('2026-03-15T18:00:00Z'),
-    attendedCount: 4,
-    noShowCount: 1,
-    goingCount: 6,
-    ...overrides,
-  };
 }
 
 function renderScreen() {

--- a/frontend/src/screens/admin/JoinRequestsScreen.test.tsx
+++ b/frontend/src/screens/admin/JoinRequestsScreen.test.tsx
@@ -6,6 +6,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type * as JoinApi from '@/api/join';
 import { JoinRequestStatus, type JoinRequestSummary } from '@/api/join';
+import { makeRequest } from '@/test/fixtures';
 
 vi.mock('@/api/join', async (importOriginal) => {
   const actual = await importOriginal<typeof JoinApi>();
@@ -30,33 +31,6 @@ import { useDecideJoinRequest, useJoinRequests } from '@/api/join';
 import JoinRequestsScreen from './JoinRequestsScreen';
 
 const mockUseJoinRequests = vi.mocked(useJoinRequests);
-
-function makeRequest(overrides: Partial<JoinRequestSummary> = {}): JoinRequestSummary {
-  return {
-    id: 'jr-1',
-    fullName: 'Ada Lovelace',
-    phoneNumber: '+16505550001',
-    email: 'ada@example.com',
-    answers: [],
-    submittedAt: '2026-01-01T00:00:00Z',
-    status: JoinRequestStatus.PENDING,
-    userId: null,
-    previouslyArchived: false,
-    approvedAt: null,
-    approvedByName: null,
-    rejectedAt: null,
-    rejectedByName: null,
-    onboardedAt: null,
-    rsvpBreakdown: {
-      attendedOfficial: 0,
-      attendedClub: 0,
-      upcomingOfficial: 0,
-      upcomingClub: 0,
-    },
-    rsvpEvents: [],
-    ...overrides,
-  };
-}
 
 function renderScreen() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/frontend/src/screens/admin/MembersScreen.test.tsx
+++ b/frontend/src/screens/admin/MembersScreen.test.tsx
@@ -4,10 +4,10 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { Member } from '@/api/users';
 import { useAuthStore } from '@/auth/store';
 import { Permission } from '@/models/permissions';
 import type { User } from '@/models/user';
+import { makeMember } from '@/test/fixtures';
 
 // Mock the users API module so we can drive loading / error / data states
 // without hitting the network. useCreateUser is only pulled in transitively
@@ -67,29 +67,6 @@ function adminUser(permissions: string[] = [Permission.ManageUsers]): User {
         permissions,
       },
     ],
-  };
-}
-
-function makeMember(overrides: Partial<Member> = {}): Member {
-  return {
-    id: 'member-1',
-    firstName: 'Ada',
-    lastName: '',
-    fullName: 'Ada',
-    phoneNumber: '+15551230001',
-    email: '',
-    bio: '',
-    profilePhotoUrl: '',
-    showPhone: true,
-    showEmail: true,
-    isMember: true,
-    isSuperuser: false,
-    isPaused: false,
-    needsOnboarding: false,
-    loginLinkRequested: false,
-    lastAttendedAt: null,
-    roles: [],
-    ...overrides,
   };
 }
 

--- a/frontend/src/screens/notifications/NotificationsScreen.test.tsx
+++ b/frontend/src/screens/notifications/NotificationsScreen.test.tsx
@@ -3,8 +3,6 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { NotificationType } from '@/models/notification';
-
 vi.mock('@/api/notifications', () => ({
   useNotificationHistory: vi.fn(),
   useMarkNotificationRead: vi.fn(),
@@ -15,23 +13,12 @@ vi.mock('@/utils/errorReporter', () => ({
 }));
 
 import { useMarkNotificationRead, useNotificationHistory } from '@/api/notifications';
+import { makeNotification } from '@/test/fixtures';
 
 import NotificationsScreen from './NotificationsScreen';
 
 const mockUseHistory = vi.mocked(useNotificationHistory);
 const mockUseMarkRead = vi.mocked(useMarkNotificationRead);
-
-function makeNotification(id: string, message: string, isRead = false) {
-  return {
-    id,
-    notificationType: NotificationType.EventInvite,
-    eventId: 'evt1',
-    relatedUserId: null,
-    message,
-    isRead,
-    createdAt: '2024-01-01T00:00:00Z',
-  };
-}
 
 function renderScreen() {
   return render(

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -1,3 +1,7 @@
+import type { EventAttendanceRow } from '@/api/attendanceReport';
+import type { JoinRequestSummary } from '@/api/join';
+import { JoinRequestStatus } from '@/api/join';
+import type { Member } from '@/api/users';
 import type { Event, EventGuest } from '@/models/event';
 import {
   AttendanceStatus,
@@ -7,6 +11,8 @@ import {
   InvitePermission,
   RsvpServerStatus,
 } from '@/models/event';
+import type { AppNotification } from '@/models/notification';
+import { NotificationType } from '@/models/notification';
 import type { User } from '@/models/user';
 
 export function makeGuest(overrides: Partial<EventGuest> = {}): EventGuest {
@@ -127,5 +133,79 @@ export function makeUser(overrides: Partial<User> = {}): User {
     photoUpdatedAt: null,
     roles: [],
     ...overrides,
+  };
+}
+
+export function makeMember(overrides: Partial<Member> = {}): Member {
+  return {
+    id: 'member-1',
+    firstName: 'Ada',
+    lastName: '',
+    fullName: 'Ada',
+    phoneNumber: '+15551230001',
+    email: '',
+    bio: '',
+    profilePhotoUrl: '',
+    showPhone: true,
+    showEmail: true,
+    isMember: true,
+    isSuperuser: false,
+    isPaused: false,
+    needsOnboarding: false,
+    loginLinkRequested: false,
+    lastAttendedAt: null,
+    roles: [],
+    ...overrides,
+  };
+}
+
+export function makeRequest(overrides: Partial<JoinRequestSummary> = {}): JoinRequestSummary {
+  return {
+    id: 'jr-1',
+    fullName: 'Ada Lovelace',
+    phoneNumber: '+16505550001',
+    email: 'ada@example.com',
+    answers: [],
+    submittedAt: '2026-01-01T00:00:00Z',
+    status: JoinRequestStatus.PENDING,
+    userId: null,
+    previouslyArchived: false,
+    approvedAt: null,
+    approvedByName: null,
+    rejectedAt: null,
+    rejectedByName: null,
+    onboardedAt: null,
+    rsvpBreakdown: {
+      attendedOfficial: 0,
+      attendedClub: 0,
+      upcomingOfficial: 0,
+      upcomingClub: 0,
+    },
+    rsvpEvents: [],
+    ...overrides,
+  };
+}
+
+export function makeRow(overrides: Partial<EventAttendanceRow> = {}): EventAttendanceRow {
+  return {
+    eventId: 'e1',
+    title: 'Potluck',
+    startDatetime: new Date('2026-03-15T18:00:00Z'),
+    attendedCount: 4,
+    noShowCount: 1,
+    goingCount: 6,
+    ...overrides,
+  };
+}
+
+export function makeNotification(id: string, message: string, isRead = false): AppNotification {
+  return {
+    id,
+    notificationType: NotificationType.EventInvite,
+    eventId: 'evt1',
+    relatedUserId: null,
+    message,
+    isRead,
+    createdAt: '2024-01-01T00:00:00Z',
   };
 }


### PR DESCRIPTION
## Summary
- Follow-up to #938: moves `makeMember`, `makeRequest`, `makeRow`, and `makeNotification` out of their respective test files into `frontend/src/test/fixtures.ts`, matching the existing `makeEvent`/`makeGuest`/`makeUser` pattern.
- Each test file now imports its factory from the shared fixtures module instead of defining it locally.

Closes #939

## Test plan
- [x] `npx vitest run` on the 4 affected test files (45 tests passed)
- [x] `make agent-frontend-typecheck`
- [x] `make agent-frontend-lint`