### PR TITLE
fix(rsvp): stop leaking member-only fields in waitlist-promotion emails (Issue 1004)

### DIFF
--- a/backend/community/_public_rsvp_shared.py
+++ b/backend/community/_public_rsvp_shared.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import replace
 
 from config.audit import audit_log
 from django.conf import settings
@@ -80,7 +81,14 @@ def _log_email_failure(request, event: Event, user: User, exc: Exception) -> Non
 
 
 def _email_promoted_non_members(request, event: Event, promoted_user_ids: list[str]) -> None:
-    """Email any promoted non-members their manage link. Best-effort per user."""
+    """Email any promoted non-members their manage link. Best-effort per user.
+
+    By the time a spot frees up, the event may have dropped out of public-RSVP
+    eligibility since the non-member first waitlisted. Strip the member-only
+    location/links in that case, matching what _event_out/get_event/my-rsvps
+    already hide from them — the promotion itself is still worth telling them
+    about.
+    """
     if not promoted_user_ids:
         return
     promoted = User.objects.filter(id__in=promoted_user_ids, is_member=False, email__isnull=False)
@@ -89,9 +97,12 @@ def _email_promoted_non_members(request, event: Event, promoted_user_ids: list[s
             continue
         try:
             token = NonMemberRsvpToken.issue_or_extend(user)
+            details = _email_details(event, user, token.token)
+            if not event.is_public_rsvp_eligible:
+                details = replace(details, event_location="", event_links=[])
             result = send_rsvp_waitlist_promoted_email(
                 sender=get_email_sender(),
-                details=_email_details(event, user, token.token),
+                details=details,
             )
             if not result.success:
                 raise RuntimeError(result.error or "send returned failure")

--- a/backend/community/_public_rsvp_shared.py
+++ b/backend/community/_public_rsvp_shared.py
@@ -80,15 +80,17 @@ def _log_email_failure(request, event: Event, user: User, exc: Exception) -> Non
     )
 
 
-def _email_promoted_non_members(request, event: Event, promoted_user_ids: list[str]) -> None:
-    """Email any promoted non-members their manage link. Best-effort per user.
+def _build_promoted_email_details(event: Event, user: User, token_str: str) -> RsvpEmailDetails:
+    """_email_details, minus member-only location/links once the event is no longer
+    public-RSVP-eligible — matches what _event_out/get_event/my-rsvps already hide."""
+    details = _email_details(event, user, token_str)
+    if not event.is_public_rsvp_eligible:
+        details = replace(details, event_location="", event_links=[])
+    return details
 
-    By the time a spot frees up, the event may have dropped out of public-RSVP
-    eligibility since the non-member first waitlisted. Strip the member-only
-    location/links in that case, matching what _event_out/get_event/my-rsvps
-    already hide from them — the promotion itself is still worth telling them
-    about.
-    """
+
+def _email_promoted_non_members(request, event: Event, promoted_user_ids: list[str]) -> None:
+    """Email any promoted non-members their manage link. Best-effort per user."""
     if not promoted_user_ids:
         return
     promoted = User.objects.filter(id__in=promoted_user_ids, is_member=False, email__isnull=False)
@@ -97,9 +99,7 @@ def _email_promoted_non_members(request, event: Event, promoted_user_ids: list[s
             continue
         try:
             token = NonMemberRsvpToken.issue_or_extend(user)
-            details = _email_details(event, user, token.token)
-            if not event.is_public_rsvp_eligible:
-                details = replace(details, event_location="", event_links=[])
+            details = _build_promoted_email_details(event, user, token.token)
             result = send_rsvp_waitlist_promoted_email(
                 sender=get_email_sender(),
                 details=details,

--- a/backend/tests/test_waitlist_promotion_emails.py
+++ b/backend/tests/test_waitlist_promotion_emails.py
@@ -1,5 +1,5 @@
 import pytest
-from community.models import Event, EventRSVP, RSVPStatus
+from community.models import Event, EventRSVP, EventType, RSVPStatus
 from users.models import User
 
 from tests._public_rsvp_helpers import make_non_member
@@ -75,3 +75,35 @@ class TestWaitlistPromotionEmailsNonMember:
 
         assert EventRSVP.objects.get(event=event, user=member).status == RSVPStatus.ATTENDING
         assert _promoted_email_count(fake_email_sender, "member@e.com") == 0
+
+    def test_ineligible_event_omits_location_and_links_from_promotion_email(
+        self, api_client, test_user, auth_headers, fake_email_sender
+    ):
+        """Issue 1004: event drops out of public-RSVP eligibility after a non-member
+        waitlists, but before a spot frees up — the promotion email must not leak
+        the member-only location/links."""
+        event = _one_spot_event(test_user)
+        event.location = "1234 Secret Member Ave"
+        event.whatsapp_link = "https://chat.whatsapp.com/secret-invite"
+        event.save()
+        _rsvp(api_client, event, auth_headers)
+        waited = make_non_member("+14155559914", "waited3@e.com", name="Waited Three")
+        EventRSVP.objects.create(event=event, user=waited, status=RSVPStatus.WAITLISTED)
+
+        event.event_type = EventType.COMMUNITY
+        event.save(update_fields=["event_type"])
+        assert not event.is_public_rsvp_eligible
+
+        api_client.delete(f"/api/community/events/{event.id}/rsvp/", **auth_headers)
+
+        assert EventRSVP.objects.get(event=event, user=waited).status == RSVPStatus.ATTENDING
+        assert _promoted_email_count(fake_email_sender, "waited3@e.com") == 1
+        call = next(
+            c
+            for c in fake_email_sender.send.call_args_list
+            if c.kwargs["to"] == "waited3@e.com" and "off the waitlist" in c.kwargs["subject"]
+        )
+        assert "1234 Secret Member Ave" not in call.kwargs["html"]
+        assert "1234 Secret Member Ave" not in call.kwargs["text"]
+        assert "secret-invite" not in call.kwargs["html"]
+        assert "secret-invite" not in call.kwargs["text"]


### PR DESCRIPTION
part of #999
fixes #1004

## the leak

`_email_promoted_non_members` (`backend/community/_public_rsvp_shared.py`) builds the "you're off the waitlist" email via `_email_details`, which sets `event_location=event.location` and `event_links=_event_links(event)` (whatsapp/partiful/other) with no eligibility check. `promote_from_waitlist` (`_event_helpers.py`) only guards on `max_attendees is not None` — no visibility/event_type check — so it fires whenever a spot frees up, even if the event has since become ineligible for public RSVP.

Repro: a PUBLIC/OFFICIAL event with `max_attendees` gets a non-member waitlisted, then a host edits `event_type` OFFICIAL → COMMUNITY (passes validation, `is_public_rsvp_eligible` goes false, but the waitlist row and `max_attendees` stay). When a spot later frees up, the promoted non-member gets an email containing the event's member-gated location and links — the same fields `_event_out`/`get_event`/`/my-rsvps` (via `public_rsvp_eligible_q`) already hide from them.

## fix

Gate on `event.is_public_rsvp_eligible` inside `_email_promoted_non_members` and strip `event_location`/`event_links` (via `dataclasses.replace`) when the event is no longer eligible, rather than suppressing the email outright — being off the waitlist is still worth telling them, and both email templates already `{% if event_location %}` / loop over `event_links`, so an empty-fields email renders cleanly (subject/body still make sense without a location).

**Scope:** the fix lives in `_email_promoted_non_members`, not in `_email_details` itself. `_email_details` is also called from `_send_confirmation_email` and `_send_updated_email` in `_public_rsvp_submit.py` / `_public_rsvp_manage.py`, but both of those run after `_load_public_rsvp_event`, which just verified eligibility in the same request — so gating there would be redundant and those call sites are correctly left unconditional.

## testing

- Added `test_ineligible_event_omits_location_and_links_from_promotion_email` to `backend/tests/test_waitlist_promotion_emails.py`: waitlists a non-member, flips `event_type` to `COMMUNITY` (event becomes ineligible), frees the spot, and asserts the promoted non-member's email (`html`/`text`) does not contain the event's location or whatsapp link.
- `cd backend && uv run pytest tests/test_waitlist_promotion_emails.py tests/test_public_rsvp.py tests/test_public_rsvp_capacity.py -q` → 47 passed
- `uv run ruff check` / `uv run ruff format --check` on both touched files → clean

Did not run the full `make agent-ci` suite per scope of this fix (single-file backend change + tests).
