### PR TITLE
feat(calendar): search, global filter, date jump, unbounded chips (Issue 957)

### DIFF
--- a/frontend/src/screens/calendar/AgendaList.test.tsx
+++ b/frontend/src/screens/calendar/AgendaList.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import { EventType } from '@/models/event';
@@ -7,39 +6,19 @@ import { makeEvent } from '@/test/fixtures';
 
 import { AgendaList } from './AgendaList';
 
-describe('AgendaList type filter', () => {
-  const events = [
-    makeEvent({ id: 'a', title: 'official meeting', eventType: EventType.Official }),
-    makeEvent({ id: 'b', title: 'community picnic', eventType: EventType.Community }),
-  ];
-
-  it('defaults to showing all event types', () => {
+describe('AgendaList', () => {
+  it('renders all upcoming events', () => {
+    const events = [
+      makeEvent({ id: 'a', title: 'official meeting', eventType: EventType.Official }),
+      makeEvent({ id: 'b', title: 'community picnic', eventType: EventType.Community }),
+    ];
     render(<AgendaList events={events} onSelectEvent={vi.fn()} />);
     expect(screen.getByRole('button', { name: 'official meeting' })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'community picnic' })).toBeInTheDocument();
   });
 
-  it('filters to pda official only', async () => {
-    const user = userEvent.setup();
-    render(<AgendaList events={events} onSelectEvent={vi.fn()} />);
-    await user.click(screen.getByRole('radio', { name: 'pda official' }));
-    expect(screen.getByRole('button', { name: 'official meeting' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: 'community picnic' })).not.toBeInTheDocument();
-  });
-
-  it('filters to community only', async () => {
-    const user = userEvent.setup();
-    render(<AgendaList events={events} onSelectEvent={vi.fn()} />);
-    await user.click(screen.getByRole('radio', { name: 'community' }));
-    expect(screen.queryByRole('button', { name: 'official meeting' })).not.toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'community picnic' })).toBeInTheDocument();
-  });
-
-  it('shows a filter-aware empty state when no events match', async () => {
-    const user = userEvent.setup();
-    const communityOnly = [makeEvent({ eventType: EventType.Community })];
-    render(<AgendaList events={communityOnly} onSelectEvent={vi.fn()} />);
-    await user.click(screen.getByRole('radio', { name: 'pda official' }));
-    expect(screen.getByText('no pda official events coming up')).toBeInTheDocument();
+  it('shows an empty state when there are no upcoming events', () => {
+    render(<AgendaList events={[]} onSelectEvent={vi.fn()} />);
+    expect(screen.getByText('nothing on the horizon — pop back later')).toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/calendar/AgendaList.tsx
+++ b/frontend/src/screens/calendar/AgendaList.tsx
@@ -9,6 +9,7 @@ import { cn } from '@/utils/cn';
 interface Props {
   events: PdaEvent[];
   onSelectEvent: (event: PdaEvent) => void;
+  isFiltered?: boolean;
 }
 
 const lower = (d: Date, f: string) => format(d, f).toLowerCase();
@@ -37,13 +38,13 @@ function upcomingEvents(events: PdaEvent[]): PdaEvent[] {
     .sort((a, b) => (a.startDatetime?.getTime() ?? 0) - (b.startDatetime?.getTime() ?? 0));
 }
 
-export function AgendaList({ events, onSelectEvent }: Props) {
+export function AgendaList({ events, onSelectEvent, isFiltered = false }: Props) {
   const upcoming = useMemo(() => upcomingEvents(events), [events]);
 
   return (
     <div className="flex flex-col">
       {upcoming.length === 0 ? (
-        <EmptyState />
+        <EmptyState isFiltered={isFiltered} />
       ) : (
         <ul className="flex flex-col gap-2.5 p-3">
           {upcoming.map((event) => (
@@ -57,13 +58,17 @@ export function AgendaList({ events, onSelectEvent }: Props) {
   );
 }
 
-function EmptyState() {
+function EmptyState({ isFiltered }: { isFiltered: boolean }) {
   return (
     <div className="text-muted flex min-h-[40vh] flex-col items-center justify-center">
       <span aria-hidden="true" className="mb-3 text-4xl">
         🌿
       </span>
-      <p className="text-sm">nothing on the horizon — pop back later</p>
+      <p className="text-sm">
+        {isFiltered
+          ? 'no events match your search or filter'
+          : 'nothing on the horizon — pop back later'}
+      </p>
     </div>
   );
 }

--- a/frontend/src/screens/calendar/AgendaList.tsx
+++ b/frontend/src/screens/calendar/AgendaList.tsx
@@ -1,24 +1,10 @@
 import { format, isSameDay } from 'date-fns';
-import { useMemo, useState } from 'react';
+import { useMemo } from 'react';
 
-import { SegmentedControl } from '@/components/ui/SegmentedControl';
 import { type Event as PdaEvent, eventClass, EventType } from '@/models/event';
 import { EventBadge } from '@/screens/events/EventBadge';
 import { EventCardBadges } from '@/screens/events/EventCardBadges';
 import { cn } from '@/utils/cn';
-
-type TypeFilter =
-  | 'all'
-  | typeof EventType.Official
-  | typeof EventType.Club
-  | typeof EventType.Community;
-
-const FILTER_OPTIONS: { value: TypeFilter; label: string }[] = [
-  { value: 'all', label: 'all' },
-  { value: EventType.Official, label: 'pda official' },
-  { value: EventType.Club, label: 'pda club' },
-  { value: EventType.Community, label: 'community' },
-];
 
 interface Props {
   events: PdaEvent[];
@@ -52,29 +38,15 @@ function upcomingEvents(events: PdaEvent[]): PdaEvent[] {
 }
 
 export function AgendaList({ events, onSelectEvent }: Props) {
-  const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
   const upcoming = useMemo(() => upcomingEvents(events), [events]);
-  const filtered = useMemo(
-    () => (typeFilter === 'all' ? upcoming : upcoming.filter((e) => e.eventType === typeFilter)),
-    [upcoming, typeFilter],
-  );
 
   return (
     <div className="flex flex-col">
-      <div className="flex justify-center px-3 pt-3">
-        <SegmentedControl<TypeFilter>
-          name="agenda-type-filter"
-          ariaLabel="event type filter"
-          options={FILTER_OPTIONS}
-          value={typeFilter}
-          onChange={setTypeFilter}
-        />
-      </div>
-      {filtered.length === 0 ? (
-        <EmptyState filter={typeFilter} />
+      {upcoming.length === 0 ? (
+        <EmptyState />
       ) : (
         <ul className="flex flex-col gap-2.5 p-3">
-          {filtered.map((event) => (
+          {upcoming.map((event) => (
             <li key={event.id}>
               <AgendaCard event={event} onSelect={onSelectEvent} />
             </li>
@@ -85,20 +57,13 @@ export function AgendaList({ events, onSelectEvent }: Props) {
   );
 }
 
-function emptyMessage(filter: TypeFilter): string {
-  if (filter === EventType.Official) return 'no pda official events coming up';
-  if (filter === EventType.Community) return 'no community events coming up';
-  return 'nothing on the horizon — pop back later';
-}
-
-function EmptyState({ filter }: { filter: TypeFilter }) {
-  const message = emptyMessage(filter);
+function EmptyState() {
   return (
     <div className="text-muted flex min-h-[40vh] flex-col items-center justify-center">
       <span aria-hidden="true" className="mb-3 text-4xl">
         🌿
       </span>
-      <p className="text-sm">{message}</p>
+      <p className="text-sm">nothing on the horizon — pop back later</p>
     </div>
   );
 }

--- a/frontend/src/screens/calendar/CalendarFilterBar.tsx
+++ b/frontend/src/screens/calendar/CalendarFilterBar.tsx
@@ -21,8 +21,8 @@ interface Props {
   onSearchChange: (value: string) => void;
   typeFilter: TypeFilter;
   onTypeFilterChange: (value: TypeFilter) => void;
-  date: Date;
-  onDateChange: (date: Date) => void;
+  date?: Date;
+  onDateChange?: (date: Date) => void;
 }
 
 export function CalendarFilterBar({
@@ -52,15 +52,17 @@ export function CalendarFilterBar({
         value={typeFilter}
         onChange={onTypeFilterChange}
       />
-      <div className="w-full max-w-xs">
-        <DateTimePicker
-          label="jump to date"
-          value={date.toISOString()}
-          onChange={(iso) => {
-            if (iso) onDateChange(new Date(iso));
-          }}
-        />
-      </div>
+      {date && onDateChange ? (
+        <div className="w-full max-w-xs">
+          <DateTimePicker
+            label="jump to date"
+            value={date.toISOString()}
+            onChange={(iso) => {
+              if (iso) onDateChange(new Date(iso));
+            }}
+          />
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/screens/calendar/CalendarFilterBar.tsx
+++ b/frontend/src/screens/calendar/CalendarFilterBar.tsx
@@ -1,0 +1,66 @@
+import { DateTimePicker } from '@/components/ui/DateTimePicker';
+import { SegmentedControl } from '@/components/ui/SegmentedControl';
+import { TextField } from '@/components/ui/TextField';
+import { EventType } from '@/models/event';
+
+export type TypeFilter =
+  | 'all'
+  | typeof EventType.Official
+  | typeof EventType.Club
+  | typeof EventType.Community;
+
+const TYPE_FILTER_OPTIONS: { value: TypeFilter; label: string }[] = [
+  { value: 'all', label: 'all' },
+  { value: EventType.Official, label: 'pda official' },
+  { value: EventType.Club, label: 'pda club' },
+  { value: EventType.Community, label: 'community' },
+];
+
+interface Props {
+  search: string;
+  onSearchChange: (value: string) => void;
+  typeFilter: TypeFilter;
+  onTypeFilterChange: (value: TypeFilter) => void;
+  date: Date;
+  onDateChange: (date: Date) => void;
+}
+
+export function CalendarFilterBar({
+  search,
+  onSearchChange,
+  typeFilter,
+  onTypeFilterChange,
+  date,
+  onDateChange,
+}: Props) {
+  return (
+    <div className="mb-4 flex flex-col items-center gap-3">
+      <div className="w-full max-w-xs">
+        <TextField
+          label="search events"
+          placeholder="search by title"
+          value={search}
+          onChange={(e) => {
+            onSearchChange(e.target.value);
+          }}
+        />
+      </div>
+      <SegmentedControl<TypeFilter>
+        name="calendar-type-filter"
+        ariaLabel="event type filter"
+        options={TYPE_FILTER_OPTIONS}
+        value={typeFilter}
+        onChange={onTypeFilterChange}
+      />
+      <div className="w-full max-w-xs">
+        <DateTimePicker
+          label="jump to date"
+          value={date.toISOString()}
+          onChange={(iso) => {
+            if (iso) onDateChange(new Date(iso));
+          }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/screens/calendar/CalendarScreen.test.tsx
+++ b/frontend/src/screens/calendar/CalendarScreen.test.tsx
@@ -167,6 +167,15 @@ describe('CalendarScreen filtering', () => {
     expect(screen.queryByRole('button', { name: 'community picnic' })).not.toBeInTheDocument();
   });
 
+  it('filters to community only', async () => {
+    const user = userEvent.setup();
+    renderCalendar();
+    await goToAgenda(user);
+    await user.click(screen.getByRole('radio', { name: 'community' }));
+    expect(screen.queryByRole('button', { name: 'official meeting' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'community picnic' })).toBeInTheDocument();
+  });
+
   it('filters by search term across all views', async () => {
     const user = userEvent.setup();
     renderCalendar();
@@ -174,5 +183,28 @@ describe('CalendarScreen filtering', () => {
     await user.type(screen.getByLabelText('search events'), 'picnic');
     expect(screen.queryByRole('button', { name: 'official meeting' })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'community picnic' })).toBeInTheDocument();
+  });
+
+  it('shows a filter-aware empty state when the type filter matches nothing', async () => {
+    const user = userEvent.setup();
+    renderCalendar();
+    await goToAgenda(user);
+    await user.click(screen.getByRole('radio', { name: 'pda club' }));
+    expect(screen.getByText('no events match your search or filter')).toBeInTheDocument();
+  });
+
+  it('shows a filter-aware empty state when search matches nothing', async () => {
+    const user = userEvent.setup();
+    renderCalendar();
+    await goToAgenda(user);
+    await user.type(screen.getByLabelText('search events'), 'no such event');
+    expect(screen.getByText('no events match your search or filter')).toBeInTheDocument();
+  });
+
+  it('does not show the jump-to-date picker in list view', async () => {
+    const user = userEvent.setup();
+    renderCalendar();
+    await goToAgenda(user);
+    expect(screen.queryByLabelText('jump to date')).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/calendar/CalendarScreen.test.tsx
+++ b/frontend/src/screens/calendar/CalendarScreen.test.tsx
@@ -5,6 +5,8 @@ import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAuthStore } from '@/auth/store';
+import { EventType } from '@/models/event';
+import { makeEvent } from '@/test/fixtures';
 
 // react-big-calendar is a heavy component that requires CSS imports and relies
 // on browser layout. Stub it so tests focus on CalendarScreen logic.
@@ -126,5 +128,51 @@ describe('CalendarScreen', () => {
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /go to today/i })).toBeInTheDocument();
     });
+  });
+});
+
+describe('CalendarScreen filtering', () => {
+  const events = [
+    makeEvent({ id: 'a', title: 'official meeting', eventType: EventType.Official }),
+    makeEvent({ id: 'b', title: 'community picnic', eventType: EventType.Community }),
+  ];
+
+  beforeEach(() => {
+    mockUseEvents.mockReturnValue({
+      data: events,
+      isPending: false,
+      isError: false,
+      refetch: vi.fn(),
+    } as unknown as ReturnType<typeof useEvents>);
+  });
+
+  async function goToAgenda(user: ReturnType<typeof userEvent.setup>) {
+    await user.click(screen.getByRole('radio', { name: /^list$/i }));
+  }
+
+  it('defaults to showing all event types', async () => {
+    const user = userEvent.setup();
+    renderCalendar();
+    await goToAgenda(user);
+    expect(screen.getByRole('button', { name: 'official meeting' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'community picnic' })).toBeInTheDocument();
+  });
+
+  it('filters to pda official only', async () => {
+    const user = userEvent.setup();
+    renderCalendar();
+    await goToAgenda(user);
+    await user.click(screen.getByRole('radio', { name: 'pda official' }));
+    expect(screen.getByRole('button', { name: 'official meeting' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'community picnic' })).not.toBeInTheDocument();
+  });
+
+  it('filters by search term across all views', async () => {
+    const user = userEvent.setup();
+    renderCalendar();
+    await goToAgenda(user);
+    await user.type(screen.getByLabelText('search events'), 'picnic');
+    expect(screen.queryByRole('button', { name: 'official meeting' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'community picnic' })).toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/calendar/CalendarScreen.tsx
+++ b/frontend/src/screens/calendar/CalendarScreen.tsx
@@ -11,6 +11,7 @@ import { useIsWideScreen } from '@/hooks/useResponsive';
 import { type Event as PdaEvent, eventClass } from '@/models/event';
 
 import { AgendaList } from './AgendaList';
+import { CalendarFilterBar, type TypeFilter } from './CalendarFilterBar';
 import { makeLocalizer } from './calendarLocalizer';
 import { CalendarToolbar } from './CalendarToolbar';
 import { DayEventList } from './DayEventList';
@@ -68,15 +69,27 @@ export default function CalendarScreen() {
   const isWide = useIsWideScreen(720);
 
   const { data: events = [], isPending, isError, refetch } = useEvents();
+  const [typeFilter, setTypeFilter] = useState<TypeFilter>('all');
+  const [search, setSearch] = useState('');
+
+  const filteredEvents = useMemo(() => {
+    const term = search.trim().toLowerCase();
+    return events.filter((e) => {
+      if (typeFilter !== 'all' && e.eventType !== typeFilter) return false;
+      if (term && !e.title.toLowerCase().includes(term)) return false;
+      return true;
+    });
+  }, [events, typeFilter, search]);
+
   const bigCalEvents = useMemo<BigCalEvent[]>(
     () =>
-      events
+      filteredEvents
         .filter((e) => !e.datetimeTbd)
         .map(toBigCalEvent)
         .filter((e): e is BigCalEvent => e !== null),
-    [events],
+    [filteredEvents],
   );
-  const datedEvents = useMemo(() => events.filter((e) => !e.datetimeTbd), [events]);
+  const datedEvents = useMemo(() => filteredEvents.filter((e) => !e.datetimeTbd), [filteredEvents]);
 
   const [view, setView] = useState<View>('month');
   const [date, setDate] = useState<Date>(new Date());
@@ -99,6 +112,15 @@ export default function CalendarScreen() {
       <header className="mb-4 flex justify-center">
         <ViewSwitcher value={view} onChange={setView} />
       </header>
+
+      <CalendarFilterBar
+        search={search}
+        onSearchChange={setSearch}
+        typeFilter={typeFilter}
+        onTypeFilterChange={setTypeFilter}
+        date={date}
+        onDateChange={setDate}
+      />
 
       {isError ? (
         <div className="border-destructive bg-destructive-subtle text-destructive mb-4 rounded-md border px-3 py-2 text-sm">

--- a/frontend/src/screens/calendar/CalendarScreen.tsx
+++ b/frontend/src/screens/calendar/CalendarScreen.tsx
@@ -81,15 +81,11 @@ export default function CalendarScreen() {
     });
   }, [events, typeFilter, search]);
 
-  const bigCalEvents = useMemo<BigCalEvent[]>(
-    () =>
-      filteredEvents
-        .filter((e) => !e.datetimeTbd)
-        .map(toBigCalEvent)
-        .filter((e): e is BigCalEvent => e !== null),
-    [filteredEvents],
-  );
   const datedEvents = useMemo(() => filteredEvents.filter((e) => !e.datetimeTbd), [filteredEvents]);
+  const bigCalEvents = useMemo<BigCalEvent[]>(
+    () => datedEvents.map(toBigCalEvent).filter((e): e is BigCalEvent => e !== null),
+    [datedEvents],
+  );
 
   const [view, setView] = useState<View>('month');
   const [date, setDate] = useState<Date>(new Date());
@@ -118,8 +114,7 @@ export default function CalendarScreen() {
         onSearchChange={setSearch}
         typeFilter={typeFilter}
         onTypeFilterChange={setTypeFilter}
-        date={date}
-        onDateChange={setDate}
+        {...(useAgendaList ? {} : { date, onDateChange: setDate })}
       />
 
       {isError ? (
@@ -172,7 +167,11 @@ export default function CalendarScreen() {
           </>
         ) : useAgendaList ? (
           <div className="flex-1 overflow-y-auto">
-            <AgendaList events={datedEvents} onSelectEvent={goToEvent} />
+            <AgendaList
+              events={datedEvents}
+              onSelectEvent={goToEvent}
+              isFiltered={typeFilter !== 'all' || search.trim() !== ''}
+            />
           </div>
         ) : (
           <Calendar<BigCalEvent>

--- a/frontend/src/screens/calendar/NarrowWeekView.tsx
+++ b/frontend/src/screens/calendar/NarrowWeekView.tsx
@@ -54,13 +54,9 @@ interface DayRowProps {
   onSelectEvent: (event: PdaEvent) => void;
 }
 
-const MAX_CHIPS_PER_DAY = 2;
-
 function DayRow({ day, isLast, isToday, events, onSelectEvent }: DayRowProps) {
   const weekdayLabel = lower(day, 'EEE');
   const dayNumber = format(day, 'd');
-  const visibleEvents = events.slice(0, MAX_CHIPS_PER_DAY);
-  const overflowCount = events.length - visibleEvents.length;
   return (
     <li
       aria-label={`${weekdayLabel} ${dayNumber}`}
@@ -80,21 +76,10 @@ function DayRow({ day, isLast, isToday, events, onSelectEvent }: DayRowProps) {
         </div>
       </div>
 
-      <div className="flex min-w-0 flex-1 flex-col justify-center gap-1 overflow-hidden px-2 py-1.5">
-        {visibleEvents.map((event) => (
+      <div className="flex min-w-0 flex-1 flex-col gap-1 overflow-y-auto px-2 py-1.5">
+        {events.map((event) => (
           <EventChip key={event.id} event={event} onSelect={onSelectEvent} />
         ))}
-        {overflowCount > 0 ? (
-          <span
-            className="text-brand-700 text-[11px] font-medium"
-            style={{
-              borderInlineStart: '3px solid transparent',
-              paddingInlineStart: '6px',
-            }}
-          >
-            {String(overflowCount)} more
-          </span>
-        ) : null}
       </div>
     </li>
   );


### PR DESCRIPTION
## Overview

Calendar browsing follow-up from the event UI audit (Theme B, issue #944). Note: RSVP/capacity badge surfacing on cards was already shipped before this branch started.

- **Keyword search** — new `CalendarFilterBar` search field, applied across all calendar views (was entirely missing).
- **Global type filter** — the official/community filter previously only existed inside `AgendaList`'s agenda view; it's now in `CalendarFilterBar` and applies to month/week/day/agenda uniformly.
- **Jump-to-date** — a `DateTimePicker` in the filter bar lets you jump to any date instead of only stepping via chevrons. Hidden on list/agenda view, which has no concept of a displayed date to jump to.
- **`NarrowWeekView` 2-chip cap removed** — day cells scroll instead of hard-truncating at 2 events with a "+N more" overflow.

Closes #957

## Post-review fixes

- Hid the jump-to-date picker on agenda/list view (it silently did nothing there before).
- Restored a filter-aware empty state in agenda view ("no events match your search or filter" vs. the generic empty message), which had been dropped when the type filter moved out of `AgendaList`.
- `bigCalEvents` now derives from `datedEvents` instead of re-filtering independently.
- Added test coverage for the community filter and both filter-narrowed-to-zero-results empty states.

## Test plan

- [x] `CalendarScreen.test.tsx` (filter + empty-state + jump-to-date-visibility tests), `AgendaList.test.tsx`, `CalendarViews.a11y.test.tsx` all pass
- [x] eslint + prettier clean on touched files
- [x] `make agent-frontend-typecheck` clean
- [ ] Note: only touched-file tests were run per instruction, not the full suite
