### PR TITLE
fix(deploy): retry db connection at boot instead of crashing

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,5 +16,20 @@ nginx -t
 nginx -g 'daemon off;' || kill "$$" &
 
 cd backend
-uv run python manage.py migrate
+
+# Railway's private network (internal IPv6 mesh + DNS) can lag the container
+# boot, so the first DB connect times out even though Postgres is up. Poll until
+# reachable instead of letting a single-shot migrate kill the whole deploy.
+# ponytail: fixed 60s ceiling, bump the loop count if cold starts get slower.
+attempt=1
+until uv run python manage.py migrate; do
+  if [ "$attempt" -ge 12 ]; then
+    echo "database unreachable after $attempt attempts, giving up" >&2
+    exit 1
+  fi
+  echo "database not ready (attempt $attempt), retrying in 5s..." >&2
+  attempt=$((attempt + 1))
+  sleep 5
+done
+
 uv run uvicorn config.asgi:application --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Overview

Staging returned 502 on nearly every endpoint after a deploy. The deploy log showed `manage.py migrate` failing with `psycopg ... connection timeout expired` reaching `postgres-*.railway.internal:5432`. Because the entrypoint ran a **single-shot** migrate under `set -e`, one failed DB connect at boot killed the process before uvicorn started — leaving nginx with no upstream and serving 502 everywhere until manual intervention.

## Change

Poll `manage.py migrate` up to 12 times (5s apart, ~60s total) before starting uvicorn. On success it proceeds immediately; if the DB is truly unreachable it exits nonzero so the failure is still visible.

## Why this is the right fix (and its limits)

- Prod was unaffected because it had not redeployed in a while; only staging (auto-deploys on every push to `main`) kept re-rolling the boot-time DB connect.
- This hardens against **transient** unreachability (private-network cold-start lag, provider networking blips).
- ⚠️ It does **not** fix a *consistent* inability to reach the DB — if migrate fails all 12 times the deploy still fails by design. If staging is 502-ing across repeated redeploys, the underlying DB reachability (service state / private networking / `DATABASE_URL`) must be fixed on the Railway side.

## Test

Extracted the loop and exercised it with a stubbed `migrate`: immediate success, recovery on the Nth attempt, and give-up-with-nonzero after the cap. `sh -n entrypoint.sh` passes.
