### PR TITLE
feat(events): note vegan-only +1 on public rsvp form (Issue 980)

### DIFF
--- a/frontend/src/screens/events/PublicRsvpForm.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.test.tsx
@@ -80,6 +80,7 @@ describe('PublicRsvpForm', () => {
     const { rerender } = renderForm(makeEvent({ allowPlusOnes: true }));
     fillPhoneStep();
     await waitFor(() => expect(screen.getByRole('switch')).toBeInTheDocument());
+    expect(screen.getByText(/your \+1 must be vegan too/i)).toBeInTheDocument();
     rerender(
       <MemoryRouter>
         <PublicRsvpForm
@@ -91,6 +92,7 @@ describe('PublicRsvpForm', () => {
       </MemoryRouter>,
     );
     expect(screen.queryByRole('switch')).not.toBeInTheDocument();
+    expect(screen.queryByText(/your \+1 must be vegan too/i)).not.toBeInTheDocument();
   });
 
   it('shows only going/maybe status options in step one', () => {

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -192,12 +192,17 @@ export function PublicRsvpForm({ event, onSuccess, onMember, onAlreadyRsvpd }: P
         <PhoneField label="phone" value={phone} onChange={setPhone} error={errors.phone} />
 
         {event.allowPlusOnes ? (
-          <Toggle
-            label="bring a +1"
-            checked={hasPlusOne}
-            onChange={setHasPlusOne}
-            className="justify-start gap-2"
-          />
+          <div className="flex flex-col gap-1">
+            <Toggle
+              label="bring a +1"
+              checked={hasPlusOne}
+              onChange={setHasPlusOne}
+              className="justify-start gap-2"
+            />
+            <p className="text-foreground-tertiary text-xs">
+              these events are vegan only — your +1 must be vegan too
+            </p>
+          </div>
         ) : null}
 
         <Button type="submit" disabled={submit.isPending} fullWidth>


### PR DESCRIPTION
## overview

the non-member public rsvp form now shows a note under the "bring a +1" toggle
letting people know these events are vegan-only, so their +1 must be vegan too.

## changes

- add a vegan-only note under the "bring a +1" toggle in `PublicRsvpForm.tsx`
- assert the note renders in `PublicRsvpForm.test.tsx`

Closes #980
