### PR TITLE
fix(rsvp): guard waitlist promotion against +1 overfill

### DIFF
--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -138,6 +138,20 @@ def _cancellations(event: Event, viewer=None) -> list[CancellationOut]:
     return rows
 
 
+def _next_promotable_waitlist_rsvp(event: Event, headcount: int) -> EventRSVP | None:
+    """Return the oldest waitlisted RSVP that still fits under max_attendees, if any."""
+    oldest = (
+        EventRSVP.objects.filter(event=event, status=RSVPStatus.WAITLISTED)
+        .order_by("created_at")
+        .first()
+    )
+    if not oldest:
+        return None
+    if headcount + (2 if oldest.has_plus_one else 1) > event.max_attendees:
+        return None
+    return oldest
+
+
 def promote_from_waitlist(event: Event) -> list[str]:
     """Promote oldest waitlisted users to attending (FIFO by created_at).
 
@@ -152,14 +166,8 @@ def promote_from_waitlist(event: Event) -> list[str]:
         headcount = _attending_headcount_db(event)
         if headcount >= event.max_attendees:
             break
-        oldest = (
-            EventRSVP.objects.filter(event=event, status=RSVPStatus.WAITLISTED)
-            .order_by("created_at")
-            .first()
-        )
-        if not oldest:
-            break
-        if headcount + (2 if oldest.has_plus_one else 1) > event.max_attendees:
+        oldest = _next_promotable_waitlist_rsvp(event, headcount)
+        if oldest is None:
             break
         oldest.status = RSVPStatus.ATTENDING
         oldest.save(update_fields=["status", "updated_at"])

--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -159,6 +159,8 @@ def promote_from_waitlist(event: Event) -> list[str]:
         )
         if not oldest:
             break
+        if headcount + (2 if oldest.has_plus_one else 1) > event.max_attendees:
+            break
         oldest.status = RSVPStatus.ATTENDING
         oldest.save(update_fields=["status", "updated_at"])
         promoted_user_ids.append(str(oldest.user_id))

--- a/backend/tests/test_event_capacity.py
+++ b/backend/tests/test_event_capacity.py
@@ -4,6 +4,7 @@ import json
 from datetime import timedelta
 
 import pytest
+from community._event_helpers import promote_from_waitlist
 from community._validation import Code
 from community.models import Event, EventRSVP, RSVPStatus
 from django.utils import timezone
@@ -265,6 +266,33 @@ class TestWaitlistPromotion:
         # Delete one — no waitlisted to promote, should not crash
         resp = api_client.delete(f"/api/community/events/{capped_event.id}/rsvp/", **headers1)
         assert resp.status_code == 204
+
+    def test_waitlisted_plus_one_not_promoted_into_single_seat(self, test_user, user2):
+        """A WAITLISTED +1 row, unreachable via the API but forced here, must not overfill."""
+        event = Event.objects.create(
+            title="Single Seat Event",
+            start_datetime=future_iso(days=30),
+            rsvp_enabled=True,
+            max_attendees=1,
+            allow_plus_ones=True,
+            created_by=test_user,
+        )
+        EventRSVP.objects.create(
+            event=event,
+            user=user2,
+            status=RSVPStatus.WAITLISTED,
+            has_plus_one=True,
+        )
+
+        promote_from_waitlist(event)
+
+        headcount = sum(
+            1 + (1 if r.has_plus_one else 0)
+            for r in EventRSVP.objects.filter(event=event, status=RSVPStatus.ATTENDING)
+        )
+        assert headcount <= event.max_attendees
+        rsvp2 = EventRSVP.objects.get(event=event, user=user2)
+        assert rsvp2.status == RSVPStatus.WAITLISTED
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `promote_from_waitlist` promoted the oldest WAITLISTED row to ATTENDING while `headcount < max_attendees`, without rechecking whether that candidate's weight (2 if `has_plus_one`, else 1) still fits in the remaining capacity.
- Currently latent/unreachable via the API — the only writer of WAITLISTED status (`_resolve_rsvp_status`) always forces `has_plus_one=False` — but hardened defensively so a future code path or legacy data import that creates a +1 waitlist row can never over-fill capacity.
- Added a guard that breaks the promotion loop (preserving strict oldest-first fairness) when the oldest candidate wouldn't fit.

Closes #974

## Test plan
- [x] Added `test_waitlisted_plus_one_not_promoted_into_single_seat` to `TestWaitlistPromotion` in `backend/tests/test_event_capacity.py` — forces a WAITLISTED+`has_plus_one=True` row directly via the model (bypassing the API, which can't produce this state), then asserts `promote_from_waitlist` leaves it WAITLISTED and weighted attending headcount stays `<= max_attendees`.
- [x] `uv run pytest tests/test_event_capacity.py -q` — 27 passed
- [x] `make agent-typecheck` — clean
- [x] `make agent-lint` — clean
- Full `make agent-ci` intentionally not run per task scope (changed-files-only verification).