### PR TITLE
test(e2e): harden non-member rsvp coverage (Issue 999)

### DIFF
--- a/backend/community/management/commands/e2e_seed.py
+++ b/backend/community/management/commands/e2e_seed.py
@@ -31,6 +31,8 @@ def _random_event(scenario: str, **overrides) -> Event:
         "visibility": PageVisibility.PUBLIC,
         "status": EventStatus.ACTIVE,
         "rsvp_enabled": True,
+        # member-gated field: hidden from anon, revealed once a public rsvp unlocks the event.
+        "location": f"secret loft {secrets.token_hex(3)}",
     }
     base.update(overrides)
     return Event.objects.create(**base)
@@ -71,6 +73,7 @@ def _seed_member() -> dict:
     return {
         "event_id": str(event.id),
         "event_title": event.title,
+        "event_location": event.location,
         "user_phone": phone,
         "user_password": E2E_PASSWORD,
         "access_token": _access_token(user),
@@ -79,7 +82,11 @@ def _seed_member() -> dict:
 
 def _seed_public_new() -> dict:
     event = _random_event("public-new")
-    return {"event_id": str(event.id), "event_title": event.title}
+    return {
+        "event_id": str(event.id),
+        "event_title": event.title,
+        "event_location": event.location,
+    }
 
 
 def _seed_public_returning() -> dict:

--- a/backend/community/management/commands/e2e_seed.py
+++ b/backend/community/management/commands/e2e_seed.py
@@ -31,7 +31,6 @@ def _random_event(scenario: str, **overrides) -> Event:
         "visibility": PageVisibility.PUBLIC,
         "status": EventStatus.ACTIVE,
         "rsvp_enabled": True,
-        # member-gated field: hidden from anon, revealed once a public rsvp unlocks the event.
         "location": f"secret loft {secrets.token_hex(3)}",
     }
     base.update(overrides)

--- a/backend/tests/test_e2e_seed_command.py
+++ b/backend/tests/test_e2e_seed_command.py
@@ -23,7 +23,7 @@ def test_e2e_seed_public_new(capsys):
     call_command("e2e_seed", "public-new")
     out = json.loads(capsys.readouterr().out)
     assert Event.objects.filter(id=out["event_id"]).exists()
