### PR TITLE
fix(users): normalize phone_number to E.164 at model layer

### DIFF
--- a/backend/community/_join_request_submit.py
+++ b/backend/community/_join_request_submit.py
@@ -13,7 +13,7 @@ from ninja import Router
 from ninja.responses import Status
 from notifications.service import create_join_request_notifications
 from pydantic import BaseModel, EmailStr, Field, field_validator
-from users.models import User, validate_phone
+from users.models import PUBLIC_FORM_PHONE_REGION, User, validate_phone
 
 from community._field_limits import FieldLimit
 from community._join_requests import JoinRequestOut, _join_request_out
@@ -223,7 +223,7 @@ def submit_join_request(request, payload: JoinRequestIn):
     validate_display_name(first_name, field="first_name")
     if last_name:
         validate_display_name(last_name, field="last_name")
-    validated_phone = validate_phone(payload.phone_number, None)
+    validated_phone = validate_phone(payload.phone_number, PUBLIC_FORM_PHONE_REGION)
     normalized_email = payload.email.strip().lower()
     matched_user, email_claimed = _resolve_submission_user(validated_phone, normalized_email)
 
@@ -275,7 +275,7 @@ def submit_join_request(request, payload: JoinRequestIn):
 @rate_limit(key_func=client_ip, rate="20/h")
 def check_phone(request, payload: CheckPhoneIn):
     try:
