### PR TITLE
fix(events): drop struck-through options from locked visibility read-out (Issue 979)

### DIFF
--- a/frontend/src/screens/events/form/EventFormDetails.test.tsx
+++ b/frontend/src/screens/events/form/EventFormDetails.test.tsx
@@ -33,10 +33,9 @@ describe('EventFormDetails', () => {
     expect(screen.getByText('official and club pda events are always public')).toBeInTheDocument();
   });
 
-  it('greys out the non-public options in the locked read-out', () => {
+  it('shows only public in the locked read-out, no struck-through alternatives', () => {
     render(<EventFormDetails values={values()} onChange={vi.fn()} errors={{}} typeLocked />);
-    expect(screen.getByText(/members only/)).toHaveClass('line-through');
-    expect(screen.getByText(/invite only/)).toHaveClass('line-through');
-    expect(screen.getByText(/members only/)).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.queryByText(/members only/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/invite only/)).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/events/form/EventFormDetails.tsx
+++ b/frontend/src/screens/events/form/EventFormDetails.tsx
@@ -99,12 +99,6 @@ function LockedVisibility({ helper }: { helper: string }) {
         <span className="text-foreground font-medium">
           public<span className="sr-only"> — selected, locked</span>
         </span>
-        <span className="text-foreground-secondary line-through" aria-disabled="true">
-          members only<span className="sr-only"> (not available)</span>
-        </span>
-        <span className="text-foreground-secondary line-through" aria-disabled="true">
-          invite only<span className="sr-only"> (not available)</span>
-        </span>
         <span className="border-border-strong text-foreground-secondary ml-auto rounded-full border px-2 py-0.5 text-xs">
           locked
         </span>


### PR DESCRIPTION
for official/club events, visibility is forced to public. the locked read-out on `/events/add` previously listed "members only" and "invite only" with strikethroughs — pure noise. now it shows only "public" alongside the "locked" badge. updated the component test to match.

Closes #979