### PR TITLE
fix(rsvp): submit public rsvp form on cmd/ctrl+enter

### DIFF
--- a/frontend/src/screens/events/PublicRsvpForm.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.test.tsx
@@ -391,6 +391,18 @@ describe('PublicRsvpForm', () => {
     expect(submitMutate).not.toHaveBeenCalled();
   });
 
+  it('submits the form on cmd+enter from the comment field', async () => {
+    const onSuccess = vi.fn();
+    renderForm(makeEvent(), onSuccess);
+    await fillRequired();
+    fireEvent.keyDown(screen.getByLabelText('comment (optional)'), {
+      key: 'Enter',
+      metaKey: true,
+    });
+    await waitFor(() => expect(submitMutate).toHaveBeenCalled());
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+  });
+
   it('shows an inline error and does not submit when the phone is edited to an invalid number', async () => {
     checkPhoneMutate.mockResolvedValue({ status: 'new', rsvp_token: '' });
     renderForm();

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -1,4 +1,4 @@
-import { type SyntheticEvent, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { isValidPhoneNumber } from 'react-phone-number-input';
 import { Link, useNavigate } from 'react-router-dom';
 
@@ -103,8 +103,7 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
     return Object.keys(next).length === 0;
   }
 
-  async function onSubmit(e: SyntheticEvent) {
-    e.preventDefault();
+  async function onSubmit() {
     setSubmitError(null);
     if (!status || !validate()) return;
     try {
@@ -179,7 +178,14 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
       );
     }
     return (
-      <form onSubmit={(e) => void onSubmit(e)} className="flex flex-col gap-4" noValidate>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          void onSubmit();
+        }}
+        className="flex flex-col gap-4"
+        noValidate
+      >
         <Honeypot value={website} onChange={setWebsite} />
 
         <div className="flex items-center justify-between">
@@ -232,7 +238,12 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
         />
         <PhoneField label="phone" value={phone} onChange={setPhone} error={errors.phone} />
 
-        <RsvpCommentField value={comment} onChange={setComment} disabled={submit.isPending} />
+        <RsvpCommentField
+          value={comment}
+          onChange={setComment}
+          disabled={submit.isPending}
+          onSubmitShortcut={() => void onSubmit()}
+        />
 
         <Button type="submit" disabled={submit.isPending} fullWidth>
           rsvp

--- a/frontend/src/screens/events/RsvpCommentField.test.tsx
+++ b/frontend/src/screens/events/RsvpCommentField.test.tsx
@@ -20,4 +20,25 @@ describe('RsvpCommentField', () => {
     render(<RsvpCommentField value="ab" onChange={() => {}} />);
     expect(screen.getByText(`${RSVP_COMMENT_MAX_LENGTH - 2} characters left`)).toBeInTheDocument();
   });
+
+  it('triggers onSubmitShortcut on cmd+enter', () => {
+    const onSubmitShortcut = vi.fn();
+    render(<RsvpCommentField value="hi" onChange={() => {}} onSubmitShortcut={onSubmitShortcut} />);
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter', metaKey: true });
+    expect(onSubmitShortcut).toHaveBeenCalledTimes(1);
+  });
+
+  it('triggers onSubmitShortcut on ctrl+enter', () => {
+    const onSubmitShortcut = vi.fn();
+    render(<RsvpCommentField value="hi" onChange={() => {}} onSubmitShortcut={onSubmitShortcut} />);
+    fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter', ctrlKey: true });
+    expect(onSubmitShortcut).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when onSubmitShortcut is not provided', () => {
+    render(<RsvpCommentField value="hi" onChange={() => {}} />);
+    expect(() => {
+      fireEvent.keyDown(screen.getByRole('textbox'), { key: 'Enter', metaKey: true });
+    }).not.toThrow();
+  });
 });

--- a/frontend/src/screens/events/RsvpCommentField.tsx
+++ b/frontend/src/screens/events/RsvpCommentField.tsx
@@ -1,3 +1,5 @@
+import type { KeyboardEvent } from 'react';
+
 import { Textarea } from '@/components/ui/Textarea';
 
 export const RSVP_COMMENT_MAX_LENGTH = 300;
@@ -6,10 +8,19 @@ interface Props {
   value: string;
   onChange: (value: string) => void;
   disabled?: boolean;
+  onSubmitShortcut?: () => void;
 }
 
-export function RsvpCommentField({ value, onChange, disabled = false }: Props) {
+export function RsvpCommentField({ value, onChange, disabled = false, onSubmitShortcut }: Props) {
   const remaining = RSVP_COMMENT_MAX_LENGTH - value.length;
+
+  function handleKeyDown(e: KeyboardEvent<HTMLTextAreaElement>) {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      onSubmitShortcut?.();
+    }
+  }
+
   return (
     <Textarea
       id="rsvp-comment"
@@ -24,6 +35,7 @@ export function RsvpCommentField({ value, onChange, disabled = false }: Props) {
       onChange={(e) => {
         onChange(e.target.value);
       }}
+      onKeyDown={handleKeyDown}
     />
   );
 }


### PR DESCRIPTION
## Overview

The public RSVP form (`/events/<uuid>`) had no keyboard-submit shortcut at all. The report named "cmd+shift+enter" but the codebase's established convention (`CommentComposer.tsx`) is cmd/ctrl+enter, so this adds that same pattern rather than inventing a new shortcut.

Changes:
- `RsvpCommentField` gains an optional `onSubmitShortcut` prop, wired to an `onKeyDown` handler that fires on cmd/ctrl+enter (mirrors `CommentComposer`'s existing handler).
- `PublicRsvpForm` passes its submit handler through as `onSubmitShortcut`, and `onSubmit` no longer requires a `SyntheticEvent` so it can be called directly from the keyboard handler.

Closes #1040

## Test plan

- [x] `make agent-frontend-typecheck` — clean
- [x] `make agent-frontend-lint` — clean
- [x] `vitest run` on `PublicRsvpForm.test.tsx` and `RsvpCommentField.test.tsx` — 30/30 passed, including new cmd+enter / ctrl+enter cases
- [x] Manually verified in a real browser: filled out the public RSVP form, pressed cmd+enter in the comment field, form submitted successfully
