### PR TITLE
fix(join-requests): collapse message template triggers into a select

### DIFF
--- a/frontend/src/screens/admin/JoinRequestMessageEditors.test.tsx
+++ b/frontend/src/screens/admin/JoinRequestMessageEditors.test.tsx
@@ -71,28 +71,26 @@ describe('JoinRequestMessageEditors', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('renders a template select with all options with permission', () => {
+  it('renders all edit triggers with permission', () => {
     const user = makeUser({
       roles: [
         { id: 'r1', name: 'vetter', isDefault: false, permissions: ['approve_join_requests'] },
       ],
     });
     renderEditors(user);
-    const select = screen.getByLabelText('message templates');
-    expect(select).toBeInTheDocument();
     expect(
-      screen.getByRole('option', { name: /edit shared welcome template/i }),
+      screen.getByRole('button', { name: /edit shared welcome template/i }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('option', { name: /edit tentative approval message/i }),
+      screen.getByRole('button', { name: /edit tentative approval message/i }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('option', { name: /edit member promotion message/i }),
+      screen.getByRole('button', { name: /edit member promotion message/i }),
     ).toBeInTheDocument();
-    expect(screen.getByRole('option', { name: /edit whatsapp link/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /edit whatsapp link/i })).toBeInTheDocument();
   });
 
-  it('opens the whatsapp link editor dialog when selected', async () => {
+  it('opens the whatsapp link editor dialog when clicked', async () => {
     const { default: userEvent } = await import('@testing-library/user-event');
     const user = makeUser({
       roles: [
@@ -100,7 +98,7 @@ describe('JoinRequestMessageEditors', () => {
       ],
     });
     renderEditors(user);
-    await userEvent.selectOptions(screen.getByLabelText('message templates'), 'edit whatsapp link');
+    await userEvent.click(screen.getByRole('button', { name: /edit whatsapp link/i }));
     expect(screen.getByLabelText('whatsapp link')).toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/admin/JoinRequestMessageEditors.test.tsx
+++ b/frontend/src/screens/admin/JoinRequestMessageEditors.test.tsx
@@ -100,10 +100,7 @@ describe('JoinRequestMessageEditors', () => {
       ],
     });
     renderEditors(user);
-    await userEvent.selectOptions(
-      screen.getByLabelText('message templates'),
-      'edit whatsapp link',
-    );
+    await userEvent.selectOptions(screen.getByLabelText('message templates'), 'edit whatsapp link');
     expect(screen.getByLabelText('whatsapp link')).toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/admin/JoinRequestMessageEditors.test.tsx
+++ b/frontend/src/screens/admin/JoinRequestMessageEditors.test.tsx
@@ -71,26 +71,28 @@ describe('JoinRequestMessageEditors', () => {
     expect(container).toBeEmptyDOMElement();
   });
 
-  it('renders all edit triggers with permission', () => {
+  it('renders a template select with all options with permission', () => {
     const user = makeUser({
       roles: [
         { id: 'r1', name: 'vetter', isDefault: false, permissions: ['approve_join_requests'] },
       ],
     });
     renderEditors(user);
+    const select = screen.getByLabelText('message templates');
+    expect(select).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: /edit shared welcome template/i }),
+      screen.getByRole('option', { name: /edit shared welcome template/i }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: /edit tentative approval message/i }),
+      screen.getByRole('option', { name: /edit tentative approval message/i }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole('button', { name: /edit member promotion message/i }),
+      screen.getByRole('option', { name: /edit member promotion message/i }),
     ).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /edit whatsapp link/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /edit whatsapp link/i })).toBeInTheDocument();
   });
 
-  it('opens the whatsapp link editor dialog when clicked', async () => {
+  it('opens the whatsapp link editor dialog when selected', async () => {
     const { default: userEvent } = await import('@testing-library/user-event');
     const user = makeUser({
       roles: [
@@ -98,7 +100,10 @@ describe('JoinRequestMessageEditors', () => {
       ],
     });
     renderEditors(user);
-    await userEvent.click(screen.getByRole('button', { name: /edit whatsapp link/i }));
+    await userEvent.selectOptions(
+      screen.getByLabelText('message templates'),
+      'edit whatsapp link',
+    );
     expect(screen.getByLabelText('whatsapp link')).toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/admin/JoinRequestMessageEditors.tsx
+++ b/frontend/src/screens/admin/JoinRequestMessageEditors.tsx
@@ -14,13 +14,18 @@ import { TentativeApprovalMessageEditorDialog } from './TentativeApprovalMessage
 import { WelcomeTemplateEditorDialog } from './WelcomeTemplateEditorDialog';
 import { WhatsAppLinkEditorDialog } from './WhatsAppLinkEditorDialog';
 
-type EditorKey = 'welcome' | 'tentative' | 'memberPromotion' | 'whatsapp';
+enum EditorKey {
+  Welcome = 'welcome',
+  Tentative = 'tentative',
+  MemberPromotion = 'memberPromotion',
+  WhatsApp = 'whatsapp',
+}
 
 const EDITOR_OPTIONS: { value: EditorKey; label: string }[] = [
-  { value: 'welcome', label: 'edit shared welcome template' },
-  { value: 'tentative', label: 'edit tentative approval message' },
-  { value: 'memberPromotion', label: 'edit member promotion message' },
-  { value: 'whatsapp', label: 'edit whatsapp link' },
+  { value: EditorKey.Welcome, label: 'edit shared welcome template' },
+  { value: EditorKey.Tentative, label: 'edit tentative approval message' },
+  { value: EditorKey.MemberPromotion, label: 'edit member promotion message' },
+  { value: EditorKey.WhatsApp, label: 'edit whatsapp link' },
 ];
 
 export function JoinRequestMessageEditors() {
@@ -63,22 +68,22 @@ export function JoinRequestMessageEditors() {
         ))}
       </select>
       <WelcomeTemplateEditorDialog
-        open={openEditor === 'welcome'}
+        open={openEditor === EditorKey.Welcome}
         onClose={closeEditor}
         template={welcomeQ.data ?? null}
       />
       <TentativeApprovalMessageEditorDialog
-        open={openEditor === 'tentative'}
+        open={openEditor === EditorKey.Tentative}
         onClose={closeEditor}
         template={tentativeQ.data ?? null}
       />
       <MemberPromotionMessageEditorDialog
-        open={openEditor === 'memberPromotion'}
+        open={openEditor === EditorKey.MemberPromotion}
         onClose={closeEditor}
         template={memberPromotionQ.data ?? null}
       />
       <WhatsAppLinkEditorDialog
-        open={openEditor === 'whatsapp'}
+        open={openEditor === EditorKey.WhatsApp}
         onClose={closeEditor}
         whatsappLink={whatsappQ.data ?? null}
       />

--- a/frontend/src/screens/admin/JoinRequestMessageEditors.tsx
+++ b/frontend/src/screens/admin/JoinRequestMessageEditors.tsx
@@ -14,11 +14,17 @@ import { TentativeApprovalMessageEditorDialog } from './TentativeApprovalMessage
 import { WelcomeTemplateEditorDialog } from './WelcomeTemplateEditorDialog';
 import { WhatsAppLinkEditorDialog } from './WhatsAppLinkEditorDialog';
 
+type EditorKey = 'welcome' | 'tentative' | 'memberPromotion' | 'whatsapp';
+
+const EDITOR_OPTIONS: { value: EditorKey; label: string }[] = [
+  { value: 'welcome', label: 'edit shared welcome template' },
+  { value: 'tentative', label: 'edit tentative approval message' },
+  { value: 'memberPromotion', label: 'edit member promotion message' },
+  { value: 'whatsapp', label: 'edit whatsapp link' },
+];
+
 export function JoinRequestMessageEditors() {
-  const [welcomeOpen, setWelcomeOpen] = useState(false);
-  const [tentativeOpen, setTentativeOpen] = useState(false);
-  const [memberPromotionOpen, setMemberPromotionOpen] = useState(false);
-  const [whatsappOpen, setWhatsappOpen] = useState(false);
+  const [openEditor, setOpenEditor] = useState<EditorKey | null>(null);
   const currentUser = useAuthStore((s) => s.user);
   const welcomeQ = useWelcomeTemplate();
   const tentativeQ = useTentativeApprovalMessage();
@@ -27,77 +33,55 @@ export function JoinRequestMessageEditors() {
 
   if (!hasPermission(currentUser, Permission.ApproveJoinRequests)) return null;
 
+  function closeEditor() {
+    setOpenEditor(null);
+  }
+
   return (
     <div className="border-border bg-surface-dim mb-4 rounded-md border p-3">
-      <p className="text-muted mb-2 text-xs font-medium tracking-wide uppercase">
+      <label
+        htmlFor="join-request-message-template-select"
+        className="text-muted mb-2 block text-xs font-medium tracking-wide uppercase"
+      >
         message templates
-      </p>
-      <div className="flex flex-wrap gap-2">
-        <EditorTrigger
-          label="edit shared welcome template"
-          onClick={() => {
-            setWelcomeOpen(true);
-          }}
-        />
-        <EditorTrigger
-          label="edit tentative approval message"
-          onClick={() => {
-            setTentativeOpen(true);
-          }}
-        />
-        <EditorTrigger
-          label="edit member promotion message"
-          onClick={() => {
-            setMemberPromotionOpen(true);
-          }}
-        />
-        <EditorTrigger
-          label="edit whatsapp link"
-          onClick={() => {
-            setWhatsappOpen(true);
-          }}
-        />
-      </div>
-      <WelcomeTemplateEditorDialog
-        open={welcomeOpen}
-        onClose={() => {
-          setWelcomeOpen(false);
+      </label>
+      <select
+        id="join-request-message-template-select"
+        className="border-border-strong bg-surface text-foreground-secondary focus-visible:ring-brand-200 w-full rounded-md border px-2.5 py-1.5 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none"
+        value=""
+        onChange={(e) => {
+          setOpenEditor(e.target.value as EditorKey);
         }}
+      >
+        <option value="" disabled>
+          choose a template to edit&hellip;
+        </option>
+        {EDITOR_OPTIONS.map((o) => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+      <WelcomeTemplateEditorDialog
+        open={openEditor === 'welcome'}
+        onClose={closeEditor}
         template={welcomeQ.data ?? null}
       />
       <TentativeApprovalMessageEditorDialog
-        open={tentativeOpen}
-        onClose={() => {
-          setTentativeOpen(false);
-        }}
+        open={openEditor === 'tentative'}
+        onClose={closeEditor}
         template={tentativeQ.data ?? null}
       />
       <MemberPromotionMessageEditorDialog
-        open={memberPromotionOpen}
-        onClose={() => {
-          setMemberPromotionOpen(false);
-        }}
+        open={openEditor === 'memberPromotion'}
+        onClose={closeEditor}
         template={memberPromotionQ.data ?? null}
       />
       <WhatsAppLinkEditorDialog
-        open={whatsappOpen}
-        onClose={() => {
-          setWhatsappOpen(false);
-        }}
+        open={openEditor === 'whatsapp'}
+        onClose={closeEditor}
         whatsappLink={whatsappQ.data ?? null}
       />
     </div>
-  );
-}
-
-function EditorTrigger({ label, onClick }: { label: string; onClick: () => void }) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className="border-border-strong bg-surface text-foreground-secondary hover:bg-background focus-visible:ring-brand-200 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none"
-    >
-      {label}
-    </button>
   );
 }

--- a/frontend/src/screens/admin/JoinRequestMessageEditors.tsx
+++ b/frontend/src/screens/admin/JoinRequestMessageEditors.tsx
@@ -14,22 +14,11 @@ import { TentativeApprovalMessageEditorDialog } from './TentativeApprovalMessage
 import { WelcomeTemplateEditorDialog } from './WelcomeTemplateEditorDialog';
 import { WhatsAppLinkEditorDialog } from './WhatsAppLinkEditorDialog';
 
-enum EditorKey {
-  Welcome = 'welcome',
-  Tentative = 'tentative',
-  MemberPromotion = 'memberPromotion',
-  WhatsApp = 'whatsapp',
-}
-
-const EDITOR_OPTIONS: { value: EditorKey; label: string }[] = [
-  { value: EditorKey.Welcome, label: 'edit shared welcome template' },
-  { value: EditorKey.Tentative, label: 'edit tentative approval message' },
-  { value: EditorKey.MemberPromotion, label: 'edit member promotion message' },
-  { value: EditorKey.WhatsApp, label: 'edit whatsapp link' },
-];
-
 export function JoinRequestMessageEditors() {
-  const [openEditor, setOpenEditor] = useState<EditorKey | null>(null);
+  const [welcomeOpen, setWelcomeOpen] = useState(false);
+  const [tentativeOpen, setTentativeOpen] = useState(false);
+  const [memberPromotionOpen, setMemberPromotionOpen] = useState(false);
+  const [whatsappOpen, setWhatsappOpen] = useState(false);
   const currentUser = useAuthStore((s) => s.user);
   const welcomeQ = useWelcomeTemplate();
   const tentativeQ = useTentativeApprovalMessage();
@@ -38,55 +27,77 @@ export function JoinRequestMessageEditors() {
 
   if (!hasPermission(currentUser, Permission.ApproveJoinRequests)) return null;
 
-  function closeEditor() {
-    setOpenEditor(null);
-  }
-
   return (
-    <div className="border-border bg-surface-dim mb-4 rounded-md border p-3">
-      <label
-        htmlFor="join-request-message-template-select"
-        className="text-muted mb-2 block text-xs font-medium tracking-wide uppercase"
-      >
+    <details className="border-border bg-surface-dim mb-4 rounded-md border p-3">
+      <summary className="text-muted text-xs font-medium tracking-wide uppercase [&::-webkit-details-marker]:hidden">
         message templates
-      </label>
-      <select
-        id="join-request-message-template-select"
-        className="border-border-strong bg-surface text-foreground-secondary focus-visible:ring-brand-200 w-full rounded-md border px-2.5 py-1.5 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none"
-        value=""
-        onChange={(e) => {
-          setOpenEditor(e.target.value as EditorKey);
-        }}
-      >
-        <option value="" disabled>
-          choose a template to edit&hellip;
-        </option>
-        {EDITOR_OPTIONS.map((o) => (
-          <option key={o.value} value={o.value}>
-            {o.label}
-          </option>
-        ))}
-      </select>
+      </summary>
+      <div className="mt-2 flex flex-wrap gap-2">
+        <EditorTrigger
+          label="edit shared welcome template"
+          onClick={() => {
+            setWelcomeOpen(true);
+          }}
+        />
+        <EditorTrigger
+          label="edit tentative approval message"
+          onClick={() => {
+            setTentativeOpen(true);
+          }}
+        />
+        <EditorTrigger
+          label="edit member promotion message"
+          onClick={() => {
+            setMemberPromotionOpen(true);
+          }}
+        />
+        <EditorTrigger
+          label="edit whatsapp link"
+          onClick={() => {
+            setWhatsappOpen(true);
+          }}
+        />
+      </div>
       <WelcomeTemplateEditorDialog
-        open={openEditor === EditorKey.Welcome}
-        onClose={closeEditor}
+        open={welcomeOpen}
+        onClose={() => {
+          setWelcomeOpen(false);
+        }}
         template={welcomeQ.data ?? null}
       />
       <TentativeApprovalMessageEditorDialog
-        open={openEditor === EditorKey.Tentative}
-        onClose={closeEditor}
+        open={tentativeOpen}
+        onClose={() => {
+          setTentativeOpen(false);
+        }}
         template={tentativeQ.data ?? null}
       />
       <MemberPromotionMessageEditorDialog
-        open={openEditor === EditorKey.MemberPromotion}
-        onClose={closeEditor}
+        open={memberPromotionOpen}
+        onClose={() => {
+          setMemberPromotionOpen(false);
+        }}
         template={memberPromotionQ.data ?? null}
       />
       <WhatsAppLinkEditorDialog
-        open={openEditor === EditorKey.WhatsApp}
-        onClose={closeEditor}
+        open={whatsappOpen}
+        onClose={() => {
+          setWhatsappOpen(false);
+        }}
         whatsappLink={whatsappQ.data ?? null}
       />
-    </div>
+    </details>
+  );
+}
+
+function EditorTrigger({ label, onClick }: { label: string; onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="border-border-strong bg-surface text-foreground-secondary hover:bg-background focus-visible:ring-brand-200 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors focus-visible:ring-2 focus-visible:outline-none"
+    >
+      {label}
+    </button>
   );
 }

--- a/frontend/src/screens/admin/JoinRequestsScreen.tsx
+++ b/frontend/src/screens/admin/JoinRequestsScreen.tsx
@@ -158,10 +158,11 @@ export default function JoinRequestsScreen() {
 
       <JoinRequestMessageEditors />
 
-      <div className="mb-4 flex justify-center">
+      <div className="mb-4 overflow-x-auto">
         <SegmentedControl
           name="join-filter"
           ariaLabel="filter"
+          className="mx-auto w-max"
           options={FILTERS}
           value={filter}
           onChange={setFilter}


### PR DESCRIPTION
## Overview

On mobile, the join requests screen's message templates section rendered as 4 wrapping buttons (welcome template, tentative approval message, member promotion message, whatsapp link), each opening an editor dialog. On narrow viewports these wrapped across multiple rows, pushing the actual join-request list down the page.

Replaces the 4 buttons with a single native `<select>` that opens the corresponding editor dialog on change, reclaiming vertical space on mobile.

Closes #1036

## Test plan

- [x] `make agent-frontend-typecheck` — clean
- [x] `make agent-frontend-lint` — clean
- [x] `JoinRequestMessageEditors.test.tsx` run directly via vitest — 3/3 passing
- [ ] Manual mobile-viewport verification in browser (TODO — not completed this session)
