### PR TITLE
fix: 1010 - surface actionable rsvp submit error messages

### DIFF
--- a/frontend/src/screens/events/PublicRsvpForm.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.test.tsx
@@ -222,6 +222,36 @@ describe('PublicRsvpForm', () => {
     await screen.findByText("you're rsvping too fast — try again in a few minutes");
   });
 
+  it('surfaces the backend message from a 400 response', async () => {
+    submitMutate.mockRejectedValue({
+      isAxiosError: true,
+      response: { status: 400, data: { detail: "this event is full — you can't bring a +1" } },
+    });
+    renderForm();
+    await fillRequired();
+    fireEvent.click(screen.getByRole('button', { name: 'rsvp' }));
+    await screen.findByText("this event is full — you can't bring a +1");
+  });
+
+  it('surfaces the backend message from a 422 response', async () => {
+    submitMutate.mockRejectedValue({
+      isAxiosError: true,
+      response: { status: 422, data: { detail: 'name contains invalid characters' } },
+    });
+    renderForm();
+    await fillRequired();
+    fireEvent.click(screen.getByRole('button', { name: 'rsvp' }));
+    await screen.findByText('name contains invalid characters');
+  });
+
+  it('falls back to the generic message when a 400 has no actionable body', async () => {
+    submitMutate.mockRejectedValue({ isAxiosError: true, response: { status: 400 } });
+    renderForm();
+    await fillRequired();
+    fireEvent.click(screen.getByRole('button', { name: 'rsvp' }));
+    await screen.findByText('something went wrong — try again');
+  });
+
   it('renders the hidden honeypot field', async () => {
     checkPhoneMutate.mockResolvedValue({ status: 'new', rsvp_token: '' });
     renderForm();

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -45,7 +45,6 @@ function messageForStatus(status: number | null, err: unknown): SubmitError {
   if (status === 404) {
     return { text: "this event isn't accepting public rsvps anymore — refresh", showSignIn: false };
   }
-  // 400/422 carry an actionable backend message (event full, invalid name, etc.)
   return { text: extractApiErrorOr(err, 'something went wrong — try again'), showSignIn: false };
 }
 

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -1,7 +1,7 @@
 import { type SyntheticEvent, useState } from 'react';
 import { Link } from 'react-router-dom';
 
-import { getApiStatus } from '@/api/apiErrors';
+import { extractApiErrorOr, getApiStatus } from '@/api/apiErrors';
 import { type PublicRsvpOut, useSubmitPublicRsvp } from '@/api/publicRsvp';
 import { Button } from '@/components/ui/Button';
 import { Honeypot } from '@/components/ui/Honeypot';
@@ -35,7 +35,7 @@ interface SubmitError {
   showSignIn: boolean;
 }
 
-function messageForStatus(status: number | null): SubmitError {
+function messageForStatus(status: number | null, err: unknown): SubmitError {
   if (status === 409) {
     return { text: 'looks like you already have an account — sign in to rsvp', showSignIn: true };
   }
@@ -45,7 +45,8 @@ function messageForStatus(status: number | null): SubmitError {
   if (status === 404) {
     return { text: "this event isn't accepting public rsvps anymore — refresh", showSignIn: false };
   }
-  return { text: 'something went wrong — try again', showSignIn: false };
+  // 400/422 carry an actionable backend message (event full, invalid name, etc.)
+  return { text: extractApiErrorOr(err, 'something went wrong — try again'), showSignIn: false };
 }
 
 function statusLabel(status: RsvpInputStatus, atCapacity: boolean): string {
@@ -99,7 +100,7 @@ export function PublicRsvpForm({ event, onSuccess, onMember }: Props) {
       });
       onSuccess(result);
     } catch (err) {
-      setSubmitError(messageForStatus(getApiStatus(err)));
+      setSubmitError(messageForStatus(getApiStatus(err), err));
     }
   }
 


### PR DESCRIPTION
## summary

- `messageForStatus()` in `PublicRsvpForm.tsx` only special-cased 409/429/404 and fell through to a generic "something went wrong" message for every other status, including 400 and 422.
- Backend 400/422 responses (e.g. `NO_PLUS_ONE_SPOTS` when an event is at capacity, or `validate_display_name` rejecting invalid characters) carry an actionable `ErrorOut.detail` message that was being discarded.
- `PublicRsvpCard.errorMessage()` already solves this correctly via `extractApiErrorOr` — this change brings `PublicRsvpForm` in line with that existing pattern.

## changes

- `frontend/src/screens/events/PublicRsvpForm.tsx`: `messageForStatus` now uses `extractApiErrorOr` for the 400/422 fallthrough case instead of a hardcoded generic string. 409/429/404 special-casing is unchanged.
- `frontend/src/screens/events/PublicRsvpForm.test.tsx`: added tests for a 400 with an actionable body, a 422 with an actionable body, and a 400 with no body (falls back to the generic message).

Closes #1010

## test plan

- [x] `pnpm exec vitest run src/screens/events/PublicRsvpForm.test.tsx` — 21 passed
- [x] `make agent-frontend-typecheck` — clean
- [x] `make agent-frontend-lint` — clean
- [ ] backend tests not run (frontend-only change; backend untouched)
