### PR TITLE
fix: 1007 - stop unverified rsvp recognized-link emails

### DIFF
--- a/backend/community/_public_rsvp_submit.py
+++ b/backend/community/_public_rsvp_submit.py
@@ -210,7 +210,6 @@ def check_public_rsvp_phone(request, event_id, payload: PublicRsvpPhoneCheckIn):
             _send_recognized_login_link(request, user)
         return Status(200, PublicRsvpPhoneCheckOut(status=PublicRsvpPhoneStatus.ALREADY_RSVPD))
     if user.email and user.event_rsvps.exists():
-        _send_recognized_login_link(request, user)
         return Status(200, PublicRsvpPhoneCheckOut(status=PublicRsvpPhoneStatus.RECOGNIZED))
     return Status(200, PublicRsvpPhoneCheckOut(status=PublicRsvpPhoneStatus.NEW))
 

--- a/backend/tests/test_public_rsvp_phone_check.py
+++ b/backend/tests/test_public_rsvp_phone_check.py
@@ -111,18 +111,34 @@ class TestPublicRsvpPhoneCheck:
         assert body["status"] == "recognized"
         assert body["rsvp_token"] == ""
 
-    def test_recognized_sends_login_link_email(self, api_client, official_event, fake_email_sender):
+    def test_recognized_sends_no_email_and_no_token_on_bare_phone_match(
+        self, api_client, official_event, fake_email_sender
+    ):
         guest = make_non_member("+14155550199", "guest@example.com")
         other_event = make_official_event(title="Other Event", start_datetime=future_iso(days=45))
         EventRSVP.objects.create(event=other_event, user=guest, status=RSVPStatus.ATTENDING)
 
+        response = post(api_client, official_event, phone_number="+14155550199")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "recognized"
+        fake_email_sender.send.assert_not_called()
+        assert not NonMemberRsvpToken.objects.filter(user=guest).exists()
+
+    def test_recognized_does_not_extend_existing_token(
+        self, api_client, official_event, fake_email_sender
+    ):
+        guest = make_non_member("+14155550199", "guest@example.com")
+        other_event = make_official_event(title="Other Event", start_datetime=future_iso(days=45))
+        EventRSVP.objects.create(event=other_event, user=guest, status=RSVPStatus.ATTENDING)
+        existing_token = NonMemberRsvpToken.issue_or_extend(guest)
+        original_expires_at = existing_token.expires_at
+
         post(api_client, official_event, phone_number="+14155550199")
 
-        fake_email_sender.send.assert_called_once()
-        sent = fake_email_sender.send.call_args.kwargs
-        assert sent["to"] == "guest@example.com"
-        token = NonMemberRsvpToken.objects.get(user=guest)
-        assert token.token in sent["text"]
+        existing_token.refresh_from_db()
+        assert existing_token.expires_at == original_expires_at
+        fake_email_sender.send.assert_not_called()
 
     def test_recognized_without_email_falls_back_to_new(
         self, api_client, official_event, fake_email_sender


### PR DESCRIPTION
## Summary

- Fixes an unauthenticated info/email-abuse issue: the RECOGNIZED branch of `check_public_rsvp_phone` (`backend/community/_public_rsvp_submit.py`) sent a non-member's rsvp manage-link email and extended their token's expiry off a bare phone-number match, with no proof the caller controls that phone or email
- The phone-check endpoint's request schema has no email field, so there's no way to verify ownership at this step (unlike the sibling resend endpoint, which requires phone+email to match before sending). The fix removes the email/token side effect from the RECOGNIZED branch entirely — the endpoint still returns `status: "recognized"` so the frontend UX is unchanged, it just no longer fires an email or extends a token off a bare phone probe
- `already_rsvpd` branch and the resend endpoint are untouched, per the issue's scope

## Test plan

- [x] `uv run pytest backend/tests/test_public_rsvp_phone_check.py -q` — 12 passed (updated `test_recognized_sends_login_link_email` to assert no email/no token; added `test_recognized_does_not_extend_existing_token`)
- [x] `make agent-lint` — clean
- [x] `make agent-typecheck` — clean
- [ ] no frontend changes; no OpenAPI schema change (response shape unchanged), so `frontend-types` regen not needed

Closes #1007
