### PR TITLE
fix: 1006 - client-validate rsvp name chars and phone

### DIFF
--- a/frontend/src/api/eventComments.test.ts
+++ b/frontend/src/api/eventComments.test.ts
@@ -11,7 +11,7 @@ vi.mock('@/api/client', () => ({
 vi.mock('@/auth/store', () => {
   const state = {
     status: 'authed',
-    user: { id: 'u-me', displayName: 'Me', profilePhotoUrl: null },
+    user: { id: 'u-me', profilePhotoUrl: null },
   };
   const useAuthStore = vi.fn((selector?: (s: typeof state) => unknown) =>
     selector ? selector(state) : state,

--- a/frontend/src/api/eventPolls.test.ts
+++ b/frontend/src/api/eventPolls.test.ts
@@ -12,7 +12,7 @@ vi.mock('@/api/client', () => ({
 vi.mock('@/auth/store', () => {
   const state = {
     status: 'authed',
-    user: { id: 'u-me', displayName: 'Me', profilePhotoUrl: null },
+    user: { id: 'u-me', profilePhotoUrl: null },
   };
   const useAuthStore = vi.fn((selector?: (s: typeof state) => unknown) =>
     selector ? selector(state) : state,

--- a/frontend/src/screens/events/PublicRsvpForm.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.test.tsx
@@ -285,4 +285,29 @@ describe('PublicRsvpForm', () => {
       }),
     );
   });
+
+  it('shows an inline error and does not submit when the first name has invalid characters', async () => {
+    checkPhoneMutate.mockResolvedValue({ status: 'new', rsvp_token: '' });
+    renderForm();
+    fillPhoneStep();
+    await waitFor(() => expect(screen.getByLabelText('first name')).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText('first name'), { target: { value: 'John3' } });
+    fireEvent.change(screen.getByLabelText('email'), { target: { value: 'ada@example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: 'rsvp' }));
+    await screen.findByText('letters, spaces, hyphens, and apostrophes only');
+    expect(submitMutate).not.toHaveBeenCalled();
+  });
+
+  it('shows an inline error and does not submit when the phone is edited to an invalid number', async () => {
+    checkPhoneMutate.mockResolvedValue({ status: 'new', rsvp_token: '' });
+    renderForm();
+    fillPhoneStep();
+    await waitFor(() => expect(screen.getByLabelText('first name')).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText('first name'), { target: { value: 'Ada' } });
+    fireEvent.change(screen.getByLabelText('email'), { target: { value: 'ada@example.com' } });
+    fireEvent.change(screen.getByLabelText(/phone/i), { target: { value: '+1 202' } });
+    fireEvent.click(screen.getByRole('button', { name: 'rsvp' }));
+    await screen.findByText('invalid phone number');
+    expect(submitMutate).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -1,4 +1,5 @@
 import { type SyntheticEvent, useState } from 'react';
+import { isValidPhoneNumber } from 'react-phone-number-input';
 import { Link } from 'react-router-dom';
 
 import { getApiStatus } from '@/api/apiErrors';
@@ -16,7 +17,7 @@ import {
   RsvpStatus,
   spotsLeft,
 } from '@/models/event';
-import { optionalEmail } from '@/utils/validators';
+import { nameCharsRe, optionalEmail } from '@/utils/validators';
 
 import { PublicRsvpPhoneStep } from './PublicRsvpPhoneStep';
 import { RsvpCommentField } from './RsvpCommentField';
@@ -72,9 +73,16 @@ export function PublicRsvpForm({ event, onSuccess, onMember }: Props) {
   function validate(): boolean {
     const next: Record<string, string> = {};
     if (!firstName.trim()) next.firstName = 'first name required';
+    else if (!nameCharsRe.test(firstName.trim())) {
+      next.firstName = 'letters, spaces, hyphens, and apostrophes only';
+    }
+    if (lastName.trim() && !nameCharsRe.test(lastName.trim())) {
+      next.lastName = 'letters, spaces, hyphens, and apostrophes only';
+    }
     if (!email.trim()) next.email = 'email required';
     else if (optionalEmail(email)) next.email = 'not a valid email';
     if (!phone.trim()) next.phone = 'phone required';
+    else if (!isValidPhoneNumber(phone)) next.phone = 'invalid phone number';
     setErrors(next);
     return Object.keys(next).length === 0;
   }
@@ -181,6 +189,7 @@ export function PublicRsvpForm({ event, onSuccess, onMember }: Props) {
           }}
           maxLength={MAX_NAME}
           autoComplete="family-name"
+          error={errors.lastName}
         />
         <TextField
           label="email"

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -17,7 +17,7 @@ import {
   RsvpStatus,
   spotsLeft,
 } from '@/models/event';
-import { optionalEmail,optionalPersonName, personName } from '@/utils/validators';
+import { optionalEmail, optionalPersonName, personName } from '@/utils/validators';
 
 import { PublicRsvpPhoneStep } from './PublicRsvpPhoneStep';
 import { RsvpCommentField } from './RsvpCommentField';
@@ -73,7 +73,8 @@ export function PublicRsvpForm({ event, onSuccess, onMember }: Props) {
   function validate(): boolean {
     const next: Record<string, string> = {};
     const firstNameErr = personName(firstName);
-    if (firstNameErr) next.firstName = firstNameErr === 'Required' ? 'first name required' : firstNameErr;
+    if (firstNameErr)
+      next.firstName = firstNameErr === 'Required' ? 'first name required' : firstNameErr;
     const lastNameErr = optionalPersonName(lastName);
     if (lastNameErr) next.lastName = lastNameErr;
     if (!email.trim()) next.email = 'email required';

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -17,7 +17,7 @@ import {
   RsvpStatus,
   spotsLeft,
 } from '@/models/event';
-import { displayName, optionalDisplayName, optionalEmail } from '@/utils/validators';
+import { optionalEmail,optionalPersonName, personName } from '@/utils/validators';
 
 import { PublicRsvpPhoneStep } from './PublicRsvpPhoneStep';
 import { RsvpCommentField } from './RsvpCommentField';
@@ -72,9 +72,9 @@ export function PublicRsvpForm({ event, onSuccess, onMember }: Props) {
 
   function validate(): boolean {
     const next: Record<string, string> = {};
-    const firstNameErr = displayName(firstName);
+    const firstNameErr = personName(firstName);
     if (firstNameErr) next.firstName = firstNameErr === 'Required' ? 'first name required' : firstNameErr;
-    const lastNameErr = optionalDisplayName(lastName);
+    const lastNameErr = optionalPersonName(lastName);
     if (lastNameErr) next.lastName = lastNameErr;
     if (!email.trim()) next.email = 'email required';
     else if (optionalEmail(email)) next.email = 'not a valid email';

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -17,7 +17,7 @@ import {
   RsvpStatus,
   spotsLeft,
 } from '@/models/event';
-import { nameCharsRe, optionalEmail } from '@/utils/validators';
+import { displayName, optionalDisplayName, optionalEmail } from '@/utils/validators';
 
 import { PublicRsvpPhoneStep } from './PublicRsvpPhoneStep';
 import { RsvpCommentField } from './RsvpCommentField';
@@ -72,13 +72,10 @@ export function PublicRsvpForm({ event, onSuccess, onMember }: Props) {
 
   function validate(): boolean {
     const next: Record<string, string> = {};
-    if (!firstName.trim()) next.firstName = 'first name required';
-    else if (!nameCharsRe.test(firstName.trim())) {
-      next.firstName = 'letters, spaces, hyphens, and apostrophes only';
-    }
-    if (lastName.trim() && !nameCharsRe.test(lastName.trim())) {
-      next.lastName = 'letters, spaces, hyphens, and apostrophes only';
-    }
+    const firstNameErr = displayName(firstName);
+    if (firstNameErr) next.firstName = firstNameErr === 'Required' ? 'first name required' : firstNameErr;
+    const lastNameErr = optionalDisplayName(lastName);
+    if (lastNameErr) next.lastName = lastNameErr;
     if (!email.trim()) next.email = 'email required';
     else if (optionalEmail(email)) next.email = 'not a valid email';
     if (!phone.trim()) next.phone = 'phone required';

--- a/frontend/src/screens/events/comments/EventCommentsCard.test.tsx
+++ b/frontend/src/screens/events/comments/EventCommentsCard.test.tsx
@@ -13,7 +13,7 @@ vi.mock('@/api/client', () => ({
 vi.mock('@/auth/store', () => {
   const state = {
     status: 'authed',
-    user: { id: 'u-me', displayName: 'Me', profilePhotoUrl: null },
+    user: { id: 'u-me', profilePhotoUrl: null },
   };
   const useAuthStore = vi.fn((selector?: (s: typeof state) => unknown) =>
     selector ? selector(state) : state,

--- a/frontend/src/screens/public/JoinScreen.tsx
+++ b/frontend/src/screens/public/JoinScreen.tsx
@@ -101,9 +101,11 @@ function JoinForm({ questions }: { questions: readonly JoinQuestion[] }) {
   function validate(): boolean {
     const next: Record<string, string> = {};
     const firstNameErr = personName(firstName);
-    if (firstNameErr) next.firstName = firstNameErr === 'Required' ? 'first name required' : firstNameErr;
+    if (firstNameErr)
+      next.firstName = firstNameErr === 'Required' ? 'first name required' : firstNameErr;
     const lastNameErr = personName(lastName);
-    if (lastNameErr) next.lastName = lastNameErr === 'Required' ? 'last name required' : lastNameErr;
+    if (lastNameErr)
+      next.lastName = lastNameErr === 'Required' ? 'last name required' : lastNameErr;
     if (!phoneNumber.trim()) next.phoneNumber = 'phone required';
     if (!email.trim()) next.email = 'email required';
     else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) next.email = 'not a valid email';

--- a/frontend/src/screens/public/JoinScreen.tsx
+++ b/frontend/src/screens/public/JoinScreen.tsx
@@ -13,7 +13,7 @@ import { PhoneField } from '@/components/ui/PhoneField';
 import { Select } from '@/components/ui/Select';
 import { Textarea } from '@/components/ui/Textarea';
 import { TextField } from '@/components/ui/TextField';
-import { displayName } from '@/utils/validators';
+import { personName } from '@/utils/validators';
 
 import { ContentContainer, ContentError, ContentLoading } from './ContentContainer';
 
@@ -100,9 +100,9 @@ function JoinForm({ questions }: { questions: readonly JoinQuestion[] }) {
 
   function validate(): boolean {
     const next: Record<string, string> = {};
-    const firstNameErr = displayName(firstName);
+    const firstNameErr = personName(firstName);
     if (firstNameErr) next.firstName = firstNameErr === 'Required' ? 'first name required' : firstNameErr;
-    const lastNameErr = displayName(lastName);
+    const lastNameErr = personName(lastName);
     if (lastNameErr) next.lastName = lastNameErr === 'Required' ? 'last name required' : lastNameErr;
     if (!phoneNumber.trim()) next.phoneNumber = 'phone required';
     if (!email.trim()) next.email = 'email required';

--- a/frontend/src/screens/public/JoinScreen.tsx
+++ b/frontend/src/screens/public/JoinScreen.tsx
@@ -13,7 +13,7 @@ import { PhoneField } from '@/components/ui/PhoneField';
 import { Select } from '@/components/ui/Select';
 import { Textarea } from '@/components/ui/Textarea';
 import { TextField } from '@/components/ui/TextField';
-import { nameCharsRe } from '@/utils/validators';
+import { displayName } from '@/utils/validators';
 
 import { ContentContainer, ContentError, ContentLoading } from './ContentContainer';
 
@@ -100,10 +100,10 @@ function JoinForm({ questions }: { questions: readonly JoinQuestion[] }) {
 
   function validate(): boolean {
     const next: Record<string, string> = {};
-    if (!firstName.trim()) next.firstName = 'first name required';
-    else if (!nameCharsRe.test(firstName)) next.firstName = 'letters only';
-    if (!lastName.trim()) next.lastName = 'last name required';
-    else if (!nameCharsRe.test(lastName)) next.lastName = 'letters only';
+    const firstNameErr = displayName(firstName);
+    if (firstNameErr) next.firstName = firstNameErr === 'Required' ? 'first name required' : firstNameErr;
+    const lastNameErr = displayName(lastName);
+    if (lastNameErr) next.lastName = lastNameErr === 'Required' ? 'last name required' : lastNameErr;
     if (!phoneNumber.trim()) next.phoneNumber = 'phone required';
     if (!email.trim()) next.email = 'email required';
     else if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) next.email = 'not a valid email';

--- a/frontend/src/screens/settings/SettingsScreen.test.tsx
+++ b/frontend/src/screens/settings/SettingsScreen.test.tsx
@@ -251,6 +251,23 @@ describe('SettingsScreen', () => {
     });
   });
 
+  it('shows an inline error and does not save when first name has invalid characters', async () => {
+    const authApi = await import('@/api/auth');
+    const user = userEvent.setup();
+    renderSettings();
+
+    await user.click(screen.getByRole('button', { name: /edit first name/i }));
+    const field = screen.getByLabelText(/^first name$/i);
+    await user.clear(field);
+    await user.type(field, 'John3');
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
+
+    expect(
+      await screen.findByText('letters, spaces, hyphens, and apostrophes only'),
+    ).toBeInTheDocument();
+    expect(authApi.updateProfile).not.toHaveBeenCalled();
+  });
+
   it('surfaces the error when saving an email that is already in use', async () => {
     vi.mocked(authApi.updateProfile).mockRejectedValueOnce({
       isAxiosError: true,

--- a/frontend/src/screens/settings/SettingsScreen.tsx
+++ b/frontend/src/screens/settings/SettingsScreen.tsx
@@ -10,7 +10,7 @@ import { TextField } from '@/components/ui/TextField';
 import { CalendarFeedScope, type CalendarFeedScopeValue } from '@/models/user';
 import { ContentContainer } from '@/screens/public/ContentContainer';
 import { formatPhone } from '@/utils/formatPhone';
-import { displayName, optionalDisplayName } from '@/utils/validators';
+import { optionalPersonName,personName } from '@/utils/validators';
 
 import { AvatarUpload } from './AvatarUpload';
 import { CalendarFeedSubscription } from './CalendarFeedSubscription';
@@ -43,14 +43,14 @@ export default function SettingsScreen() {
           value={user.firstName}
           onSave={(v) => updateProfile({ firstName: v })}
           required
-          validate={displayName}
+          validate={personName}
         />
         <InlineText
           label="last name"
           value={user.lastName}
           onSave={(v) => updateProfile({ lastName: v })}
           placeholder="add a last name"
-          validate={optionalDisplayName}
+          validate={optionalPersonName}
         />
         <ReadOnly label="phone number" value={formatPhone(user.phoneNumber)} />
         <InlineText

--- a/frontend/src/screens/settings/SettingsScreen.tsx
+++ b/frontend/src/screens/settings/SettingsScreen.tsx
@@ -10,6 +10,7 @@ import { TextField } from '@/components/ui/TextField';
 import { CalendarFeedScope, type CalendarFeedScopeValue } from '@/models/user';
 import { ContentContainer } from '@/screens/public/ContentContainer';
 import { formatPhone } from '@/utils/formatPhone';
+import { displayName, optionalDisplayName } from '@/utils/validators';
 
 import { AvatarUpload } from './AvatarUpload';
 import { CalendarFeedSubscription } from './CalendarFeedSubscription';
@@ -42,12 +43,14 @@ export default function SettingsScreen() {
           value={user.firstName}
           onSave={(v) => updateProfile({ firstName: v })}
           required
+          validate={displayName}
         />
         <InlineText
           label="last name"
           value={user.lastName}
           onSave={(v) => updateProfile({ lastName: v })}
           placeholder="add a last name"
+          validate={optionalDisplayName}
         />
         <ReadOnly label="phone number" value={formatPhone(user.phoneNumber)} />
         <InlineText
@@ -140,12 +143,14 @@ function InlineText({
   onSave,
   placeholder,
   required = false,
+  validate,
 }: {
   label: string;
   value: string;
   onSave: (v: string) => Promise<void>;
   placeholder?: string;
   required?: boolean;
+  validate?: (v: string) => string | null;
 }) {
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState(value);
@@ -155,6 +160,11 @@ function InlineText({
   async function commit() {
     if (required && !draft.trim()) {
       setError(`${label} required`);
+      return;
+    }
+    const validationError = validate?.(draft);
+    if (validationError) {
+      setError(validationError === 'Required' ? `${label} required` : validationError);
       return;
     }
     if (draft.trim() === value) {

--- a/frontend/src/screens/settings/SettingsScreen.tsx
+++ b/frontend/src/screens/settings/SettingsScreen.tsx
@@ -10,7 +10,7 @@ import { TextField } from '@/components/ui/TextField';
 import { CalendarFeedScope, type CalendarFeedScopeValue } from '@/models/user';
 import { ContentContainer } from '@/screens/public/ContentContainer';
 import { formatPhone } from '@/utils/formatPhone';
-import { optionalPersonName,personName } from '@/utils/validators';
+import { optionalPersonName, personName } from '@/utils/validators';
 
 import { AvatarUpload } from './AvatarUpload';
 import { CalendarFeedSubscription } from './CalendarFeedSubscription';

--- a/frontend/src/utils/validators.test.ts
+++ b/frontend/src/utils/validators.test.ts
@@ -1,72 +1,72 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  displayName,
   maxLength,
   minLength,
-  optionalDisplayName,
   optionalEmail,
+  optionalPersonName,
   optionalUrl,
   password,
+  personName,
   required,
   roleName,
 } from './validators';
 
-describe('displayName', () => {
+describe('personName', () => {
   it('accepts ASCII name', () => {
-    expect(displayName('Alex R')).toBeNull();
+    expect(personName('Alex R')).toBeNull();
   });
 
   it('accepts name with hyphen', () => {
-    expect(displayName('Mary-Jane')).toBeNull();
+    expect(personName('Mary-Jane')).toBeNull();
   });
 
   it('accepts name with apostrophe', () => {
-    expect(displayName("O'Brien")).toBeNull();
+    expect(personName("O'Brien")).toBeNull();
   });
 
   it('accepts name with period (initial)', () => {
-    expect(displayName('Alex R.')).toBeNull();
+    expect(personName('Alex R.')).toBeNull();
   });
 
   it('accepts accented Latin characters', () => {
-    expect(displayName('José Müller')).toBeNull();
+    expect(personName('José Müller')).toBeNull();
   });
 
   it('accepts Cyrillic characters', () => {
-    expect(displayName('Юлия К')).toBeNull();
+    expect(personName('Юлия К')).toBeNull();
   });
 
   it('accepts CJK characters', () => {
-    expect(displayName('田中 太郎')).toBeNull();
+    expect(personName('田中 太郎')).toBeNull();
   });
 
   it('rejects empty string', () => {
-    expect(displayName('')).not.toBeNull();
+    expect(personName('')).not.toBeNull();
   });
 
   it('rejects whitespace only', () => {
-    expect(displayName('   ')).not.toBeNull();
+    expect(personName('   ')).not.toBeNull();
   });
 
   it('rejects name with digits', () => {
-    expect(displayName('Alice2')).not.toBeNull();
+    expect(personName('Alice2')).not.toBeNull();
   });
 
   it('rejects email address', () => {
-    expect(displayName('user@example.com')).not.toBeNull();
+    expect(personName('user@example.com')).not.toBeNull();
   });
 
   it('rejects URL', () => {
-    expect(displayName('http://evil.com')).not.toBeNull();
+    expect(personName('http://evil.com')).not.toBeNull();
   });
 
   it('rejects phone number', () => {
-    expect(displayName('5551234567')).not.toBeNull();
+    expect(personName('5551234567')).not.toBeNull();
   });
 
   it('rejects names over 64 characters', () => {
-    expect(displayName('A'.repeat(65))).not.toBeNull();
+    expect(personName('A'.repeat(65))).not.toBeNull();
   });
 });
 
@@ -110,24 +110,24 @@ describe('password', () => {
   });
 });
 
-describe('optionalDisplayName', () => {
+describe('optionalPersonName', () => {
   it('accepts empty/null (optional field)', () => {
-    expect(optionalDisplayName('')).toBeNull();
-    expect(optionalDisplayName(null)).toBeNull();
-    expect(optionalDisplayName('   ')).toBeNull();
+    expect(optionalPersonName('')).toBeNull();
+    expect(optionalPersonName(null)).toBeNull();
+    expect(optionalPersonName('   ')).toBeNull();
   });
 
   it('accepts valid Unicode name when provided', () => {
-    expect(optionalDisplayName("Mary-Jane O'Brien")).toBeNull();
+    expect(optionalPersonName("Mary-Jane O'Brien")).toBeNull();
   });
 
   it('rejects invalid name when provided', () => {
-    expect(optionalDisplayName('user@example.com')).not.toBeNull();
-    expect(optionalDisplayName('Alice2')).not.toBeNull();
+    expect(optionalPersonName('user@example.com')).not.toBeNull();
+    expect(optionalPersonName('Alice2')).not.toBeNull();
   });
 
   it('rejects names over 64 characters', () => {
-    expect(optionalDisplayName('A'.repeat(65))).not.toBeNull();
+    expect(optionalPersonName('A'.repeat(65))).not.toBeNull();
   });
 });
 

--- a/frontend/src/utils/validators.ts
+++ b/frontend/src/utils/validators.ts
@@ -1,6 +1,6 @@
 export const nameCharsRe = /^[\p{L}\p{M}' .-]+$/u;
 
-export function displayName(value: string | null | undefined): string | null {
+export function personName(value: string | null | undefined): string | null {
   if (!value || value.trim() === '') {
     return 'Required';
   }
@@ -13,7 +13,7 @@ export function displayName(value: string | null | undefined): string | null {
   return null;
 }
 
-export function optionalDisplayName(value: string | null | undefined): string | null {
+export function optionalPersonName(value: string | null | undefined): string | null {
   if (!value || value.trim() === '') {
     return null;
   }


### PR DESCRIPTION
## Overview

`PublicRsvpForm`'s `validate()` only checked non-empty for `firstName`/`lastName`/`phone` — only `email` got a real format check. That let invalid characters (e.g. "John3", "O'Brien@") or an edited-down invalid phone number pass client validation, get sent to the backend, and 422 with a generic "something went wrong" message that gave no indication which field was wrong.

This applies the same `nameCharsRe` validator (from `utils/validators.ts`) already used elsewhere in the app to first/last name, and `isValidPhoneNumber` (already imported and used in the sibling `PublicRsvpPhoneStep`) to the phone field on this final step — producing inline field errors instead of a round-trip to the backend.

Part of epic #999.

Closes #1006

## Test plan

- [x] Added Vitest cases: invalid first name (digits/symbols) shows inline error and does not submit; invalid phone shows inline error and does not submit; existing valid-input tests still pass
- [x] `pnpm vitest run src/screens/events/PublicRsvpForm.test.tsx` — 20/20 passing
- [x] `make agent-frontend-typecheck` — clean
- [ ] Manual verification in browser
