### PR TITLE
fix(users): require email on admin user creation (Issue 1039)

### DIFF
--- a/backend/community/_public_rsvp_submit.py
+++ b/backend/community/_public_rsvp_submit.py
@@ -82,18 +82,6 @@ def _reject_email_collision(request, email: str) -> NoReturn:
     raise_validation(Code.Event.RSVP_COULD_NOT_BE_CREATED, status_code=409)
 
 
-def _backfill_email(request, phone_match: User, email: str) -> User:
-    """Backfill the email only if blank — never overwrite an existing one."""
-    if email and not phone_match.email:
-        try:
-            with transaction.atomic():
-                phone_match.email = email
-                phone_match.save(update_fields=["email"])
-        except IntegrityError:
-            _reject_email_collision(request, email)
-    return phone_match
-
-
 def _create_non_member(
     request, first_name: str, last_name: str, email: str, phone: str
 ) -> tuple[User, bool]:
@@ -135,7 +123,7 @@ def _resolve_non_member(
         _reject_email_collision(request, email)
 
     if phone_match:
-        return _backfill_email(request, phone_match, email), False
+        return phone_match, False
     return _create_non_member(request, first_name, last_name, email, phone)
 
 

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -5007,16 +5007,9 @@
       "UserCreateIn": {
         "properties": {
           "email": {
-            "anyOf": [
-              {
-                "format": "email",
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Email"
+            "format": "email",
+            "title": "Email",
+            "type": "string"
           },
           "first_name": {
             "default": "",
@@ -5048,7 +5041,8 @@
           }
         },
         "required": [
-          "phone_number"
+          "phone_number",
+          "email"
         ],
         "title": "UserCreateIn",
         "type": "object"

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -172,7 +172,7 @@ class TestUserManagementAPI:
     def test_create_user_requires_permission(self, api_client, auth_headers):
         response = api_client.post(
             "/api/auth/create-user/",
-            {"phone_number": "+12025550999", "first_name": "Denied"},
+            {"phone_number": "+12025550999", "first_name": "Denied", "email": "denied@e.com"},
             content_type="application/json",
             **auth_headers,
         )
@@ -181,7 +181,12 @@ class TestUserManagementAPI:
     def test_create_user_success(self, api_client, admin_headers):
         response = api_client.post(
             "/api/auth/create-user/",
-            {"phone_number": "+12025551234", "first_name": "New", "last_name": "Member"},
+            {
+                "phone_number": "+12025551234",
+                "first_name": "New",
+                "last_name": "Member",
+                "email": "new.member@e.com",
+            },
             content_type="application/json",
             **admin_headers,
         )
@@ -191,10 +196,20 @@ class TestUserManagementAPI:
         assert "magic_link_token" in data
         assert len(data["magic_link_token"]) == 36  # UUID format
 
+    def test_create_user_requires_email(self, api_client, admin_headers):
+        response = api_client.post(
+            "/api/auth/create-user/",
+            {"phone_number": "+12025551235", "first_name": "Noemail"},
+            content_type="application/json",
+            **admin_headers,
+        )
+        assert response.status_code == 422
+        assert any(e["field"] == "email" for e in response.json()["detail"])
+
     def test_create_user_duplicate_phone(self, api_client, admin_headers, test_user):
         response = api_client.post(
             "/api/auth/create-user/",
-            {"phone_number": "+12025550101", "first_name": "Dupe"},
+            {"phone_number": "+12025550101", "first_name": "Dupe", "email": "dupe@e.com"},
             content_type="application/json",
             **admin_headers,
         )
@@ -204,7 +219,11 @@ class TestUserManagementAPI:
     def test_create_user_assigns_member_role_by_default(self, api_client, admin_headers):
         response = api_client.post(
             "/api/auth/create-user/",
-            {"phone_number": "+12125551234", "first_name": "Defaultrole"},
+            {
+                "phone_number": "+12125551234",
+                "first_name": "Defaultrole",
+                "email": "defaultrole@e.com",
+            },
             content_type="application/json",
             **admin_headers,
         )

--- a/backend/tests/test_public_rsvp.py
+++ b/backend/tests/test_public_rsvp.py
@@ -103,16 +103,6 @@ class TestPublicRsvpDedup:
         assert existing.email == "old@example.com"
         assert NonMemberRsvpToken.objects.filter(user=existing).count() == 1
 
-    def test_returning_by_phone_saves_email_if_blank(
-        self, api_client, official_event, fake_email_sender
-    ):
-        existing = make_non_member("+14155550123", None)
-
-        post(api_client, official_event, email="sam@example.com")
-
-        existing.refresh_from_db()
-        assert existing.email == "sam@example.com"
-
     def test_email_match_alone_is_not_adopted(self, api_client, official_event, fake_email_sender):
         existing = make_non_member("+14155550999", "sam@example.com")
 

--- a/backend/tests/test_public_rsvp_archived.py
+++ b/backend/tests/test_public_rsvp_archived.py
@@ -1,10 +1,8 @@
 """Archived-member/non-member scenarios for the public RSVP flow."""
 
 import pytest
-from community._public_rsvp_submit import _backfill_email
-from community._validation import Code, ValidationException
+from community._validation import Code
 from community.models import EventRSVP
-from django.test import RequestFactory
 from django.utils import timezone
 from users.models import NonMemberRsvpToken, User
 
@@ -84,19 +82,3 @@ class TestArchivedNonMemberGate:
         assert archived.archived_at is not None
         assert not NonMemberRsvpToken.objects.filter(user=archived).exists()
         fake_email_sender.send.assert_not_called()
-
-
-@pytest.mark.django_db
-class TestBackfillEmailCollision:
-    def test_concurrent_email_claim_is_handled_gracefully(self):
-        phone_match = make_non_member("+14155550123", None)
-        User.objects.create_user(
-            phone_number="+14155550999", first_name="Other", email="sam@example.com"
-        )
-
-        request = RequestFactory().post("/")
-        with pytest.raises(ValidationException) as exc_info:
-            _backfill_email(request, phone_match, "sam@example.com")
-        assert exc_info.value.code == Code.Event.RSVP_COULD_NOT_BE_CREATED
-        phone_match.refresh_from_db()
-        assert phone_match.email is None

--- a/backend/tests/test_user_management.py
+++ b/backend/tests/test_user_management.py
@@ -7,7 +7,7 @@ class TestCreateUserFirstNameRequired:
     def test_create_user_without_any_name_is_rejected(self, api_client, manage_users_headers, db):
         resp = api_client.post(
             "/api/auth/create-user/",
-            data={"phone_number": "+12025550120"},
+            data={"phone_number": "+12025550120", "email": "noname@example.com"},
             content_type="application/json",
             **manage_users_headers,
         )
@@ -18,7 +18,11 @@ class TestCreateUserFirstNameRequired:
     def test_create_user_last_name_only_is_rejected(self, api_client, manage_users_headers, db):
         resp = api_client.post(
             "/api/auth/create-user/",
-            data={"phone_number": "+12025550121", "last_name": "Lovelace"},
+            data={
+                "phone_number": "+12025550121",
+                "last_name": "Lovelace",
+                "email": "lastonly@example.com",
+            },
             content_type="application/json",
             **manage_users_headers,
         )
@@ -28,7 +32,11 @@ class TestCreateUserFirstNameRequired:
     def test_create_user_first_name_only_succeeds(self, api_client, manage_users_headers, db):
         resp = api_client.post(
             "/api/auth/create-user/",
-            data={"phone_number": "+12025550122", "first_name": "Ada"},
+            data={
+                "phone_number": "+12025550122",
+                "first_name": "Ada",
+                "email": "ada@example.com",
+            },
             content_type="application/json",
             **manage_users_headers,
         )

--- a/backend/tests/users/test_users_crud.py
+++ b/backend/tests/users/test_users_crud.py
@@ -12,18 +12,34 @@ class TestCreateUser:
     def test_create_user_invalid_phone(self, api_client, manage_users_headers):
         response = api_client.post(
             "/api/auth/create-user/",
-            {"phone_number": "not-a-phone", "first_name": "Test"},
+            {"phone_number": "not-a-phone", "first_name": "Test", "email": "test@e.com"},
             content_type="application/json",
             **manage_users_headers,
         )
         assert response.status_code == 422
         assert_error_code(response, Code.Phone.INVALID, "phone_number")
 
+    def test_create_user_requires_email(self, api_client, manage_users_headers):
+        response = api_client.post(
+            "/api/auth/create-user/",
+            {"phone_number": "+12025550910", "first_name": "Noemail"},
+            content_type="application/json",
+            **manage_users_headers,
+        )
+        assert response.status_code == 422
+        assert any(e["field"] == "email" for e in response.json()["detail"])
+        assert not User.objects.filter(phone_number="+12025550910").exists()
+
     def test_create_user_with_role_id(self, api_client, manage_users_headers, db):
         role = Role.objects.create(name="custom_role", permissions=[])
         response = api_client.post(
             "/api/auth/create-user/",
-            {"phone_number": "+12025550901", "first_name": "Roled", "role_id": str(role.id)},
+            {
+                "phone_number": "+12025550901",
+                "first_name": "Roled",
+                "role_id": str(role.id),
+                "email": "roled@e.com",
+            },
             content_type="application/json",
             **manage_users_headers,
         )
@@ -33,7 +49,12 @@ class TestCreateUser:
         admin_role = Role.objects.get(name="admin")
         response = api_client.post(
             "/api/auth/create-user/",
-            {"phone_number": "+12025550950", "first_name": "Nope", "role_id": str(admin_role.id)},
+            {
+                "phone_number": "+12025550950",
+                "first_name": "Nope",
+                "role_id": str(admin_role.id),
+                "email": "nope@e.com",
+            },
             content_type="application/json",
             **manage_users_headers,
         )
@@ -48,6 +69,7 @@ class TestCreateUser:
                 "phone_number": "+12025550902",
                 "first_name": "Badrole",
                 "role_id": "00000000-0000-0000-0000-000000000000",
+                "email": "badrole@e.com",
             },
             content_type="application/json",
             **manage_users_headers,
@@ -58,7 +80,7 @@ class TestCreateUser:
     def test_create_user_sets_needs_onboarding(self, api_client, manage_users_headers):
         response = api_client.post(
             "/api/auth/create-user/",
-            {"phone_number": "+12025550903", "first_name": "Onboard"},
+            {"phone_number": "+12025550903", "first_name": "Onboard", "email": "onboard@e.com"},
             content_type="application/json",
             **manage_users_headers,
         )
@@ -69,7 +91,11 @@ class TestCreateUser:
     def test_create_user_keeps_contact_visibility_default(self, api_client, manage_users_headers):
         response = api_client.post(
             "/api/auth/create-user/",
-            {"phone_number": "+12025550907", "first_name": "Newmember"},
+            {
+                "phone_number": "+12025550907",
+                "first_name": "Newmember",
+                "email": "newmember@e.com",
+            },
             content_type="application/json",
             **manage_users_headers,
         )
@@ -94,6 +120,7 @@ class TestCreateUser:
                 "phone_number": "+12025550905",
                 "first_name": "",
                 "last_name": "",
+                "email": "blank@e.com",
             },
             content_type="application/json",
             **manage_users_headers,
@@ -104,7 +131,7 @@ class TestCreateUser:
     def test_create_user_rejects_omitted_name(self, api_client, manage_users_headers):
         response = api_client.post(
             "/api/auth/create-user/",
-            {"phone_number": "+12025550906"},
+            {"phone_number": "+12025550906", "email": "omitted@e.com"},
             content_type="application/json",
             **manage_users_headers,
         )
@@ -114,7 +141,11 @@ class TestCreateUser:
     def test_create_user_rejects_whitespace_only_name(self, api_client, manage_users_headers):
         response = api_client.post(
             "/api/auth/create-user/",
-            {"phone_number": "+12025550908", "first_name": "   "},
+            {
+                "phone_number": "+12025550908",
+                "first_name": "   ",
+                "email": "whitespace@e.com",
+            },
             content_type="application/json",
             **manage_users_headers,
         )
@@ -124,7 +155,12 @@ class TestCreateUser:
     def test_create_user_strips_name_whitespace(self, api_client, manage_users_headers):
         response = api_client.post(
             "/api/auth/create-user/",
-            {"phone_number": "+12025550909", "first_name": "  Jamie  ", "last_name": "  Rivera  "},
+            {
+                "phone_number": "+12025550909",
+                "first_name": "  Jamie  ",
+                "last_name": "  Rivera  ",
+                "email": "jamie@e.com",
+            },
             content_type="application/json",
             **manage_users_headers,
         )

--- a/backend/users/schemas.py
+++ b/backend/users/schemas.py
@@ -221,7 +221,7 @@ class UserCreateIn(BaseModel):
     phone_number: str = Field(max_length=FieldLimit.PHONE)
     first_name: str = Field(default="", max_length=FieldLimit.FIRST_NAME)
     last_name: str = Field(default="", max_length=FieldLimit.LAST_NAME)
-    email: OptionalEmail = None
+    email: EmailStr
     role_id: str | None = None
 
 

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -3991,8 +3991,11 @@ export interface components {
         };
         /** UserCreateIn */
         UserCreateIn: {
-            /** Email */
-            email?: string | null;
+            /**
+             * Email
+             * Format: email
+             */
+            email: string;
             /**
              * First Name
              * @default

--- a/frontend/src/api/users.test.ts
+++ b/frontend/src/api/users.test.ts
@@ -201,10 +201,14 @@ describe('useCreateUser', () => {
     const qc = makeQc();
     const { result } = renderHook(() => useCreateUser(), { wrapper: makeWrapper(qc) });
 
-    await result.current.mutateAsync({ phoneNumber: '+15551230003' });
+    await result.current.mutateAsync({
+      phoneNumber: '+15551230003',
+      email: 'grace3@example.com',
+    });
 
     expect(mockedPost).toHaveBeenCalledWith('/api/auth/create-user/', {
       phone_number: '+15551230003',
+      email: 'grace3@example.com',
     });
   });
 });

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -112,9 +112,9 @@ export function useUsers(includeNonMembers = false) {
 
 export interface CreateUserInput {
   phoneNumber: string;
+  email: string;
   firstName?: string;
   lastName?: string;
-  email?: string;
   roleId?: string;
 }
 
@@ -138,10 +138,12 @@ export function useCreateUser() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async (input: CreateUserInput): Promise<CreateUserResult> => {
-      const body: Record<string, unknown> = { phone_number: input.phoneNumber };
+      const body: Record<string, unknown> = {
+        phone_number: input.phoneNumber,
+        email: input.email,
+      };
       if (input.firstName !== undefined) body.first_name = input.firstName;
       if (input.lastName !== undefined) body.last_name = input.lastName;
-      if (input.email !== undefined) body.email = input.email;
       if (input.roleId !== undefined) body.role_id = input.roleId;
       const { data } = await apiClient.post<WireCreateResult>('/api/auth/create-user/', body);
       return {

--- a/frontend/src/screens/admin/MemberCreateDialog.test.tsx
+++ b/frontend/src/screens/admin/MemberCreateDialog.test.tsx
@@ -28,31 +28,41 @@ describe('MemberCreateDialog', () => {
     } as unknown as ReturnType<typeof useCreateUser>);
   });
 
-  it('renders email field with nudge copy', () => {
+  it('renders email field', () => {
     render(<MemberCreateDialog open onClose={() => {}} />);
     expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
-    expect(screen.getByText(/asked for one at first login/i)).toBeInTheDocument();
   });
 
   it('does not submit when first name is blank', async () => {
     render(<MemberCreateDialog open onClose={() => {}} />);
     fireEvent.change(screen.getByLabelText(/phone number/i), { target: { value: '+12025550101' } });
+    await userEvent.type(screen.getByLabelText(/email/i), 'new@example.com');
     await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
     expect(mutateAsync).not.toHaveBeenCalled();
   });
 
-  it('submits with first name and no last name / email when left blank', async () => {
+  it('does not submit when email is blank', async () => {
     render(<MemberCreateDialog open onClose={() => {}} />);
     await userEvent.type(screen.getByLabelText(/first name/i), 'Ada');
     fireEvent.change(screen.getByLabelText(/phone number/i), { target: { value: '+12025550101' } });
     await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
+    expect(mutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('submits with first name, phone, and email when no last name given', async () => {
+    render(<MemberCreateDialog open onClose={() => {}} />);
+    await userEvent.type(screen.getByLabelText(/first name/i), 'Ada');
+    fireEvent.change(screen.getByLabelText(/phone number/i), { target: { value: '+12025550101' } });
+    await userEvent.type(screen.getByLabelText(/email/i), 'new@example.com');
+    await userEvent.click(screen.getByRole('button', { name: /^create$/i }));
     expect(mutateAsync).toHaveBeenCalledWith({
       phoneNumber: '+12025550101',
       firstName: 'Ada',
+      email: 'new@example.com',
     });
   });
 
-  it('submits with last name and email when filled', async () => {
+  it('submits with last name when filled', async () => {
     render(<MemberCreateDialog open onClose={() => {}} />);
     await userEvent.type(screen.getByLabelText(/first name/i), 'Ada');
     await userEvent.type(screen.getByLabelText(/last name/i), 'Lovelace');
@@ -62,8 +72,8 @@ describe('MemberCreateDialog', () => {
     expect(mutateAsync).toHaveBeenCalledWith({
       phoneNumber: '+12025550101',
       firstName: 'Ada',
-      lastName: 'Lovelace',
       email: 'new@example.com',
+      lastName: 'Lovelace',
     });
   });
 });

--- a/frontend/src/screens/admin/MemberCreateDialog.tsx
+++ b/frontend/src/screens/admin/MemberCreateDialog.tsx
@@ -34,14 +34,17 @@ export function MemberCreateDialog({ open, onClose }: Props) {
       setFormError('phone number is required');
       return;
     }
+    if (!email.trim()) {
+      setFormError('email is required');
+      return;
+    }
     try {
       const trimmedLast = lastName.trim();
-      const trimmedEmail = email.trim();
       const created = await createUser.mutateAsync({
         phoneNumber: phone.trim(),
         firstName: firstName.trim(),
+        email: email.trim(),
         ...(trimmedLast ? { lastName: trimmedLast } : {}),
-        ...(trimmedEmail ? { email: trimmedEmail } : {}),
       });
       setResult(created);
     } catch (err) {
@@ -102,13 +105,13 @@ export function MemberCreateDialog({ open, onClose }: Props) {
           required
         />
         <TextField
-          label="email (optional)"
+          label="email"
           type="email"
-          hint="if you skip, they'll be asked for one at first login"
           value={email}
           onChange={(e) => {
             setEmail(e.target.value);
           }}
+          required
         />
         {formError ? (
           <p role="alert" className="text-sm text-red-600">


### PR DESCRIPTION
## Overview

`_backfill_email` in `backend/community/_public_rsvp_submit.py` existed solely to handle non-member `User` rows with a blank `email` — reachable only because `UserCreateIn.email` allowed admin-created users to skip email entirely. Every other path that creates a non-member row (public RSVP join form, join-request approval, tentative-join provisioning) already required an email.

This PR makes `email` required on `UserCreateIn` (backend schema) and the members-screen create-user form (frontend), closing the only path that could leave a non-member row with a blank email. With that path closed, `_backfill_email` and its call site in `_resolve_non_member` are dead code — removed, and the phone-match branch now returns the matched user directly.

Closes #1039

### Changes

- `backend/users/schemas.py`: `UserCreateIn.email` changed from `OptionalEmail = None` to required `EmailStr`
- `backend/community/_public_rsvp_submit.py`: removed `_backfill_email`; `_resolve_non_member`'s phone-match branch now returns the matched user directly
- `frontend/src/screens/admin/MemberCreateDialog.tsx`: email field is now required (was "email (optional)")
- `frontend/src/api/users.ts`: `CreateUserInput.email` is now required
- Regenerated `backend/openapi_schema.json` and `frontend/src/api/types.gen.ts`
- Updated tests in `test_public_rsvp.py`, `test_public_rsvp_archived.py` (removed `test_returning_by_phone_saves_email_if_blank` and `TestBackfillEmailCollision`), `test_user_management.py`, `test_api.py`, and `test_users_crud.py` to always pass email on create-user payloads

### Paths verified for blank-email non-member creation (all require email already, except the one this PR fixes)

- Public RSVP join form (`PublicRsvpIn.email: EmailStr`) — always required
- Join-request submission (`JoinRequestIn.email: EmailStr`) and the `JoinRequest.email` model field (non-blank `EmailField`) — always required
- Tentative join provisioning (`_provision_tentative_user` in `_join_request_approval.py`) — sources email from `join_request.email`, always present
- Admin create-user (`UserCreateIn` via `create_user`) — **was the only gap**, now fixed
- `bulk_create_users` — creates members (`is_member=True`) only, unaffected by non-member backfill logic
- Seed/staging fixtures (`seed_staging.py`) intentionally create blank-email non-members as test fixtures for historical-data scenarios; left as-is since they're dev-only fixtures, not a production path

## Test plan

- [x] Backend: `ruff check`/`format`, `ty check` clean
- [x] Backend: targeted pytest — `test_public_rsvp.py`, `test_public_rsvp_archived.py`, `test_user_management.py`, `test_api.py`, `tests/users/test_users_crud.py` (118 passed)
- [x] Backend: sanity check on `test_join_request_management.py`, `test_public_rsvp_capacity.py` (36 passed)
- [x] Frontend: `tsc -b --noEmit`, `eslint` clean
- [x] Frontend: targeted vitest — `MemberCreateDialog.test.tsx`, `users.test.ts` (15 passed, 1 pre-existing skip)
- [ ] Full `make agent-ci` (not run per this batch's instructions — only affected files were verified)
