### PR TITLE
fix(rsvp): stop leaking manage tokens from phone-check (Issue 1000)

### DIFF
--- a/backend/community/_public_rsvp_submit.py
+++ b/backend/community/_public_rsvp_submit.py
@@ -208,13 +208,9 @@ def check_public_rsvp_phone(request, event_id, payload: PublicRsvpPhoneCheckIn):
     if user.is_member:
         return Status(200, PublicRsvpPhoneCheckOut(status=PublicRsvpPhoneStatus.MEMBER))
     if event.rsvps.filter(user=user).exists():
-        token = NonMemberRsvpToken.issue_or_extend(user)
-        return Status(
-            200,
-            PublicRsvpPhoneCheckOut(
-                status=PublicRsvpPhoneStatus.ALREADY_RSVPD, rsvp_token=token.token
-            ),
-        )
+        if user.email:
+            _send_recognized_login_link(request, user)
+        return Status(200, PublicRsvpPhoneCheckOut(status=PublicRsvpPhoneStatus.ALREADY_RSVPD))
     if user.email and user.event_rsvps.exists():
         _send_recognized_login_link(request, user)
         return Status(200, PublicRsvpPhoneCheckOut(status=PublicRsvpPhoneStatus.RECOGNIZED))

--- a/backend/tests/test_public_rsvp_phone_check.py
+++ b/backend/tests/test_public_rsvp_phone_check.py
@@ -56,7 +56,9 @@ class TestPublicRsvpPhoneCheck:
         assert body["status"] == "new"
         assert body["rsvp_token"] == ""
 
-    def test_non_member_already_rsvpd_returns_token(self, api_client, official_event):
+    def test_non_member_already_rsvpd_returns_no_token(
+        self, api_client, official_event, fake_email_sender
+    ):
         guest = make_non_member("+14155550199", "guest@example.com")
         EventRSVP.objects.create(event=official_event, user=guest, status=RSVPStatus.ATTENDING)
 
@@ -65,8 +67,35 @@ class TestPublicRsvpPhoneCheck:
         assert response.status_code == 200
         body = response.json()
         assert body["status"] == "already_rsvpd"
