### PR TITLE
fix(rsvp): broadcast + invalidate on non-member rsvp comment (Issue 1047)

### DIFF
--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -8,7 +8,11 @@ from django.db import transaction
 from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
-from notifications.service import notify_event_comment, notify_rsvp_declined_note
+from notifications.service import (
+    broadcast_event_comment_update,
+    notify_event_comment,
+    notify_rsvp_declined_note,
+)
 
 from community._event_helpers import (
     _event_out,
@@ -119,6 +123,7 @@ def _post_rsvp_comment(event_id, user, final_status: str, comment: str | None) -
                 event=event, author=user, body=cleaned_comment
             )
             notify_event_comment(posted_comment)
+            broadcast_event_comment_update(event)
     except Exception:
         # RSVP already committed — a failure here must not 500 an already-successful RSVP.
         logging.getLogger(__name__).exception(

--- a/backend/tests/test_rsvp_comment.py
+++ b/backend/tests/test_rsvp_comment.py
@@ -113,6 +113,16 @@ class TestRSVPCommentRouting:
         _rsvp(api_client, member_headers, rsvp_event, RSVPStatus.MAYBE)
         assert EventComment.objects.filter(event=rsvp_event, author=member).count() == 1
 
+    def test_going_comment_broadcasts_live_update(
+        self, api_client, member_headers, member, rsvp_event
+    ):
+        with patch("community._event_rsvps.broadcast_event_comment_update") as mock_broadcast:
+            resp = _rsvp(
+                api_client, member_headers, rsvp_event, RSVPStatus.ATTENDING, "bringing snacks"
+            )
+        assert resp.status_code == 200
+        mock_broadcast.assert_called_once()
+
     def test_comment_post_failure_does_not_fail_the_rsvp(
         self, api_client, member_headers, member, rsvp_event
     ):

--- a/frontend/src/api/publicRsvp.test.ts
+++ b/frontend/src/api/publicRsvp.test.ts
@@ -4,15 +4,27 @@ import { createElement, type ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { apiClient } from './client';
-import { useSubmitPublicRsvp } from './publicRsvp';
+import { eventCommentKeys } from './eventComments';
+import { eventKeys } from './events';
+import { useSubmitPublicRsvp, useUpdatePublicMyRsvp } from './publicRsvp';
 
-vi.mock('./client', () => ({ apiClient: { post: vi.fn() } }));
+vi.mock('./client', () => ({
+  apiClient: { post: vi.fn(), get: vi.fn(), delete: vi.fn() },
+  setAuthBridge: vi.fn(),
+}));
 
-function wrapper({ children }: { children: ReactNode }) {
+function makeWrapper() {
   const qc = new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
-  return createElement(QueryClientProvider, { client: qc }, children);
+  function wrapper({ children }: { children: ReactNode }) {
+    return createElement(QueryClientProvider, { client: qc }, children);
+  }
+  return { qc, wrapper };
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  return makeWrapper().wrapper({ children });
 }
 
 describe('useSubmitPublicRsvp', () => {
@@ -37,5 +49,28 @@ describe('useSubmitPublicRsvp', () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(apiClient.post).toHaveBeenCalledWith('/api/community/public/events/ev1/rsvp/', payload);
     expect(result.current.data).toEqual(out);
+  });
+});
+
+describe('useUpdatePublicMyRsvp', () => {
+  beforeEach(() => vi.mocked(apiClient.post).mockReset());
+
+  it('invalidates the token event-detail and comment-list queries on success', async () => {
+    const token = 'tok123';
+    vi.mocked(apiClient.post).mockResolvedValue({ data: { event: { id: 'ev1' } } });
+    const { qc, wrapper } = makeWrapper();
+    const invalidate = vi.spyOn(qc, 'invalidateQueries');
+    const { result } = renderHook(() => useUpdatePublicMyRsvp(token), { wrapper });
+
+    result.current.mutate({
+      eventId: 'ev1',
+      status: 'attending',
+      hasPlusOne: false,
+      comment: 'hi',
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: eventKeys.detail('ev1', false, token) });
+    expect(invalidate).toHaveBeenCalledWith({ queryKey: eventCommentKeys.list('ev1') });
   });
 });

--- a/frontend/src/api/publicRsvp.ts
+++ b/frontend/src/api/publicRsvp.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
+import { eventCommentKeys } from '@/api/eventComments';
 import { mapEvent, type WireEvent } from '@/api/eventMapper';
+import { eventKeys } from '@/api/events';
 import type { components } from '@/api/types.gen';
 import type { Event, RsvpInputStatus } from '@/models/event';
 
@@ -110,12 +112,18 @@ interface UpdateArgs {
 
 function useManageInvalidate(token: string) {
   const queryClient = useQueryClient();
-  return () => {
+  return (eventId: string) => {
     void queryClient.invalidateQueries({ queryKey: manageQueryKey(token) });
+    // The event-detail screen renders a token holder's rsvp + comments from
+    // these queries, not the manage list — refresh them so a returning
+    // non-member sees their own rsvp/comment without a reload (issue 1047).
+    void queryClient.invalidateQueries({ queryKey: eventKeys.detail(eventId, false, token) });
+    void queryClient.invalidateQueries({ queryKey: eventCommentKeys.list(eventId) });
   };
 }
 
 export function useUpdatePublicMyRsvp(token: string) {
+  const invalidate = useManageInvalidate(token);
   return useMutation({
     mutationFn: async ({ eventId, status, hasPlusOne, comment }: UpdateArgs) => {
       const body: PublicRsvpManageIn = {
@@ -128,15 +136,21 @@ export function useUpdatePublicMyRsvp(token: string) {
       });
       return data;
     },
-    onSuccess: useManageInvalidate(token),
+    onSuccess: (_data, { eventId }) => {
+      invalidate(eventId);
+    },
   });
 }
 
 export function useCancelPublicMyRsvp(token: string) {
+  const invalidate = useManageInvalidate(token);
   return useMutation({
     mutationFn: async (eventId: string) => {
       await apiClient.delete(`${MANAGE_BASE}${eventId}/`, { params: { token } });
+      return eventId;
     },
-    onSuccess: useManageInvalidate(token),
+    onSuccess: (eventId) => {
+      invalidate(eventId);
+    },
   });
 }


### PR DESCRIPTION
Closes #1047

## Root cause

A non-member reported that RSVPing to a **second** event (with a comment) didn't show up live — neither the RSVP nor the comment appeared for the non-member or the host until a page reload. Two independent gaps:

### (a) Host got no live comment update — backend

The shared `_post_rsvp_comment` helper (used by the member RSVP endpoint, public RSVP submit, and public RSVP manage) posted the comment and fired the host's bell notification via `notify_event_comment`, but **never called `broadcast_event_comment_update`**. The dedicated `post_comment` endpoint does. So the comment never pinged the `event_updates` SSE channel — the host's (and everyone's) comment list only refreshed on reload.

**Fix (root):** one `broadcast_event_comment_update(event)` call added to `_post_rsvp_comment`, so all three RSVP-comment callers now broadcast.

### (b) Non-member didn't see their own RSVP/comment — frontend

A returning non-member already has a stored RSVP token, so on the second event the detail screen renders the token-unlocked member section and their RSVP goes through `useUpdatePublicMyRsvp` (the token path). That mutation only invalidated the `['public-my-rsvps', token]` manage-screen query — **not** `eventKeys.detail(eventId, false, token)` or `eventCommentKeys.list(eventId)`, which are what the detail screen actually renders from. The member RSVP path (`useSetRsvp`) already invalidates those.

**Fix:** `useUpdatePublicMyRsvp` / `useCancelPublicMyRsvp` now also invalidate the token event-detail and comment-list queries.

## Overlap with #1043

Issue #1043 fixes the SSE **transport** so non-member (anon-ticket) viewers can connect and receive comment broadcasts at all. This PR fixes that the RSVP-comment path never *sent* a comment broadcast, plus the frontend local-invalidation. Complementary, no file conflicts.

## Tests

- Backend: added `test_going_comment_broadcasts_live_update` asserting `broadcast_event_comment_update` fires on the RSVP-comment path. `test_rsvp_comment.py` + `test_public_rsvp.py` + comment tests pass (SQLite-isolated).
- Frontend: added a `useUpdatePublicMyRsvp` test asserting it invalidates the event-detail and comment-list queries. `publicRsvp.test.ts` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
