### PR TITLE
feat(rsvp): wire up phone-only resend-manage-link ui (Issue 1031)

### DIFF
--- a/backend/community/_public_rsvp_resend.py
+++ b/backend/community/_public_rsvp_resend.py
@@ -26,7 +26,8 @@ _NEUTRAL_RESPONSE = (
 
 
 class ResendManageLinkIn(BaseModel):
-    email: EmailStr
+    # Phone alone recovers; email is an optional extra match signal.
+    email: EmailStr | None = None
     phone_number: str = Field(max_length=FieldLimit.PHONE)
     # Honeypot: hidden field humans never fill in. A non-empty value is spam.
     website: str = Field(default="", max_length=FieldLimit.DISPLAY_NAME)
@@ -83,7 +84,7 @@ def _send_manage_link(request, user: User) -> None:
 )
 @rate_limit(key_func=client_ip, rate="3/h")
 def resend_manage_link(request, payload: ResendManageLinkIn):
-    """Public recovery path: re-send a non-member's manage-rsvp link by phone + email.
+    """Public recovery path: re-send a non-member's manage-rsvp link by phone (email optional).
 
     Honeypot trips, bad phones, unknown contacts, and member contacts all
     resolve to the same neutral 200 body; only a matching non-member with an
@@ -104,7 +105,7 @@ def resend_manage_link(request, payload: ResendManageLinkIn):
         validated_phone = validate_phone(payload.phone_number, PUBLIC_FORM_PHONE_REGION)
     except ValidationException:
         return _neutral()
-    normalized_email = payload.email.strip().lower()
+    normalized_email = (payload.email or "").strip().lower()
 
     user = _find_non_member(validated_phone, normalized_email)
     if user is not None and user.email:

--- a/backend/community/_public_rsvp_resend.py
+++ b/backend/community/_public_rsvp_resend.py
@@ -7,7 +7,7 @@ from ninja import Router
 from ninja.responses import Status
 from notifications._email_helpers import send_rsvp_manage_link_email
 from notifications.email_sender import get_email_sender
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, Field
 from users.models import PUBLIC_FORM_PHONE_REGION, NonMemberRsvpToken, User, validate_phone
 
 from community._field_limits import FieldLimit
@@ -26,8 +26,6 @@ _NEUTRAL_RESPONSE = (
 
 
 class ResendManageLinkIn(BaseModel):
-    # Phone alone recovers; email is an optional extra match signal.
-    email: EmailStr | None = None
     phone_number: str = Field(max_length=FieldLimit.PHONE)
     # Honeypot: hidden field humans never fill in. A non-empty value is spam.
     website: str = Field(default="", max_length=FieldLimit.DISPLAY_NAME)
@@ -41,16 +39,12 @@ def _neutral() -> Status:
     return Status(200, ResendManageLinkOut(detail=_NEUTRAL_RESPONSE))
 
 
-def _find_non_member(phone: str, email: str) -> User | None:
-    """Find the non-member User matching this phone (canonical) or email.
-
-    Returns None when there's no match OR the match is a member.
-    """
-    phone_match = User.objects.filter(phone_number=phone).first()
-    email_match = User.objects.filter(email__iexact=email).first() if email else None
-    if (phone_match and phone_match.is_member) or (email_match and email_match.is_member):
+def _find_non_member(phone: str) -> User | None:
+    """Find the non-member User matching this phone. None if no match or a member."""
+    match = User.objects.filter(phone_number=phone).first()
+    if match and match.is_member:
         return None
-    return phone_match or email_match
+    return match
 
 
 def _send_manage_link(request, user: User) -> None:
@@ -84,14 +78,14 @@ def _send_manage_link(request, user: User) -> None:
 )
 @rate_limit(key_func=client_ip, rate="3/h")
 def resend_manage_link(request, payload: ResendManageLinkIn):
-    """Public recovery path: re-send a non-member's manage-rsvp link by phone (email optional).
+    """Public recovery path: re-send a non-member's manage-rsvp link by phone.
 
     Honeypot trips, bad phones, unknown contacts, and member contacts all
     resolve to the same neutral 200 body; only a matching non-member with an
     email on file is actually sent a link. The response body never reveals