-    assert set(out.keys()) == {"event_id", "event_title"}
+    assert set(out.keys()) == {"event_id", "event_title", "event_location"}
 
 
 @pytest.mark.django_db

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -6,11 +6,12 @@ export interface SeedScenarioMap {
   member: {
     event_id: string;
     event_title: string;
+    event_location: string;
     user_phone: string;
     user_password: string;
     access_token: string;
   };
-  'public-new': { event_id: string; event_title: string };
+  'public-new': { event_id: string; event_title: string; event_location: string };
   'public-returning': {
     event_id: string;
     event_title: string;

--- a/frontend/e2e/my-rsvps.spec.ts
+++ b/frontend/e2e/my-rsvps.spec.ts
@@ -12,7 +12,6 @@ test('non-member views, updates, and cancels rsvp via my-rsvps manage link', asy
   await expect(card).toBeVisible();
   await expect(card.getByText("you're going")).toBeVisible();
 
-  // change the status through the manage card and confirm it sticks.
   await card.getByRole('button', { name: 'maybe' }).click();
   await expect(page.getByText('rsvp updated', { exact: false })).toBeVisible();
   await expect(card.getByText("you're a maybe")).toBeVisible();

--- a/frontend/e2e/my-rsvps.spec.ts
+++ b/frontend/e2e/my-rsvps.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 
 import { seed } from './fixtures';
 
-test('non-member views and cancels rsvp via my-rsvps manage link', async ({ page }) => {
+test('non-member views, updates, and cancels rsvp via my-rsvps manage link', async ({ page }) => {
   const { event_title, rsvp_token } = seed('my-rsvps');
 
   await page.goto(`/my-rsvps?token=${rsvp_token}`);
@@ -12,6 +12,18 @@ test('non-member views and cancels rsvp via my-rsvps manage link', async ({ page
   await expect(card).toBeVisible();
   await expect(card.getByText("you're going")).toBeVisible();
 
+  // change the status through the manage card and confirm it sticks.
+  await card.getByRole('button', { name: 'maybe' }).click();
+  await expect(page.getByText('rsvp updated', { exact: false })).toBeVisible();
+  await expect(card.getByText("you're a maybe")).toBeVisible();
+
   await card.getByRole('button', { name: 'cancel rsvp' }).click();
   await expect(page.getByText('rsvp cancelled')).toBeVisible();
+});
+
+test('invalid manage token shows the re-rsvp prompt, not an error', async ({ page }) => {
+  await page.goto('/my-rsvps?token=definitely-not-a-real-token');
+
+  await expect(page.getByText("this link's expired or invalid", { exact: false })).toBeVisible();
+  await expect(page.getByRole('heading', { name: 'your rsvps' })).toBeHidden();
 });

--- a/frontend/e2e/rsvp-public-member-gate.spec.ts
+++ b/frontend/e2e/rsvp-public-member-gate.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test';
+
+import { seed } from './fixtures';
+
+test('member phone in the public rsvp form is bounced to sign-in', async ({ page }) => {
+  // the `member` seed makes a public-rsvp-eligible event plus a member account;
+  // an anon visitor who enters that member's phone must be gated to sign-in, not
+  // allowed to rsvp as a non-member.
+  const { event_id, user_phone } = seed('member');
+
+  await page.goto(`/events/${event_id}`);
+
+  const rsvpSection = page.getByLabel('rsvp');
+  await rsvpSection.getByRole('button', { name: "i'm going" }).click();
+  await rsvpSection.getByLabel('phone number').pressSequentially(user_phone.replace('+1', ''));
+  await rsvpSection.getByRole('button', { name: 'continue' }).click();
+
+  await expect(page.getByText('looks like you already have an account')).toBeVisible();
+  await expect(rsvpSection.getByRole('link', { name: 'sign in' })).toBeVisible();
+  // never reaches the contact form.
+  await expect(rsvpSection.getByLabel('first name')).toBeHidden();
+});

--- a/frontend/e2e/rsvp-public-member-gate.spec.ts
+++ b/frontend/e2e/rsvp-public-member-gate.spec.ts
@@ -3,9 +3,6 @@ import { expect, test } from '@playwright/test';
 import { seed } from './fixtures';
 
 test('member phone in the public rsvp form is bounced to sign-in', async ({ page }) => {
-  // the `member` seed makes a public-rsvp-eligible event plus a member account;
-  // an anon visitor who enters that member's phone must be gated to sign-in, not
-  // allowed to rsvp as a non-member.
   const { event_id, user_phone } = seed('member');
 
   await page.goto(`/events/${event_id}`);
@@ -17,6 +14,5 @@ test('member phone in the public rsvp form is bounced to sign-in', async ({ page
 
   await expect(page.getByText('looks like you already have an account')).toBeVisible();
   await expect(rsvpSection.getByRole('link', { name: 'sign in' })).toBeVisible();
-  // never reaches the contact form.
   await expect(rsvpSection.getByLabel('first name')).toBeHidden();
 });

--- a/frontend/e2e/rsvp-public-new.spec.ts
+++ b/frontend/e2e/rsvp-public-new.spec.ts
@@ -3,10 +3,13 @@ import { expect, test } from '@playwright/test';
 import { seed } from './fixtures';
 
 test('new non-member rsvps via public event link', async ({ page }) => {
-  const { event_id, event_title } = seed('public-new');
+  const { event_id, event_title, event_location } = seed('public-new');
 
   await page.goto(`/events/${event_id}`);
   await expect(page.getByRole('heading', { name: event_title })).toBeVisible();
+
+  // member-gated location is hidden until the visitor rsvps and unlocks the event.
+  await expect(page.getByText(event_location)).toBeHidden();
 
   const phone = '202555' + String(Math.floor(1000 + Math.random() * 9000));
 
@@ -21,4 +24,7 @@ test('new non-member rsvps via public event link', async ({ page }) => {
   await rsvpSection.getByRole('button', { name: 'rsvp' }).click();
 
   await expect(page.getByLabel('rsvp').getByText("you're going")).toBeVisible();
+
+  // the rsvp unlocked the event: the previously-gated location is now visible.
+  await expect(page.getByText(event_location)).toBeVisible();
 });

--- a/frontend/e2e/rsvp-public-new.spec.ts
+++ b/frontend/e2e/rsvp-public-new.spec.ts
@@ -8,7 +8,6 @@ test('new non-member rsvps via public event link', async ({ page }) => {
   await page.goto(`/events/${event_id}`);
   await expect(page.getByRole('heading', { name: event_title })).toBeVisible();
 
-  // member-gated location is hidden until the visitor rsvps and unlocks the event.
   await expect(page.getByText(event_location)).toBeHidden();
 
   const phone = '202555' + String(Math.floor(1000 + Math.random() * 9000));
@@ -25,6 +24,5 @@ test('new non-member rsvps via public event link', async ({ page }) => {
 
   await expect(page.getByLabel('rsvp').getByText("you're going")).toBeVisible();
 
-  // the rsvp unlocked the event: the previously-gated location is now visible.
   await expect(page.getByText(event_location)).toBeVisible();
 });


### PR DESCRIPTION
## what

hardens the non-member rsvp playwright e2e suite, which previously had one happy-path test per flow. adds edge-case coverage the e2e audit (#999) found missing.

## new / expanded coverage

- **`rsvp-public-new`** — now asserts the core feature promise: the member-gated `location` is **hidden** before rsvp and **visible** after, proving the rsvp actually unlocks member-only event details.
- **`rsvp-public-member-gate`** (new) — a member who enters their phone in the public form is bounced to the sign-in prompt and never reaches the contact form. covers the security boundary that keeps members off the non-member path.
- **`my-rsvps`** — now also exercises a **status update** (going → maybe) via the manage card, plus a new test that an **invalid manage token** shows the re-rsvp prompt rather than an error.

## seed change

`e2e_seed` events now set and return `event_location` (`member` + `public-new` scenarios) so the unlock assertion has a concrete gated field to check.

## verification

- `tsc -b --noEmit` ✓ · eslint ✓ · prettier ✓ (frontend)
- ruff check + format ✓ (backend seed)
- `e2e_seed public-new` / `e2e_seed member` run and emit `event_location` ✓

> note: the full playwright run needs the live server stack + postgres and wasn't run locally (shared-db contention with concurrent sessions). CI's e2e job will run it. every UI assertion is grounded in the actual component copy (button labels, toast text, invalid-token copy, location rendering).

part of #999
