### PR TITLE
fix(events): gate delete_my_rsvp on full rsvp eligibility (Issue 1011)

### DIFF
--- a/backend/community/_public_rsvp_manage.py
+++ b/backend/community/_public_rsvp_manage.py
@@ -173,7 +173,7 @@ def update_my_rsvp(request, event_id, payload: PublicRsvpManageIn, token: str = 
 
 @router.delete(
     "/public/my-rsvps/{event_id}/",
-    response={204: None, 404: ErrorOut, 429: ErrorOut},
+    response={204: None, 400: ErrorOut, 404: ErrorOut, 429: ErrorOut},
     auth=None,
 )
 @rate_limit(key_func=client_ip, rate="30/h")
@@ -181,19 +181,10 @@ def delete_my_rsvp(request, event_id, token: str = ""):
     user = _resolve_token_user(token)
     promoted_user_ids: list[str] = []
     with transaction.atomic():
-        event = (
-            Event.objects.select_for_update()
-            .prefetch_related("co_hosts", "invited_users")
-            .filter(id=event_id)
-            .first()
-        )
-        if event is None:
-            raise_validation(Code.Event.NOT_FOUND, status_code=404)
+        event = _load_public_rsvp_event(event_id, for_update=True)
         rsvp = EventRSVP.objects.filter(event=event, user=user).first()
         if not rsvp:
             raise_validation(Code.Event.RSVP_NOT_FOUND, status_code=404)
-        if event.is_cancelled:
-            raise_validation(Code.Event.RSVPS_CLOSED_CANCELLED, status_code=400)
         was_attending = rsvp.status == RSVPStatus.ATTENDING
         rsvp.delete()
         if was_attending:

--- a/backend/community/_public_rsvp_shared.py
+++ b/backend/community/_public_rsvp_shared.py
@@ -28,10 +28,13 @@ class PublicRsvpOut(BaseModel):
     rsvp_token: str
 
 
-def _load_public_rsvp_event(event_id) -> Event:
+def _load_public_rsvp_event(event_id, *, for_update: bool = False) -> Event:
     """Fetch a public-RSVP event: 404 if it can't be seen at all, else 400 with the
     specific reason if it's visible but closed — mirrors _validate_rsvp_access."""
-    event = Event.objects.prefetch_related("co_hosts", "invited_users").filter(id=event_id).first()
+    qs = Event.objects.prefetch_related("co_hosts", "invited_users")
+    if for_update:
+        qs = qs.select_for_update()
+    event = qs.filter(id=event_id).first()
     if event is None or not event.is_public_rsvp_visible:
         raise_validation(Code.Event.NOT_FOUND, status_code=404)
     if not event.rsvp_enabled:

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -11742,6 +11742,16 @@
           "204": {
             "description": "No Content"
           },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
           "404": {
             "content": {
               "application/json": {

--- a/backend/tests/test_public_rsvp_manage.py
+++ b/backend/tests/test_public_rsvp_manage.py
@@ -300,6 +300,37 @@ class TestDeleteMyRsvps:
         assert waiter_rsvp.status == RSVPStatus.WAITLISTED
         fake_email_sender.send.assert_not_called()
 
+    def test_delete_on_past_event_rejected(self, api_client, nonmember, fake_email_sender):
+        past_event = make_official_event(
+            title="Past", start_datetime=past_iso(days=2), end_datetime=past_iso(days=1)
+        )
+        past_event.max_attendees = 1
+        past_event.save(update_fields=["max_attendees"])
+        EventRSVP.objects.create(event=past_event, user=nonmember, status=RSVPStatus.ATTENDING)
+        waiter = make_non_member("+14155550004", "w3@example.com", name="waiter three")
+        EventRSVP.objects.create(event=past_event, user=waiter, status=RSVPStatus.WAITLISTED)
+        token = NonMemberRsvpToken.issue_or_extend(nonmember)
+
+        resp = api_client.delete(f"{_post_url(past_event)}?token={token.token}")
+
+        assert resp.status_code == 400
+        assert first_code(resp) == Code.Event.RSVPS_CLOSED_PAST
+        assert EventRSVP.objects.filter(event=past_event, user=nonmember).exists()
+        assert EventRSVP.objects.get(event=past_event, user=waiter).status == RSVPStatus.WAITLISTED
+        fake_email_sender.send.assert_not_called()
+
+    def test_delete_on_rsvp_disabled_event_rejected(self, api_client, nonmember, fake_email_sender):
+        event = make_official_event(title="No RSVP", rsvp_enabled=False)
+        EventRSVP.objects.create(event=event, user=nonmember, status=RSVPStatus.ATTENDING)
+        token = NonMemberRsvpToken.issue_or_extend(nonmember)
+
+        resp = api_client.delete(f"{_post_url(event)}?token={token.token}")
+
+        assert resp.status_code == 400
+        assert first_code(resp) == Code.Event.RSVPS_NOT_ENABLED
+        assert EventRSVP.objects.filter(event=event, user=nonmember).exists()
+        fake_email_sender.send.assert_not_called()
+
 
 @pytest.mark.django_db
 class TestPublicRsvpManageComment:

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -8737,6 +8737,15 @@ export interface operations {
                 };
                 content?: never;
             };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
             /** @description Not Found */
             404: {
                 headers: {


### PR DESCRIPTION
## Overview

Follow-up to #1025 (Issue 1011). That PR gated `delete_my_rsvp` on **cancelled** events only, explicitly punting on the other ineligible states. But `delete_my_rsvp` was still the only one of the three public-RSVP endpoints not routing through the shared eligibility gate:

| state | `update_my_rsvp` | `list_my_rsvps` | `delete_my_rsvp` (before) |
|---|---|---|---|
| cancelled | 400 | hidden | ✅ 400 (#1025) |
| **past** | 400 | hidden | ❌ 204 + promotes |
| **rsvp-disabled** | 400 | hidden | ❌ 204 + promotes |
| **not visible** | 404 | hidden | ❌ 204 + promotes |

So a non-member holding a token could still `DELETE` on a **past** or otherwise-ineligible event, and if they were `ATTENDING`, `promote_from_waitlist` flipped a waitlisted non-member to `ATTENDING` and emailed them a "spot opened up" — the exact dead-event promotion #1025 was closing, reachable through a different ineligible state. `list_my_rsvps` already hides these events, so there's no legitimate delete flow that returned 204 here.

## Change

Route `delete_my_rsvp` through `_load_public_rsvp_event` (the same gate `update_my_rsvp` uses), adding a `for_update` flag so it keeps the `select_for_update` the waitlist promotion needs. This collapses the ad-hoc `event is None` + `is_cancelled` checks into the shared gate and covers every ineligible state at once — 404 for not-visible, 400 with the specific reason for cancelled/past/rsvp-disabled — matching `update_my_rsvp` exactly.

## Test plan

- [x] Added `test_delete_on_past_event_rejected` and `test_delete_on_rsvp_disabled_event_rejected`: each fills an event, waitlists a second non-member where applicable, and asserts the DELETE returns 400 with the right code, the RSVP is not deleted, no waitlist promotion, and no email is sent
- [x] Existing `test_delete_on_cancelled_event_rejected` and legitimate-delete tests still pass
- [x] `uv run pytest tests/test_public_rsvp_manage.py` — 33/33 passing (was 31)
- [x] `ruff check` + `ruff format --check` — clean

Closes #1011 (fully — #1025 addressed the cancelled slice).
