### PR TITLE
fix(events): stack host contact buttons on mobile (Issue 1044)

### DIFF
--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -71,7 +71,7 @@ export function EventMemberSection({ event, token }: Props) {
             {...(token ? { token } : {})}
           />
           {canInvite || isCoHost ? (
-            <div className="mt-4 flex flex-col items-stretch gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:justify-end">
+            <div className="mt-4 flex flex-col items-stretch gap-2">
               {canInvite ? <InviteSection event={event} /> : null}
               {isCoHost ? (
                 <div className="flex flex-wrap justify-end gap-2">

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -71,13 +71,13 @@ export function EventMemberSection({ event, token }: Props) {
             {...(token ? { token } : {})}
           />
           {canInvite || isCoHost ? (
-            <div className="mt-4 flex flex-wrap justify-end gap-2">
+            <div className="mt-4 flex flex-col items-stretch gap-2 sm:flex-row sm:flex-wrap sm:items-center sm:justify-end">
               {canInvite ? <InviteSection event={event} /> : null}
               {isCoHost ? (
-                <>
+                <div className="flex flex-wrap justify-end gap-2">
                   <EmailBlastButton event={event} />
                   <GroupTextButton event={event} />
-                </>
+                </div>
               ) : null}
             </div>
           ) : null}


### PR DESCRIPTION
## overview

on mobile, the event detail host-contact area rendered "invite members" and the two contact buttons ("email blast", "group text") in a single `flex-wrap justify-end` row. the larger "invite members" button pushed the contact buttons apart and wrapped them badly.

## change

`frontend/src/screens/events/EventMemberSection.tsx` — the button container now stacks into two rows on all screen sizes:

- row 1: "invite members" (full-width via `items-stretch`)
- row 2: the two contact buttons grouped together

no breakpoint-specific behavior — same stacked layout on mobile and desktop, no logic or copy changes.

## verification

- `make agent-frontend-typecheck` — pass
- `make agent-frontend-lint` — pass
- `pnpm vitest run src/screens/events/EventMemberSection.test.tsx` — 32/32 pass

Closes #1044
