### PR TITLE
feat(events):  edit-window note (Issue 959)

### DIFF
--- a/frontend/src/screens/events/EventAdminActions.tsx
+++ b/frontend/src/screens/events/EventAdminActions.tsx
@@ -125,6 +125,11 @@ function AdminActionRow({
           </Button>
         ) : null}
       </div>
+      {!canEditEvent && !isCancelled ? (
+        <p className="text-foreground-tertiary text-center text-xs">
+          editing closes 6 hours after the event ends
+        </p>
+      ) : null}
       {publishError ? (
         <p role="alert" className="text-sm text-red-600">
           {publishError}


### PR DESCRIPTION
## Overview

Adds a note when the 6-hour edit window has closed (Issue 959) — `EventAdminActions` shows "editing closes 6 hours after the event ends" instead of silently hiding the edit button.

The co-host visibility and on-blur date-validation changes from the original audit were dropped as over-engineered; only the edit-window note remains.

Closes #959

## Test plan

- [x] `make agent-frontend-typecheck` clean
