### PR TITLE
fix: 1009 - stop rsvp phone-check recognized status on ineligible-only rsvp

### DIFF
--- a/backend/community/_public_rsvp_submit.py
+++ b/backend/community/_public_rsvp_submit.py
@@ -5,6 +5,7 @@ from config.audit import audit_log
 from config.ratelimit import client_ip, rate_limit
 from django.conf import settings
 from django.db import IntegrityError, transaction
+from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
 from notifications._email_helpers import send_rsvp_confirmation_email, send_rsvp_manage_link_email
@@ -30,6 +31,7 @@ from community._public_rsvp_shared import (
 from community._shared import ErrorOut, validate_display_name
 from community._validation import Code, ValidationException, raise_validation
 from community.models import Event, RSVPStatus
+from community.models.event import public_rsvp_eligible_q
 
 router = Router()
 
@@ -209,7 +211,10 @@ def check_public_rsvp_phone(request, event_id, payload: PublicRsvpPhoneCheckIn):
         if user.email:
             _send_recognized_login_link(request, user)
         return Status(200, PublicRsvpPhoneCheckOut(status=PublicRsvpPhoneStatus.ALREADY_RSVPD))
-    if user.email and user.event_rsvps.exists():
+    has_eligible_rsvp = user.event_rsvps.filter(
+        public_rsvp_eligible_q(timezone.now(), prefix="event__")
+    ).exists()
+    if user.email and has_eligible_rsvp:
         _send_recognized_login_link(request, user)
         return Status(200, PublicRsvpPhoneCheckOut(status=PublicRsvpPhoneStatus.RECOGNIZED))
     return Status(200, PublicRsvpPhoneCheckOut(status=PublicRsvpPhoneStatus.NEW))

--- a/backend/tests/test_public_rsvp_phone_check.py
+++ b/backend/tests/test_public_rsvp_phone_check.py
@@ -124,6 +124,21 @@ class TestPublicRsvpPhoneCheck:
         token = NonMemberRsvpToken.objects.get(user=guest)
         assert token.token in sent["text"]
 
+    def test_rsvp_on_ineligible_event_falls_back_to_new(
+        self, api_client, official_event, fake_email_sender
+    ):
+        guest = make_non_member("+14155550199", "guest@example.com")
+        ineligible_event = make_official_event(
+            title="Past Event", start_datetime=future_iso(days=45), rsvp_enabled=False
+        )
+        EventRSVP.objects.create(event=ineligible_event, user=guest, status=RSVPStatus.ATTENDING)
+
+        response = post(api_client, official_event, phone_number="+14155550199")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "new"
+        fake_email_sender.send.assert_not_called()
+
     def test_recognized_without_email_falls_back_to_new(
         self, api_client, official_event, fake_email_sender
     ):


### PR DESCRIPTION
## Overview

`check_public_rsvp_phone`'s RECOGNIZED gate used `user.event_rsvps.exists()` — unfiltered, so it was true even when the non-member's only prior RSVP was on an event that's no longer public-RSVP-eligible (past, cancelled, or `rsvp_enabled` turned off). That non-member got told "recognized" and emailed a manage link, but the `/my-rsvps` manage list (which correctly filters via `public_rsvp_eligible_q`) would show zero RSVPs — a dead end, and it blocked them from falling through to the NEW flow to actually RSVP to the event they were currently trying to RSVP to.

This filters the RECOGNIZED check with the same `public_rsvp_eligible_q(timezone.now(), prefix="event__")` used by `_eligible_event_rsvps` in `_public_rsvp_manage.py`, so RECOGNIZED (and the email) only fires when there's at least one actionable RSVP to manage.

Scoped narrowly to the `event_rsvps.exists()` check — the neighboring `already_rsvpd` and `is_member` branches are untouched, and the per-user email cooldown added in #1018 (Issue 1007) is unaffected.

Closes #1009

## Test plan

- [x] Added `test_rsvp_on_ineligible_event_falls_back_to_new` — non-member with an rsvp-disabled prior event now gets `status: "new"` (was `"recognized"`) and no email is sent
- [x] Confirmed the new test fails against pre-fix code (`recognized` instead of `new`)
- [x] `uv run pytest backend/tests/test_public_rsvp_phone_check.py -q` — 12/12 passing
- [x] `make agent-lint` — clean
- [x] `make agent-typecheck` — clean