### PR TITLE
test(e2e): add playwright rsvp e2e suite + ci job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,11 +141,10 @@ jobs:
       - name: Install Playwright browsers
         run: cd frontend && pnpm exec playwright install --with-deps chromium
 
-      - name: Migrate and seed database
-        run: |
-          cd backend
-          uv run python manage.py migrate
-          uv run python manage.py seed
+      # Only migrate — each spec seeds its own data via the e2e_seed command;
+      # the global demo seed isn't needed and would just add a failure surface.
+      - name: Migrate database
+        run: cd backend && uv run python manage.py migrate
 
       # Start both servers and run the specs in a single step: background
       # processes started in one step aren't guaranteed to survive into the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,9 @@ jobs:
     env:
       DATABASE_URL: postgresql://pda:pda@localhost:5432/pda
       SECRET_KEY: ci-only-not-used-in-prod
+      # The live uvicorn server enforces ALLOWED_HOSTS (unlike pytest's test
+      # client), so the e2e job must allow the hosts Playwright hits.
+      ALLOWED_HOSTS: localhost,127.0.0.1
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,91 @@ jobs:
 
       - name: Run frontend CI
         run: make agent-frontend-ci
+
+  e2e:
+    name: E2E
+    runs-on: ubuntu-latest
+
+    # Playwright specs drive the real app end-to-end, including the SSE
+    # comment live-update path, which needs pg_notify — Postgres, not SQLite.
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: pda
+          POSTGRES_PASSWORD: pda
+          POSTGRES_DB: pda
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 3s
+          --health-retries 10
+
+    env:
+      DATABASE_URL: postgresql://pda:pda@localhost:5432/pda
+      SECRET_KEY: ci-only-not-used-in-prod
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 10.33.0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install backend dependencies
+        run: uv sync --locked
+
+      - name: Install frontend dependencies
+        run: cd frontend && pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: cd frontend && pnpm exec playwright install --with-deps chromium
+
+      - name: Migrate and seed database
+        run: |
+          cd backend
+          uv run python manage.py migrate
+          uv run python manage.py seed
+
+      # Start both servers and run the specs in a single step: background
+      # processes started in one step aren't guaranteed to survive into the
+      # next, so serving and testing must share a step.
+      - name: Run e2e tests
+        run: |
+          (cd backend && uv run uvicorn config.asgi:application --host 0.0.0.0 --port 8000) &
+          (cd frontend && pnpm dev --host 0.0.0.0 --port 3000) &
+          wait_for() {
+            for _ in $(seq 1 60); do
+              curl -sf "$1" > /dev/null && return 0
+              sleep 1
+            done
+            echo "timed out waiting for $1" >&2
+            return 1
+          }
+          wait_for http://localhost:8000/api/openapi.json
+          wait_for http://localhost:3000
+          make agent-frontend-e2e
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,9 @@ jobs:
       - name: Run e2e tests
         run: |
           (cd backend && uv run uvicorn config.asgi:application --host 0.0.0.0 --port 8000) &
