### PR TITLE
fix(rsvp): reject public rsvp submit when phone matches an archived non-member

### DIFF
--- a/backend/community/_public_rsvp_submit.py
+++ b/backend/community/_public_rsvp_submit.py
@@ -128,6 +128,14 @@ def _resolve_non_member(
     if phone_match and phone_match.is_member:
         raise_validation(Code.Event.MEMBER_CONTACT_MUST_SIGN_IN, status_code=409)
 
+    # Reject outright rather than excluding archived_at from the lookup above —
+    # phone_number is globally unique, so filtering it out would just let
+    # get_or_create resurrect the row under _create_non_member instead (Issue 1030).
+    # An email-only archived match still 409s below via the generic collision path,
+    # without a distinct code — that stays a no-oracle rejection (Issue 1001).
+    if phone_match and phone_match.archived_at:
+        raise_validation(Code.Auth.ACCOUNT_ARCHIVED, status_code=403)
+
     if email_match and email_match.pk != (phone_match.pk if phone_match else None):
         _reject_email_collision(request, email)
 

--- a/backend/community/_public_rsvp_submit.py
+++ b/backend/community/_public_rsvp_submit.py
@@ -128,11 +128,6 @@ def _resolve_non_member(
     if phone_match and phone_match.is_member:
         raise_validation(Code.Event.MEMBER_CONTACT_MUST_SIGN_IN, status_code=409)
 
-    # Reject outright rather than excluding archived_at from the lookup above —
-    # phone_number is globally unique, so filtering it out would just let
-    # get_or_create resurrect the row under _create_non_member instead (Issue 1030).
-    # An email-only archived match still 409s below via the generic collision path,
-    # without a distinct code — that stays a no-oracle rejection (Issue 1001).
     if phone_match and phone_match.archived_at:
         raise_validation(Code.Auth.ACCOUNT_ARCHIVED, status_code=403)
 

--- a/backend/tests/test_public_rsvp_archived.py
+++ b/backend/tests/test_public_rsvp_archived.py
@@ -6,7 +6,7 @@ from community._validation import Code, ValidationException
 from community.models import EventRSVP
 from django.test import RequestFactory
 from django.utils import timezone
-from users.models import User
+from users.models import NonMemberRsvpToken, User
 
 from tests._public_rsvp_helpers import make_non_member, make_official_event, post
 
@@ -64,6 +64,26 @@ class TestArchivedMemberGate:
         assert response.json()["detail"][0]["code"] == Code.Event.RSVP_COULD_NOT_BE_CREATED
         assert not User.objects.filter(phone_number="+14155550123").exists()
         assert not EventRSVP.objects.filter(event=official_event, user=archived).exists()
+
+
+@pytest.mark.django_db
+class TestArchivedNonMemberGate:
+    def test_phone_belongs_to_archived_non_member(
+        self, api_client, official_event, fake_email_sender
+    ):
+        archived = make_non_member("+14155550123", "old@example.com", name="Archived NonMember")
+        archived.archived_at = timezone.now()
+        archived.save(update_fields=["archived_at"])
+
+        response = post(api_client, official_event)
+
+        assert response.status_code == 403
+        assert response.json()["detail"][0]["code"] == Code.Auth.ACCOUNT_ARCHIVED
+        assert not EventRSVP.objects.filter(event=official_event, user=archived).exists()
+        archived.refresh_from_db()
+        assert archived.archived_at is not None
+        assert not NonMemberRsvpToken.objects.filter(user=archived).exists()
+        fake_email_sender.send.assert_not_called()
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- Fixes Issue 1030: `_resolve_non_member` in `backend/community/_public_rsvp_submit.py` matched non-members by `phone_number`/`email` without excluding archived accounts, so an admin-archived non-member could be resurrected via public RSVP submit and issued a fresh 90-day manage token via `NonMemberRsvpToken.issue_or_extend`.
- Guard-and-reject, not filter-only: since `phone_number` is globally unique, excluding `archived_at` from the lookup would just let `_create_non_member`'s `get_or_create` recreate/collide with the same row. Instead, raise `Code.Auth.ACCOUNT_ARCHIVED` (403) as soon as the phone match is found archived, before any backfill or token issuance touches the row.
- An email-only match against an archived row (no phone ownership asserted) continues through the existing generic collision path (409, no distinct code) rather than surfacing `ACCOUNT_ARCHIVED` — keeps parity with the no-account-existence-oracle design from Issue 1001.
- Archived-**member** RSVP by phone already hit the 409 member gate; this closes the equivalent gap for non-members.

## Test plan
- [x] Added `TestArchivedNonMemberGate::test_phone_belongs_to_archived_non_member` in `backend/tests/test_public_rsvp_archived.py` — asserts 403 `ACCOUNT_ARCHIVED`, no RSVP created, `archived_at` untouched, no `NonMemberRsvpToken` minted, no email sent.
- [x] Ran `backend/tests/test_public_rsvp*.py` (109 tests) — all pass.
- [x] `ruff check` / `ruff format --check` on changed files — clean.
- [x] `ty check` on backend — clean.
- [x] Cognitive complexity check on changed file — clean.