### PR TITLE
fix: 1056 - add spacing between event actions and find-a-time poll

### DIFF
--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -85,7 +85,7 @@ export default function EventDetailScreen() {
       <EventTagChips tags={event.tags} className="mt-2" />
       <EventActions event={event} />
       {isAuthed ? <CohostInviteBanner event={event} /> : null}
-      <EventPollCard event={event} />
+      <EventPollCard event={event} className="mt-3" />
 
       {event.description ? (
         <section className="mt-6">

--- a/frontend/src/screens/events/poll/EventPollCard.tsx
+++ b/frontend/src/screens/events/poll/EventPollCard.tsx
@@ -15,9 +15,10 @@ import { PollRespondDialog } from './PollRespondDialog';
 
 interface Props {
   event: Event;
+  className?: string;
 }
 
-export function EventPollCard({ event }: Props) {
+export function EventPollCard({ event, className }: Props) {
   const user = useAuthStore((s) => s.user);
   const isAuthed = useAuthStore((s) => s.status === 'authed');
   const canManage = canManagePoll(event, user);
@@ -35,11 +36,13 @@ export function EventPollCard({ event }: Props) {
   }
 
   if (isPending) {
-    return <p className="text-foreground-tertiary text-sm">loading poll…</p>;
+    return <p className={`text-foreground-tertiary text-sm ${className ?? ''}`}>loading poll…</p>;
   }
   if (isError || !poll) {
     return (
-      <p className="text-foreground-tertiary text-sm">couldn't load the poll — try refreshing</p>
+      <p className={`text-foreground-tertiary text-sm ${className ?? ''}`}>
+        couldn't load the poll — try refreshing
+      </p>
     );
   }
 
@@ -49,7 +52,9 @@ export function EventPollCard({ event }: Props) {
   }
 
   return (
-    <div className="border-border bg-surface flex flex-col gap-3 rounded-md border p-4">
+    <div
+      className={`border-border bg-surface flex flex-col gap-3 rounded-md border p-4 ${className ?? ''}`}
+    >
       <div className="flex items-center justify-between gap-2">
         <h2 className="text-sm font-medium">find a time</h2>
         <span className="text-foreground-tertiary text-xs">


### PR DESCRIPTION
## overview

on the event detail page there was no vertical space between the add-to-calendar/share button row and the "find a time" poll card below it. adds an optional `className` prop to `EventPollCard` (threaded onto its content render paths, not the `null` returns) and passes `mt-3` at the call site, matching the existing `mt-*` spacing rhythm in `EventDetailScreen`.

Closes #1056

## test plan

- [x] frontend typecheck + lint clean
- [ ] eyeball spacing on an event detail page
