### PR TITLE
fix(rsvp): show reach-out message for archived-account rsvp rejection

### DIFF
--- a/frontend/src/screens/events/PublicRsvpForm.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.test.tsx
@@ -222,6 +222,21 @@ describe('PublicRsvpForm', () => {
     expect(screen.queryByRole('link', { name: 'sign in' })).not.toBeInTheDocument();
   });
 
+  it('shows a reach-out message without a sign-in link when the phone matches an archived account', async () => {
+    submitMutate.mockRejectedValue({
+      isAxiosError: true,
+      response: {
+        status: 403,
+        data: { detail: [{ code: 'auth.account_archived' }] },
+      },
+    });
+    renderForm();
+    await fillRequired();
+    fireEvent.click(screen.getByRole('button', { name: 'rsvp' }));
+    await screen.findByText("we couldn't set up your rsvp — reach out and we'll help");
+    expect(screen.queryByRole('link', { name: 'sign in' })).not.toBeInTheDocument();
+  });
+
   it('shows a 429 rate-limit error', async () => {
     submitMutate.mockRejectedValue({ isAxiosError: true, response: { status: 429 } });
     renderForm();

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -42,6 +42,12 @@ function messageForStatus(status: number | null, err: unknown): SubmitError {
       showSignIn: false,
     };
   }
+  if (hasErrorCode(err, Code.Auth.AccountArchived)) {
+    return {
+      text: "we couldn't set up your rsvp — reach out and we'll help",
+      showSignIn: false,
+    };
+  }
   if (status === 409) {
     return { text: 'looks like you already have an account — sign in to rsvp', showSignIn: true };
   }


### PR DESCRIPTION
## Summary
- PR #1049 made public RSVP submit return `Code.Auth.ACCOUNT_ARCHIVED` (403) when the phone matches an archived non-member, but `PublicRsvpForm`'s `messageForStatus` had no branch for it — the error fell through to the generic `'something went wrong — try again'` fallback with no path forward for the user.
- Adds a dedicated branch matching the sibling `RsvpCouldNotBeCreated` copy: `"we couldn't set up your rsvp — reach out and we'll help"`, no sign-in link (they can't sign in — the account's archived).

## Test plan
- [x] Added a test asserting the reach-out message renders (no sign-in link) for a 403 `auth.account_archived` response.
- [x] `pnpm test src/screens/events/PublicRsvpForm.test.tsx` — 24/24 pass.
- [x] `make agent-frontend-typecheck` / `make agent-frontend-lint` — clean.