-        assert body["rsvp_token"] != ""
-        assert NonMemberRsvpToken.resolve_user(body["rsvp_token"]) == guest
+        assert body["rsvp_token"] == ""
+
+    def test_already_rsvpd_sends_login_link_email(
+        self, api_client, official_event, fake_email_sender
+    ):
+        guest = make_non_member("+14155550199", "guest@example.com")
+        EventRSVP.objects.create(event=official_event, user=guest, status=RSVPStatus.ATTENDING)
+
+        post(api_client, official_event, phone_number="+14155550199")
+
+        fake_email_sender.send.assert_called_once()
+        sent = fake_email_sender.send.call_args.kwargs
+        assert sent["to"] == "guest@example.com"
+        token = NonMemberRsvpToken.objects.get(user=guest)
+        assert token.token in sent["text"]
+
+    def test_already_rsvpd_without_email_sends_no_email_and_no_token(
+        self, api_client, official_event, fake_email_sender
+    ):
+        guest = make_non_member("+14155550199", "")
+        EventRSVP.objects.create(event=official_event, user=guest, status=RSVPStatus.ATTENDING)
+
+        response = post(api_client, official_event, phone_number="+14155550199")
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["status"] == "already_rsvpd"
+        assert body["rsvp_token"] == ""
+        fake_email_sender.send.assert_not_called()
 
     def test_already_rsvpd_on_other_event_is_recognized_for_this_one(
         self, api_client, official_event, fake_email_sender

--- a/frontend/src/screens/events/PublicRsvp.a11y.test.tsx
+++ b/frontend/src/screens/events/PublicRsvp.a11y.test.tsx
@@ -17,12 +17,7 @@ import { PublicRsvpForm } from './PublicRsvpForm';
 function renderForm(event: Event) {
   return render(
     <MemoryRouter>
-      <PublicRsvpForm
-        event={event}
-        onSuccess={vi.fn()}
-        onMember={vi.fn()}
-        onAlreadyRsvpd={vi.fn()}
-      />
+      <PublicRsvpForm event={event} onSuccess={vi.fn()} onMember={vi.fn()} />
     </MemoryRouter>,
   );
 }

--- a/frontend/src/screens/events/PublicRsvpForm.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.test.tsx
@@ -13,20 +13,10 @@ vi.mock('@/api/publicRsvp', () => ({
 
 import { PublicRsvpForm } from './PublicRsvpForm';
 
-function renderForm(
-  event = makeEvent(),
-  onSuccess = vi.fn(),
-  onMember = vi.fn(),
-  onAlreadyRsvpd = vi.fn(),
-) {
+function renderForm(event = makeEvent(), onSuccess = vi.fn(), onMember = vi.fn()) {
   return render(
     <MemoryRouter>
-      <PublicRsvpForm
-        event={event}
-        onSuccess={onSuccess}
-        onMember={onMember}
-        onAlreadyRsvpd={onAlreadyRsvpd}
-      />
+      <PublicRsvpForm event={event} onSuccess={onSuccess} onMember={onMember} />
     </MemoryRouter>,
   );
 }
@@ -87,7 +77,6 @@ describe('PublicRsvpForm', () => {
           event={makeEvent({ allowPlusOnes: false })}
           onSuccess={vi.fn()}
           onMember={vi.fn()}
-          onAlreadyRsvpd={vi.fn()}
         />
       </MemoryRouter>,
     );
@@ -129,12 +118,14 @@ describe('PublicRsvpForm', () => {
     await waitFor(() => expect(onMember).toHaveBeenCalled());
   });
 
-  it('calls onAlreadyRsvpd with the refreshed token when already rsvpd', async () => {
-    checkPhoneMutate.mockResolvedValue({ status: 'already_rsvpd', rsvp_token: 'tok-xyz' });
-    const onAlreadyRsvpd = vi.fn();
-    renderForm(makeEvent(), vi.fn(), vi.fn(), onAlreadyRsvpd);
+  it('shows a check-your-email message instead of the contact form when already rsvpd', async () => {
+    checkPhoneMutate.mockResolvedValue({ status: 'already_rsvpd', rsvp_token: '' });
+    renderForm();
     fillPhoneStep();
-    await waitFor(() => expect(onAlreadyRsvpd).toHaveBeenCalledWith({ rsvpToken: 'tok-xyz' }));
+    await screen.findByText(
+      'we recognized your number — check your email for a link to confirm your rsvp',
+    );
+    expect(screen.queryByLabelText('first name')).not.toBeInTheDocument();
   });
 
   it('shows a check-your-email message instead of the contact form when recognized', async () => {

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -18,7 +18,7 @@ import {
 } from '@/models/event';
 import { optionalEmail } from '@/utils/validators';
 
-import { type AlreadyRsvpdResult, PublicRsvpPhoneStep } from './PublicRsvpPhoneStep';
+import { PublicRsvpPhoneStep } from './PublicRsvpPhoneStep';
 import { RsvpCommentField } from './RsvpCommentField';
 
 const MAX_NAME = 100;
@@ -28,7 +28,6 @@ interface Props {
   event: Event;
   onSuccess: (result: PublicRsvpOut) => void;
   onMember: () => void;
-  onAlreadyRsvpd: (result: AlreadyRsvpdResult) => void;
 }
 
 interface SubmitError {
@@ -54,7 +53,7 @@ function statusLabel(status: RsvpInputStatus, atCapacity: boolean): string {
   return RSVP_STATUS_LABELS.find((s) => s.status === status)?.label ?? status;
 }
 
-export function PublicRsvpForm({ event, onSuccess, onMember, onAlreadyRsvpd }: Props) {
+export function PublicRsvpForm({ event, onSuccess, onMember }: Props) {
   const submit = useSubmitPublicRsvp();
   const atCapacity = spotsLeft(event) === 0;
   const [status, setStatus] = useState<RsvpInputStatus | null>(null);
@@ -129,7 +128,9 @@ export function PublicRsvpForm({ event, onSuccess, onMember, onAlreadyRsvpd }: P
         <PublicRsvpPhoneStep
           eventId={event.id}
           onMember={onMember}
-          onAlreadyRsvpd={onAlreadyRsvpd}
+          onAlreadyRsvpd={() => {
+            setRecognized(true);
+          }}
           onRecognized={() => {
             setRecognized(true);
           }}

--- a/frontend/src/screens/events/PublicRsvpPhoneStep.tsx
+++ b/frontend/src/screens/events/PublicRsvpPhoneStep.tsx
@@ -11,14 +11,10 @@ export interface PhoneStepResult {
   status: 'new';
 }
 
-export interface AlreadyRsvpdResult {
-  rsvpToken: string;
-}
-
 interface Props {
   onNew: (result: PhoneStepResult) => void;
   onMember: () => void;
-  onAlreadyRsvpd: (result: AlreadyRsvpdResult) => void;
+  onAlreadyRsvpd: () => void;
   onRecognized: () => void;
   eventId: string;
 }
@@ -48,7 +44,7 @@ export function PublicRsvpPhoneStep({
         return;
       }
       if (result.status === 'already_rsvpd') {
-        onAlreadyRsvpd({ rsvpToken: result.rsvp_token });
+        onAlreadyRsvpd();
         return;
       }
       if (result.status === 'recognized') {

--- a/frontend/src/screens/events/PublicRsvpSection.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpSection.test.tsx
@@ -110,8 +110,8 @@ describe('PublicRsvpSection', () => {
     expect(screen.queryByLabelText(/first name/i)).not.toBeInTheDocument();
   });
 
-  it('unlocks the event page when already rsvpd, skipping the form', async () => {
-    mockCheckPhone.mockResolvedValue({ status: 'already_rsvpd', rsvp_token: 'tok-returning' });
+  it('shows a check-your-email message when already rsvpd, without leaking a token', async () => {
+    mockCheckPhone.mockResolvedValue({ status: 'already_rsvpd', rsvp_token: '' });
     const user = userEvent.setup();
     render(
       <MemoryRouter>
@@ -123,8 +123,10 @@ describe('PublicRsvpSection', () => {
     await user.type(screen.getByLabelText(/phone number/i), '4155550123');
     await user.click(screen.getByRole('button', { name: 'continue' }));
 
-    expect(mockNavigate).toHaveBeenCalledWith(0);
+    await screen.findByText(
+      'we recognized your number — check your email for a link to confirm your rsvp',
+    );
     expect(mockSubmit).not.toHaveBeenCalled();
-    expect(localStorage.getItem('pda-rsvp-token')).toBe('tok-returning');
+    expect(localStorage.getItem('pda-rsvp-token')).toBeNull();
   });
 });

--- a/frontend/src/screens/events/PublicRsvpSection.tsx
+++ b/frontend/src/screens/events/PublicRsvpSection.tsx
@@ -31,9 +31,6 @@ export function PublicRsvpSection({ event }: Props) {
       onMember={() => {
         setIsMember(true);
       }}
-      onAlreadyRsvpd={(result) => {
-        unlockWithToken(result.rsvpToken);
-      }}
     />
   );
 }


### PR DESCRIPTION
## Summary

Critical account-takeover bug: `check_public_rsvp_phone` (`POST /api/community/public/events/{event_id}/rsvp-phone-check/`, unauthenticated, phone-number-only input) returned a live `NonMemberRsvpToken` in the response body whenever the phone matched a non-member who'd already RSVP'd to the event (`status="already_rsvpd"`).

That token grants full control of the victim's non-member identity with no proof of phone ownership:
- `GET /public/my-rsvps/?token=...` discloses the victim's name, email, and phone number plus all their RSVPs
- `POST`/`DELETE` on that endpoint let the caller mutate or cancel the victim's RSVPs
- the token also unlocks member-only event fields (location, links, guest list) and lets the caller comment/react as the victim

Phone numbers are low-entropy and effectively enumerable, and the 20/h-per-IP rate limit is trivially bypassed by rotating source IPs.

The sibling `RECOGNIZED` branch (a non-member with a prior RSVP on a *different* event) already does this correctly — it emails the manage link to the address on file and returns no token in the body. The dedicated `resend_manage_link` endpoint also deliberately requires phone **and** email for exactly this reason.

## Fix

`already_rsvpd` now follows the same pattern as `RECOGNIZED`: email the existing manage link (reusing `_send_recognized_login_link`) and return `status="already_rsvpd"` with **no token** in the response body. `PublicRsvpPhoneCheckOut.rsvp_token` simply comes back `""` for this status now — same shape the schema already used for `member`/`recognized`/`new`, so no contract break. If the matched user has no email on file, no email is sent (mirrors the existing `RECOGNIZED` fallback) and still no token is returned.

Frontend: since the phone-check response no longer carries a usable token for this path, `PublicRsvpForm`'s `already_rsvpd` handling now shows the same "check your email for a link" message already used for `recognized`, instead of immediately unlocking the event page from a token pulled out of the response. Removed the now-dead `AlreadyRsvpdResult` type and the `unlockWithToken` wiring in `PublicRsvpSection` for this path.

part of #999
fixes #1000

## Test plan

- [x] Backend: `cd backend && uv run pytest tests/test_public_rsvp_phone_check.py tests/test_public_rsvp.py tests/test_nonmember_rsvp_token.py -q` — 65 passed
- [x] Backend lint: `uv run ruff check` / `ruff format --check` on touched files — clean
- [x] Frontend: `pnpm exec vitest run PublicRsvpForm.test.tsx PublicRsvpSection.test.tsx PublicRsvp.a11y.test.tsx` — 31 passed
- [x] Frontend typecheck: `pnpm exec tsc -b --noEmit` — clean
- [x] Frontend lint/format on touched files — clean
- [x] Verified OpenAPI schema for `PublicRsvpPhoneCheckOut` is unchanged (still `rsvp_token: str = ""`), so no `frontend-types` regen needed