-    whether an account exists — the one residual signal is that the match+email
-    path sends synchronously, so it's marginally slower; the 3/h IP rate limit
-    keeps that timing side channel impractical to exploit.
+    whether an account exists — the one residual signal is that the match path
+    sends synchronously, so it's marginally slower; the 3/h IP rate limit keeps
+    that timing side channel impractical to exploit.
     """
     if payload.website.strip():
         audit_log(
@@ -105,9 +99,8 @@ def resend_manage_link(request, payload: ResendManageLinkIn):
         validated_phone = validate_phone(payload.phone_number, PUBLIC_FORM_PHONE_REGION)
     except ValidationException:
         return _neutral()
-    normalized_email = (payload.email or "").strip().lower()
 
-    user = _find_non_member(validated_phone, normalized_email)
+    user = _find_non_member(validated_phone)
     if user is not None and user.email:
         _send_manage_link(request, user)
         audit_log(

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -4231,18 +4231,6 @@
       },
       "ResendManageLinkIn": {
         "properties": {
-          "email": {
-            "anyOf": [
-              {
-                "format": "email",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Email"
-          },
           "phone_number": {
             "maxLength": 20,
             "title": "Phone Number",
@@ -11695,7 +11683,7 @@
     },
     "/api/community/public/my-rsvps/resend/": {
       "post": {
-        "description": "Public recovery path: re-send a non-member's manage-rsvp link by phone + email.\n\nHoneypot trips, bad phones, unknown contacts, and member contacts all\nresolve to the same neutral 200 body; only a matching non-member with an\nemail on file is actually sent a link. The response body never reveals\nwhether an account exists \u2014 the one residual signal is that the match+email\npath sends synchronously, so it's marginally slower; the 3/h IP rate limit\nkeeps that timing side channel impractical to exploit.",
+        "description": "Public recovery path: re-send a non-member's manage-rsvp link by phone.\n\nHoneypot trips, bad phones, unknown contacts, and member contacts all\nresolve to the same neutral 200 body; only a matching non-member with an\nemail on file is actually sent a link. The response body never reveals\nwhether an account exists \u2014 the one residual signal is that the match path\nsends synchronously, so it's marginally slower; the 3/h IP rate limit keeps\nthat timing side channel impractical to exploit.",
         "operationId": "community__public_rsvp_resend_resend_manage_link",
         "parameters": [],
         "requestBody": {

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -4232,9 +4232,16 @@
       "ResendManageLinkIn": {
         "properties": {
           "email": {
-            "format": "email",
-            "title": "Email",
-            "type": "string"
+            "anyOf": [
+              {
+                "format": "email",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
           },
           "phone_number": {
             "maxLength": 20,
@@ -4249,7 +4256,6 @@
           }
         },
         "required": [
-          "email",
           "phone_number"
         ],
         "title": "ResendManageLinkIn",

--- a/backend/tests/test_public_rsvp_resend.py
+++ b/backend/tests/test_public_rsvp_resend.py
@@ -1,7 +1,7 @@
 """Tests for the public "resend my manage link" recovery endpoint.
 
