### PR TITLE
refactor(rsvp): enum retyping + capacity race test (Issue 949, 945)

### DIFF
--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -109,11 +109,11 @@ class TagIn(BaseModel):
 class RSVPGuestOut(BaseModel):
     user_id: str
     name: str
-    status: str
+    status: RSVPStatus
     has_plus_one: bool = False
     phone: str | None = None
     photo_url: str = ""
-    attendance: str = AttendanceStatus.UNKNOWN
+    attendance: AttendanceStatus = AttendanceStatus.UNKNOWN
     checked_in_at: datetime | None = None
     is_member: bool = True
 

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -4023,9 +4023,12 @@
       "RSVPGuestOut": {
         "properties": {
           "attendance": {
-            "default": "unknown",
-            "title": "Attendance",
-            "type": "string"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/AttendanceStatus"
+              }
+            ],
+            "default": "unknown"
           },
           "checked_in_at": {
             "anyOf": [
@@ -4070,8 +4073,7 @@
             "type": "string"
           },
           "status": {
-            "title": "Status",
-            "type": "string"
+            "$ref": "#/components/schemas/RSVPStatus"
           },
           "user_id": {
             "title": "User Id",

--- a/backend/tests/test_rsvp_capacity_race.py
+++ b/backend/tests/test_rsvp_capacity_race.py
@@ -1,0 +1,68 @@
+import threading
+
+import pytest
+from community.models import Event, EventRSVP, RSVPStatus
+from django import db
+from django.test import Client
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
+
+from tests.conftest import future_iso
+
+
+def _make_user(i):
+    return User.objects.create_user(
+        phone_number=f"+1415555{9100 + i}",
+        password="Testpass123!",
+        first_name=f"Racer{i}",
+        last_name="",
+    )
+
+
+def _jwt_headers(user):
+    refresh = RefreshToken.for_user(user)
+    return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
+
+
+@pytest.mark.django_db(transaction=True)
+class TestRsvpCapacityRace:
+    def test_concurrent_rsvps_never_exceed_capacity(self, test_user):
+        """N threads RSVP to a 1-seat event at once; select_for_update() on the
+        Event row must serialize them so exactly 1 lands attending, the rest
+        waitlisted — never an overbooked headcount (issue #945)."""
+        event = Event.objects.create(
+            title="Race Event",
+            start_datetime=future_iso(days=30),
+            rsvp_enabled=True,
+            max_attendees=1,
+            created_by=test_user,
+        )
+        thread_count = 8
+        users = [_make_user(i) for i in range(thread_count)]
+        results = [None] * thread_count
+
+        def rsvp(i):
+            try:
+                client = Client()
+                resp = client.post(
+                    f"/api/community/events/{event.id}/rsvp/",
+                    {"status": RSVPStatus.ATTENDING, "has_plus_one": False},
+                    content_type="application/json",
+                    **_jwt_headers(users[i]),
+                )
+                results[i] = resp.status_code
+            finally:
+                db.connections.close_all()
+
+        threads = [threading.Thread(target=rsvp, args=(i,)) for i in range(thread_count)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert all(code == 200 for code in results), results
+
+        attending = EventRSVP.objects.filter(event=event, status=RSVPStatus.ATTENDING).count()
+        waitlisted = EventRSVP.objects.filter(event=event, status=RSVPStatus.WAITLISTED).count()
+        assert attending == 1
+        assert waitlisted == thread_count - 1

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -3607,11 +3607,8 @@ export interface components {
         };
         /** RSVPGuestOut */
         RSVPGuestOut: {
-            /**
-             * Attendance
-             * @default unknown
-             */
-            attendance: string;
+            /** @default unknown */
+            attendance: components["schemas"]["AttendanceStatus"];
             /** Checked In At */
             checked_in_at?: string | null;
             /**
@@ -3633,8 +3630,7 @@ export interface components {
              * @default
              */
             photo_url: string;
-            /** Status */
-            status: string;
+            status: components["schemas"]["RSVPStatus"];
             /** User Id */
             user_id: string;
         };


### PR DESCRIPTION
## Overview

Two small follow-ups from the RSVP/attendance audit (epic #545):

- **Issue 949**: `RSVPGuestOut.status`/`.attendance` were still raw `str` while the input schemas (`RSVPIn`/`AttendanceIn`) already used `RSVPStatus`/`AttendanceStatus` `TextChoices`. Retyped to match, regenerated frontend API types.
- **Issue 945** (concurrency test item only — the other 3 items were decided as deferred/YAGNI, see comments on #945): added a threaded test exercising `upsert_rsvp`'s `select_for_update()` capacity-race guarantee. Postgres-only (sqlite can't exercise real concurrent writers) — verified it fails reliably without the lock and passes with it.

Closes #949
Closes #945

## Test plan

- [x] `make agent-ci` (typecheck, lint, complexity, full test suite on sqlite)
- [x] Full backend suite + new race test run against per-worktree Postgres (1592 passed)
- [x] Manually removed `select_for_update()` and confirmed the new race test fails (3/3 runs), then restored and confirmed it passes
