### PR TITLE
test(rsvp): pin public rsvp token exposure + recognized-phone e2e

### DIFF
--- a/backend/community/management/commands/e2e_seed.py
+++ b/backend/community/management/commands/e2e_seed.py
@@ -102,6 +102,22 @@ def _seed_public_returning() -> dict:
     }
 
 
+def _seed_public_recognized() -> dict:
+    # A non-member with an email and a prior RSVP on a DIFFERENT eligible event,
+    # but no token on this device — entering their phone should be RECOGNIZED and
+    # trigger a manage-link email rather than the new-contact form.
+    prior_event = _random_event("public-recognized-prior")
+    target_event = _random_event("public-recognized")
+    phone = _random_phone()
+    user = _non_member_user(phone)
+    EventRSVP.objects.create(event=prior_event, user=user, status=RSVPStatus.ATTENDING)
+    return {
+        "event_id": str(target_event.id),
+        "event_title": target_event.title,
+        "user_phone": phone,
+    }
+
+
 def _seed_comments() -> dict:
     event = _random_event("comments")
     phone = _random_phone()
@@ -138,6 +154,7 @@ def _seed_live_updates() -> dict:
 SCENARIOS = {
     "member": _seed_member,
     "public-new": _seed_public_new,
+    "public-recognized": _seed_public_recognized,
     "public-returning": _seed_public_returning,
     "comments": _seed_comments,
     "my-rsvps": _seed_my_rsvps,

--- a/backend/community/management/commands/e2e_seed.py
+++ b/backend/community/management/commands/e2e_seed.py
@@ -103,9 +103,7 @@ def _seed_public_returning() -> dict:
 
 
 def _seed_public_recognized() -> dict:
-    # A non-member with an email and a prior RSVP on a DIFFERENT eligible event,
-    # but no token on this device — entering their phone should be RECOGNIZED and
-    # trigger a manage-link email rather than the new-contact form.
+    # non-member with an email, no token on this device
     prior_event = _random_event("public-recognized-prior")
     target_event = _random_event("public-recognized")
     phone = _random_phone()

--- a/backend/tests/test_public_rsvp_token_exposure.py
+++ b/backend/tests/test_public_rsvp_token_exposure.py
@@ -1,0 +1,94 @@
+"""Regression tests for manage-token exposure in the public RSVP submit response.
+
+The submit endpoint (POST /api/community/public/events/{event_id}/rsvp/) backs each
+RSVP with a NonMemberRsvpToken. The token is a scoped magic link granting read/write
+over that user's RSVP identity via /public/my-rsvps/. Whether it may appear in the
+HTTP response body — versus being delivered only by email to the address on file —
+depends on whether the submitter proved control of the resolved account.
+
+These tests pin the current behaviour so the account-takeover surface (issue 1029)
+is visible and any change to it is deliberate. They assert on the exact response
+key `rsvp_token` (the earlier happy-path test checked `"token" not in body`, which
+never matches that key and so silently passed while the token was present).
+"""
+
+import pytest
+from community.models import EventRSVP, RSVPStatus
+from users.models import NonMemberRsvpToken
+
+from tests._public_rsvp_helpers import make_non_member, make_official_event, post
+
+
+@pytest.fixture
+def official_event(db):
+    return make_official_event(
+        location="123 Vegan Way", whatsapp_link="https://chat.whatsapp.com/abc123"
+    )
+
+
+def _manage(api_client, token: str):
+    return api_client.get(f"/api/community/public/my-rsvps/?token={token}")
+
+
+@pytest.mark.django_db
+class TestSubmitTokenExposure:
+    def test_body_carries_the_rsvp_token_key(self, api_client, official_event, fake_email_sender):
+        # A brand-new submitter proved control of the phone they entered, so the
+        # token in the body unlocks only their own just-created RSVP.
+        body = post(api_client, official_event).json()
+        assert "rsvp_token" in body
+
+    def test_phone_match_returns_a_token_scoped_to_the_existing_row(
+        self, api_client, official_event, fake_email_sender
+    ):
+        # An existing non-member matched by PHONE. Whoever submitted controls that
+        # phone number, so scoping the token to the matched row is defensible —
+        # but the token IS handed back in the body (issue 1029). Pin it.
+        existing = make_non_member("+14155550123", "old@example.com")
+
+        body = post(api_client, official_event, email="attacker@example.com").json()
+
+        returned = body["rsvp_token"]
+        assert returned  # non-empty token in the body today
+        assert NonMemberRsvpToken.resolve_user(returned) == existing
+
+    def test_email_only_match_hands_back_a_token_for_a_row_the_caller_may_not_own(
+        self, api_client, official_event, fake_email_sender
+    ):
+        # THE takeover vector (issue 1029): the submitter supplies a fresh phone
+        # they control plus a VICTIM'S email. phone_match is None, email_match is
+        # the victim, and the body returns a live token bound to the victim — with
+        # no proof the caller owns that email. This test documents the current
+        # (vulnerable) behaviour; when 1029 is fixed, flip the assertions to expect
+        # an empty rsvp_token and an emailed link instead.
+        victim = make_non_member("+14155550999", "victim@example.com", name="Victim Person")
+
+        body = post(
+            api_client,
+            official_event,
+            phone_number="+14155550123",  # attacker's own fresh number
+            email="victim@example.com",  # the victim's email
+        ).json()
+
+        returned = body["rsvp_token"]
+        assert returned
+        # The token resolves to the VICTIM, and the RSVP landed on the victim's row.
+        assert NonMemberRsvpToken.resolve_user(returned) == victim
+        assert EventRSVP.objects.filter(event=official_event, user=victim).exists()
+
+        # And that token is a working credential over the victim's identity.
+        manage = _manage(api_client, returned)
+        assert manage.status_code == 200
+        assert manage.json()["user"]["email"] == "victim@example.com"
+
+    def test_returned_token_grants_manage_access(
+        self, api_client, official_event, fake_email_sender
+    ):
+        body = post(api_client, official_event).json()
+        manage = _manage(api_client, body["rsvp_token"])
+        assert manage.status_code == 200
+        assert manage.json()["user"]["phone_number"] == "+14155550123"
+        assert any(
+            r["event"]["id"] == str(official_event.id) and r["status"] == RSVPStatus.ATTENDING
+            for r in manage.json()["rsvps"]
+        )

--- a/backend/tests/test_public_rsvp_token_exposure.py
+++ b/backend/tests/test_public_rsvp_token_exposure.py
@@ -1,17 +1,3 @@
-"""Regression tests for manage-token exposure in the public RSVP submit response.
-
-The submit endpoint (POST /api/community/public/events/{event_id}/rsvp/) backs each
-RSVP with a NonMemberRsvpToken. The token is a scoped magic link granting read/write
-over that user's RSVP identity via /public/my-rsvps/. Whether it may appear in the
-HTTP response body — versus being delivered only by email to the address on file —
-depends on whether the submitter proved control of the resolved account.
-
-These tests pin the current behaviour so the account-takeover surface (issue 1029)
-is visible and any change to it is deliberate. They assert on the exact response
-key `rsvp_token` (the earlier happy-path test checked `"token" not in body`, which
-never matches that key and so silently passed while the token was present).
-"""
-
 import pytest
 from community.models import EventRSVP, RSVPStatus
 from users.models import NonMemberRsvpToken
@@ -33,50 +19,38 @@ def _manage(api_client, token: str):
 @pytest.mark.django_db
 class TestSubmitTokenExposure:
     def test_body_carries_the_rsvp_token_key(self, api_client, official_event, fake_email_sender):
-        # A brand-new submitter proved control of the phone they entered, so the
-        # token in the body unlocks only their own just-created RSVP.
         body = post(api_client, official_event).json()
         assert "rsvp_token" in body
 
     def test_phone_match_returns_a_token_scoped_to_the_existing_row(
         self, api_client, official_event, fake_email_sender
     ):
-        # An existing non-member matched by PHONE. Whoever submitted controls that
-        # phone number, so scoping the token to the matched row is defensible —
-        # but the token IS handed back in the body (issue 1029). Pin it.
         existing = make_non_member("+14155550123", "old@example.com")
 
         body = post(api_client, official_event, email="attacker@example.com").json()
 
         returned = body["rsvp_token"]
-        assert returned  # non-empty token in the body today
+        assert returned
         assert NonMemberRsvpToken.resolve_user(returned) == existing
 
     def test_email_only_match_hands_back_a_token_for_a_row_the_caller_may_not_own(
         self, api_client, official_event, fake_email_sender
     ):
-        # THE takeover vector (issue 1029): the submitter supplies a fresh phone
-        # they control plus a VICTIM'S email. phone_match is None, email_match is
-        # the victim, and the body returns a live token bound to the victim — with
-        # no proof the caller owns that email. This test documents the current
-        # (vulnerable) behaviour; when 1029 is fixed, flip the assertions to expect
-        # an empty rsvp_token and an emailed link instead.
+        # issue 1029: fresh phone + victim's email → token bound to the victim, no proof of ownership
         victim = make_non_member("+14155550999", "victim@example.com", name="Victim Person")
 
         body = post(
             api_client,
             official_event,
-            phone_number="+14155550123",  # attacker's own fresh number
-            email="victim@example.com",  # the victim's email
+            phone_number="+14155550123",
+            email="victim@example.com",
         ).json()
 
         returned = body["rsvp_token"]
         assert returned
-        # The token resolves to the VICTIM, and the RSVP landed on the victim's row.
         assert NonMemberRsvpToken.resolve_user(returned) == victim
         assert EventRSVP.objects.filter(event=official_event, user=victim).exists()
 
-        # And that token is a working credential over the victim's identity.
         manage = _manage(api_client, returned)
         assert manage.status_code == 200
         assert manage.json()["user"]["email"] == "victim@example.com"

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -12,6 +12,7 @@ export interface SeedScenarioMap {
     access_token: string;
   };
   'public-new': { event_id: string; event_title: string; event_location: string };
+  'public-recognized': { event_id: string; event_title: string; user_phone: string };
   'public-returning': {
     event_id: string;
     event_title: string;

--- a/frontend/e2e/fixtures.ts
+++ b/frontend/e2e/fixtures.ts
@@ -38,9 +38,7 @@ const ROOT_DIR = path.resolve(__dirname, '../..');
 const BACKEND_DIR = path.resolve(ROOT_DIR, 'backend');
 
 function resolveDatabaseUrl(): string {
-  // CI sets DATABASE_URL to the shared `pda` database the backend serves from;
-  // honor it directly. Locally it's unset, so fall back to the per-worktree
-  // Postgres name that `make dev-pg` runs against.
+  // falls back to per-worktree postgres (make dev-pg) when DATABASE_URL is unset locally
   if (process.env.DATABASE_URL) {
     return process.env.DATABASE_URL;
   }

--- a/frontend/e2e/rsvp-public-recognized.spec.ts
+++ b/frontend/e2e/rsvp-public-recognized.spec.ts
@@ -2,7 +2,7 @@ import { expect, test } from '@playwright/test';
 
 import { seed } from './fixtures';
 
-test('recognized non-member (prior rsvp, no stored token) is emailed a link, not re-asked', async ({
+test('non-member with email, no stored token, is emailed a link and not re-asked', async ({
   page,
 }) => {
   const { event_id, event_title, user_phone } = seed('public-recognized');
@@ -15,8 +15,6 @@ test('recognized non-member (prior rsvp, no stored token) is emailed a link, not
   await rsvpSection.getByLabel('phone number').pressSequentially(user_phone.replace('+1', ''));
   await rsvpSection.getByRole('button', { name: 'continue' }).click();
 
-  // Their phone is recognized from a prior rsvp, so the flow stops at the
-  // "check your email" step instead of showing the new-contact form.
   await expect(rsvpSection.getByText('we recognized your number', { exact: false })).toBeVisible();
   await expect(rsvpSection.getByLabel('first name')).toBeHidden();
 });

--- a/frontend/e2e/rsvp-public-recognized.spec.ts
+++ b/frontend/e2e/rsvp-public-recognized.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test';
+
+import { seed } from './fixtures';
+
+test('recognized non-member (prior rsvp, no stored token) is emailed a link, not re-asked', async ({
+  page,
+}) => {
+  const { event_id, event_title, user_phone } = seed('public-recognized');
+
+  await page.goto(`/events/${event_id}`);
+  await expect(page.getByRole('heading', { name: event_title })).toBeVisible();
+
+  const rsvpSection = page.getByLabel('rsvp');
+  await rsvpSection.getByRole('button', { name: "i'm going" }).click();
+  await rsvpSection.getByLabel('phone number').pressSequentially(user_phone.replace('+1', ''));
+  await rsvpSection.getByRole('button', { name: 'continue' }).click();
+
+  // Their phone is recognized from a prior rsvp, so the flow stops at the
+  // "check your email" step instead of showing the new-contact form.
+  await expect(rsvpSection.getByText('we recognized your number', { exact: false })).toBeVisible();
+  await expect(rsvpSection.getByLabel('first name')).toBeHidden();
+});


### PR DESCRIPTION
## overview

hardens the public / non-member rsvp e2e + regression coverage, from a full re-audit of the flow (epic #999). test-only — no product code changed.

### what's added
- **`backend/tests/test_public_rsvp_token_exposure.py`** — pins the current manage-token exposure on the public submit endpoint (Issue 1029). the earlier happy-path guard asserted `"token" not in body`, which never matches the real `rsvp_token` key and so silently passed while the token was present; these tests assert on the actual key and document the email-only takeover vector so any change to it is deliberate.
- **`public-recognized` e2e scenario + `rsvp-public-recognized.spec.ts`** — covers the recognized-phone caller (prior rsvp on file, no stored token → "we recognized your number, check your email" step, not the new-contact form), which the suite did not exercise.

### verified locally
- `test_public_rsvp_token_exposure.py` + existing `test_public_rsvp*.py` / `test_public_rsvp_archived.py` — **46 passed** together (sqlite).
- frontend `tsc --noEmit`, eslint, prettier — clean.
- `e2e_seed public-recognized` emits valid JSON.
- the playwright spec itself needs the live stack (Vite+Django+PG), so it runs here in CI — mirrors the existing `rsvp-public-member-gate` spec shape.

### notes
- when Issue 1029 (submit token-in-body takeover) is fixed, flip the email-only assertions in the exposure test to expect `rsvp_token == ""` + an emailed link.
- part of the round-2 re-audit under epic #999 (findings #1029–#1034).

related: Issue 1029
