### PR TITLE
fix(events): show "nothing here" on 404 event, not a refresh prompt (Issue 978)

### DIFF
--- a/frontend/src/screens/events/EventDetailScreen.test.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.test.tsx
@@ -345,7 +345,7 @@ describe('EventDetailScreen', () => {
         isPending: false,
         isError: true,
         error: err,
-      } as ReturnType<typeof useEvent>);
+      } as unknown as ReturnType<typeof useEvent>);
     }
 
     it('shows a "nothing here" notice on 404 instead of a refresh prompt', () => {

--- a/frontend/src/screens/events/EventDetailScreen.test.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
+import { AxiosError, type AxiosResponse } from 'axios';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -332,6 +333,34 @@ describe('EventDetailScreen', () => {
       renderScreen('ev1');
 
       expect(mockUseEvent).toHaveBeenCalledWith('ev1', undefined, undefined);
+    });
+  });
+
+  describe('error states', () => {
+    function mockError(status: number) {
+      const err = new AxiosError('boom');
+      err.response = { status } as AxiosResponse;
+      mockUseEvent.mockReturnValue({
+        data: undefined,
+        isPending: false,
+        isError: true,
+        error: err,
+      } as ReturnType<typeof useEvent>);
+    }
+
+    it('shows a "nothing here" notice on 404 instead of a refresh prompt', () => {
+      mockError(404);
+      renderScreen('ev1');
+
+      expect(screen.getByText(/nothing here/i)).toBeInTheDocument();
+      expect(screen.queryByText(/try refreshing/i)).not.toBeInTheDocument();
+    });
+
+    it('shows a refresh prompt on a generic error', () => {
+      mockError(500);
+      renderScreen('ev1');
+
+      expect(screen.getByText(/try refreshing/i)).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -48,8 +48,7 @@ export default function EventDetailScreen() {
       const message = extractApiError(error) ?? "you don't have permission to see this event";
       return <ForbiddenNotice message={message} />;
     }
-    // A members-only event resolves to 404 for signed-out visitors — refreshing
-    // never helps, so tell them there's nothing here (issue #978).
+    // members-only events 404 for signed-out visitors, so refreshing never helps
     if (status === 404) {
       return (
         <ForbiddenNotice

--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -43,9 +43,20 @@ export default function EventDetailScreen() {
 
   if (isPending) return <ContentLoading />;
   if (isError) {
-    if (getApiStatus(error) === 403) {
+    const status = getApiStatus(error);
+    if (status === 403) {
       const message = extractApiError(error) ?? "you don't have permission to see this event";
       return <ForbiddenNotice message={message} />;
+    }
+    // A members-only event resolves to 404 for signed-out visitors — refreshing
+    // never helps, so tell them there's nothing here (issue #978).
+    if (status === 404) {
+      return (
+        <ForbiddenNotice
+          message="there's nothing here"
+          subtext="this event isn't public or no longer exists"
+        />
+      );
     }
     return <ContentError message="couldn't load this event — try refreshing" />;
   }
@@ -119,14 +130,18 @@ function WhenLine({ event }: { event: Event }) {
   );
 }
 
-function ForbiddenNotice({ message }: { message: string }) {
+function ForbiddenNotice({
+  message,
+  subtext = 'if you think this is a mistake, reach out to the host',
+}: {
+  message: string;
+  subtext?: string;
+}) {
   return (
     <ContentContainer>
       <section className="border-border bg-surface mt-8 rounded-lg border p-6">
         <h2 className="mb-2 text-base font-medium">{message}</h2>
-        <p className="text-foreground-tertiary mb-4 text-sm">
-          if you think this is a mistake, reach out to the host
-        </p>
+        <p className="text-foreground-tertiary mb-4 text-sm">{subtext}</p>
         <Link
           to="/calendar"
           className="border-border-strong text-foreground-secondary hover:bg-background inline-flex h-10 items-center rounded-md border px-4 text-sm font-medium"


### PR DESCRIPTION
## summary

A members-only event resolves to a 404 for signed-out visitors. The old "couldn't load this event — try refreshing" message was misleading because refreshing never helps: the event simply isn't public.

Now a 404 shows a "there's nothing here / this event isn't public or no longer exists" notice, while other (generic) errors still surface the refresh prompt.

## tests

Added tests for the 404 path and the generic-error path.

Closes #978