### PR TITLE
fix(a11y): pair red-only cues with non-colour markers (Issue 958)

### DIFF
--- a/frontend/src/screens/events/EventAdminActions.test.tsx
+++ b/frontend/src/screens/events/EventAdminActions.test.tsx
@@ -112,7 +112,7 @@ describe('EventAdminActions', () => {
     expect(screen.getByRole('button', { name: /^edit$/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /cancel event/i })).toBeInTheDocument();
     // With attendees, the event must be cancelled before it can be deleted.
-    expect(screen.queryByRole('button', { name: /^delete$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /delete$/i })).not.toBeInTheDocument();
   });
 
   it('creator sees delete (no cancel) for active upcoming event with no attendees', () => {
@@ -123,7 +123,7 @@ describe('EventAdminActions', () => {
     renderActions(emptyEvent);
 
     expect(screen.getByRole('button', { name: /^edit$/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /delete$/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /cancel event/i })).not.toBeInTheDocument();
   });
 
@@ -136,7 +136,7 @@ describe('EventAdminActions', () => {
 
     expect(screen.getByRole('button', { name: /^edit$/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /^publish$/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /delete$/i })).toBeInTheDocument();
   });
 
   it('co-host sees edit and cancel buttons for upcoming event', () => {
@@ -148,7 +148,7 @@ describe('EventAdminActions', () => {
     expect(screen.getByRole('button', { name: /^edit$/i })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /cancel event/i })).toBeInTheDocument();
     // Co-host is not the creator, so no delete button (canDelete = isCreator || canManage)
-    expect(screen.queryByRole('button', { name: /^delete$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /delete$/i })).not.toBeInTheDocument();
   });
 
   it('creator sees no cancel button for a past event', () => {
@@ -162,7 +162,7 @@ describe('EventAdminActions', () => {
     // Edit and delete present, but no cancel-event button for already-cancelled events
     expect(screen.getByRole('button', { name: /^edit$/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /cancel event/i })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /delete$/i })).toBeInTheDocument();
   });
 
   it('regular member (not creator, not co-host) sees no admin action buttons', () => {
@@ -173,7 +173,7 @@ describe('EventAdminActions', () => {
 
     expect(screen.queryByRole('button', { name: /^edit$/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /cancel event/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /^delete$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /delete$/i })).not.toBeInTheDocument();
   });
 
   it('unauthenticated user sees no admin action buttons', () => {
@@ -183,7 +183,7 @@ describe('EventAdminActions', () => {
 
     expect(screen.queryByRole('button', { name: /^edit$/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /cancel event/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /^delete$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /delete$/i })).not.toBeInTheDocument();
   });
 
   // A draft event with attendees still shows delete: drafts haven't been
@@ -199,7 +199,7 @@ describe('EventAdminActions', () => {
     };
     renderActions(draftWithAttendees);
 
-    expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /delete$/i })).toBeInTheDocument();
   });
 
   // Past events can't be edited (would change historical record). Delete is
@@ -219,7 +219,7 @@ describe('EventAdminActions', () => {
     renderActions(pastCancelled);
 
     expect(screen.queryByRole('button', { name: /^edit$/i })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /^delete$/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /delete$/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /cancel event/i })).not.toBeInTheDocument();
   });
 

