### PR TITLE
fix(events): email promoted non-members on public rsvp cancel

### DIFF
--- a/backend/community/_public_rsvp_manage.py
+++ b/backend/community/_public_rsvp_manage.py
@@ -178,6 +178,7 @@ def update_my_rsvp(request, event_id, payload: PublicRsvpManageIn, token: str = 
 @rate_limit(key_func=client_ip, rate="30/h")
 def delete_my_rsvp(request, event_id, token: str = ""):
     user = _resolve_token_user(token)
+    promoted_user_ids: list[str] = []
     with transaction.atomic():
         event = (
             Event.objects.select_for_update()
@@ -193,7 +194,7 @@ def delete_my_rsvp(request, event_id, token: str = ""):
         was_attending = rsvp.status == RSVPStatus.ATTENDING
         rsvp.delete()
         if was_attending:
-            promote_from_waitlist(event)
+            promoted_user_ids = promote_from_waitlist(event)
 
     audit_log(
         logging.INFO,
@@ -203,4 +204,5 @@ def delete_my_rsvp(request, event_id, token: str = ""):
         target_id=str(event_id),
         details={"user_id": str(user.pk)},
     )
+    _email_promoted_non_members(request, event, promoted_user_ids)
     return Status(204, None)

--- a/backend/tests/test_public_rsvp_manage.py
+++ b/backend/tests/test_public_rsvp_manage.py
@@ -230,7 +230,9 @@ class TestDeleteMyRsvps:
         listed = api_client.get(f"{GET_URL}?token={token.token}").json()["rsvps"]
         assert listed == []
 
-    def test_delete_promotes_waitlist(self, api_client, nonmember, official_event):
+    def test_delete_promotes_waitlist(
+        self, api_client, nonmember, official_event, fake_email_sender
+    ):
         official_event.max_attendees = 1
         official_event.save(update_fields=["max_attendees"])
         EventRSVP.objects.create(event=official_event, user=nonmember, status=RSVPStatus.ATTENDING)
@@ -241,6 +243,10 @@ class TestDeleteMyRsvps:
         assert resp.status_code == 204
         waiter_rsvp = EventRSVP.objects.get(event=official_event, user=waiter)
         assert waiter_rsvp.status == RSVPStatus.ATTENDING
+        fake_email_sender.send.assert_called_once()
+        sent = fake_email_sender.send.call_args.kwargs
+        assert sent["to"] == waiter.email
+        assert sent["subject"] == "you're off the waitlist for official a"
 
     def test_delete_no_rsvp_404(self, api_client, nonmember, official_event):
         token = NonMemberRsvpToken.issue_or_extend(nonmember)


### PR DESCRIPTION
## Overview

`delete_my_rsvp` in `backend/community/_public_rsvp_manage.py` discarded the `promoted_user_ids` returned by `promote_from_waitlist(event)`, so a non-member promoted off the waitlist when another non-member cancelled their attending RSVP never received the "you're off the waitlist" email. Non-members have no login/dashboard/in-app-notification visibility, so email is their only real channel for this.

This mirrors the fix already applied for the member path (`delete_rsvp` in `_event_rsvps.py`) and the sibling non-member update path (`update_my_rsvp` in the same file), both of which already capture `promoted_user_ids` and call `_email_promoted_non_members`.

Part of epic #999.

Closes #1005

## Test plan

- [x] Updated `backend/tests/test_public_rsvp_manage.py::TestDeleteMyRsvps::test_delete_promotes_waitlist` to assert the promoted non-member is emailed (via `fake_email_sender`), in addition to the existing DB-state assertion.
- [x] Ran `pytest backend/tests/test_public_rsvp_manage.py` — 28 passed.
