### PR TITLE
feat: 1062 - remove remove-photo path from event photo form

### DIFF
--- a/backend/community/_event_actions.py
+++ b/backend/community/_event_actions.py
@@ -1,5 +1,3 @@
-"""Event photo upload endpoint."""
-
 import logging
 import time
 from uuid import UUID

--- a/backend/community/_event_actions.py
+++ b/backend/community/_event_actions.py
@@ -1,4 +1,4 @@
-"""Event photo upload/delete endpoints."""
+"""Event photo upload endpoint."""
 
 import logging
 import time
@@ -76,41 +76,5 @@ def upload_event_photo(request, event_id: UUID, photo: UploadedFile = File(...))
     event.save(update_fields=["photo", "photo_updated_at"])
     audit_log(
         logging.INFO, "event_photo_uploaded", request, target_type="event", target_id=str(event_id)
-    )
-    return Status(200, _event_out(event, request.auth))
-
-
-@router.delete(
-    "/events/{event_id}/photo/",
-    response={200: EventOut, 403: ErrorOut, 404: ErrorOut},
-    auth=gated_jwt,
-)
-def delete_event_photo(request, event_id: UUID):
-    try:
-        event = Event.objects.get(id=event_id)
-    except Event.DoesNotExist:
-        raise_validation(Code.Event.NOT_FOUND, status_code=404)
-    is_manager = request.auth.has_permission(PermissionKey.MANAGE_EVENTS)
-    is_creator = event.created_by_id == request.auth.pk
-    is_cohost = event.co_hosts.filter(pk=request.auth.pk).exists()
-    if not is_manager and not is_creator and not is_cohost:
-        audit_log(
-            logging.WARNING,
-            "permission_denied",
-            request,
-            target_type="event",
-            target_id=str(event_id),
-            details={"endpoint": "delete_event_photo"},
-        )
-        raise_validation(Code.Perm.DENIED, status_code=403, action="delete_event_photo")
-    if event.is_cancelled:
-        raise_validation(Code.Event.CANCELLED_CANNOT_BE_EDITED, status_code=400)
-    if event.photo:
-        event.photo.delete(save=False)
-        event.photo = ""
-        event.photo_updated_at = None
-        event.save(update_fields=["photo", "photo_updated_at"])
-    audit_log(
-        logging.INFO, "event_photo_deleted", request, target_type="event", target_id=str(event_id)
     )
     return Status(200, _event_out(event, request.auth))

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -9119,62 +9119,6 @@
       }
     },
     "/api/community/events/{event_id}/photo/": {
-      "delete": {
-        "operationId": "community__event_actions_delete_event_photo",
-        "parameters": [
-          {
-            "in": "path",
-            "name": "event_id",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "title": "Event Id",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EventOut"
-                }
-              }
-            },
-            "description": "OK"
-          },
-          "403": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorOut"
-                }
-              }
-            },
-            "description": "Forbidden"
-          },
-          "404": {
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ErrorOut"
-                }
-              }
-            },
-            "description": "Not Found"
-          }
-        },
-        "security": [
-          {
-            "GatedJWTAuth": []
-          }
-        ],
-        "summary": "Delete Event Photo",
-        "tags": [
-          "community"
-        ]
-      },
       "post": {
         "operationId": "community__event_actions_upload_event_photo",
         "parameters": [

--- a/backend/tests/test_photos.py
+++ b/backend/tests/test_photos.py
@@ -186,24 +186,6 @@ class TestEventPhoto:
         )
         assert response.status_code == 400
 
-    def test_delete_photo(self, api_client, member, event):
-        photo = _make_test_image()
-        api_client.post(
-            f"/api/community/events/{event.id}/photo/",
-            {"photo": photo},
-            **_auth(member),
-        )
-        response = api_client.delete(
-            f"/api/community/events/{event.id}/photo/",
-            **_auth(member),
-        )
-        assert response.status_code == 200
-        body = response.json()
-        assert body["photo_url"] == ""
-        assert body["photo_updated_at"] is None
-        event.refresh_from_db()
-        assert event.photo_updated_at is None
-
     def test_photo_url_in_event_detail(self, api_client, member, event):
         photo = _make_test_image()
         api_client.post(

--- a/backend/tests/test_photos.py
+++ b/backend/tests/test_photos.py
@@ -1,5 +1,3 @@
-"""Tests for profile and event photo upload/delete endpoints."""
-
 import io
 
 import pytest
@@ -63,11 +61,6 @@ def event(db, member):
     )
 
 
-# ---------------------------------------------------------------------------
-# Profile photo tests
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.django_db
 class TestProfilePhoto:
     def test_upload_photo(self, api_client, member):
@@ -121,11 +114,6 @@ class TestProfilePhoto:
         photo = _make_test_image()
         response = api_client.post("/api/auth/me/photo/", {"photo": photo})
         assert response.status_code == 401
-
-
-# ---------------------------------------------------------------------------
-# Event photo tests
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.django_db
@@ -208,11 +196,6 @@ class TestEventPhoto:
             **_auth(member),
         )
         assert response.status_code == 404
