### PR TITLE
fix: 1011 - gate delete_my_rsvp on cancelled events

### DIFF
--- a/backend/community/_public_rsvp_manage.py
+++ b/backend/community/_public_rsvp_manage.py
@@ -192,6 +192,8 @@ def delete_my_rsvp(request, event_id, token: str = ""):
         rsvp = EventRSVP.objects.filter(event=event, user=user).first()
         if not rsvp:
             raise_validation(Code.Event.RSVP_NOT_FOUND, status_code=404)
+        if event.is_cancelled:
+            raise_validation(Code.Event.RSVPS_CLOSED_CANCELLED, status_code=400)
         was_attending = rsvp.status == RSVPStatus.ATTENDING
         rsvp.delete()
         if was_attending:

--- a/backend/tests/test_public_rsvp_manage.py
+++ b/backend/tests/test_public_rsvp_manage.py
@@ -2,6 +2,7 @@ import logging
 from unittest.mock import patch
 
 import pytest
+from community._validation import Code
 from community.models import (
     EventRSVP,
     EventStatus,
@@ -13,7 +14,7 @@ from django.utils import timezone
 from notifications.email_sender import SendResult
 from users.models import NonMemberRsvpToken
 
-from tests._public_rsvp_helpers import make_non_member, make_official_event
+from tests._public_rsvp_helpers import first_code, make_non_member, make_official_event
 from tests.conftest import future_iso, past_iso
 
 GET_URL = "/api/community/public/my-rsvps/"
@@ -277,6 +278,27 @@ class TestDeleteMyRsvps:
             api_client.delete(f"{_post_url(official_event)}?token={token.token}")
         mock_broadcast.assert_called_once()
         assert mock_broadcast.call_args.args[0] == official_event.id
+
+    def test_delete_on_cancelled_event_rejected(
+        self, api_client, nonmember, official_event, fake_email_sender
+    ):
+        official_event.max_attendees = 1
+        official_event.save(update_fields=["max_attendees"])
+        EventRSVP.objects.create(event=official_event, user=nonmember, status=RSVPStatus.ATTENDING)
+        waiter = make_non_member("+14155550003", "w2@example.com", name="waiter two")
+        EventRSVP.objects.create(event=official_event, user=waiter, status=RSVPStatus.WAITLISTED)
+        official_event.status = EventStatus.CANCELLED
+        official_event.save(update_fields=["status"])
+        token = NonMemberRsvpToken.issue_or_extend(nonmember)
+
+        resp = api_client.delete(f"{_post_url(official_event)}?token={token.token}")
+
+        assert resp.status_code == 400
+        assert first_code(resp) == Code.Event.RSVPS_CLOSED_CANCELLED
+        assert EventRSVP.objects.filter(event=official_event, user=nonmember).exists()
+        waiter_rsvp = EventRSVP.objects.get(event=official_event, user=waiter)
+        assert waiter_rsvp.status == RSVPStatus.WAITLISTED
+        fake_email_sender.send.assert_not_called()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Overview

`delete_my_rsvp` in `backend/community/_public_rsvp_manage.py` fetched the event by id with only a `None` check — unlike its sibling `update_my_rsvp`, which routes through `_load_public_rsvp_event` (`_public_rsvp_shared.py`) and 404s any event that's cancelled, past, or otherwise public-RSVP-ineligible.

This let a non-member delete their RSVP on a **CANCELLED** event. If they were `ATTENDING`, the delete called `promote_from_waitlist(event)`, flipping a waitlisted non-member to `ATTENDING` and sending them a "spot opened up" email — on a dead/cancelled event that should be frozen.

Per the issue's severity note, this fix is scoped narrowly to the cancelled-event case (the "clean, reproducible defect"). It does **not** add an `is_past` check or swap in the full `_load_public_rsvp_event` — the broader claims (members-only/community routing, past-with-editor) were called out as muddier and out of scope, and swapping in the shared loader risks breaking legitimate deletes on already-past-but-not-cancelled events.

The fix mirrors the existing member-side guard in `_delete_rsvp_in_transaction` (`backend/community/_event_rsvps.py`), reusing the same `Code.Event.RSVPS_CLOSED_CANCELLED` error (400) rather than inventing a new one.

Closes #1011

## Test plan

- [x] Added `test_delete_on_cancelled_event_rejected` in `backend/tests/test_public_rsvp_manage.py`: fills a max-1 event with an attending non-member, waitlists a second, cancels the event, then asserts the DELETE returns 400 `RSVPS_CLOSED_CANCELLED`, the RSVP is not deleted, the waitlisted user is not promoted, and no email is sent
- [x] Confirmed the new test fails against pre-fix code (204 instead of 400)
- [x] `uv run pytest backend/tests/test_public_rsvp_manage.py -q` — 31/31 passing, including existing legitimate-delete-on-active-event tests (`test_delete_removes_rsvp`, `test_delete_promotes_waitlist`)
- [x] `make agent-lint` — clean
- [x] `make agent-typecheck` — clean