### PR TITLE
fix: skip RSVP write on no-op resubmit to preserve updated_at

### DIFF
--- a/backend/community/_event_host_actions.py
+++ b/backend/community/_event_host_actions.py
@@ -214,6 +214,13 @@ def _apply_host_rsvp_in_transaction(
     was_attending = existing is not None and existing.status == RSVPStatus.ATTENDING
     had_plus_one = existing is not None and existing.has_plus_one
 
+    if (
+        existing is not None
+        and existing.status == final_status
+        and existing.has_plus_one == final_plus_one
+    ):
+        return final_status, []
+
     EventRSVP.objects.update_or_create(
         event=event,
         user=target_user,

--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -152,6 +152,13 @@ def _apply_rsvp_in_transaction(
     was_attending = existing is not None and existing.status == RSVPStatus.ATTENDING
     had_plus_one = existing is not None and existing.has_plus_one
 
+    if (
+        existing is not None
+        and existing.status == final_status
+        and existing.has_plus_one == final_plus_one
+    ):
+        return final_status, []
+
     EventRSVP.objects.update_or_create(
         event=event,
         user=user,

--- a/backend/tests/test_event_cohosts.py
+++ b/backend/tests/test_event_cohosts.py
@@ -1,0 +1,128 @@
+import pytest
+from community.models import Event, RSVPStatus
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
+
+from tests.conftest import future_iso
+
+
+@pytest.fixture
+def rsvp_event(db, test_user):
+    return Event.objects.create(
+        title="RSVP Event",
+        description="An event with RSVPs enabled",
+        start_datetime=future_iso(days=30),
+        end_datetime=future_iso(days=30, hours=2),
+        location="Community Space",
+        rsvp_enabled=True,
+        created_by=test_user,
+    )
+
+
+@pytest.fixture
+def other_user(db):
+    return User.objects.create_user(
+        phone_number="+12025550302",
+        password="otherpass",
+        first_name="Other",
+        last_name="Member",
+    )
+
+
+@pytest.fixture
+def other_headers(other_user):
+    refresh = RefreshToken.for_user(other_user)
+    return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
+
+
+@pytest.mark.django_db
+class TestCreateEventWithCohosts:
+    def test_create_event_with_cohosts_creates_pending_invite(
+        self, api_client, auth_headers, other_user
+    ):
+        # With the invite-approval flow (#363), passing ``co_host_ids`` queues
+        # a PENDING invite — the user is NOT in event.co_hosts until they accept.
+        response = api_client.post(
+            "/api/community/events/",
+            {
+                "title": "Cohost Event",
+                "start_datetime": future_iso(days=60),
+                "end_datetime": future_iso(days=60, hours=2),
+                "co_host_ids": [str(other_user.pk)],
+            },
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 201
+        data = response.json()
+        assert data["co_host_ids"] == []
+        assert any(inv["user_id"] == str(other_user.pk) for inv in data["pending_cohost_invites"])
+
+    def test_create_event_with_rsvp_enabled(self, api_client, auth_headers):
+        response = api_client.post(
+            "/api/community/events/",
+            {
+                "title": "RSVP Event",
+                "start_datetime": future_iso(days=60),
+                "end_datetime": future_iso(days=60, hours=2),
+                "rsvp_enabled": True,
+            },
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 201
+        assert response.json()["rsvp_enabled"] is True
+
+    def test_update_event_toggle_rsvp(self, api_client, auth_headers, rsvp_event):
+        response = api_client.patch(
+            f"/api/community/events/{rsvp_event.id}/",
+            {"rsvp_enabled": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+        assert response.json()["rsvp_enabled"] is False
+
+    def test_cohost_sees_guest_phones(
+        self, api_client, auth_headers, other_user, other_headers, test_user
+    ):
+        # Create event inviting other_user as co-host (PENDING under the
+        # invite-approval flow), then have them accept so they're an actual
+        # co-host with phone visibility.
+        create_resp = api_client.post(
+            "/api/community/events/",
+            {
+                "title": "Cohost Phone Test",
+                "start_datetime": future_iso(days=90),
+                "end_datetime": future_iso(days=90, hours=2),
+                "rsvp_enabled": True,
+                "co_host_ids": [str(other_user.pk)],
+            },
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert create_resp.status_code == 201
+        event_id = create_resp.json()["id"]
+        invite_id = create_resp.json()["pending_cohost_invites"][0]["id"]
+
+        # other_user accepts the invite → becomes an accepted co-host.
+        accept_resp = api_client.post(
+            f"/api/community/events/{event_id}/cohost-invites/{invite_id}/accept/",
+            **other_headers,
+        )
+        assert accept_resp.status_code == 200
+
+        # Creator RSVPs.
+        api_client.post(
+            f"/api/community/events/{event_id}/rsvp/",
+            {"status": RSVPStatus.ATTENDING},
+            content_type="application/json",
+            **auth_headers,
+        )
+
+        # Co-host fetches — should see phones.
+        response = api_client.get(f"/api/community/events/{event_id}/", **other_headers)
+        assert response.status_code == 200
+        guests = response.json()["guests"]
+        assert len(guests) == 1
+        assert guests[0]["phone"] == test_user.phone_number

--- a/backend/tests/test_rsvp.py
+++ b/backend/tests/test_rsvp.py
@@ -149,6 +149,27 @@ class TestRSVP:
         assert response.status_code == 200
         assert response.json()["my_rsvp"] == RSVPStatus.CANT_GO
 
+    def test_resubmitting_same_status_does_not_bump_updated_at(
+        self, api_client, auth_headers, rsvp_event, test_user
+    ):
+        api_client.post(
+            f"/api/community/events/{rsvp_event.id}/rsvp/",
+            {"status": RSVPStatus.ATTENDING},
+            content_type="application/json",
+            **auth_headers,
+        )
+        first_updated_at = EventRSVP.objects.get(event=rsvp_event, user=test_user).updated_at
+
+        api_client.post(
+            f"/api/community/events/{rsvp_event.id}/rsvp/",
+            {"status": RSVPStatus.ATTENDING},
+            content_type="application/json",
+            **auth_headers,
+        )
+        second_updated_at = EventRSVP.objects.get(event=rsvp_event, user=test_user).updated_at
+
+        assert second_updated_at == first_updated_at
+
     def test_rsvp_invalid_status(self, api_client, auth_headers, rsvp_event):
         # "going" is not an RSVPStatus member, so Pydantic rejects it at parse time (422).
         response = api_client.post(
@@ -289,104 +310,6 @@ class TestRSVP:
         guests = response.json()["guests"]
         assert len(guests) == 1
         assert guests[0]["is_member"] is False
-
-
-# ---------------------------------------------------------------------------
-# TestCreateEventWithCohosts
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.django_db
-class TestCreateEventWithCohosts:
-    def test_create_event_with_cohosts_creates_pending_invite(
-        self, api_client, auth_headers, other_user
-    ):
-        # With the invite-approval flow (#363), passing ``co_host_ids`` queues
-        # a PENDING invite — the user is NOT in event.co_hosts until they accept.
-        response = api_client.post(
-            "/api/community/events/",
-            {
-                "title": "Cohost Event",
-                "start_datetime": future_iso(days=60),
-                "end_datetime": future_iso(days=60, hours=2),
-                "co_host_ids": [str(other_user.pk)],
-            },
-            content_type="application/json",
-            **auth_headers,
-        )
-        assert response.status_code == 201
-        data = response.json()
-        assert data["co_host_ids"] == []
-        assert any(inv["user_id"] == str(other_user.pk) for inv in data["pending_cohost_invites"])
-
-    def test_create_event_with_rsvp_enabled(self, api_client, auth_headers):
-        response = api_client.post(
-            "/api/community/events/",
-            {
-                "title": "RSVP Event",
-                "start_datetime": future_iso(days=60),
-                "end_datetime": future_iso(days=60, hours=2),
-                "rsvp_enabled": True,
-            },
-            content_type="application/json",
-            **auth_headers,
-        )
-        assert response.status_code == 201
-        assert response.json()["rsvp_enabled"] is True
-
-    def test_update_event_toggle_rsvp(self, api_client, auth_headers, rsvp_event):
-        response = api_client.patch(
-            f"/api/community/events/{rsvp_event.id}/",
-            {"rsvp_enabled": False},
-            content_type="application/json",
-            **auth_headers,
-        )
-        assert response.status_code == 200
-        assert response.json()["rsvp_enabled"] is False
-
-    def test_cohost_sees_guest_phones(
-        self, api_client, auth_headers, other_user, other_headers, test_user
-    ):
-        # Create event inviting other_user as co-host (PENDING under the
-        # invite-approval flow), then have them accept so they're an actual
-        # co-host with phone visibility.
-        create_resp = api_client.post(
-            "/api/community/events/",
-            {
-                "title": "Cohost Phone Test",
-                "start_datetime": future_iso(days=90),
-                "end_datetime": future_iso(days=90, hours=2),
-                "rsvp_enabled": True,
-                "co_host_ids": [str(other_user.pk)],
-            },
-            content_type="application/json",
-            **auth_headers,
-        )
-        assert create_resp.status_code == 201
-        event_id = create_resp.json()["id"]
-        invite_id = create_resp.json()["pending_cohost_invites"][0]["id"]
-
-        # other_user accepts the invite → becomes an accepted co-host.
-        accept_resp = api_client.post(
-            f"/api/community/events/{event_id}/cohost-invites/{invite_id}/accept/",
-            **other_headers,
-        )
-        assert accept_resp.status_code == 200
-
-        # Creator RSVPs.
-        api_client.post(
-            f"/api/community/events/{event_id}/rsvp/",
-            {"status": RSVPStatus.ATTENDING},
-            content_type="application/json",
-            **auth_headers,
-        )
-
-        # Co-host fetches — should see phones.
-        response = api_client.get(f"/api/community/events/{event_id}/", **other_headers)
-        assert response.status_code == 200
-        guests = response.json()["guests"]
-        assert len(guests) == 1
-        assert guests[0]["phone"] == test_user.phone_number
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `_apply_rsvp_in_transaction` and `_apply_host_rsvp_in_transaction` both called `EventRSVP.objects.update_or_create(...)` unconditionally, bumping `updated_at` (auto_now) even when the member resubmitted the same status/plus_one with no actual change
- Both now short-circuit and skip the write when the resolved status and plus-one match the existing row

Per issue #948 discussion: `checked_in_at`/`cancelled_at` were already shipped (#774). The `EventRSVPHistory` table was descoped — not worth the schema complexity — but `updated_at` incorrectly churning on no-op resubmits was a real bug worth fixing directly, since `cancelled_at`'s fallback to `updated_at` for legacy rows depends on it being meaningful.

Closes #948

## Test plan
- [x] Added `test_resubmitting_same_status_does_not_bump_updated_at` in `test_rsvp.py`
- [x] `pytest tests/test_rsvp.py tests/test_host_rsvp.py tests/test_event_stats.py` — 72 passed
- [x] `make agent-typecheck` — clean
- [x] `make agent-lint` — clean