+          # Vite dev (not preview): only the dev server proxies /api, including
+          # the SSE stream with buffering disabled. A preview build would break
+          # the live-update spec.
           (cd frontend && pnpm dev --host 0.0.0.0 --port 3000) &
           wait_for() {
             for _ in $(seq 1 60); do

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ AGENT_XDIST_N = $${PYTEST_XDIST_AUTO_NUM_WORKERS:-3}
         dump-codes generate-codes check-codes dump-openapi frontend-types-check \
         parallel-frontend parallel-agent-frontend \
         agent-lint agent-check agent-test agent-test-since agent-typecheck agent-complexity agent-check-codes \
-        agent-frontend-lint agent-frontend-format agent-frontend-format-check agent-frontend-test agent-frontend-typecheck
+        agent-frontend-lint agent-frontend-format agent-frontend-format-check agent-frontend-test agent-frontend-e2e agent-frontend-typecheck
 
 help:
 	@echo "Backend commands:"
@@ -303,6 +303,9 @@ agent-frontend-format-check:
 
 agent-frontend-test:
 	cd frontend && pnpm exec vitest run --reporter=dot --silent passed-only
+
+agent-frontend-e2e:
+	@cd frontend && pnpm test:e2e
 
 agent-frontend-typecheck:
 	cd frontend && pnpm exec tsc -b --noEmit --pretty false

--- a/backend/community/management/commands/e2e_seed.py
+++ b/backend/community/management/commands/e2e_seed.py
@@ -1,0 +1,155 @@
+import json
+import secrets
+from datetime import timedelta
+
+from django.core.management.base import BaseCommand, CommandError
+from django.utils import timezone
+from ninja_jwt.tokens import RefreshToken
+from users.models import NonMemberRsvpToken, User
+
+from community.models import (
+    Event,
+    EventRSVP,
+    EventStatus,
+    EventType,
+    PageVisibility,
+    RSVPStatus,
+)
+
+E2E_PASSWORD = "e2e-test-pass-123"
+
+
+def _random_phone() -> str:
+    return "+1555" + str(secrets.randbelow(10_000_000)).zfill(7)
+
+
+def _random_event(scenario: str, **overrides) -> Event:
+    base = {
+        "title": f"E2E {scenario} {secrets.token_hex(4)}",
+        "start_datetime": timezone.now() + timedelta(days=30),
+        "event_type": EventType.OFFICIAL,
+        "visibility": PageVisibility.PUBLIC,
+        "status": EventStatus.ACTIVE,
+        "rsvp_enabled": True,
+    }
+    base.update(overrides)
+    return Event.objects.create(**base)
+
+
+def _member_user(phone: str) -> User:
+    user = User.objects.create_user(
+        phone_number=phone,
+        first_name="E2E",
+        last_name="Member",
+        email=f"{phone.lstrip('+')}@example.com",
+        is_member=True,
+        password=E2E_PASSWORD,
+    )
+    return user
+
+
+def _non_member_user(phone: str) -> User:
+    user = User.objects.create_user(
+        phone_number=phone,
+        first_name="E2E",
+        last_name="Guest",
+        email=f"{phone.lstrip('+')}@example.com",
+        is_member=False,
+    )
+    user.set_unusable_password()
+    user.save(update_fields=["password"])
+    return user
+
+
+def _access_token(user: User) -> str:
+    refresh = RefreshToken.for_user(user)
+    return str(refresh.access_token)  # type: ignore[attr-defined]
+
+
+def _seed_member() -> dict:
+    event = _random_event("member")
+    phone = _random_phone()
+    user = _member_user(phone)
+    return {
+        "event_id": str(event.id),
+        "event_title": event.title,
+        "user_phone": phone,
+        "user_password": E2E_PASSWORD,
+        "access_token": _access_token(user),
+    }
+
+
+def _seed_public_new() -> dict:
+    event = _random_event("public-new")
+    return {"event_id": str(event.id), "event_title": event.title}
+
+
+def _seed_public_returning() -> dict:
+    event = _random_event("public-returning")
+    phone = _random_phone()
+    user = _non_member_user(phone)
+    EventRSVP.objects.create(event=event, user=user, status=RSVPStatus.ATTENDING)
+    token = NonMemberRsvpToken.issue_or_extend(user)
+    return {
+        "event_id": str(event.id),
+        "event_title": event.title,
+        "user_phone": phone,
+        "rsvp_token": token.token,
+    }
+
+
+def _seed_comments() -> dict:
+    event = _random_event("comments")
+    phone = _random_phone()
+    user = _non_member_user(phone)
+    EventRSVP.objects.create(event=event, user=user, status=RSVPStatus.ATTENDING)
+    token = NonMemberRsvpToken.issue_or_extend(user)
+    return {"event_id": str(event.id), "event_title": event.title, "rsvp_token": token.token}
+
+
+def _seed_my_rsvps() -> dict:
+    event = _random_event("my-rsvps")
+    phone = _random_phone()
+    user = _non_member_user(phone)
+    EventRSVP.objects.create(event=event, user=user, status=RSVPStatus.ATTENDING)
+    token = NonMemberRsvpToken.issue_or_extend(user)
+    return {"event_id": str(event.id), "event_title": event.title, "rsvp_token": token.token}
+
+
+def _seed_live_updates() -> dict:
+    event = _random_event("live-updates")
+    phone_a, phone_b = _random_phone(), _random_phone()
+    _member_user(phone_a)
+    _member_user(phone_b)
+    return {
+        "event_id": str(event.id),
+        "event_title": event.title,
+        "user_a_phone": phone_a,
+        "user_a_password": E2E_PASSWORD,
+        "user_b_phone": phone_b,
+        "user_b_password": E2E_PASSWORD,
+    }
+
+
+SCENARIOS = {
+    "member": _seed_member,
+    "public-new": _seed_public_new,
+    "public-returning": _seed_public_returning,
+    "comments": _seed_comments,
+    "my-rsvps": _seed_my_rsvps,
+    "live-updates": _seed_live_updates,
+}
+
+
+class Command(BaseCommand):
+    help = "Seed one-off data for a Playwright e2e scenario and print it as JSON."
+
+    def add_arguments(self, parser):
+        parser.add_argument("scenario", choices=sorted(SCENARIOS))
+
+    def handle(self, *args, **options):
+        scenario = options["scenario"]
+        builder = SCENARIOS.get(scenario)
+        if builder is None:
+            raise CommandError(f"Unknown scenario: {scenario}")
+        self.stdout.write(json.dumps(builder()))

--- a/backend/community/management/commands/e2e_seed.py
+++ b/backend/community/management/commands/e2e_seed.py
@@ -2,7 +2,7 @@ import json
 import secrets
 from datetime import timedelta
 
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from django.utils import timezone
 from ninja_jwt.tokens import RefreshToken
 from users.models import NonMemberRsvpToken, User
@@ -49,16 +49,14 @@ def _member_user(phone: str) -> User:
 
 
 def _non_member_user(phone: str) -> User:
-    user = User.objects.create_user(
+    # create_user with no password calls set_password(None) → unusable password.
+    return User.objects.create_user(
         phone_number=phone,
         first_name="E2E",
         last_name="Guest",
         email=f"{phone.lstrip('+')}@example.com",
         is_member=False,
     )
-    user.set_unusable_password()
-    user.save(update_fields=["password"])
-    return user
 
 
 def _access_token(user: User) -> str:
@@ -148,8 +146,5 @@ class Command(BaseCommand):
         parser.add_argument("scenario", choices=sorted(SCENARIOS))
 
     def handle(self, *args, **options):
-        scenario = options["scenario"]
-        builder = SCENARIOS.get(scenario)
-        if builder is None:
-            raise CommandError(f"Unknown scenario: {scenario}")
-        self.stdout.write(json.dumps(builder()))
+        # argparse choices= already rejects any unknown scenario before handle runs.
+        self.stdout.write(json.dumps(SCENARIOS[options["scenario"]]()))

--- a/backend/community/management/commands/e2e_seed.py
+++ b/backend/community/management/commands/e2e_seed.py
@@ -20,7 +20,7 @@ E2E_PASSWORD = "e2e-test-pass-123"
 
 
 def _random_phone() -> str:
-    return "+1555" + str(secrets.randbelow(10_000_000)).zfill(7)
+    return "+1202555" + str(secrets.randbelow(10_000)).zfill(4)
 
 
 def _random_event(scenario: str, **overrides) -> Event:

--- a/backend/tests/test_e2e_seed_command.py
+++ b/backend/tests/test_e2e_seed_command.py
@@ -1,0 +1,66 @@
+import json
+
+import pytest
+from community.models import Event, EventRSVP
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from users.models import NonMemberRsvpToken, User
+
+
+@pytest.mark.django_db
+def test_e2e_seed_member(capsys):
+    call_command("e2e_seed", "member")
+    out = json.loads(capsys.readouterr().out)
+    assert Event.objects.filter(id=out["event_id"]).exists()
+    user = User.objects.get(phone_number=out["user_phone"])
+    assert user.is_member is True
+    assert user.check_password(out["user_password"])
+    assert out["access_token"]
+
+
+@pytest.mark.django_db
+def test_e2e_seed_public_new(capsys):
+    call_command("e2e_seed", "public-new")
+    out = json.loads(capsys.readouterr().out)
+    assert Event.objects.filter(id=out["event_id"]).exists()
+    assert set(out.keys()) == {"event_id", "event_title"}
+
+
+@pytest.mark.django_db
+def test_e2e_seed_public_returning(capsys):
+    call_command("e2e_seed", "public-returning")
+    out = json.loads(capsys.readouterr().out)
+    user = User.objects.get(phone_number=out["user_phone"])
+    assert EventRSVP.objects.filter(event_id=out["event_id"], user=user).exists()
+    assert NonMemberRsvpToken.resolve_user(out["rsvp_token"]) == user
+
+
+@pytest.mark.django_db
+def test_e2e_seed_comments(capsys):
+    call_command("e2e_seed", "comments")
+    out = json.loads(capsys.readouterr().out)
+    assert NonMemberRsvpToken.resolve_user(out["rsvp_token"]) is not None
+    assert EventRSVP.objects.filter(event_id=out["event_id"]).exists()
+
+
+@pytest.mark.django_db
+def test_e2e_seed_my_rsvps(capsys):
+    call_command("e2e_seed", "my-rsvps")
+    out = json.loads(capsys.readouterr().out)
+    assert NonMemberRsvpToken.resolve_user(out["rsvp_token"]) is not None
+
+
+@pytest.mark.django_db
+def test_e2e_seed_live_updates(capsys):
+    call_command("e2e_seed", "live-updates")
+    out = json.loads(capsys.readouterr().out)
+    for key in ("user_a_phone", "user_a_password", "user_b_phone", "user_b_password"):
+        assert out[key]
+    assert User.objects.get(phone_number=out["user_a_phone"]).is_member is True
+    assert User.objects.get(phone_number=out["user_b_phone"]).is_member is True
+
+
+@pytest.mark.django_db
+def test_e2e_seed_unknown_scenario():
+    with pytest.raises(CommandError):
+        call_command("e2e_seed", "not-a-real-scenario")

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -7,6 +7,12 @@ dist-ssr
 .vitest
 coverage
 
+# Playwright
+test-results
+playwright-report
+blob-report
+playwright/.cache
+
 # Editor
 .vscode/*
 !.vscode/extensions.json

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -1,0 +1,20 @@
+import { execFileSync } from 'node:child_process';
+import path from 'node:path';
+
+export type SeedScenario =
+  | 'member'
+  | 'public-new'
+  | 'public-returning'
+  | 'comments'
+  | 'my-rsvps'
+  | 'live-updates';
+
+const BACKEND_DIR = path.resolve(__dirname, '../../backend');
+
+export function seed<T = Record<string, string>>(scenario: SeedScenario): T {
+  const output = execFileSync('uv', ['run', 'python', 'manage.py', 'e2e_seed', scenario], {
+    cwd: BACKEND_DIR,
+    encoding: 'utf-8',
+  });
+  return JSON.parse(output.trim()) as T;
+}

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -2,13 +2,23 @@ import { execFileSync } from 'node:child_process';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-export type SeedScenario =
-  | 'member'
-  | 'public-new'
-  | 'public-returning'
-  | 'comments'
-  | 'my-rsvps'
-  | 'live-updates';
+export interface SeedScenarioMap {
+  member: { event_id: string; event_title: string; user_phone: string; user_password: string; access_token: string };
+  'public-new': { event_id: string; event_title: string };
+  'public-returning': { event_id: string; event_title: string; user_phone: string; rsvp_token: string };
+  comments: { event_id: string; event_title: string; rsvp_token: string };
+  'my-rsvps': { event_id: string; event_title: string; rsvp_token: string };
+  'live-updates': {
+    event_id: string;
+    event_title: string;
+    user_a_phone: string;
+    user_a_password: string;
+    user_b_phone: string;
+    user_b_password: string;
+  };
+}
+
+export type SeedScenario = keyof SeedScenarioMap;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = path.resolve(__dirname, '../..');
@@ -21,11 +31,11 @@ function resolveDatabaseUrl(): string {
   }).trim();
 }
 
-export function seed<T = Record<string, string>>(scenario: SeedScenario): T {
+export function seed<S extends SeedScenario>(scenario: S): SeedScenarioMap[S] {
   const output = execFileSync('uv', ['run', 'python', 'manage.py', 'e2e_seed', scenario], {
     cwd: BACKEND_DIR,
     encoding: 'utf-8',
     env: { ...process.env, DATABASE_URL: resolveDatabaseUrl() },
   });
-  return JSON.parse(output.trim()) as T;
+  return JSON.parse(output.trim()) as SeedScenarioMap[S];
 }

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from 'node:child_process';
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 export type SeedScenario =
   | 'member'
@@ -9,12 +10,22 @@ export type SeedScenario =
   | 'my-rsvps'
   | 'live-updates';
 
-const BACKEND_DIR = path.resolve(__dirname, '../../backend');
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.resolve(__dirname, '../..');
+const BACKEND_DIR = path.resolve(ROOT_DIR, 'backend');
+
+function resolveDatabaseUrl(): string {
+  return execFileSync('./scripts/dev_pg_db.sh', ['url'], {
+    cwd: ROOT_DIR,
+    encoding: 'utf-8',
+  }).trim();
+}
 
 export function seed<T = Record<string, string>>(scenario: SeedScenario): T {
   const output = execFileSync('uv', ['run', 'python', 'manage.py', 'e2e_seed', scenario], {
     cwd: BACKEND_DIR,
     encoding: 'utf-8',
+    env: { ...process.env, DATABASE_URL: resolveDatabaseUrl() },
   });
   return JSON.parse(output.trim()) as T;
 }

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -3,9 +3,20 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 export interface SeedScenarioMap {
-  member: { event_id: string; event_title: string; user_phone: string; user_password: string; access_token: string };
+  member: {
+    event_id: string;
+    event_title: string;
+    user_phone: string;
+    user_password: string;
+    access_token: string;
+  };
   'public-new': { event_id: string; event_title: string };
-  'public-returning': { event_id: string; event_title: string; user_phone: string; rsvp_token: string };
+  'public-returning': {
+    event_id: string;
+    event_title: string;
+    user_phone: string;
+    rsvp_token: string;
+  };
   comments: { event_id: string; event_title: string; rsvp_token: string };
   'my-rsvps': { event_id: string; event_title: string; rsvp_token: string };
   'live-updates': {

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -36,6 +36,12 @@ const ROOT_DIR = path.resolve(__dirname, '../..');
 const BACKEND_DIR = path.resolve(ROOT_DIR, 'backend');
 
 function resolveDatabaseUrl(): string {
+  // CI sets DATABASE_URL to the shared `pda` database the backend serves from;
+  // honor it directly. Locally it's unset, so fall back to the per-worktree
+  // Postgres name that `make dev-pg` runs against.
+  if (process.env.DATABASE_URL) {
+    return process.env.DATABASE_URL;
+  }
   return execFileSync('./scripts/dev_pg_db.sh', ['url'], {
     cwd: ROOT_DIR,
     encoding: 'utf-8',

--- a/frontend/e2e/live-updates.spec.ts
+++ b/frontend/e2e/live-updates.spec.ts
@@ -1,0 +1,64 @@
+import { expect, type Page, test } from '@playwright/test';
+
+import { seed } from './fixtures';
+
+async function loginAsMember(page: Page, phone: string, password: string) {
+  await page.goto('/login');
+  await page.getByLabel('phone number').pressSequentially(phone.replace('+1', ''));
+  await page.getByRole('button', { name: 'continue' }).click();
+  await page.getByRole('textbox', { name: 'password' }).fill(password);
+  await page.getByRole('button', { name: 'sign in' }).click();
+  await page.waitForURL((url) => url.pathname !== '/login');
+
+  if (page.url().includes('/consent')) {
+    await page
+      .getByRole('checkbox', {
+        name: 'i have read and agree to the community guidelines and community agreements',
+      })
+      .check();
+    await page.getByRole('checkbox', { name: 'i agree to the sms policy' }).check();
+    await page.getByRole('button', { name: 'continue' }).click();
+    await page.waitForURL((url) => !url.pathname.includes('/consent'));
+  }
+}
+
+test('member A comment appears live in member B open event view via SSE', async ({ browser }) => {
+  const { event_id, user_a_phone, user_a_password, user_b_phone, user_b_password } =
+    seed('live-updates');
+
+  const contextA = await browser.newContext();
+  const contextB = await browser.newContext();
+  const pageA = await contextA.newPage();
+  const pageB = await contextB.newPage();
+
+  try {
+    await loginAsMember(pageA, user_a_phone, user_a_password);
+    await loginAsMember(pageB, user_b_phone, user_b_password);
+
+    await pageA.goto(`/events/${event_id}`);
+    await pageB.goto(`/events/${event_id}`);
+
+    const rsvpSectionA = pageA.getByLabel('rsvp');
+    await rsvpSectionA.getByRole('button', { name: "i'm going" }).click();
+    await pageA
+      .getByRole('dialog', { name: 'rsvp' })
+      .getByRole('button', { name: 'confirm' })
+      .click();
+    await expect(rsvpSectionA.getByText("you're going")).toBeVisible();
+
+    const commentsSectionA = pageA.locator('section', {
+      has: pageA.getByRole('heading', { name: 'comments' }),
+    });
+    await commentsSectionA.scrollIntoViewIfNeeded();
+
+    const commentText = `live e2e comment ${String(Date.now())}`;
+    await commentsSectionA.getByLabel('comment', { exact: true }).fill(commentText);
+    await commentsSectionA.getByRole('button', { name: 'post' }).click();
+    await expect(commentsSectionA.getByText(commentText)).toBeVisible();
+
+    await expect(pageB.getByText(commentText)).toBeVisible({ timeout: 15_000 });
+  } finally {
+    await contextA.close();
+    await contextB.close();
+  }
+});

--- a/frontend/e2e/my-rsvps.spec.ts
+++ b/frontend/e2e/my-rsvps.spec.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@playwright/test';
+
+import { seed } from './fixtures';
+
+test('non-member views and cancels rsvp via my-rsvps manage link', async ({ page }) => {
+  const { event_title, rsvp_token } = seed('my-rsvps');
+
+  await page.goto(`/my-rsvps?token=${rsvp_token}`);
+
+  await expect(page.getByRole('heading', { name: 'your rsvps' })).toBeVisible();
+  const card = page.getByLabel(event_title);
+  await expect(card).toBeVisible();
+  await expect(card.getByText("you're going")).toBeVisible();
+
+  await card.getByRole('button', { name: 'cancel rsvp' }).click();
+  await expect(page.getByText('rsvp cancelled')).toBeVisible();
+});

--- a/frontend/e2e/rsvp-comments-public.spec.ts
+++ b/frontend/e2e/rsvp-comments-public.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from '@playwright/test';
+
+import { seed } from './fixtures';
+
+test('non-member with rsvp token can comment, reply, and react', async ({ page }) => {
+  const { event_id, rsvp_token } = seed('comments');
+
+  await page.addInitScript((token) => {
+    localStorage.setItem('pda-rsvp-token', token);
+  }, rsvp_token);
+
+  await page.goto(`/events/${event_id}`);
+
+  const commentsSection = page.locator('section', {
+    has: page.getByRole('heading', { name: 'comments' }),
+  });
+  await commentsSection.scrollIntoViewIfNeeded();
+
+  const commentText = `e2e comment ${String(Date.now())}`;
+  await commentsSection.getByLabel('comment', { exact: true }).fill(commentText);
+  await commentsSection.getByRole('button', { name: 'post' }).click();
+
+  const postedComment = commentsSection.locator('article', { hasText: commentText });
+  await expect(postedComment).toBeVisible();
+
+  await postedComment.getByRole('button', { name: 'reply' }).click();
+  const replyText = `e2e reply ${String(Date.now())}`;
+  await postedComment.getByLabel('reply', { exact: true }).fill(replyText);
+  await postedComment.getByRole('button', { name: 'post' }).click();
+  await expect(postedComment.getByText(replyText)).toBeVisible();
+
+  await postedComment.getByRole('button', { name: 'add reaction' }).click();
+  await postedComment.getByRole('button', { name: '❤️' }).click();
+  await expect(postedComment.getByRole('button', { name: '❤️ 1' })).toBeVisible();
+});

--- a/frontend/e2e/rsvp-member.spec.ts
+++ b/frontend/e2e/rsvp-member.spec.ts
@@ -1,4 +1,4 @@
-import { expect,test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 import { seed } from './fixtures';
 

--- a/frontend/e2e/rsvp-member.spec.ts
+++ b/frontend/e2e/rsvp-member.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+import { seed } from './fixtures';
+
+test('member rsvps to an event from event detail', async ({ page }) => {
+  const { event_id, event_title, user_phone, user_password } = seed('member');
+
+  await page.goto('/login');
+  await page.getByLabel('phone number').pressSequentially(user_phone.replace('+1', ''));
+  await page.getByRole('button', { name: 'continue' }).click();
+  await page.getByRole('textbox', { name: 'password' }).fill(user_password);
+  await page.getByRole('button', { name: 'sign in' }).click();
+  await page.waitForURL((url) => url.pathname !== '/login');
+
+  if (page.url().includes('/consent')) {
+    await page
+      .getByRole('checkbox', {
+        name: 'i have read and agree to the community guidelines and community agreements',
+      })
+      .check();
+    await page.getByRole('checkbox', { name: 'i agree to the sms policy' }).check();
+    await page.getByRole('button', { name: 'continue' }).click();
+    await page.waitForURL((url) => !url.pathname.includes('/consent'));
+  }
+
+  await page.goto(`/events/${event_id}`);
+  await expect(page.getByRole('heading', { name: event_title })).toBeVisible();
+
+  const rsvpSection = page.getByLabel('rsvp');
+  await rsvpSection.getByRole('button', { name: "i'm going" }).click();
+
+  const rsvpDialog = page.getByRole('dialog', { name: 'rsvp' });
+  await rsvpDialog.getByRole('button', { name: 'confirm' }).click();
+
+  await expect(rsvpSection.getByText("you're going")).toBeVisible();
+});

--- a/frontend/e2e/rsvp-member.spec.ts
+++ b/frontend/e2e/rsvp-member.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect } from '@playwright/test';
+import { expect,test } from '@playwright/test';
+
 import { seed } from './fixtures';
 
 test('member rsvps to an event from event detail', async ({ page }) => {

--- a/frontend/e2e/rsvp-public-new.spec.ts
+++ b/frontend/e2e/rsvp-public-new.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+import { seed } from './fixtures';
+
+test('new non-member rsvps via public event link', async ({ page }) => {
+  const { event_id, event_title } = seed('public-new');
+
+  await page.goto(`/events/${event_id}`);
+  await expect(page.getByRole('heading', { name: event_title })).toBeVisible();
+
+  const phone = '202555' + String(Math.floor(1000 + Math.random() * 9000));
+
+  const rsvpSection = page.getByLabel('rsvp');
+  await rsvpSection.getByRole('button', { name: "i'm going" }).click();
+  await rsvpSection.getByLabel('phone number').pressSequentially(phone);
+  await rsvpSection.getByRole('button', { name: 'continue' }).click();
+
+  await rsvpSection.getByLabel('first name').fill('Playwright');
+  await rsvpSection.getByLabel('last name').fill('Tester');
+  await rsvpSection.getByLabel('email').fill('playwright-new@example.com');
+  await rsvpSection.getByRole('button', { name: 'rsvp' }).click();
+
+  await expect(page.getByLabel('rsvp').getByText("you're going")).toBeVisible();
+});

--- a/frontend/e2e/rsvp-public-new.spec.ts
+++ b/frontend/e2e/rsvp-public-new.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect } from '@playwright/test';
+import { expect,test } from '@playwright/test';
+
 import { seed } from './fixtures';
 
 test('new non-member rsvps via public event link', async ({ page }) => {

--- a/frontend/e2e/rsvp-public-new.spec.ts
+++ b/frontend/e2e/rsvp-public-new.spec.ts
@@ -1,4 +1,4 @@
-import { expect,test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 import { seed } from './fixtures';
 

--- a/frontend/e2e/rsvp-public-returning.spec.ts
+++ b/frontend/e2e/rsvp-public-returning.spec.ts
@@ -1,4 +1,4 @@
-import { expect,test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 import { seed } from './fixtures';
 

--- a/frontend/e2e/rsvp-public-returning.spec.ts
+++ b/frontend/e2e/rsvp-public-returning.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+import { seed } from './fixtures';
+
+test('returning non-member with stored token skips phone-check', async ({ page }) => {
+  const { event_id, event_title, rsvp_token } = seed('public-returning');
+
+  await page.addInitScript((token) => {
+    localStorage.setItem('pda-rsvp-token', token);
+  }, rsvp_token);
+
+  await page.goto(`/events/${event_id}`);
+  await expect(page.getByRole('heading', { name: event_title })).toBeVisible();
+
+  const rsvpSection = page.getByLabel('rsvp');
+  await expect(rsvpSection.getByLabel('phone number')).not.toBeVisible();
+  await expect(rsvpSection.getByText("you're going")).toBeVisible();
+
+  await rsvpSection.getByRole('button', { name: 'edit rsvp' }).click();
+
+  const rsvpDialog = page.getByRole('dialog', { name: 'rsvp' });
+  await expect(rsvpDialog).toBeVisible();
+});

--- a/frontend/e2e/rsvp-public-returning.spec.ts
+++ b/frontend/e2e/rsvp-public-returning.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect } from '@playwright/test';
+import { expect,test } from '@playwright/test';
+
 import { seed } from './fixtures';
 
 test('returning non-member with stored token skips phone-check', async ({ page }) => {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "typecheck": "tsc -b --noEmit",
     "test": "vitest run",
     "test:watch": "vitest",
+    "test:e2e": "playwright test",
     "types:api": "openapi-typescript ../backend/openapi_schema.json -o src/api/types.gen.ts",
     "types:api:check": "openapi-typescript ../backend/openapi_schema.json -o src/api/types.gen.ts --check"
   },
@@ -51,6 +52,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4.2.2",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 2 : undefined,
+  reporter: process.env.CI ? 'dot' : 'list',
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+});

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -6,7 +6,9 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
   workers: process.env.CI ? 2 : undefined,
-  reporter: process.env.CI ? 'dot' : 'list',
+  reporter: process.env.CI
+    ? [['dot'], ['html', { outputFolder: 'playwright-report', open: 'never' }]]
+    : 'list',
   use: {
     baseURL: 'http://localhost:3000',
     trace: 'on-first-retry',

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -99,6 +99,9 @@ importers:
       '@eslint/js':
         specifier: ^9.39.4
         version: 9.39.4
+      '@playwright/test':
+        specifier: ^1.61.1
+        version: 1.61.1
       '@tailwindcss/postcss':
         specifier: ^4.2.2
         version: 4.2.2
@@ -464,6 +467,11 @@ packages:
 
   '@oxc-project/types@0.124.0':
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
+
+  '@playwright/test@1.61.1':
+    resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
@@ -1518,6 +1526,11 @@ packages:
   fraction.js@5.3.4:
     resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -2079,6 +2092,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.61.1:
+    resolution: {integrity: sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.61.1:
+    resolution: {integrity: sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   pluralize@8.0.0:
     resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
@@ -3049,6 +3072,10 @@ snapshots:
     optional: true
 
   '@oxc-project/types@0.124.0': {}
+
+  '@playwright/test@1.61.1':
+    dependencies:
+      playwright: 1.61.1
 
   '@popperjs/core@2.11.8': {}
 
@@ -4167,6 +4194,9 @@ snapshots:
 
   fraction.js@5.3.4: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -4693,6 +4723,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.61.1: {}
+
+  playwright@1.61.1:
+    dependencies:
+      playwright-core: 1.61.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   pluralize@8.0.0: {}
 

--- a/frontend/tsconfig.e2e.json
+++ b/frontend/tsconfig.e2e.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.e2e.tsbuildinfo",
+    "target": "ES2022",
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["node"],
+
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["e2e/**/*.ts", "playwright.config.ts"]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -3,6 +3,7 @@
   "references": [
     { "path": "./tsconfig.app.json" },
     { "path": "./tsconfig.node.json" },
-    { "path": "./tsconfig.test.json" }
+    { "path": "./tsconfig.test.json" },
+    { "path": "./tsconfig.e2e.json" }
   ]
 }

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -10,6 +10,9 @@ export default defineConfig({
     },
   },
   test: {
+    // Scope Vitest to src/ so it never picks up the Playwright e2e/ specs
+    // (calling Playwright's test() under Vitest throws).
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./src/test/setup.ts'],


### PR DESCRIPTION
## Summary

- Adds a Playwright e2e suite (`@playwright/test`) covering the RSVP flows end to end: member RSVP, non-member new-visitor (phone-check → RSVP), non-member returning (token skips phone-check), non-member comment/reply/react via token, my-rsvps manage-link view/cancel, and live SSE comment propagation across two sessions.
- Backend `e2e_seed` management command seeds one-off per-scenario fixtures (JSON to stdout); `frontend/e2e/fixtures.ts` shells out to it. Each spec seeds its own isolated data.
- New `e2e` CI job (`.github/workflows/ci.yml`) runs the suite against the Postgres stack (required — SSE uses `pg_notify`, which 503s on SQLite), starting uvicorn + the Vite dev server (dev, not preview, so `/api` and the SSE stream are proxied) and uploading the Playwright HTML report on failure.
- `make agent-frontend-e2e` target; `frontend/tsconfig.e2e.json` so ESLint type-aware linting covers `e2e/`.

All 6 specs pass locally in a single parallel run (~13s), including the SSE spec. Backend `e2e_seed` tests pass (7); frontend eslint/tsc/prettier clean.

### Scope note

This is **Phase 1 — happy paths**. These are smoke tests that confirm the primary click-through of each flow; they intentionally don't probe edges. An adversarial bug-hunt run alongside this work surfaced real edge-case bugs now filed separately (#970, #971, #972, #973, and latent #974, #975) — each of those issues includes adding its own targeted regression test. A Phase 2 backlog (token expiry, capacity/waitlist, host management, resend-link, comment-delete) is documented in the design doc.

## Test plan

- [ ] CI `e2e` job passes on first real GitHub Actions run (never exercised locally — the one unverified piece)
- [ ] `make agent-frontend-e2e` passes locally against `make dev-pg`
- [ ] Watch `live-updates.spec.ts` for any SSE-timing flake under CI load (`retries: 1` is configured)