### PR TITLE
fix(feedback): 962 - time out GitHub API call to avoid 502

### DIFF
--- a/backend/community/_feedback.py
+++ b/backend/community/_feedback.py
@@ -23,6 +23,10 @@ router = Router()
 
 frontend_logger = logging.getLogger("pda.frontend")
 
+# Cap the GitHub API call so a slow/unresponsive upstream raises (caught → 503)
+# instead of hanging until the gateway times out and returns a 502.
+_GITHUB_TIMEOUT_SECONDS = 10
+
 
 class ErrorReportIn(BaseModel):
     error: str = Field(max_length=2000)
@@ -128,7 +132,7 @@ def _github_request(url: str, token: str, data: dict) -> dict:
         },
         method="POST",
     )
-    with urlopen(req) as response:
+    with urlopen(req, timeout=_GITHUB_TIMEOUT_SECONDS) as response:
         return json_module.loads(response.read())
 
 

--- a/backend/tests/test_feedback.py
+++ b/backend/tests/test_feedback.py
@@ -13,7 +13,7 @@ def _mock_urlopen(monkeypatch, issue_url="https://github.com/leahpeker/pda/issue
     """Patch community.api.urlopen to return a fake GitHub issue creation response."""
     captured: dict = {"calls": []}
 
-    def fake_urlopen(request):
+    def fake_urlopen(request, timeout=None):
         captured["calls"].append(request)
         buf = io.BytesIO(json.dumps({"html_url": issue_url}).encode())
         buf.status = 201  # ty: ignore[unresolved-attribute]
@@ -226,6 +226,25 @@ class TestFeedback:
                 "title": "Bug report",
                 "description": "Details here",
             },
+            content_type="application/json",
+        )
+        assert response.status_code == 503
+        assert response.json()["detail"][0]["code"] == "feedback.creation_failed"
+
+    def test_feedback_returns_503_on_github_timeout(self, api_client, settings, monkeypatch):
+        for k, v in _APP_SETTINGS.items():
+            setattr(settings, k, v)
+        monkeypatch.setattr(
+            "community._feedback._get_github_app_token", lambda *_: "ghs_inst_token"
+        )
+        monkeypatch.setattr(
+            "community._feedback.urlopen",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(TimeoutError("timed out")),
+        )
+
+        response = api_client.post(
+            "/api/community/feedback/",
+            {"title": "Bug report", "description": "Details here"},
             content_type="application/json",
         )
         assert response.status_code == 503


### PR DESCRIPTION
## Overview

The in-app feedback form was returning a **502** on submission. `submit_feedback` creates a GitHub issue via `urllib.urlopen` (in `_github_request`), and none of those calls passed a `timeout`. When GitHub's API is slow, the request hangs until the gateway kills the upstream — surfacing as a 502, never reaching the endpoint's own `try/except` that would return a clean 503.

Cap the shared `_github_request` `urlopen` at 10s. A urllib timeout raises `TimeoutError` (an `OSError` subclass), which the existing `except Exception` catches → clean `503 feedback.creation_failed`. Both GitHub calls (token exchange + issue creation) route through `_github_request`, so the single timeout covers both.

Closes #962

## Test plan

- [x] `backend/tests/test_feedback.py` — 20 passed, including new `test_feedback_returns_503_on_github_timeout` proving a hanging call now yields 503, not a 502.
- [x] `make agent-lint` / `make agent-typecheck` clean.
