### PR TITLE
fix(rsvp): let recognized non-members rsvp to a second event inline (Issue 981)

### DIFF
--- a/backend/community/_public_rsvp_submit.py
+++ b/backend/community/_public_rsvp_submit.py
@@ -3,11 +3,10 @@ from enum import StrEnum
 
 from config.audit import audit_log
 from config.ratelimit import client_ip, rate_limit
-from django.conf import settings
 from django.db import IntegrityError, transaction
 from ninja import Router
 from ninja.responses import Status
-from notifications._email_helpers import send_rsvp_confirmation_email, send_rsvp_manage_link_email
+from notifications._email_helpers import send_rsvp_confirmation_email
 from notifications.email_sender import get_email_sender
 from pydantic import BaseModel, EmailStr, Field
 from users.models import NonMemberRsvpToken, User
@@ -156,33 +155,6 @@ def _send_confirmation_email(
         _log_email_failure(request, event, user, exc)
 
 
-def _send_recognized_login_link(request, user: User) -> None:
-    """Email a returning non-member their manage link instead of re-asking for contact info.
-
-    Best-effort — a send failure must not block the phone-check response.
-    """
-    token = NonMemberRsvpToken.issue_or_extend(user)
-    manage_url = f"{settings.FRONTEND_BASE_URL}/my-rsvps?token={token.token}"
-    try:
-        result = send_rsvp_manage_link_email(
-            sender=get_email_sender(),
-            to=user.email,
-            display_name=user.full_name,
-            manage_url=manage_url,
-        )
-        if not result.success:
-            raise RuntimeError(result.error or "send returned failure")
-    except Exception as exc:
-        audit_log(
-            logging.WARNING,
-            "public_rsvp_recognized_email_failed",
-            request,
-            target_type="user",
-            target_id=str(user.pk),
-            details={"error": str(exc)},
-        )
-
-
 @router.post(
     "/public/events/{event_id}/rsvp-phone-check/",
     response={200: PublicRsvpPhoneCheckOut, 404: ErrorOut, 429: ErrorOut},
@@ -211,8 +183,16 @@ def check_public_rsvp_phone(request, event_id, payload: PublicRsvpPhoneCheckIn):
             ),
         )
     if user.email and user.event_rsvps.exists():
-        _send_recognized_login_link(request, user)
-        return Status(200, PublicRsvpPhoneCheckOut(status=PublicRsvpPhoneStatus.RECOGNIZED))
+        # Returning non-member (rsvp'd to some other event): unlock inline rsvp
+        # with a fresh token instead of forcing an email round-trip, which
+        # dead-ended them and blocked rsvping to a second event (issue #981).
+        token = NonMemberRsvpToken.issue_or_extend(user)
+        return Status(
+            200,
+            PublicRsvpPhoneCheckOut(
+                status=PublicRsvpPhoneStatus.RECOGNIZED, rsvp_token=token.token
+            ),
+        )
     return Status(200, PublicRsvpPhoneCheckOut(status=PublicRsvpPhoneStatus.NEW))
 
 

--- a/backend/tests/test_public_rsvp_phone_check.py
+++ b/backend/tests/test_public_rsvp_phone_check.py
@@ -68,9 +68,11 @@ class TestPublicRsvpPhoneCheck:
         assert body["rsvp_token"] != ""
         assert NonMemberRsvpToken.resolve_user(body["rsvp_token"]) == guest
 