-
-
-# ---------------------------------------------------------------------------
-# Media proxy tests
-# ---------------------------------------------------------------------------
 
 
 @pytest.mark.django_db

--- a/frontend/src/api/eventWrites.ts
+++ b/frontend/src/api/eventWrites.ts
@@ -267,24 +267,6 @@ export function useUploadEventPhoto() {
   });
 }
 
-export function useDeleteEventPhoto(eventId: string) {
-  const qc = useQueryClient();
-  const isAuthed = useAuthStore((s) => s.status === 'authed');
-  return useMutation({
-    mutationFn: async () => {
-      const { data } = await apiClient.delete<WireEvent>(`/api/community/events/${eventId}/photo/`);
-      return mapEvent(data);
-    },
-    onSuccess: (event) => {
-      qc.setQueryData(eventKeys.detail(event.id, isAuthed), event);
-      void qc.invalidateQueries({ queryKey: eventKeys.list(isAuthed) });
-    },
-    onError: (err) => {
-      void reportError(err, ROUTE, { action: 'delete-event-photo', eventId });
-    },
-  });
-}
-
 export function extractEventError(err: unknown): string {
   // Event-create has a hard daily rate limit; surface that specifically.
   if (getApiStatus(err) === 429) {

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -893,8 +893,7 @@ export interface paths {
         put?: never;
         /** Upload Event Photo */
         post: operations["community__event_actions_upload_event_photo"];
-        /** Delete Event Photo */
-        delete: operations["community__event_actions_delete_event_photo"];
+        delete?: never;
         options?: never;
         head?: never;
         patch?: never;
@@ -6879,46 +6878,6 @@ export interface operations {
             };
             /** @description Too Many Requests */
             429: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorOut"];
-                };
-            };
-        };
-    };
-    community__event_actions_delete_event_photo: {
-        parameters: {
-            query?: never;
-            header?: never;
-            path: {
-                event_id: string;
-            };
-            cookie?: never;
-        };
-        requestBody?: never;
-        responses: {
-            /** @description OK */
-            200: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["EventOut"];
-                };
-            };
-            /** @description Forbidden */
-            403: {
-                headers: {
-                    [name: string]: unknown;
-                };
-                content: {
-                    "application/json": components["schemas"]["ErrorOut"];
-                };
-            };
-            /** @description Not Found */
-            404: {
                 headers: {
                     [name: string]: unknown;
                 };


### PR DESCRIPTION
## overview

removes the now-dead "remove photo" plumbing. the form ui removal already landed on main; this cleans up the remaining orphaned pieces: the unused `useDeleteEventPhoto` hook, the `delete_event_photo` backend endpoint, its test, and regenerated api types. changing/replacing a photo is unaffected.

Closes #1062

## test plan

- [x] backend photos tests pass (19), lint + typecheck clean
- [x] frontend typecheck + lint clean
- [x] grep sweeps clean (`useDeleteEventPhoto`, `delete_event_photo`, `remove photo`, `onDeletePhoto`)
- [x] api types regenerated via `make frontend-types`
