### PR TITLE
fix(rsvp): unify closed-state status codes between member and public paths (Issue 973)

### DIFF
--- a/backend/community/_public_rsvp_shared.py
+++ b/backend/community/_public_rsvp_shared.py
@@ -29,10 +29,17 @@ class PublicRsvpOut(BaseModel):
 
 
 def _load_public_rsvp_event(event_id) -> Event:
-    """Fetch a public-RSVP-eligible event, else 404 (every ineligible state hides as NOT_FOUND)."""
+    """Fetch a public-RSVP event: 404 if it can't be seen at all, else 400 with the
+    specific reason if it's visible but closed — mirrors _validate_rsvp_access."""
     event = Event.objects.prefetch_related("co_hosts", "invited_users").filter(id=event_id).first()
-    if event is None or not event.is_public_rsvp_eligible:
+    if event is None or not event.is_public_rsvp_visible:
         raise_validation(Code.Event.NOT_FOUND, status_code=404)
+    if not event.rsvp_enabled:
+        raise_validation(Code.Event.RSVPS_NOT_ENABLED, status_code=400)
+    if event.is_cancelled:
+        raise_validation(Code.Event.RSVPS_CLOSED_CANCELLED, status_code=400)
+    if event.is_past:
+        raise_validation(Code.Event.RSVPS_CLOSED_PAST, status_code=400)
     return event
 
 

--- a/backend/community/models/event.py
+++ b/backend/community/models/event.py
@@ -127,12 +127,25 @@ class Event(models.Model):
         ordering = ["start_datetime"]
 
     @property
+    def is_public_rsvp_visible(self) -> bool:
+        """Event exists in a state a public visitor may even know about (Issue 973).
+
+        Split out of is_public_rsvp_eligible so callers can 404 on "can't see this
+        event" while still 400-ing with a specific reason when it's visible but closed
+        (cancelled / past / rsvp-disabled) — matching the member-side RSVP error codes.
+        """
+        return (
+            self.event_type == EventType.OFFICIAL
+            and self.visibility == PageVisibility.PUBLIC
+            and self.status not in (EventStatus.DRAFT, EventStatus.DELETED)
+        )
+
+    @property
     def is_public_rsvp_eligible(self) -> bool:
         """Object-level mirror of public_rsvp_eligible_q()."""
         return (
-            self.event_type == EventType.OFFICIAL
+            self.is_public_rsvp_visible
             and self.status == EventStatus.ACTIVE
-            and self.visibility == PageVisibility.PUBLIC
             and self.rsvp_enabled
             and not self.is_past
         )

--- a/backend/tests/test_public_rsvp.py
+++ b/backend/tests/test_public_rsvp.py
@@ -247,20 +247,8 @@ class TestPublicRsvpEventGating:
         event = make_official_event(visibility=PageVisibility.INVITE_ONLY)
         assert post(api_client, event).status_code == 404
 
-    def test_rsvp_disabled(self, api_client, fake_email_sender):
-        event = make_official_event(rsvp_enabled=False)
-        assert post(api_client, event).status_code == 404
-
     def test_draft(self, api_client, fake_email_sender):
         event = make_official_event(status=EventStatus.DRAFT)
-        assert post(api_client, event).status_code == 404
-
-    def test_cancelled(self, api_client, fake_email_sender):
-        event = make_official_event(status=EventStatus.CANCELLED)
-        assert post(api_client, event).status_code == 404
-
-    def test_past(self, api_client, fake_email_sender):
-        event = make_official_event(start_datetime=past_iso(days=2), end_datetime=past_iso(days=2))
         assert post(api_client, event).status_code == 404
 
     def test_nonexistent(self, api_client, fake_email_sender):
@@ -277,6 +265,44 @@ class TestPublicRsvpEventGating:
         event = make_official_event(event_type=EventType.COMMUNITY)
         response = post(api_client, event)
         assert first_code(response) == Code.Event.NOT_FOUND
+
+
+@pytest.mark.django_db
+class TestPublicRsvpClosedStateParity:
+    """A publicly-visible event that's merely closed for RSVPs must 400 with the
+    same reason code as the member path — not 404 (Issue 973)."""
+
+    def test_rsvp_disabled_returns_400_matching_member_code(self, api_client, fake_email_sender):
+        event = make_official_event(rsvp_enabled=False)
+        response = post(api_client, event)
+        assert response.status_code == 400
+        assert first_code(response) == Code.Event.RSVPS_NOT_ENABLED
+
+    def test_cancelled_returns_400_matching_member_code(self, api_client, fake_email_sender):
+        event = make_official_event(status=EventStatus.CANCELLED)
+        response = post(api_client, event)
+        assert response.status_code == 400
+        assert first_code(response) == Code.Event.RSVPS_CLOSED_CANCELLED
+
+    def test_past_returns_400_matching_member_code(self, api_client, fake_email_sender):
+        event = make_official_event(start_datetime=past_iso(days=2), end_datetime=past_iso(days=2))
+        response = post(api_client, event)
+        assert response.status_code == 400
+        assert first_code(response) == Code.Event.RSVPS_CLOSED_PAST
+
+    def test_missing_private_and_non_official_events_still_404(self, api_client, fake_email_sender):
+        import uuid
+
+        missing = api_client.post(
+            URL_TEMPLATE.format(event_id=uuid.uuid4()), payload(), content_type="application/json"
+        )
+        members_only = post(api_client, make_official_event(visibility=PageVisibility.MEMBERS_ONLY))
+        invite_only = post(api_client, make_official_event(visibility=PageVisibility.INVITE_ONLY))
+        community = post(api_client, make_official_event(event_type=EventType.COMMUNITY))
+
+        for response in (missing, members_only, invite_only, community):
+            assert response.status_code == 404
+            assert first_code(response) == Code.Event.NOT_FOUND
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- Split `Event.is_public_rsvp_eligible` into `is_public_rsvp_visible` (existence/visibility gate: official, public, not draft/deleted) and the full eligibility check that also covers cancelled/rsvp-disabled/past.
- `_load_public_rsvp_event` (backs both `POST /public/events/{id}/rsvp/` and the phone-check endpoint) now 404s only when the event genuinely can't be seen (missing, private, non-official, draft) — enumeration hardening preserved — and 400s with `event.rsvps_not_enabled` / `event.rsvps_closed_cancelled` / `event.rsvps_closed_past` when the event is visible but merely closed, matching the member path (`_validate_rsvp_access`) exactly.

Closes #973

## Test plan
- [x] `uv run pytest tests/test_public_rsvp.py tests/test_public_rsvp_phone_check.py tests/test_public_rsvp_manage.py tests/test_event_viewer.py -q` — 82 passed
- [x] `uv run pytest tests/test_public_rsvp_capacity.py tests/test_rsvp.py -q` — 32 passed
- [x] `make agent-typecheck` — clean
- [x] `make agent-lint` — clean
- [x] `make agent-complexity` — clean