### PR TITLE
fix: 1034 - recoverable exits for public rsvp form dead-ends

### DIFF
--- a/frontend/src/screens/events/PublicRsvpForm.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.test.tsx
@@ -139,7 +139,9 @@ describe('PublicRsvpForm', () => {
     fireEvent.click(screen.getByRole('button', { name: 'use a different number' }));
     expect(screen.getByLabelText(/phone number/i)).toBeInTheDocument();
     expect(
-      screen.queryByText('we recognized your number — check your email for a link to manage your rsvp'),
+      screen.queryByText(
+        'we recognized your number — check your email for a link to manage your rsvp',
+      ),
     ).not.toBeInTheDocument();
   });
 

--- a/frontend/src/screens/events/PublicRsvpForm.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.test.tsx
@@ -129,6 +129,20 @@ describe('PublicRsvpForm', () => {
     expect(screen.queryByLabelText('first name')).not.toBeInTheDocument();
   });
 
+  it('lets a recognized non-member go back and retry with a different number', async () => {
+    checkPhoneMutate.mockResolvedValue({ status: 'non_member' });
+    renderForm();
+    fillPhoneStep();
+    await screen.findByText(
+      'we recognized your number — check your email for a link to manage your rsvp',
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'use a different number' }));
+    expect(screen.getByLabelText(/phone number/i)).toBeInTheDocument();
+    expect(
+      screen.queryByText('we recognized your number — check your email for a link to manage your rsvp'),
+    ).not.toBeInTheDocument();
+  });
+
   it('lets you change the status and go back to step one from the details step', async () => {
     checkPhoneMutate.mockResolvedValue({ status: 'new' });
     renderForm();
@@ -141,6 +155,21 @@ describe('PublicRsvpForm', () => {
     fireEvent.click(screen.getByRole('button', { name: 'change' }));
     expect(screen.getByRole('button', { name: "i'm going" })).toBeInTheDocument();
     expect(screen.queryByLabelText('first name')).not.toBeInTheDocument();
+  });
+
+  it('preserves the confirmed phone after "change" so the phone step is skipped', async () => {
+    checkPhoneMutate.mockResolvedValue({ status: 'new' });
+    renderForm();
+    fireEvent.click(screen.getByRole('button', { name: 'maybe' }));
+    fireEvent.change(screen.getByLabelText(/phone number/i), {
+      target: { value: '+14155550123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'continue' }));
+    await waitFor(() => expect(screen.getByLabelText('first name')).toBeInTheDocument());
+    fireEvent.click(screen.getByRole('button', { name: 'change' }));
+    fireEvent.click(screen.getByRole('button', { name: "i'm going" }));
+    expect(checkPhoneMutate).toHaveBeenCalledTimes(1);
+    expect(screen.getByLabelText('first name')).toBeInTheDocument();
   });
 
   it('submits maybe status chosen in step one', async () => {
@@ -203,6 +232,15 @@ describe('PublicRsvpForm', () => {
     fireEvent.click(screen.getByRole('button', { name: 'rsvp' }));
     await screen.findByText('looks like you already have an account — sign in to rsvp');
     expect(screen.getByRole('link', { name: 'sign in' })).toHaveAttribute('href', '/login');
+  });
+
+  it('focuses the submit error alert so it is not missed below the fold', async () => {
+    submitMutate.mockRejectedValue({ isAxiosError: true, response: { status: 429 } });
+    renderForm();
+    await fillRequired();
+    fireEvent.click(screen.getByRole('button', { name: 'rsvp' }));
+    const alert = await screen.findByRole('alert');
+    await waitFor(() => expect(alert).toHaveFocus());
   });
 
   it('shows a neutral no-oracle error without a sign-in link on a 409 email collision', async () => {

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -1,4 +1,4 @@
-import { type SyntheticEvent, useState } from 'react';
+import { type SyntheticEvent, useEffect, useRef, useState } from 'react';
 import { isValidPhoneNumber } from 'react-phone-number-input';
 import { Link, useNavigate } from 'react-router-dom';
 
@@ -74,6 +74,13 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
   const [website, setWebsite] = useState('');
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [submitError, setSubmitError] = useState<SubmitError | null>(null);
+  const submitErrorRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!submitError) return;
+    submitErrorRef.current?.scrollIntoView({ block: 'center' });
+    submitErrorRef.current?.focus();
+  }, [submitError]);
 
   function validate(): boolean {
     const next: Record<string, string> = {};
@@ -129,9 +136,21 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
     }
     if (isNonMember) {
       return (
-        <p className="text-foreground-secondary text-sm">
-          we recognized your number — check your email for a link to manage your rsvp
-        </p>
+        <div className="flex flex-col gap-2">
+          <p className="text-foreground-secondary text-sm">
+            we recognized your number — check your email for a link to manage your rsvp
+          </p>
+          <button
+            type="button"
+            onClick={() => {
+              setIsNonMember(false);
+              setPhoneConfirmed(false);
+            }}
+            className="text-info self-start text-sm hover:underline"
+          >
+            use a different number
+          </button>
+        </div>
       );
     }
     if (!phoneConfirmed) {
@@ -166,7 +185,6 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
             type="button"
             onClick={() => {
               setStatus(null);
-              setPhoneConfirmed(false);
             }}
             className="text-info text-sm hover:underline"
           >
@@ -215,7 +233,7 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
         </Button>
 
         {submitError ? (
-          <div role="alert" className="text-destructive text-sm">
+          <div role="alert" tabIndex={-1} ref={submitErrorRef} className="text-destructive text-sm">
             <p>{submitError.text}</p>
             {submitError.showSignIn ? (
               <Link to="/login" className="text-info hover:underline">

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -67,3 +67,6 @@ Object.defineProperty(window, 'matchMedia', {
 // jsdom stops emitting "Not implemented" warnings during component rendering.
 // No test currently inspects canvas output.
 HTMLCanvasElement.prototype.getContext = (() => null) as never;
+
+// jsdom doesn't implement scrollIntoView — provide a no-op stub.
+Element.prototype.scrollIntoView = () => {};


### PR DESCRIPTION
## Overview

Fixes several "no way back" dead-ends in the non-member public RSVP form (`PublicRsvpForm.tsx`), all sharing the same lost-input/one-way-door theme:

- **Recognized-phone step is a dead end** — added a "use a different number" button so a mistyped phone number that matches someone else's on-file number can be retried instead of requiring a page reload.
- **"Change" button silently forced phone re-entry** — the button that switches attending/maybe status no longer resets `phoneConfirmed`, so it no longer wipes the already-confirmed phone field.
- **Submit error wasn't scrolled to or focused** — the error alert now scrolls into view and receives focus when it appears, so a 409/429 error doesn't go unnoticed below the fold on small viewports.

The member-detected dead-end described in the original issue (item 2) is already fixed on current `main` — `onMember` now navigates straight to `/login` with the phone prefilled, and `LoginScreen`'s phone step already has a working back action. No change needed there.

Closes #1034

## Test plan

- [x] Added 3 vitest cases covering: retry after recognized-phone, phone preserved after "change", submit error receives focus
- [x] `pnpm vitest run src/screens/events/PublicRsvpForm.test.tsx` — 26/26 pass
- [x] `pnpm exec eslint` scoped to changed files — clean
- [x] `pnpm exec tsc -b --noEmit` — clean
- [ ] Manual check in browser
