### PR TITLE
fix(rsvp): reject duplicate email on public rsvp instead of dropping it

### DIFF
--- a/backend/community/_public_rsvp_submit.py
+++ b/backend/community/_public_rsvp_submit.py
@@ -82,8 +82,8 @@ def _backfill_email(phone_match: User, email: str) -> User:
 def _create_non_member(first_name: str, last_name: str, email: str, phone: str) -> User:
     """Get-or-create the non-member User keyed on the unique phone number.
 
-    On a unique-email collision the email is dropped inside a savepoint so the
-    outer transaction and the RSVP survive; the row is just saved without it.
+    A unique-email collision (e.g. an archived user still holding that email)
+    raises email.already_exists rather than silently dropping the email.
     """
     defaults = {"first_name": first_name, "last_name": last_name, "is_member": False}
     try:
@@ -92,7 +92,7 @@ def _create_non_member(first_name: str, last_name: str, email: str, phone: str) 
                 phone_number=phone, defaults={**defaults, "email": email or None}
             )
     except IntegrityError:
-        user, created = User.objects.get_or_create(phone_number=phone, defaults=defaults)
+        raise_validation(Code.Email.ALREADY_EXISTS, field="email", status_code=409)
     if created:
         user.set_unusable_password()
         user.save(update_fields=["password"])

--- a/backend/tests/test_public_rsvp.py
+++ b/backend/tests/test_public_rsvp.py
@@ -147,11 +147,11 @@ class TestPublicRsvpDedup:
         assert EventRSVP.objects.filter(event=official_event, user=user).count() == 1
         assert EventRSVP.objects.get(event=official_event, user=user).status == RSVPStatus.MAYBE
 
-    def test_archived_email_holder_does_not_block_create(
+    def test_archived_email_holder_blocks_create(
         self, api_client, official_event, fake_email_sender
     ):
-        # An archived user holding the submitted email is ignored by the lookups;
-        # the create path must survive the unique-email collision and RSVP anyway.
+        # An archived user holding the submitted email is ignored by the lookups,
+        # so create is attempted and trips the DB's unique-email constraint.
         from django.utils import timezone
 
         archived = make_non_member("+14155550777", "sam@example.com", name="Archived")
@@ -160,12 +160,9 @@ class TestPublicRsvpDedup:
 
         response = post(api_client, official_event)
 
-        assert response.status_code == 200
-        new_user = User.objects.get(phone_number="+14155550123")
-        assert new_user.pk != archived.pk
-        # Email dropped to avoid the collision; RSVP still created.
-        assert new_user.email is None
-        assert EventRSVP.objects.filter(user=new_user).exists()
+        assert response.status_code == 409
+        assert first_code(response) == Code.Email.ALREADY_EXISTS
+        assert not User.objects.filter(phone_number="+14155550123").exists()
 
     def test_multiple_rsvps_reuse_the_same_token(
         self, api_client, official_event, fake_email_sender


### PR DESCRIPTION
## Summary
- `_create_non_member` silently dropped the submitted email on a unique-email collision (e.g. an archived user still holding that email) so the RSVP could survive — the new non-member row ended up with no email at all.
- Now raises `email.already_exists` (409) instead, matching the existing pattern used elsewhere (`users/_helpers.py::_check_and_set_email`) rather than silently losing contact info.

## Test plan
- [x] `backend/tests/test_public_rsvp.py::TestPublicRsvpDedup::test_archived_email_holder_blocks_create` updated to assert the 409 rejection and that no user row is created
- [x] Full public-rsvp test suite passes (`test_public_rsvp.py`, `test_public_rsvp_phone_check.py`, `test_public_rsvp_capacity.py`, `test_public_rsvp_resend.py`, `test_public_rsvp_manage.py`)
- [x] `make agent-lint`, `make agent-complexity` clean