### PR TITLE
fix(rsvp): send confirmation not update email on new non-member rsvp (Issue 1048)

### DIFF
--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -128,11 +128,12 @@ def _post_rsvp_comment(event_id, user, final_status: str, comment: str | None) -
 
 def _apply_rsvp_in_transaction(
     event_id, user, status: str, has_plus_one: bool
-) -> tuple[str, list[str]]:
+) -> tuple[str, list[str], bool]:
     """Execute RSVP upsert inside a locked transaction.
 
-    Returns (final_status, promoted_user_ids). promoted_user_ids is the list of
-    users promoted off the waitlist by this change (empty unless a spot freed).
+    Returns (final_status, promoted_user_ids, created). promoted_user_ids is the
+    list of users promoted off the waitlist by this change (empty unless a spot
+    freed); created is True when this call created the user's first RSVP row.
 
     Raises ValidationException on failure.
     """
@@ -150,6 +151,7 @@ def _apply_rsvp_in_transaction(
     final_status, final_plus_one = _resolve_rsvp_status(event, user, status, has_plus_one)
 
     existing = EventRSVP.objects.filter(event=event, user=user).first()
+    created = existing is None
     was_attending = existing is not None and existing.status == RSVPStatus.ATTENDING
     had_plus_one = existing is not None and existing.has_plus_one
 
@@ -158,7 +160,7 @@ def _apply_rsvp_in_transaction(
         and existing.status == final_status
         and existing.has_plus_one == final_plus_one
     ):
-        return final_status, []
+        return final_status, [], False
 
     EventRSVP.objects.update_or_create(
         event=event,
@@ -175,7 +177,7 @@ def _apply_rsvp_in_transaction(
     )
     promoted_user_ids = promote_from_waitlist(event) if spot_freed else []
 
-    return final_status, promoted_user_ids
+    return final_status, promoted_user_ids, created
 
 
 @router.post(
@@ -193,7 +195,7 @@ def upsert_rsvp(request, event_id: UUID, payload: RSVPIn):
     _validate_rsvp_status(payload.status)
 
     with transaction.atomic():
-        final_status, promoted_user_ids = _apply_rsvp_in_transaction(
+        final_status, promoted_user_ids, _created = _apply_rsvp_in_transaction(
             event_id, request.auth, payload.status, payload.has_plus_one
         )
 

--- a/backend/community/_public_rsvp_manage.py
+++ b/backend/community/_public_rsvp_manage.py
@@ -7,7 +7,7 @@ from django.db.models import Count, Q
 from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
-from notifications._email_helpers import send_rsvp_updated_email
+from notifications._email_helpers import send_rsvp_confirmation_email, send_rsvp_updated_email
 from notifications.email_sender import get_email_sender
 from pydantic import BaseModel, Field
 from users.models import NonMemberRsvpToken, User
@@ -84,15 +84,23 @@ def _eligible_event_rsvps(user):
     )
 
 
-def _send_updated_email(request, event: Event, user: User, token_str: str) -> None:
-    """Best-effort "rsvp updated" email. A send failure must NOT roll back the RSVP."""
+def _send_manage_rsvp_email(
+    request, event: Event, user: User, token_str: str, *, created: bool, waitlisted: bool
+) -> None:
+    """Best-effort email: confirmation for a first RSVP, "updated" for a change.
+
+    A send failure must NOT roll back the RSVP.
+    """
     if not user.email:
         return
+    details = _email_details(event, user, token_str)
     try:
-        result = send_rsvp_updated_email(
-            sender=get_email_sender(),
-            details=_email_details(event, user, token_str),
-        )
+        if created:
+            result = send_rsvp_confirmation_email(
+                sender=get_email_sender(), details=details, waitlisted=waitlisted
+            )
+        else:
+            result = send_rsvp_updated_email(sender=get_email_sender(), details=details)
         if not result.success:
             raise RuntimeError(result.error or "send returned failure")
     except Exception as exc:
@@ -140,7 +148,7 @@ def update_my_rsvp(request, event_id, payload: PublicRsvpManageIn, token: str = 
     _validate_rsvp_status(payload.status)
 
     with transaction.atomic():
-        final_status, promoted_user_ids = _apply_rsvp_in_transaction(
+        final_status, promoted_user_ids, created = _apply_rsvp_in_transaction(
             event.id, user, payload.status, payload.has_plus_one
         )
         rsvp_token = NonMemberRsvpToken.issue_or_extend(user)
@@ -154,7 +162,14 @@ def update_my_rsvp(request, event_id, payload: PublicRsvpManageIn, token: str = 
         details={"user_id": str(user.pk), "status": final_status},
     )
     _post_rsvp_comment(event.id, user, final_status, payload.comment)
-    _send_updated_email(request, event, user, rsvp_token.token)
+    _send_manage_rsvp_email(
+        request,
+        event,
+        user,
+        rsvp_token.token,
+        created=created,
+        waitlisted=final_status == RSVPStatus.WAITLISTED,
+    )
     _email_promoted_non_members(request, event, promoted_user_ids)
     broadcast_capacity_change(event.id)
 

--- a/backend/community/_public_rsvp_manage.py
+++ b/backend/community/_public_rsvp_manage.py
@@ -85,26 +85,30 @@ def _eligible_event_rsvps(user):
 
 
 def _send_manage_rsvp_email(
-    request, event: Event, user: User, token_str: str, *, created: bool, waitlisted: bool
-) -> None:
+    event: Event, user: User, token_str: str, *, created: bool, final_status: str
+) -> Exception | None:
     """Best-effort email: confirmation for a first RSVP, "updated" for a change.
 
-    A send failure must NOT roll back the RSVP.
+    A send failure must NOT roll back the RSVP. Returns the exception on failure, for the
+    caller to audit-log (keeps this helper request-agnostic).
     """
     if not user.email:
-        return
+        return None
     details = _email_details(event, user, token_str)
     try:
         if created:
             result = send_rsvp_confirmation_email(
-                sender=get_email_sender(), details=details, waitlisted=waitlisted
+                sender=get_email_sender(),
+                details=details,
+                waitlisted=final_status == RSVPStatus.WAITLISTED,
             )
         else:
             result = send_rsvp_updated_email(sender=get_email_sender(), details=details)
         if not result.success:
             raise RuntimeError(result.error or "send returned failure")
     except Exception as exc:
-        _log_email_failure(request, event, user, exc)
+        return exc
+    return None
 
 
 @router.get(
@@ -162,14 +166,11 @@ def update_my_rsvp(request, event_id, payload: PublicRsvpManageIn, token: str = 
         details={"user_id": str(user.pk), "status": final_status},
     )
     _post_rsvp_comment(event.id, user, final_status, payload.comment)
-    _send_manage_rsvp_email(
-        request,
-        event,
-        user,
-        rsvp_token.token,
-        created=created,
-        waitlisted=final_status == RSVPStatus.WAITLISTED,
+    email_error = _send_manage_rsvp_email(
+        event, user, rsvp_token.token, created=created, final_status=final_status
     )
+    if email_error is not None:
+        _log_email_failure(request, event, user, email_error)
     _email_promoted_non_members(request, event, promoted_user_ids)
     broadcast_capacity_change(event.id)
 

--- a/backend/community/_public_rsvp_submit.py
+++ b/backend/community/_public_rsvp_submit.py
@@ -238,7 +238,7 @@ def submit_public_rsvp(request, event_id, payload: PublicRsvpIn):
             email=normalized_email,
             phone=validated_phone,
         )
-        final_status, promoted_user_ids = _apply_rsvp_in_transaction(
+        final_status, promoted_user_ids, _rsvp_created = _apply_rsvp_in_transaction(
             event.id, user, payload.status, False
         )
         token = NonMemberRsvpToken.issue_or_extend(user)

--- a/backend/tests/test_public_rsvp_manage.py
+++ b/backend/tests/test_public_rsvp_manage.py
@@ -163,6 +163,26 @@ class TestPostMyRsvps:
         # The emailed manage link reuses the still-valid token.
         assert token.token in sent["text"]
 
+    def test_first_rsvp_sends_confirmation_then_change_sends_updated(
+        self, api_client, nonmember, official_event, fake_email_sender
+    ):
+        token = NonMemberRsvpToken.issue_or_extend(nonmember)
+        first = api_client.post(
+            f"{_post_url(official_event)}?token={token.token}",
+            {"status": RSVPStatus.ATTENDING},
+            content_type="application/json",
+        )
+        assert first.status_code == 200
+        assert fake_email_sender.send.call_args.kwargs["subject"] == "you're in for official a"
+
+        second = api_client.post(
+            f"{_post_url(official_event)}?token={token.token}",
+            {"status": RSVPStatus.MAYBE},
+            content_type="application/json",
+        )
+        assert second.status_code == 200
+        assert fake_email_sender.send.call_args.kwargs["subject"] == "your rsvp was updated"
+
     def test_email_failure_does_not_roll_back_update(
         self, api_client, nonmember, official_event, fake_email_sender, caplog
     ):


### PR DESCRIPTION
Closes #1048

## Problem

A non-member RSVPing for the first time received a "your rsvp was updated" email instead of a "you're in!" confirmation.

## Root cause

The public manage endpoint (`update_my_rsvp` in `_public_rsvp_manage.py`) always called `send_rsvp_updated_email`, regardless of whether the RSVP row already existed. A recognized non-member who lands on the manage screen and RSVPs to an event for the first time hits this path, so their first RSVP was mislabeled as an update. `_apply_rsvp_in_transaction` knew the row was new (via its `existing` lookup) but did not surface that fact.

## Fix

- `_apply_rsvp_in_transaction` now returns a `created` flag alongside `(final_status, promoted_user_ids)`.
- The manage flow uses it to send the confirmation email ("you're in for ..." / waitlist variant) on a first RSVP and the "updated" email only for a genuine change to an existing RSVP.
- The two other callers (member `upsert_rsvp`, public `submit_public_rsvp`) just unpack the extra value; their email behavior is unchanged (submit already sent the confirmation email).

## Tests

Added `test_first_rsvp_sends_confirmation_then_change_sends_updated` asserting a brand-new manage RSVP sends the confirmation subject and a subsequent status change sends the update subject.