-POST /api/community/public/my-rsvps/resend/ — no auth. Given a phone (email
-optional), re-sends a non-member's scoped manage link so they can recover access
+POST /api/community/public/my-rsvps/resend/ — no auth. Given a phone, re-sends a
+non-member's scoped manage link (to the on-file email) so they can recover access
 without re-submitting an RSVP. Always returns the same neutral 200 (no enumeration).
 """
 
@@ -21,7 +21,7 @@ EMAIL = "sam@example.com"
 
 
 def _payload(**overrides):
-    base = {"email": EMAIL, "phone_number": PHONE}
+    base = {"phone_number": PHONE}
     base.update(overrides)
     return base
 
@@ -58,25 +58,6 @@ class TestResendManageLink:
         sent = fake_email_sender.send.call_args.kwargs
         assert original.token in sent["text"]
 
-    def test_email_match_only_still_resends(self, api_client, fake_email_sender):
-        # Phone doesn't match, but the email does — still a valid recovery.
-        make_non_member("+14155559999", EMAIL)
-
-        response = post(api_client)
-
-        assert response.status_code == 200
-        fake_email_sender.send.assert_called_once()
-
-    def test_phone_only_no_email_field_still_resends(self, api_client, fake_email_sender):
-        # Email is optional; phone alone recovers, link goes to the on-file address.
-        make_non_member(PHONE, EMAIL)
-
-        response = api_client.post(URL, {"phone_number": PHONE}, content_type="application/json")
-
-        assert response.status_code == 200
-        fake_email_sender.send.assert_called_once()
-        assert fake_email_sender.send.call_args.kwargs["to"] == EMAIL
-
     def test_unknown_contact_is_neutral_no_email(self, api_client, fake_email_sender):
         response = post(api_client)
 
@@ -101,16 +82,6 @@ class TestResendManageLink:
         assert response.status_code == 200
         fake_email_sender.send.assert_not_called()
         assert not NonMemberRsvpToken.objects.filter(user=member).exists()
-
-    def test_member_email_match_gets_no_link(self, api_client, fake_email_sender):
-        # Member owns the email; a different phone is supplied. Must not leak a link.
-        member = make_non_member("+14155559999", EMAIL)
-        member.is_member = True
-        member.save(update_fields=["is_member"])
-
-        post(api_client)
-
-        fake_email_sender.send.assert_not_called()
 
     def test_matching_non_member_without_email_gets_nothing(self, api_client, fake_email_sender):
         # No email on file → nothing to send to, still neutral.

--- a/backend/tests/test_public_rsvp_resend.py
+++ b/backend/tests/test_public_rsvp_resend.py
@@ -1,8 +1,8 @@
 """Tests for the public "resend my manage link" recovery endpoint.
 