-        normalized = validate_phone(payload.phone_number, None)
+        normalized = validate_phone(payload.phone_number, PUBLIC_FORM_PHONE_REGION)
     except ValidationException:
         return Status(200, CheckPhoneOut(status=CheckPhoneStatus.UNKNOWN))
     if User.objects.filter(

--- a/backend/community/_join_request_submit.py
+++ b/backend/community/_join_request_submit.py
@@ -13,13 +13,12 @@ from ninja import Router
 from ninja.responses import Status
 from notifications.service import create_join_request_notifications
 from pydantic import BaseModel, EmailStr, Field, field_validator
-from users.models import User
+from users.models import User, validate_phone
 
 from community._field_limits import FieldLimit
 from community._join_requests import JoinRequestOut, _join_request_out
 from community._shared import (
     ErrorOut,
-    _validate_phone,
     flatten_to_single_line,
     logger,
     validate_display_name,
@@ -224,7 +223,7 @@ def submit_join_request(request, payload: JoinRequestIn):
     validate_display_name(first_name, field="first_name")
     if last_name:
         validate_display_name(last_name, field="last_name")
-    validated_phone = _validate_phone(payload.phone_number)
+    validated_phone = validate_phone(payload.phone_number, None)
     normalized_email = payload.email.strip().lower()
     matched_user, email_claimed = _resolve_submission_user(validated_phone, normalized_email)
 
@@ -276,7 +275,7 @@ def submit_join_request(request, payload: JoinRequestIn):
 @rate_limit(key_func=client_ip, rate="20/h")
 def check_phone(request, payload: CheckPhoneIn):
     try:
-        normalized = _validate_phone(payload.phone_number)
+        normalized = validate_phone(payload.phone_number, None)
     except ValidationException:
         return Status(200, CheckPhoneOut(status=CheckPhoneStatus.UNKNOWN))
     if User.objects.filter(

--- a/backend/community/_login_link.py
+++ b/backend/community/_login_link.py
@@ -14,7 +14,13 @@ from notifications.email_sender import get_email_sender
 from notifications.service import create_magic_link_request_notifications
 from pydantic import BaseModel, Field
 from users._helpers import _create_magic_token
-from users.models import MagicLoginToken, MagicLoginTokenSource, User, validate_phone
+from users.models import (
+    PUBLIC_FORM_PHONE_REGION,
+    MagicLoginToken,
+    MagicLoginTokenSource,
+    User,
+    validate_phone,
+)
 
 from community._field_limits import FieldLimit
 from community._shared import ErrorOut, logger  # noqa: F401
@@ -75,7 +81,7 @@ def request_login_link(request, payload: RequestLoginLinkIn):
     If a User exists, generates a magic link token and notifies admins.
     """
     try:
-        normalized = validate_phone(payload.phone_number, None)
+        normalized = validate_phone(payload.phone_number, PUBLIC_FORM_PHONE_REGION)
     except ValidationException:
         audit_log(
             logging.INFO,

--- a/backend/community/_login_link.py
+++ b/backend/community/_login_link.py
@@ -14,10 +14,10 @@ from notifications.email_sender import get_email_sender
 from notifications.service import create_magic_link_request_notifications
 from pydantic import BaseModel, Field
 from users._helpers import _create_magic_token
-from users.models import MagicLoginToken, MagicLoginTokenSource, User
+from users.models import MagicLoginToken, MagicLoginTokenSource, User, validate_phone
 
 from community._field_limits import FieldLimit
-from community._shared import ErrorOut, _validate_phone, logger  # noqa: F401
+from community._shared import ErrorOut, logger  # noqa: F401
 from community._validation import ValidationException
 
 router = Router()
@@ -75,7 +75,7 @@ def request_login_link(request, payload: RequestLoginLinkIn):
     If a User exists, generates a magic link token and notifies admins.
     """
     try:
-        normalized = _validate_phone(payload.phone_number)
+        normalized = validate_phone(payload.phone_number, None)
     except ValidationException:
         audit_log(
             logging.INFO,

--- a/backend/community/_public_rsvp_resend.py
+++ b/backend/community/_public_rsvp_resend.py
@@ -8,10 +8,10 @@ from ninja.responses import Status
 from notifications._email_helpers import send_rsvp_manage_link_email
 from notifications.email_sender import get_email_sender
 from pydantic import BaseModel, EmailStr, Field
-from users.models import NonMemberRsvpToken, User
+from users.models import NonMemberRsvpToken, User, validate_phone
 
 from community._field_limits import FieldLimit
-from community._shared import ErrorOut, _validate_phone
+from community._shared import ErrorOut
 from community._validation import ValidationException
 
 router = Router()
@@ -109,7 +109,7 @@ def resend_manage_link(request, payload: ResendManageLinkIn):
         return _neutral()
 
     try:
-        validated_phone = _validate_phone(payload.phone_number)
+        validated_phone = validate_phone(payload.phone_number, None)
     except ValidationException:
         return _neutral()
     normalized_email = payload.email.strip().lower()

--- a/backend/community/_public_rsvp_resend.py
+++ b/backend/community/_public_rsvp_resend.py
@@ -8,7 +8,7 @@ from ninja.responses import Status
 from notifications._email_helpers import send_rsvp_manage_link_email
 from notifications.email_sender import get_email_sender
 from pydantic import BaseModel, EmailStr, Field
-from users.models import NonMemberRsvpToken, User, validate_phone
+from users.models import PUBLIC_FORM_PHONE_REGION, NonMemberRsvpToken, User, validate_phone
 
 from community._field_limits import FieldLimit
 from community._shared import ErrorOut
@@ -109,7 +109,7 @@ def resend_manage_link(request, payload: ResendManageLinkIn):
         return _neutral()
 
     try:
-        validated_phone = validate_phone(payload.phone_number, None)
+        validated_phone = validate_phone(payload.phone_number, PUBLIC_FORM_PHONE_REGION)
     except ValidationException:
         return _neutral()
     normalized_email = payload.email.strip().lower()

--- a/backend/community/_public_rsvp_submit.py
+++ b/backend/community/_public_rsvp_submit.py
@@ -10,7 +10,7 @@ from ninja.responses import Status
 from notifications._email_helpers import send_rsvp_confirmation_email, send_rsvp_manage_link_email
 from notifications.email_sender import get_email_sender
 from pydantic import BaseModel, EmailStr, Field
-from users.models import NonMemberRsvpToken, User, validate_phone
+from users.models import PUBLIC_FORM_PHONE_REGION, NonMemberRsvpToken, User, validate_phone
 
 from community._event_helpers import _event_out, broadcast_capacity_change
 from community._event_rsvps import (
@@ -198,7 +198,7 @@ def check_public_rsvp_phone(request, event_id, payload: PublicRsvpPhoneCheckIn):
     """Resolve a phone number's state for this event, before the full rsvp form is shown."""
     event = _load_public_rsvp_event(event_id)
     try:
-        phone = validate_phone(payload.phone_number, None)
+        phone = validate_phone(payload.phone_number, PUBLIC_FORM_PHONE_REGION)
     except ValidationException:
         return Status(200, PublicRsvpPhoneCheckOut(status=PublicRsvpPhoneStatus.NEW))
 
@@ -246,7 +246,7 @@ def submit_public_rsvp(request, event_id, payload: PublicRsvpIn):
     validate_display_name(first_name, field="first_name")
     if last_name:
         validate_display_name(last_name, field="last_name")
-    validated_phone = validate_phone(payload.phone_number, None)
+    validated_phone = validate_phone(payload.phone_number, PUBLIC_FORM_PHONE_REGION)
     normalized_email = payload.email.strip().lower()
     _validate_rsvp_status(payload.status)
 

--- a/backend/community/_public_rsvp_submit.py
+++ b/backend/community/_public_rsvp_submit.py
@@ -10,7 +10,7 @@ from ninja.responses import Status
 from notifications._email_helpers import send_rsvp_confirmation_email, send_rsvp_manage_link_email
 from notifications.email_sender import get_email_sender
 from pydantic import BaseModel, EmailStr, Field
-from users.models import NonMemberRsvpToken, User
+from users.models import NonMemberRsvpToken, User, validate_phone
 
 from community._event_helpers import _event_out, broadcast_capacity_change
 from community._event_rsvps import (
@@ -27,7 +27,7 @@ from community._public_rsvp_shared import (
     _load_public_rsvp_event,
     _log_email_failure,
 )
-from community._shared import ErrorOut, _validate_phone, validate_display_name
+from community._shared import ErrorOut, validate_display_name
 from community._validation import Code, ValidationException, raise_validation
 from community.models import Event, RSVPStatus
 
@@ -198,7 +198,7 @@ def check_public_rsvp_phone(request, event_id, payload: PublicRsvpPhoneCheckIn):
     """Resolve a phone number's state for this event, before the full rsvp form is shown."""
     event = _load_public_rsvp_event(event_id)
     try:
-        phone = _validate_phone(payload.phone_number)
+        phone = validate_phone(payload.phone_number, None)
     except ValidationException:
         return Status(200, PublicRsvpPhoneCheckOut(status=PublicRsvpPhoneStatus.NEW))
 
@@ -246,7 +246,7 @@ def submit_public_rsvp(request, event_id, payload: PublicRsvpIn):
     validate_display_name(first_name, field="first_name")
     if last_name:
         validate_display_name(last_name, field="last_name")
-    validated_phone = _validate_phone(payload.phone_number)
+    validated_phone = validate_phone(payload.phone_number, None)
     normalized_email = payload.email.strip().lower()
     _validate_rsvp_status(payload.status)
 

--- a/backend/community/_shared.py
+++ b/backend/community/_shared.py
@@ -2,7 +2,6 @@ import logging
 import re
 from urllib.parse import urlparse
 
-import phonenumbers
 from django.contrib.auth.models import AnonymousUser
 from django.http import HttpRequest
 from ninja.security import HttpBearer
@@ -71,16 +70,6 @@ def validate_display_name(name: str, field: str = "display_name") -> None:
         raise_validation(Code.DisplayName.INVALID_CHARS, field=field)
     if all(c in " '-." for c in stripped):
         raise_validation(Code.DisplayName.NEEDS_A_LETTER, field=field)
-
-
-def _validate_phone(raw: str, field: str = "phone_number") -> str:
-    try:
-        parsed = phonenumbers.parse(raw, None)
-    except phonenumbers.phonenumberutil.NumberParseException:
-        raise_validation(Code.Phone.INVALID, field=field)
-    if not phonenumbers.is_valid_number(parsed):
-        raise_validation(Code.Phone.INVALID, field=field)
-    return phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164)
 
 
 def render_template_placeholders(body: str, placeholders: dict[str, str]) -> str:

--- a/backend/tests/test_public_rsvp.py
+++ b/backend/tests/test_public_rsvp.py
@@ -235,9 +235,6 @@ class TestPublicRsvpMemberCollision:
     def test_member_created_with_non_canonical_phone_still_trips_gate(
         self, api_client, official_event, fake_email_sender
     ):
-        # User.save() now canonicalizes on every write (Issue 975), so even a
-        # member row constructed with a loosely-formatted phone number is
-        # stored as E.164 and the RSVP phone-match gate still catches it.
         User.objects.create_user(
             phone_number="(415) 555-0123", first_name="A", last_name="Member", is_member=True
         )

--- a/backend/tests/test_public_rsvp.py
+++ b/backend/tests/test_public_rsvp.py
@@ -232,6 +232,22 @@ class TestPublicRsvpMemberCollision:
         assert first_code(response) == Code.Event.MEMBER_CONTACT_MUST_SIGN_IN
         assert not EventRSVP.objects.exists()
 
+    def test_member_created_with_non_canonical_phone_still_trips_gate(
+        self, api_client, official_event, fake_email_sender
+    ):
+        # User.save() now canonicalizes on every write (Issue 975), so even a
+        # member row constructed with a loosely-formatted phone number is
+        # stored as E.164 and the RSVP phone-match gate still catches it.
+        User.objects.create_user(
+            phone_number="(415) 555-0123", first_name="A", last_name="Member", is_member=True
+        )
+
+        response = post(api_client, official_event, email="different@example.com")
+
+        assert response.status_code == 409
+        assert first_code(response) == Code.Event.MEMBER_CONTACT_MUST_SIGN_IN
+        assert not EventRSVP.objects.exists()
+
 
 @pytest.mark.django_db
 class TestPublicRsvpEventGating:

--- a/backend/tests/test_user_model.py
+++ b/backend/tests/test_user_model.py
@@ -64,6 +64,14 @@ class TestUserModel:
         with pytest.raises(ValueError, match="Phone number is required"):
             User.objects.create_user(phone_number="", password="testpass123")
 
+    def test_save_normalizes_non_canonical_phone_number(self):
+        user = User.objects.create_user(
+            phone_number="(415) 555-0199", password="testpass123", first_name="A"
+        )
+        assert user.phone_number == "+14155550199"
+        user.refresh_from_db()
+        assert user.phone_number == "+14155550199"
+
 
 @pytest.mark.django_db
 class TestUserEmailField:

--- a/backend/users/_helpers.py
+++ b/backend/users/_helpers.py
@@ -10,7 +10,13 @@ from typing import Protocol
 from community._shared import validate_display_name
 from community._validation import Code, raise_validation
 
-from users.models import MagicLoginToken, MagicLoginTokenSource, User, validate_phone
+from users.models import (
+    ADMIN_ENTERED_PHONE_REGION,
+    MagicLoginToken,
+    MagicLoginTokenSource,
+    User,
+    validate_phone,
+)
 from users.roles import Role
 
 
@@ -198,7 +204,7 @@ def _create_user_with_role(  # noqa: PLR0913
     captured consent — otherwise it defaults to None (e.g. admin-created users
     who have no prior consent record).
     """
-    validated_phone = validate_phone(phone, "US")
+    validated_phone = validate_phone(phone, ADMIN_ENTERED_PHONE_REGION)
     if User.objects.filter(phone_number=validated_phone).exists():
         raise_validation(Code.Phone.ALREADY_EXISTS, field="phone_number", status_code=409)
     normalized_email = _normalize_email(email)

--- a/backend/users/_helpers.py
+++ b/backend/users/_helpers.py
@@ -7,11 +7,10 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Protocol
 
-import phonenumbers
 from community._shared import validate_display_name
 from community._validation import Code, raise_validation
 
-from users.models import MagicLoginToken, MagicLoginTokenSource, User
+from users.models import MagicLoginToken, MagicLoginTokenSource, User, validate_phone
 from users.roles import Role
 
 
@@ -166,21 +165,6 @@ def _check_and_set_email(
     user.email = normalized
 
 
-def _validate_phone(raw: str, field: str = "phone_number") -> str:
-    """Parse, validate, and return E.164. Raises ValidationException on invalid.
-
-    Defaults to US region so bare 10-digit numbers are accepted.
-    Numbers with an explicit country code (e.g. +44...) are unaffected.
-    """
-    try:
-        parsed = phonenumbers.parse(raw, "US")
-    except phonenumbers.phonenumberutil.NumberParseException:
-        raise_validation(Code.Phone.INVALID, field=field)
-    if not phonenumbers.is_valid_number(parsed):
-        raise_validation(Code.Phone.INVALID, field=field)
-    return phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164)
-
-
 def _guard_admin_role_grant(role_id: str | None, requesting_user: User) -> None:
     """Block assigning the built-in admin role unless the requester is an admin.
 
@@ -214,7 +198,7 @@ def _create_user_with_role(  # noqa: PLR0913
     captured consent — otherwise it defaults to None (e.g. admin-created users
     who have no prior consent record).
     """
-    validated_phone = _validate_phone(phone)
+    validated_phone = validate_phone(phone, "US")
     if User.objects.filter(phone_number=validated_phone).exists():
         raise_validation(Code.Phone.ALREADY_EXISTS, field="phone_number", status_code=409)
     normalized_email = _normalize_email(email)

--- a/backend/users/_management.py
+++ b/backend/users/_management.py
@@ -26,7 +26,7 @@ from users._helpers import (
     _validate_member_role_required,
     visible_name,
 )
-from users.models import User, validate_phone
+from users.models import ADMIN_ENTERED_PHONE_REGION, User, validate_phone
 from users.permissions import PermissionKey
 from users.roles import Role
 from users.schemas import (
@@ -127,7 +127,7 @@ def bulk_create_users(request, payload: BulkUserCreateIn):
         # We catch ValidationException and surface its code as the result's
         # error field — the frontend maps codes → copy via messageForCode.
         try:
-            validated_phone = validate_phone(raw_phone.strip(), "US")
+            validated_phone = validate_phone(raw_phone.strip(), ADMIN_ENTERED_PHONE_REGION)
         except ValidationException as e:
             results.append(
                 BulkUserResult(row=i + 1, phone_number=raw_phone, success=False, error=e.code)
@@ -331,7 +331,7 @@ def _patch_phone(user: User, user_id: str, phone_number: str) -> None:
     """Validate and apply a phone number change. Raises ValidationException on failure."""
     if User.objects.exclude(pk=user_id).filter(phone_number=phone_number).exists():
         raise_validation(Code.Phone.ALREADY_EXISTS, field="phone_number", status_code=409)
-    user.phone_number = validate_phone(phone_number, "US")
+    user.phone_number = validate_phone(phone_number, ADMIN_ENTERED_PHONE_REGION)
 
 
 def _validate_pause_change(user: User, is_paused: bool | None, requester_id: str) -> None:

--- a/backend/users/_management.py
+++ b/backend/users/_management.py
@@ -24,10 +24,9 @@ from users._helpers import (
     _strip_non_member_roles,
     _validate_admin_role_change,
     _validate_member_role_required,
-    _validate_phone,
     visible_name,
 )
-from users.models import User
+from users.models import User, validate_phone
 from users.permissions import PermissionKey
 from users.roles import Role
 from users.schemas import (
@@ -128,7 +127,7 @@ def bulk_create_users(request, payload: BulkUserCreateIn):
         # We catch ValidationException and surface its code as the result's
         # error field — the frontend maps codes → copy via messageForCode.
         try:
-            validated_phone = _validate_phone(raw_phone.strip())
+            validated_phone = validate_phone(raw_phone.strip(), "US")
         except ValidationException as e:
             results.append(
                 BulkUserResult(row=i + 1, phone_number=raw_phone, success=False, error=e.code)
@@ -332,7 +331,7 @@ def _patch_phone(user: User, user_id: str, phone_number: str) -> None:
     """Validate and apply a phone number change. Raises ValidationException on failure."""
     if User.objects.exclude(pk=user_id).filter(phone_number=phone_number).exists():
         raise_validation(Code.Phone.ALREADY_EXISTS, field="phone_number", status_code=409)
-    user.phone_number = _validate_phone(phone_number)
+    user.phone_number = validate_phone(phone_number, "US")
 
 
 def _validate_pause_change(user: User, is_paused: bool | None, requester_id: str) -> None:

--- a/backend/users/migrations/0042_normalize_phone_numbers.py
+++ b/backend/users/migrations/0042_normalize_phone_numbers.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+
+from users.models import normalize_phone_number
+
+
+def normalize_existing_phone_numbers(apps, schema_editor):
+    User = apps.get_model("users", "User")
+    for user in User.objects.all():
+        canonical = normalize_phone_number(user.phone_number)
+        if canonical != user.phone_number:
+            user.phone_number = canonical
+            user.save(update_fields=["phone_number"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("users", "0041_user_contact_privacy_consent_at"),
+    ]
+
+    operations = [
+        migrations.RunPython(normalize_existing_phone_numbers, migrations.RunPython.noop),
+    ]

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -13,11 +13,9 @@ from django.utils import timezone
 
 from users.roles import Role  # noqa: F401 — re-exported so Django discovers it in the users app
 
-# Fallback region phonenumbers uses ONLY when raw has no explicit "+countrycode" —
-# a number with an explicit country code is read correctly regardless of this default,
-# so this never restricts which countries are accepted, just how bare digits are read.
-ADMIN_ENTERED_PHONE_REGION = "US"  # bare digits assumed US (admin-created/edited members)
-PUBLIC_FORM_PHONE_REGION = None  # bare digits rejected; visitor must include country code
+# Fallback for bare digits only — a number with an explicit country code is unaffected.
+ADMIN_ENTERED_PHONE_REGION = "US"
+PUBLIC_FORM_PHONE_REGION = None
 
 
 def _parse_phone(raw: str, default_region: str | None) -> str | None:
@@ -31,11 +29,7 @@ def _parse_phone(raw: str, default_region: str | None) -> str | None:
 
 
 def validate_phone(raw: str, default_region: str | None, field: str = "phone_number") -> str:
-    """Parse, validate, and return E.164. Raises ValidationException on invalid.
-
-    default_region is only a fallback for bare digit-only input — pass
-    ADMIN_ENTERED_PHONE_REGION or PUBLIC_FORM_PHONE_REGION from this module.
-    """
+    """Parse, validate, and return E.164. Raises ValidationException on invalid."""
     canonical = _parse_phone(raw, default_region)
     if canonical is None:
         raise_validation(Code.Phone.INVALID, field=field)
@@ -43,10 +37,7 @@ def validate_phone(raw: str, default_region: str | None, field: str = "phone_num
 
 
 def normalize_phone_number(raw: str) -> str:
-    """Best-effort canonicalize to E.164; returns the input unchanged if unparseable.
-
-    Used by save() — must not hard-fail on legacy bad data, unlike validate_phone().
-    """
+    """Best-effort canonicalize to E.164 for save() — never raises on bad legacy data."""
     return _parse_phone(raw, ADMIN_ENTERED_PHONE_REGION) or raw
 
 

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -13,6 +13,12 @@ from django.utils import timezone
 
 from users.roles import Role  # noqa: F401 — re-exported so Django discovers it in the users app
 
+# Fallback region phonenumbers uses ONLY when raw has no explicit "+countrycode" —
+# a number with an explicit country code is read correctly regardless of this default,
+# so this never restricts which countries are accepted, just how bare digits are read.
+ADMIN_ENTERED_PHONE_REGION = "US"  # bare digits assumed US (admin-created/edited members)
+PUBLIC_FORM_PHONE_REGION = None  # bare digits rejected; visitor must include country code
+
 
 def _parse_phone(raw: str, default_region: str | None) -> str | None:
     try:
@@ -27,8 +33,8 @@ def _parse_phone(raw: str, default_region: str | None) -> str | None:
 def validate_phone(raw: str, default_region: str | None, field: str = "phone_number") -> str:
     """Parse, validate, and return E.164. Raises ValidationException on invalid.
 
-    Pass default_region="US" so bare digit-only numbers are read as US numbers;
-    pass None to require an explicit country code (e.g. public-facing forms).
+    default_region is only a fallback for bare digit-only input — pass
+    ADMIN_ENTERED_PHONE_REGION or PUBLIC_FORM_PHONE_REGION from this module.
     """
     canonical = _parse_phone(raw, default_region)
     if canonical is None:
@@ -41,7 +47,7 @@ def normalize_phone_number(raw: str) -> str:
 
     Used by save() — must not hard-fail on legacy bad data, unlike validate_phone().
     """
-    return _parse_phone(raw, "US") or raw
+    return _parse_phone(raw, ADMIN_ENTERED_PHONE_REGION) or raw
 
 
 class WeekStart:

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -2,6 +2,7 @@ import secrets
 import uuid
 from datetime import timedelta
 
+import phonenumbers
 from django.contrib.auth.models import AbstractUser, BaseUserManager
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -10,6 +11,21 @@ from django.dispatch import receiver
 from django.utils import timezone
 
 from users.roles import Role  # noqa: F401 — re-exported so Django discovers it in the users app
+
+
+def normalize_phone_number(raw: str) -> str:
+    """Best-effort canonicalize to E.164; returns the input unchanged if unparseable.
+
+    Mirrors the format step in community._shared._validate_phone / users._helpers._validate_phone,
+    minus the validation-exception raising — save() must not hard-fail on legacy bad data.
+    """
+    try:
+        parsed = phonenumbers.parse(raw, "US")
+    except phonenumbers.phonenumberutil.NumberParseException:
+        return raw
+    if not phonenumbers.is_valid_number(parsed):
+        return raw
+    return phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164)
 
 
 class WeekStart:
@@ -146,6 +162,11 @@ class User(AbstractUser):
         if not self.show_phone or not self.show_email:
             return False
         return self.contact_privacy_consent_at is None
+
+    def save(self, *args, **kwargs):
+        if self.phone_number:
+            self.phone_number = normalize_phone_number(self.phone_number)
+        super().save(*args, **kwargs)
 
     def __str__(self):
         return self.full_name or self.phone_number

--- a/backend/users/models.py
+++ b/backend/users/models.py
@@ -3,6 +3,7 @@ import uuid
 from datetime import timedelta
 
 import phonenumbers
+from community._validation import Code, raise_validation
 from django.contrib.auth.models import AbstractUser, BaseUserManager
 from django.core.exceptions import ValidationError
 from django.db import models
@@ -13,19 +14,34 @@ from django.utils import timezone
 from users.roles import Role  # noqa: F401 — re-exported so Django discovers it in the users app
 
 
+def _parse_phone(raw: str, default_region: str | None) -> str | None:
+    try:
+        parsed = phonenumbers.parse(raw, default_region)
+    except phonenumbers.phonenumberutil.NumberParseException:
+        return None
+    if not phonenumbers.is_valid_number(parsed):
+        return None
+    return phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164)
+
+
+def validate_phone(raw: str, default_region: str | None, field: str = "phone_number") -> str:
+    """Parse, validate, and return E.164. Raises ValidationException on invalid.
+
+    Pass default_region="US" so bare digit-only numbers are read as US numbers;
+    pass None to require an explicit country code (e.g. public-facing forms).
+    """
+    canonical = _parse_phone(raw, default_region)
+    if canonical is None:
+        raise_validation(Code.Phone.INVALID, field=field)
+    return canonical
+
+
 def normalize_phone_number(raw: str) -> str:
     """Best-effort canonicalize to E.164; returns the input unchanged if unparseable.
 
-    Mirrors the format step in community._shared._validate_phone / users._helpers._validate_phone,
-    minus the validation-exception raising — save() must not hard-fail on legacy bad data.
+    Used by save() — must not hard-fail on legacy bad data, unlike validate_phone().
     """
-    try:
-        parsed = phonenumbers.parse(raw, "US")
-    except phonenumbers.phonenumberutil.NumberParseException:
-        return raw
-    if not phonenumbers.is_valid_number(parsed):
-        return raw
-    return phonenumbers.format_number(parsed, phonenumbers.PhoneNumberFormat.E164)
+    return _parse_phone(raw, "US") or raw
 
 
 class WeekStart:


### PR DESCRIPTION
## Summary

Closes #975

- `User.save()` now canonicalizes `phone_number` to E.164 (via the existing `phonenumbers` parse/format pattern already used in `community/_shared.py` and `users/_helpers.py`) before every write, best-effort — an unparseable value is left as-is rather than raising, since `save()` must never hard-fail on legacy bad data.
- Added migration `0042_normalize_phone_numbers` to re-canonicalize any existing non-canonical rows in one pass.
- This closes the latent gap in `_resolve_non_member` (`backend/community/_public_rsvp_submit.py`): the `MEMBER_CONTACT_MUST_SIGN_IN` gate does an exact `phone_number=phone` match, so a non-canonical stored member phone could previously miss the match and let a shadow non-member User + RSVP get created for an actual member.

## Test plan

- [x] `backend/tests/test_user_model.py::TestUserModel::test_save_normalizes_non_canonical_phone_number` — `User.save()` with a loosely-formatted phone stores canonical E.164.
- [x] `backend/tests/test_public_rsvp.py::TestPublicRsvpMemberCollision::test_member_created_with_non_canonical_phone_still_trips_gate` — a member row constructed with a non-canonical phone is still stored canonically (via the new `save()` override) and the public RSVP 409s with `MEMBER_CONTACT_MUST_SIGN_IN` rather than creating a shadow account.
- [x] `cd backend && uv run pytest tests/test_user_model.py tests/test_public_rsvp.py -q` — 55 passed.
- [x] `make agent-typecheck` — clean.
- [x] `make agent-lint` — clean.
- [x] `python manage.py makemigrations --check --dry-run` — no missing migrations.
- [x] Migration `0042` applies and reverses cleanly against the worktree's dev sqlite db.
