### PR TITLE
fix: 1008 - broadcast capacity change on non-member rsvp update/cancel

### DIFF
--- a/backend/community/_public_rsvp_manage.py
+++ b/backend/community/_public_rsvp_manage.py
@@ -12,7 +12,7 @@ from notifications.email_sender import get_email_sender
 from pydantic import BaseModel, Field
 from users.models import NonMemberRsvpToken, User
 
-from community._event_helpers import _event_out, promote_from_waitlist
+from community._event_helpers import _event_out, broadcast_capacity_change, promote_from_waitlist
 from community._event_rsvps import (
     _apply_rsvp_in_transaction,
     _post_rsvp_comment,
@@ -156,6 +156,7 @@ def update_my_rsvp(request, event_id, payload: PublicRsvpManageIn, token: str = 
     _post_rsvp_comment(event.id, user, final_status, payload.comment)
     _send_updated_email(request, event, user, rsvp_token.token)
     _email_promoted_non_members(request, event, promoted_user_ids)
+    broadcast_capacity_change(event.id)
 
     fresh_event = (
         Event.objects.select_related("created_by")
@@ -205,4 +206,5 @@ def delete_my_rsvp(request, event_id, token: str = ""):
         details={"user_id": str(user.pk)},
     )
     _email_promoted_non_members(request, event, promoted_user_ids)
+    broadcast_capacity_change(event.id)
     return Status(204, None)

--- a/backend/tests/test_public_rsvp_manage.py
+++ b/backend/tests/test_public_rsvp_manage.py
@@ -1,4 +1,5 @@
 import logging
+from unittest.mock import patch
 
 import pytest
 from community.models import (
@@ -217,6 +218,18 @@ class TestPostMyRsvps:
         )
         assert resp.status_code == 404
 
+    def test_update_broadcasts_capacity_change(self, api_client, nonmember, official_event):
+        EventRSVP.objects.create(event=official_event, user=nonmember, status=RSVPStatus.ATTENDING)
+        token = NonMemberRsvpToken.issue_or_extend(nonmember)
+        with patch("community._public_rsvp_manage.broadcast_capacity_change") as mock_broadcast:
+            api_client.post(
+                f"{_post_url(official_event)}?token={token.token}",
+                {"status": RSVPStatus.MAYBE},
+                content_type="application/json",
+            )
+        mock_broadcast.assert_called_once()
+        assert mock_broadcast.call_args.args[0] == official_event.id
+
 
 @pytest.mark.django_db
 class TestDeleteMyRsvps:
@@ -256,6 +269,14 @@ class TestDeleteMyRsvps:
     def test_delete_bad_token_404(self, api_client, official_event):
         resp = api_client.delete(f"{_post_url(official_event)}?token=nope")
         assert resp.status_code == 404
+
+    def test_delete_broadcasts_capacity_change(self, api_client, nonmember, official_event):
+        EventRSVP.objects.create(event=official_event, user=nonmember, status=RSVPStatus.ATTENDING)
+        token = NonMemberRsvpToken.issue_or_extend(nonmember)
+        with patch("community._public_rsvp_manage.broadcast_capacity_change") as mock_broadcast:
+            api_client.delete(f"{_post_url(official_event)}?token={token.token}")
+        mock_broadcast.assert_called_once()
+        assert mock_broadcast.call_args.args[0] == official_event.id
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary

- `update_my_rsvp` and `delete_my_rsvp` (`backend/community/_public_rsvp_manage.py`) now call `broadcast_capacity_change(event.id)` after commit, matching every other RSVP mutation entrypoint (`submit_public_rsvp`, `upsert_rsvp`, `delete_rsvp`).
- Previously, a non-member freeing a spot or cancelling via the public manage form did not push an `event_updated` SSE ping, so other viewers' spots-left / attending / waitlist counts went stale until a manual refetch.
- Non-members aren't SSE-subscribed by user id, so the call omits `exclude_user_ids` — mirroring `submit_public_rsvp`'s existing call signature.

Closes #1008

## Test plan

- [x] Added `test_update_broadcasts_capacity_change` and `test_delete_broadcasts_capacity_change` to `backend/tests/test_public_rsvp_manage.py`, asserting `broadcast_capacity_change` is invoked with the event id (mirroring the existing member-path assertions in `test_rsvp.py` / `test_public_rsvp.py`).
- [x] `uv run pytest backend/tests/test_public_rsvp_manage.py -q` — 30 passed
- [x] `uv run pytest backend/tests/test_public_rsvp.py backend/tests/test_rsvp.py -q` — 65 passed
- [x] `make agent-lint` — clean
- [x] `make agent-typecheck` — clean
