### PR TITLE
fix(a11y): add role="status" to rsvp status lines (Issue 977)

### DIFF
--- a/frontend/src/screens/events/PublicRsvpCard.tsx
+++ b/frontend/src/screens/events/PublicRsvpCard.tsx
@@ -106,7 +106,7 @@ export function PublicRsvpCard({ token, event, status, hasPlusOne }: Props) {
         </ul>
       ) : null}
 
-      <p className="text-foreground-tertiary mt-4 mb-2 text-sm">
+      <p role="status" className="text-foreground-tertiary mt-4 mb-2 text-sm">
         {STATUS_LABELS[status] ?? 'your rsvp'}
       </p>
       <div className="flex flex-col gap-3">

--- a/frontend/src/screens/events/RsvpSection.tsx
+++ b/frontend/src/screens/events/RsvpSection.tsx
@@ -189,7 +189,9 @@ function RsvpControls({
   if (myInputStatus) {
     return (
       <div className="flex items-center justify-center gap-3">
-        <span className="text-foreground-secondary text-sm">{STATUS_LINES[myInputStatus]}</span>
+        <span role="status" className="text-foreground-secondary text-sm">
+          {STATUS_LINES[myInputStatus]}
+        </span>
         <Button variant="secondary" onClick={onOpenEdit} disabled={busy}>
           edit rsvp
         </Button>
@@ -212,7 +214,9 @@ function RsvpControls({
 function WaitlistView({ onLeave, busy }: { onLeave: () => void; busy: boolean }) {
   return (
     <div className="flex items-center gap-3 rounded-md bg-amber-50 px-3 py-2">
-      <span className="text-warning text-sm">you're on the waitlist</span>
+      <span role="status" className="text-warning text-sm">
+        you're on the waitlist
+      </span>
       <Button variant="ghost" onClick={onLeave} disabled={busy}>
         leave waitlist
       </Button>


### PR DESCRIPTION
Added `role="status"` to the three RSVP status-line elements so RSVP-state changes announce to assistive tech:

- RsvpSection attending/maybe/cant-go status line
- waitlist status line
- PublicRsvpCard status line

These are polite live regions, so screen readers announce the new state when a member changes their RSVP.

Note: the e2e spec `getByRole` updates were intentionally left out to keep this a source-only change.

Closes #977