-    def test_already_rsvpd_on_other_event_is_recognized_for_this_one(
+    def test_recognized_from_other_event_returns_token_and_no_email(
         self, api_client, official_event, fake_email_sender
     ):
+        # A returning non-member unlocks inline rsvp with a token instead of an
+        # email round-trip, which used to dead-end them on a second event (#981).
         guest = make_non_member("+14155550199", "guest@example.com")
         other_event = make_official_event(title="Other Event", start_datetime=future_iso(days=45))
         EventRSVP.objects.create(event=other_event, user=guest, status=RSVPStatus.ATTENDING)
@@ -80,20 +82,9 @@ class TestPublicRsvpPhoneCheck:
         assert response.status_code == 200
         body = response.json()
         assert body["status"] == "recognized"
-        assert body["rsvp_token"] == ""
-
-    def test_recognized_sends_login_link_email(self, api_client, official_event, fake_email_sender):
-        guest = make_non_member("+14155550199", "guest@example.com")
-        other_event = make_official_event(title="Other Event", start_datetime=future_iso(days=45))
-        EventRSVP.objects.create(event=other_event, user=guest, status=RSVPStatus.ATTENDING)
-
-        post(api_client, official_event, phone_number="+14155550199")
-
-        fake_email_sender.send.assert_called_once()
-        sent = fake_email_sender.send.call_args.kwargs
-        assert sent["to"] == "guest@example.com"
-        token = NonMemberRsvpToken.objects.get(user=guest)
-        assert token.token in sent["text"]
+        assert body["rsvp_token"] != ""
+        assert NonMemberRsvpToken.resolve_user(body["rsvp_token"]) == guest
+        fake_email_sender.send.assert_not_called()
 
     def test_recognized_without_email_falls_back_to_new(
         self, api_client, official_event, fake_email_sender

--- a/frontend/src/screens/events/PublicRsvpForm.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.test.tsx
@@ -135,14 +135,12 @@ describe('PublicRsvpForm', () => {
     await waitFor(() => expect(onAlreadyRsvpd).toHaveBeenCalledWith({ rsvpToken: 'tok-xyz' }));
   });
 
-  it('shows a check-your-email message instead of the contact form when recognized', async () => {
-    checkPhoneMutate.mockResolvedValue({ status: 'recognized', rsvp_token: '' });
-    renderForm();
+  it('unlocks inline rsvp via onAlreadyRsvpd when recognized from another event', async () => {
+    checkPhoneMutate.mockResolvedValue({ status: 'recognized', rsvp_token: 'tok-rec' });
+    const onAlreadyRsvpd = vi.fn();
+    renderForm(makeEvent(), vi.fn(), vi.fn(), onAlreadyRsvpd);
     fillPhoneStep();
-    await screen.findByText(
-      'we recognized your number — check your email for a link to confirm your rsvp',
-    );
-    expect(screen.queryByLabelText('first name')).not.toBeInTheDocument();
+    await waitFor(() => expect(onAlreadyRsvpd).toHaveBeenCalledWith({ rsvpToken: 'tok-rec' }));
   });
 
   it('lets you change the status and go back to step one from the details step', async () => {

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -58,7 +58,6 @@ export function PublicRsvpForm({ event, onSuccess, onMember, onAlreadyRsvpd }: P
   const atCapacity = spotsLeft(event) === 0;
   const [status, setStatus] = useState<RsvpInputStatus | null>(null);
   const [phoneConfirmed, setPhoneConfirmed] = useState(false);
-  const [recognized, setRecognized] = useState(false);
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [email, setEmail] = useState('');
@@ -114,22 +113,12 @@ export function PublicRsvpForm({ event, onSuccess, onMember, onAlreadyRsvpd }: P
         />
       );
     }
-    if (recognized) {
-      return (
-        <p className="text-foreground-secondary text-sm">
-          we recognized your number — check your email for a link to confirm your rsvp
-        </p>
-      );
-    }
     if (!phoneConfirmed) {
       return (
         <PublicRsvpPhoneStep
           eventId={event.id}
           onMember={onMember}
           onAlreadyRsvpd={onAlreadyRsvpd}
-          onRecognized={() => {
-            setRecognized(true);
-          }}
           onNew={(result) => {
             setPhone(result.phone);
             setPhoneConfirmed(true);

--- a/frontend/src/screens/events/PublicRsvpPhoneStep.tsx
+++ b/frontend/src/screens/events/PublicRsvpPhoneStep.tsx
@@ -19,17 +19,10 @@ interface Props {
   onNew: (result: PhoneStepResult) => void;
   onMember: () => void;
   onAlreadyRsvpd: (result: AlreadyRsvpdResult) => void;
-  onRecognized: () => void;
   eventId: string;
 }
 
-export function PublicRsvpPhoneStep({
-  onNew,
-  onMember,
-  onAlreadyRsvpd,
-  onRecognized,
-  eventId,
-}: Props) {
+export function PublicRsvpPhoneStep({ onNew, onMember, onAlreadyRsvpd, eventId }: Props) {
   const check = useCheckPublicRsvpPhone();
   const [phone, setPhone] = useState('');
   const [error, setError] = useState<string | undefined>(undefined);
@@ -47,12 +40,10 @@ export function PublicRsvpPhoneStep({
         onMember();
         return;
       }
-      if (result.status === 'already_rsvpd') {
+      // A returning non-member (rsvp'd here, or recognized from another event)
+      // gets a token to unlock inline rsvp — no email round-trip (issue #981).
+      if (result.status === 'already_rsvpd' || result.status === 'recognized') {
         onAlreadyRsvpd({ rsvpToken: result.rsvp_token });
-        return;
-      }
-      if (result.status === 'recognized') {
-        onRecognized();
         return;
       }
       onNew({ phone, status: 'new' });


### PR DESCRIPTION
## summary

A returning non-member who had already rsvp'd to one event was hitting a dead end when trying to rsvp to a later event.

**root cause:** on every event after their first rsvp, a recognized phone number routed into the phone-check "recognized" branch, which emailed the caller a manage link and showed a dead-end "check your email" message instead of the rsvp form. So the rsvp to a second event never went through.

**fix:** the rsvp-phone-check endpoint now issues a token for a recognized number and returns it. The public rsvp form unlocks inline rsvp with that token, exactly like the already-rsvpd path. Removed the now-unused email-link helper and the dead-end UI state. Updated backend + frontend tests.

Closes #981