-POST /api/community/public/my-rsvps/resend/ — no auth. Given phone + email,
-re-sends a non-member's scoped manage link so they can recover access without
-re-submitting an RSVP. Always returns the same neutral 200 (no enumeration).
+POST /api/community/public/my-rsvps/resend/ — no auth. Given a phone (email
+optional), re-sends a non-member's scoped manage link so they can recover access
+without re-submitting an RSVP. Always returns the same neutral 200 (no enumeration).
 """
 
 import pytest
@@ -66,6 +66,16 @@ class TestResendManageLink:
 
         assert response.status_code == 200
         fake_email_sender.send.assert_called_once()
+
+    def test_phone_only_no_email_field_still_resends(self, api_client, fake_email_sender):
+        # Email is optional; phone alone recovers, link goes to the on-file address.
+        make_non_member(PHONE, EMAIL)
+
+        response = api_client.post(URL, {"phone_number": PHONE}, content_type="application/json")
+
+        assert response.status_code == 200
+        fake_email_sender.send.assert_called_once()
+        assert fake_email_sender.send.call_args.kwargs["to"] == EMAIL
 
     def test_unknown_contact_is_neutral_no_email(self, api_client, fake_email_sender):
         response = post(api_client)

--- a/frontend/src/api/publicRsvp.ts
+++ b/frontend/src/api/publicRsvp.ts
@@ -10,6 +10,7 @@ export type PublicRsvpIn = components['schemas']['PublicRsvpIn'];
 export type PublicRsvpOut = components['schemas']['PublicRsvpOut'];
 export type PublicRsvpPhoneStatus = components['schemas']['PublicRsvpPhoneStatus'];
 export type PublicRsvpPhoneCheckOut = components['schemas']['PublicRsvpPhoneCheckOut'];
+export type ResendManageLinkOut = components['schemas']['ResendManageLinkOut'];
 type PublicRsvpManageIn = components['schemas']['PublicRsvpManageIn'];
 
 interface SubmitArgs {
@@ -40,6 +41,23 @@ export function useCheckPublicRsvpPhone() {
       const { data } = await apiClient.post<PublicRsvpPhoneCheckOut>(
         `/api/community/public/events/${eventId}/rsvp-phone-check/`,
         { phone_number: phoneNumber },
+      );
+      return data;
+    },
+  });
+}
+
+interface ResendArgs {
+  email: string;
+  phoneNumber: string;
+}
+
+export function useResendPublicRsvpManageLink() {
+  return useMutation({
+    mutationFn: async ({ email, phoneNumber }: ResendArgs) => {
+      const { data } = await apiClient.post<ResendManageLinkOut>(
+        '/api/community/public/my-rsvps/resend/',
+        { email, phone_number: phoneNumber, website: '' },
       );
       return data;
     },

--- a/frontend/src/api/publicRsvp.ts
+++ b/frontend/src/api/publicRsvp.ts
@@ -48,16 +48,15 @@ export function useCheckPublicRsvpPhone() {
 }
 
 interface ResendArgs {
-  email: string;
   phoneNumber: string;
 }
 
 export function useResendPublicRsvpManageLink() {
   return useMutation({
-    mutationFn: async ({ email, phoneNumber }: ResendArgs) => {
+    mutationFn: async ({ phoneNumber }: ResendArgs) => {
       const { data } = await apiClient.post<ResendManageLinkOut>(
         '/api/community/public/my-rsvps/resend/',
-        { email, phone_number: phoneNumber, website: '' },
+        { phone_number: phoneNumber, website: '' },
       );
       return data;
     },

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -3677,11 +3677,8 @@ export interface components {
         };
         /** ResendManageLinkIn */
         ResendManageLinkIn: {
-            /**
-             * Email
-             * Format: email
-             */
-            email: string;
+            /** Email */
+            email?: string | null;
             /** Phone Number */
             phone_number: string;
             /**

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -1430,14 +1430,14 @@ export interface paths {
         put?: never;
         /**
          * Resend Manage Link
-         * @description Public recovery path: re-send a non-member's manage-rsvp link by phone + email.
+         * @description Public recovery path: re-send a non-member's manage-rsvp link by phone.
          *
          *     Honeypot trips, bad phones, unknown contacts, and member contacts all
          *     resolve to the same neutral 200 body; only a matching non-member with an
          *     email on file is actually sent a link. The response body never reveals
-         *     whether an account exists — the one residual signal is that the match+email
-         *     path sends synchronously, so it's marginally slower; the 3/h IP rate limit
-         *     keeps that timing side channel impractical to exploit.
+         *     whether an account exists — the one residual signal is that the match path
+         *     sends synchronously, so it's marginally slower; the 3/h IP rate limit keeps
+         *     that timing side channel impractical to exploit.
          */
         post: operations["community__public_rsvp_resend_resend_manage_link"];
         delete?: never;
@@ -3677,8 +3677,6 @@ export interface components {
         };
         /** ResendManageLinkIn */
         ResendManageLinkIn: {
-            /** Email */
-            email?: string | null;
             /** Phone Number */
             phone_number: string;
             /**

--- a/frontend/src/screens/events/PublicRsvpsScreen.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpsScreen.test.tsx
@@ -19,12 +19,15 @@ vi.mock('sonner', () => ({
 
 const updateAsync = vi.fn();
 const cancelAsync = vi.fn();
+const resendAsync = vi.fn();
 const usePublicMyRsvps = vi.fn();
+const useResendPublicRsvpManageLink = vi.fn();
 
 vi.mock('@/api/publicRsvp', () => ({
   usePublicMyRsvps: (token: string) => usePublicMyRsvps(token) as unknown,
   useUpdatePublicMyRsvp: () => ({ mutateAsync: updateAsync, isPending: false }),
   useCancelPublicMyRsvp: () => ({ mutateAsync: cancelAsync, isPending: false }),
+  useResendPublicRsvpManageLink: () => useResendPublicRsvpManageLink() as unknown,
 }));
 
 // jsdom's default Storage isn't wired up for get/set round-trips — stub a real one.
@@ -79,6 +82,13 @@ beforeEach(() => {
   localStorage.clear();
   updateAsync.mockResolvedValue({});
   cancelAsync.mockResolvedValue(undefined);
+  resendAsync.mockResolvedValue({ detail: 'sent' });
+  useResendPublicRsvpManageLink.mockReturnValue({
+    mutateAsync: resendAsync,
+    isPending: false,
+    isSuccess: false,
+    data: undefined,
+  });
 });
 
 describe('PublicRsvpsScreen', () => {
@@ -94,6 +104,34 @@ describe('PublicRsvpsScreen', () => {
     usePublicMyRsvps.mockReturnValue({ data: undefined, isPending: false, isError: false });
     renderAt(null);
     expect(screen.getByText(/this link's expired or invalid/)).toBeInTheDocument();
+  });
+
+  it('resends the manage link and shows the backend detail message on success', async () => {
+    usePublicMyRsvps.mockReturnValue({ data: undefined, isPending: false, isError: false });
+    const { rerender } = renderAt(null);
+
+    fireEvent.click(screen.getByRole('button', { name: 'lost your link?' }));
+    fireEvent.change(screen.getByLabelText('email'), { target: { value: 's@x.com' } });
+    fireEvent.click(screen.getByRole('button', { name: 'resend my link' }));
+
+    await waitFor(() => {
+      expect(resendAsync).toHaveBeenCalledWith(
+        expect.objectContaining({ email: 's@x.com', phoneNumber: '' }),
+      );
+    });
+
+    useResendPublicRsvpManageLink.mockReturnValue({
+      mutateAsync: resendAsync,
+      isPending: false,
+      isSuccess: true,
+      data: { detail: 'sent' },
+    });
+    rerender(
+      <MemoryRouter initialEntries={['/my-rsvps']}>
+        <PublicRsvpsScreen />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('sent')).toBeInTheDocument();
   });
 
   it('persists the token from the url so a later visit can reuse it', () => {

--- a/frontend/src/screens/events/PublicRsvpsScreen.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpsScreen.test.tsx
@@ -111,13 +111,13 @@ describe('PublicRsvpsScreen', () => {
     const { rerender } = renderAt(null);
 
     fireEvent.click(screen.getByRole('button', { name: 'lost your link?' }));
-    fireEvent.change(screen.getByLabelText('email'), { target: { value: 's@x.com' } });
+    fireEvent.change(screen.getByLabelText('phone number'), {
+      target: { value: '+14155550001' },
+    });
     fireEvent.click(screen.getByRole('button', { name: 'resend my link' }));
 
     await waitFor(() => {
-      expect(resendAsync).toHaveBeenCalledWith(
-        expect.objectContaining({ email: 's@x.com', phoneNumber: '' }),
-      );
+      expect(resendAsync).toHaveBeenCalledWith({ phoneNumber: '+14155550001' });
     });
 
     useResendPublicRsvpManageLink.mockReturnValue({

--- a/frontend/src/screens/events/PublicRsvpsScreen.tsx
+++ b/frontend/src/screens/events/PublicRsvpsScreen.tsx
@@ -12,6 +12,7 @@ import { ConfirmDialog } from '@/components/ui/ConfirmDialog';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 
 import { PublicRsvpCard } from './PublicRsvpCard';
+import { ResendManageLinkForm } from './ResendManageLinkForm';
 
 const INVALID_TOKEN_COPY = "this link's expired or invalid — rsvp again to get a new one";
 
@@ -45,6 +46,7 @@ export default function PublicRsvpsScreen() {
     return (
       <ContentContainer>
         <p className="text-foreground text-base">{INVALID_TOKEN_COPY}</p>
+        <ResendManageLinkForm />
       </ContentContainer>
     );
   }

--- a/frontend/src/screens/events/ResendManageLinkForm.tsx
+++ b/frontend/src/screens/events/ResendManageLinkForm.tsx
@@ -1,0 +1,69 @@
+import { type SyntheticEvent, useState } from 'react';
+
+import { useResendPublicRsvpManageLink } from '@/api/publicRsvp';
+import { Button } from '@/components/ui/Button';
+import { PhoneField } from '@/components/ui/PhoneField';
+import { TextField } from '@/components/ui/TextField';
+import { extractApiError } from '@/utils/errors';
+
+export function ResendManageLinkForm() {
+  const [open, setOpen] = useState(false);
+  const [email, setEmail] = useState('');
+  const [phone, setPhone] = useState('');
+  const [error, setError] = useState<string | undefined>(undefined);
+  const resend = useResendPublicRsvpManageLink();
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => {
+          setOpen(true);
+        }}
+        className="text-foreground-secondary mt-4 text-sm underline underline-offset-2"
+      >
+        lost your link?
+      </button>
+    );
+  }
+
+  async function onSubmit(e: SyntheticEvent) {
+    e.preventDefault();
+    setError(undefined);
+    try {
+      await resend.mutateAsync({ email, phoneNumber: phone });
+    } catch (err) {
+      setError(extractApiError(err, "couldn't send that — try again").toLowerCase());
+    }
+  }
+
+  if (resend.isSuccess) {
+    return <p className="text-foreground-secondary mt-4 text-sm">{resend.data.detail}</p>;
+  }
+
+  return (
+    <form
+      onSubmit={(e) => void onSubmit(e)}
+      className="border-border-strong mt-4 flex flex-col gap-3 border-t pt-4"
+      noValidate
+    >
+      <p className="text-foreground-secondary text-sm">
+        lost your link? enter your phone + email and we'll resend it
+      </p>
+      <PhoneField label="phone number" value={phone} onChange={setPhone} />
+      <TextField
+        label="email"
+        type="email"
+        value={email}
+        onChange={(e) => {
+          setEmail(e.target.value);
+        }}
+        error={error}
+        required
+      />
+      <Button type="submit" disabled={resend.isPending} fullWidth>
+        {resend.isPending ? 'sending…' : 'resend my link'}
+      </Button>
+    </form>
+  );
+}

--- a/frontend/src/screens/events/ResendManageLinkForm.tsx
+++ b/frontend/src/screens/events/ResendManageLinkForm.tsx
@@ -3,12 +3,10 @@ import { type SyntheticEvent, useState } from 'react';
 import { useResendPublicRsvpManageLink } from '@/api/publicRsvp';
 import { Button } from '@/components/ui/Button';
 import { PhoneField } from '@/components/ui/PhoneField';
-import { TextField } from '@/components/ui/TextField';
 import { extractApiError } from '@/utils/errors';
 
 export function ResendManageLinkForm() {
   const [open, setOpen] = useState(false);
-  const [email, setEmail] = useState('');
   const [phone, setPhone] = useState('');
   const [error, setError] = useState<string | undefined>(undefined);
   const resend = useResendPublicRsvpManageLink();
@@ -31,7 +29,7 @@ export function ResendManageLinkForm() {
     e.preventDefault();
     setError(undefined);
     try {
-      await resend.mutateAsync({ email, phoneNumber: phone });
+      await resend.mutateAsync({ phoneNumber: phone });
     } catch (err) {
       setError(extractApiError(err, "couldn't send that — try again").toLowerCase());
     }
@@ -48,19 +46,9 @@ export function ResendManageLinkForm() {
       noValidate
     >
       <p className="text-foreground-secondary text-sm">
-        lost your link? enter your phone + email and we'll resend it
+        enter your phone — if we recognize you, we'll send you an email
       </p>
-      <PhoneField label="phone number" value={phone} onChange={setPhone} />
-      <TextField
-        label="email"
-        type="email"
-        value={email}
-        onChange={(e) => {
-          setEmail(e.target.value);
-        }}
-        error={error}
-        required
-      />
+      <PhoneField label="phone number" value={phone} onChange={setPhone} error={error} />
       <Button type="submit" disabled={resend.isPending} fullWidth>
         {resend.isPending ? 'sending…' : 'resend my link'}
       </Button>


### PR DESCRIPTION
## Summary
- The backend already ships a purpose-built recovery endpoint — `POST /api/community/public/my-rsvps/resend/` (`backend/community/_public_rsvp_resend.py`, neutral-response, rate-limited, honeypot-guarded) — but nothing in the frontend called it.
- Added `useResendPublicRsvpManageLink` to `frontend/src/api/publicRsvp.ts` and a small `ResendManageLinkForm` component on the invalid/missing-token branch of `PublicRsvpsScreen`, so a non-member who lost their manage link can recover it instead of hitting a dead end.
- **Recovery is phone-only.** The form asks for a phone number; the link is emailed to the address already on file. `email` was removed from `ResendManageLinkIn` entirely, and `_find_non_member` no longer does an `email__iexact` match — identity is the phone alone. This aligns with the phone-is-identity model established for the submit path in #1037.
- The neutral response, honeypot, and `3/h` IP rate limit are unchanged, so the endpoint reveals nothing about whether an account exists.

### Security trade-off
Phone-only means someone who knows a matching phone number can trigger a recovery email to the on-file address — which they never see. Mitigated by the neutral response + rate limit. Accepted deliberately for the simpler UX and to match #1037's identity model.

Closes #1031

## Test plan
- [x] `pytest backend/tests/test_public_rsvp_resend.py` — 12 passed (removed the email-match tests that no longer apply)
- [x] `npx vitest run src/screens/events/PublicRsvpsScreen.test.tsx` — 13 passed
- [x] `make agent-typecheck` / `make agent-lint` (backend) — clean
- [x] `make agent-frontend-typecheck` / `make agent-frontend-lint` — clean
