### PR TITLE
fix: 1064 - stop non-member magic-link manage flow from setting +1

### DIFF
--- a/backend/community/_public_rsvp_manage.py
+++ b/backend/community/_public_rsvp_manage.py
@@ -153,7 +153,7 @@ def update_my_rsvp(request, event_id, payload: PublicRsvpManageIn, token: str = 
 
     with transaction.atomic():
         final_status, promoted_user_ids, created = _apply_rsvp_in_transaction(
-            event.id, user, payload.status, payload.has_plus_one
+            event.id, user, payload.status, False
         )
         rsvp_token = NonMemberRsvpToken.issue_or_extend(user)
 

--- a/backend/tests/test_public_rsvp_manage.py
+++ b/backend/tests/test_public_rsvp_manage.py
@@ -128,6 +128,21 @@ class TestPostMyRsvps:
         rsvp = EventRSVP.objects.get(event=official_event, user=nonmember)
         assert rsvp.status == RSVPStatus.ATTENDING
 
+    def test_ignores_plus_one_parameter(
+        self, api_client, nonmember, official_event, fake_email_sender
+    ):
+        EventRSVP.objects.create(event=official_event, user=nonmember, status=RSVPStatus.MAYBE)
+        token = NonMemberRsvpToken.issue_or_extend(nonmember)
+        resp = api_client.post(
+            f"{_post_url(official_event)}?token={token.token}",
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": True},
+            content_type="application/json",
+        )
+        assert resp.status_code == 200
+        assert resp.json()["rsvp"]["has_plus_one"] is False
+        rsvp = EventRSVP.objects.get(event=official_event, user=nonmember)
+        assert rsvp.has_plus_one is False
+
     def test_update_extends_token_keeping_same_string(self, api_client, nonmember, official_event):
         EventRSVP.objects.create(event=official_event, user=nonmember, status=RSVPStatus.MAYBE)
         token = NonMemberRsvpToken.issue_or_extend(nonmember)

--- a/frontend/src/screens/events/PublicRsvpCard.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpCard.test.tsx
@@ -15,7 +15,7 @@ vi.mock('@/api/publicRsvp', () => ({
 
 import { PublicRsvpCard } from './PublicRsvpCard';
 
-function renderCard(props: { status: string; hasPlusOne: boolean; event?: Partial<Event> }) {
+function renderCard(props: { status: string; event?: Partial<Event> }) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={qc}>
@@ -24,7 +24,6 @@ function renderCard(props: { status: string; hasPlusOne: boolean; event?: Partia
           token="tok123"
           event={makeEvent({ allowPlusOnes: true, ...props.event })}
           status={props.status}
-          hasPlusOne={props.hasPlusOne}
         />
       </MemoryRouter>
     </QueryClientProvider>,
@@ -35,63 +34,32 @@ describe('PublicRsvpCard', () => {
   it('links the event title to the event detail page', () => {
     renderCard({
       status: RsvpServerStatus.Attending,
-      hasPlusOne: false,
       event: { id: 'ev1', title: 'Potluck' },
     });
     expect(screen.getByRole('link', { name: 'Potluck' })).toHaveAttribute('href', '/events/ev1');
   });
 
-  it('shows the +1 toggle when attending', () => {
-    renderCard({ status: RsvpServerStatus.Attending, hasPlusOne: false });
-    expect(screen.getByRole('switch', { name: /bring a \+1/i })).toBeInTheDocument();
+  it('never shows a +1 toggle — non-members cannot bring a +1', () => {
+    renderCard({ status: RsvpServerStatus.Attending });
+    expect(screen.queryByRole('switch', { name: /bring a \+1/i })).not.toBeInTheDocument();
   });
 
-  it('keeps the +1 toggle visible and checked after switching to maybe', () => {
-    renderCard({ status: RsvpServerStatus.Attending, hasPlusOne: true });
+  it('sends has_plus_one false when changing status', () => {
+    renderCard({ status: RsvpServerStatus.Attending });
     fireEvent.click(screen.getByRole('button', { name: /^maybe$/i }));
     expect(updateMutate).toHaveBeenCalledWith(
-      expect.objectContaining({ status: RsvpServerStatus.Maybe, hasPlusOne: true }),
+      expect.objectContaining({ status: RsvpServerStatus.Maybe, hasPlusOne: false }),
     );
-  });
-
-  it('preserves the +1 flag when switching to can’t go', () => {
-    renderCard({ status: RsvpServerStatus.Attending, hasPlusOne: true });
-    fireEvent.click(screen.getByRole('button', { name: /can't go/i }));
-    expect(updateMutate).toHaveBeenCalledWith(
-      expect.objectContaining({ status: RsvpServerStatus.CantGo, hasPlusOne: true }),
-    );
-  });
-
-  it('allows toggling +1 while on maybe', () => {
-    renderCard({ status: RsvpServerStatus.Maybe, hasPlusOne: false });
-    fireEvent.click(screen.getByRole('switch', { name: /bring a \+1/i }));
-    expect(updateMutate).toHaveBeenCalledWith(
-      expect.objectContaining({ status: RsvpServerStatus.Maybe, hasPlusOne: true }),
-    );
-  });
-
-  it('hides the +1 toggle when waitlisted', () => {
-    renderCard({ status: RsvpServerStatus.Waitlisted, hasPlusOne: false });
-    expect(screen.queryByRole('switch', { name: /bring a \+1/i })).not.toBeInTheDocument();
-  });
-
-  it('hides the +1 toggle when the event does not allow plus ones', () => {
-    renderCard({
-      status: RsvpServerStatus.Attending,
-      hasPlusOne: false,
-      event: { allowPlusOnes: false },
-    });
-    expect(screen.queryByRole('switch', { name: /bring a \+1/i })).not.toBeInTheDocument();
   });
 
   it('renders the comment field', () => {
-    renderCard({ status: RsvpServerStatus.Attending, hasPlusOne: false });
+    renderCard({ status: RsvpServerStatus.Attending });
     expect(screen.getByLabelText('comment (optional)')).toBeInTheDocument();
   });
 
   it('calls update with the comment when save comment is clicked', async () => {
     updateMutate.mockResolvedValue(undefined);
-    renderCard({ status: RsvpServerStatus.Attending, hasPlusOne: false });
+    renderCard({ status: RsvpServerStatus.Attending });
     fireEvent.change(screen.getByLabelText('comment (optional)'), {
       target: { value: 'bringing snacks' },
     });

--- a/frontend/src/screens/events/PublicRsvpCard.tsx
+++ b/frontend/src/screens/events/PublicRsvpCard.tsx
@@ -6,7 +6,6 @@ import { extractApiErrorOr, getApiStatus } from '@/api/apiErrors';
 import { useCancelPublicMyRsvp, useUpdatePublicMyRsvp } from '@/api/publicRsvp';
 import { Button } from '@/components/ui/Button';
 import { RsvpStatusPicker } from '@/components/ui/RsvpStatusPicker';
-import { Toggle } from '@/components/ui/Toggle';
 import { type Event, type RsvpInputStatus, RsvpServerStatus } from '@/models/event';
 import { formatEventDateTime } from '@/utils/datetime';
 import { buildEventLinks } from '@/utils/eventLinks';
@@ -34,26 +33,23 @@ interface Props {
   token: string;
   event: Event;
   status: string;
-  hasPlusOne: boolean;
 }
 
-export function PublicRsvpCard({ token, event, status, hasPlusOne }: Props) {
+export function PublicRsvpCard({ token, event, status }: Props) {
   const update = useUpdatePublicMyRsvp(token);
   const cancel = useCancelPublicMyRsvp(token);
   const [error, setError] = useState<string | null>(null);
   const [comment, setComment] = useState('');
   const links = buildEventLinks(event);
   const busy = update.isPending || cancel.isPending;
-  // the backend discards a waitlisted +1; every other status can carry one.
-  const canPlusOne = event.allowPlusOnes && status !== RsvpServerStatus.Waitlisted;
 
-  async function applyRsvp(next: RsvpInputStatus, plusOne: boolean, rsvpComment?: string) {
+  async function applyRsvp(next: RsvpInputStatus, rsvpComment?: string) {
     setError(null);
     try {
       await update.mutateAsync({
         eventId: event.id,
         status: next,
-        hasPlusOne: plusOne,
+        hasPlusOne: false,
         ...(rsvpComment !== undefined ? { comment: rsvpComment } : {}),
       });
       toast.success(UPDATED_TOAST);
@@ -64,17 +60,13 @@ export function PublicRsvpCard({ token, event, status, hasPlusOne }: Props) {
 
   function changeStatus(next: RsvpInputStatus) {
     if (next === status) return;
-    void applyRsvp(next, hasPlusOne);
-  }
-
-  function togglePlusOne(next: boolean) {
-    void applyRsvp(status as RsvpInputStatus, next);
+    void applyRsvp(next);
   }
 
   function saveComment() {
     const trimmed = comment.trim();
     if (!trimmed) return;
-    void applyRsvp(status as RsvpInputStatus, hasPlusOne, trimmed);
+    void applyRsvp(status as RsvpInputStatus, trimmed);
     setComment('');
   }
 
@@ -126,15 +118,6 @@ export function PublicRsvpCard({ token, event, status, hasPlusOne }: Props) {
       </p>
       <div className="flex flex-col gap-3">
         <RsvpStatusPicker value={status} onSelect={changeStatus} disabled={busy} />
-
-        {canPlusOne ? (
-          <Toggle
-            label="bring a +1"
-            checked={hasPlusOne}
-            onChange={togglePlusOne}
-            disabled={busy}
-          />
-        ) : null}
 
         <RsvpCommentField value={comment} onChange={setComment} disabled={busy} />
         <Button variant="ghost" onClick={saveComment} disabled={busy || !comment.trim()}>

--- a/frontend/src/screens/events/PublicRsvpsScreen.tsx
+++ b/frontend/src/screens/events/PublicRsvpsScreen.tsx
@@ -76,13 +76,7 @@ export default function PublicRsvpsScreen() {
       ) : (
         <div className="flex flex-col gap-4">
           {data.rsvps.map((r) => (
-            <PublicRsvpCard
-              key={r.event.id}
-              token={token}
-              event={r.event}
-              status={r.status}
-              hasPlusOne={r.hasPlusOne}
-            />
+            <PublicRsvpCard key={r.event.id} token={token} event={r.event} status={r.status} />
           ))}
         </div>
       )}


### PR DESCRIPTION
## overview

non-members who rsvp via a magic-link and open their manage page (`/my-rsvps?token=…`) were shown a "bring a +1" checkbox, and the backend persisted it. public/non-member rsvp +1s are meant to be members-only. PR #988 closed the initial-submit path but missed this parallel *manage* path.

this mirrors the #988 pattern: force `has_plus_one=False` at the manage call site (`_public_rsvp_manage.py`) and remove the +1 toggle from `PublicRsvpCard`.

Closes #1064

## test plan

- [x] backend: `test_ignores_plus_one_parameter` on the manage endpoint (sends `has_plus_one: true`, asserts response + persisted row are `False`)
- [x] frontend: PublicRsvpCard / PublicRsvpsScreen vitest updated (18 passed)
- [x] lint + typecheck (backend + frontend) clean
