### PR TITLE
fix: 1041 - distinguish own rsvp from breakdown, clarify waitlist

### DIFF
--- a/frontend/src/screens/events/RsvpSection.test.tsx
+++ b/frontend/src/screens/events/RsvpSection.test.tsx
@@ -147,9 +147,11 @@ describe('RsvpSection — after RSVPing', () => {
       }),
     );
 
+    expect(screen.getByText("you're on the waitlist")).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'leave waitlist' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /edit RSVP/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: "i'm going" })).not.toBeInTheDocument();
+    expect(screen.queryByText("you're going")).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/screens/events/RsvpSection.tsx
+++ b/frontend/src/screens/events/RsvpSection.tsx
@@ -190,13 +190,18 @@ function RsvpControls({
 }) {
   if (myInputStatus) {
     return (
-      <div className="flex items-center justify-center gap-3">
-        <span role="status" className="text-foreground-secondary text-sm">
+      <div className="bg-brand-600 text-brand-on flex items-center justify-between gap-3 rounded-lg px-4 py-3">
+        <span role="status" className="text-sm font-medium">
           {STATUS_LINES[myInputStatus]}
         </span>
-        <Button variant="secondary" onClick={onOpenEdit} disabled={busy}>
+        <button
+          type="button"
+          onClick={onOpenEdit}
+          disabled={busy}
+          className="border-brand-on/40 hover:bg-brand-on/10 shrink-0 rounded-full border px-3 py-1 text-sm font-medium transition-colors disabled:opacity-60"
+        >
           edit rsvp
-        </Button>
+        </button>
       </div>
     );
   }
@@ -215,8 +220,8 @@ function RsvpControls({
 
 function WaitlistView({ onLeave, busy }: { onLeave: () => void; busy: boolean }) {
   return (
-    <div className="flex items-center gap-3 rounded-md bg-amber-50 px-3 py-2">
-      <span role="status" className="text-warning text-sm">
+    <div className="bg-warning-subtle flex items-center justify-between gap-3 rounded-lg px-4 py-3">
+      <span role="status" className="text-warning text-sm font-medium">
         you're on the waitlist
       </span>
       <Button variant="ghost" onClick={onLeave} disabled={busy}>
@@ -237,14 +242,22 @@ function SpotsLeft({ event }: { event: Event }) {
 }
 
 function Summary({ event }: { event: Event }) {
-  const parts: string[] = [];
-  if (event.maxAttendees !== null) {
-    parts.push(`${String(event.attendingCount)} / ${String(event.maxAttendees)} going`);
-  } else {
-    parts.push(`${String(event.attendingCount)} going`);
-  }
-  if (event.waitlistedCount > 0) parts.push(`${String(event.waitlistedCount)} waitlisted`);
-  return <p className="text-muted text-xs">{parts.join(' · ')}</p>;
+  const goingLabel =
+    event.maxAttendees !== null
+      ? `${String(event.attendingCount)} / ${String(event.maxAttendees)} going`
+      : `${String(event.attendingCount)} going`;
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
+      <span className="bg-success-subtle text-success inline-flex items-center rounded-full px-2.5 py-0.5 font-medium">
+        {goingLabel}
+      </span>
+      {event.waitlistedCount > 0 ? (
+        <span className="bg-warning-subtle text-warning inline-flex items-center rounded-full px-2.5 py-0.5 font-medium">
+          {event.waitlistedCount} waitlisted
+        </span>
+      ) : null}
+    </div>
+  );
 }
 
 function extractError(err: unknown): string {


### PR DESCRIPTION
## overview

redesigns the member rsvp status/breakdown area on the event detail page so your own rsvp is clearly distinguished from the aggregate breakdown, and waitlist status reads honestly (never as a plain "going").

- your own rsvp is emphasized in dark green (`bg-brand-600`) with an "edit rsvp" button beside it
- the breakdown chips use a lighter green (`bg-success-subtle`) for the going segment so the aggregate reads as secondary
- a waitlisted member sees an amber "you're on the waitlist" banner (kept distinct from green + color-blind-safe), never a green going treatment

per the reporter's design direction in the issue comment. full redesign scope.

Closes #1041

## test plan

- [x] frontend typecheck + lint clean
- [x] vitest: RsvpSection + RsvpStatusPicker (31 passing), incl. assertions that a waitlisted rsvp shows "you're on the waitlist" and not "you're going"
- [ ] eyeball colors in browser (dark-green own rsvp, lighter-green breakdown, amber waitlist) — not captured due to a local dev-session auth flake; verify in review