--- a/frontend/src/screens/events/EventAdminActions.tsx
+++ b/frontend/src/screens/events/EventAdminActions.tsx
@@ -119,7 +119,7 @@ function AdminActionRow({
             onClick={() => {
               setDeleteOpen(true);
             }}
-            className="border-red-300 text-red-700 underline hover:bg-red-50"
+            className="border-red-300 font-medium text-red-700 hover:bg-red-50"
           >
             ⚠ delete
           </Button>

--- a/frontend/src/screens/events/EventAdminActions.tsx
+++ b/frontend/src/screens/events/EventAdminActions.tsx
@@ -119,15 +119,15 @@ function AdminActionRow({
             onClick={() => {
               setDeleteOpen(true);
             }}
-            className="border-red-300 text-red-700 hover:bg-red-50"
+            className="border-red-300 text-red-700 underline hover:bg-red-50"
           >
-            delete
+            ⚠ delete
           </Button>
         ) : null}
       </div>
       {publishError ? (
-        <p role="alert" className="text-sm text-red-600">
-          {publishError}
+        <p role="alert" className="text-sm font-medium text-red-600">
+          ⚠ {publishError}
         </p>
       ) : null}
 
@@ -144,8 +144,8 @@ function AdminActionRow({
           — you can't un-cancel from the react app yet.
         </p>
         {cancelError ? (
-          <p role="alert" className="mt-3 text-sm text-red-600">
-            {cancelError}
+          <p role="alert" className="mt-3 text-sm font-medium text-red-600">
+            ⚠ {cancelError}
           </p>
         ) : null}
         <div className="mt-4 flex justify-end gap-2">
@@ -182,8 +182,8 @@ function AdminActionRow({
           react app.
         </p>
         {deleteError ? (
-          <p role="alert" className="mt-3 text-sm text-red-600">
-            {deleteError}
+          <p role="alert" className="mt-3 text-sm font-medium text-red-600">
+            ⚠ {deleteError}
           </p>
         ) : null}
         <div className="mt-4 flex justify-end gap-2">

--- a/frontend/src/screens/events/comments/CommentItem.test.tsx
+++ b/frontend/src/screens/events/comments/CommentItem.test.tsx
@@ -44,7 +44,9 @@ describe('CommentItem', () => {
   it('renders the body and author', () => {
     wrap(<CommentItem comment={baseComment} eventId="evt" canReact canReply />);
     expect(screen.getByText('hello')).toBeInTheDocument();
-    expect(screen.getByText('alice')).toBeInTheDocument();
+    // Rendered lowercase via CSS text-transform, not string mutation — the DOM
+    // text content stays the real display name.
+    expect(screen.getByText('Alice')).toBeInTheDocument();
   });
 
   it('renders [deleted] placeholder when isDeleted', () => {

--- a/frontend/src/screens/events/comments/CommentItem.tsx
+++ b/frontend/src/screens/events/comments/CommentItem.tsx
@@ -64,7 +64,7 @@ export function CommentItem({
         {comment.authorPhotoUrl ? (
           <img src={comment.authorPhotoUrl} alt="" className="h-8 w-8 rounded-full object-cover" />
         ) : null}
-        <span className="text-sm font-medium">{comment.authorDisplayName.toLowerCase()}</span>
+        <span className="text-sm font-medium lowercase">{comment.authorDisplayName}</span>
         <span className="text-foreground-tertiary text-xs">
           {formatRelative(comment.createdAt)}
         </span>

--- a/frontend/src/screens/events/comments/ReplyItem.tsx
+++ b/frontend/src/screens/events/comments/ReplyItem.tsx
@@ -43,7 +43,7 @@ export function ReplyItem({ reply, eventId, token, canReact, reactDisabledReason
           {reply.authorPhotoUrl ? (
             <img src={reply.authorPhotoUrl} alt="" className="h-6 w-6 rounded-full object-cover" />
           ) : null}
-          <span className="text-sm font-medium">{reply.authorDisplayName.toLowerCase()}</span>
+          <span className="text-sm font-medium lowercase">{reply.authorDisplayName}</span>
           <span className="text-foreground-tertiary text-xs">
             {formatRelative(reply.createdAt)}
           </span>


### PR DESCRIPTION
## Overview

Accessibility follow-up from the event UI audit (Theme C, issue #944).

- `EventAdminActions`'s delete button and error text relied on red hue alone (`color-blind-friendly.md` rule violation). Added a ⚠ glyph plus underline/bold-weight as non-colour cues.
- Comment/reply author names used `.toLowerCase()` on the string at render, mangling proper nouns. Switched to CSS `text-transform: lowercase` so the DOM text content stays the real display name while still rendering lowercase per the app's tone convention.

Closes #958

## Test plan

- [x] `CommentItem.test.tsx`, `EventAdminActions.test.tsx` pass (updated to match: real display-name text content, `delete$` regex tolerating the ⚠ prefix)
- [x] eslint + prettier clean on touched files
- [x] `make agent-frontend-typecheck` clean
- [ ] Note: only touched-file tests were run per instruction, not the full suite
