### PR TITLE
fix(events): count plus-ones in waitlisted count

### DIFF
--- a/backend/community/_rsvp_counts.py
+++ b/backend/community/_rsvp_counts.py
@@ -94,8 +94,12 @@ def _attending_headcount_db(event: Event, exclude_user=None) -> int:
 
 
 def _waitlisted_count(event: Event) -> int:
-    """Count waitlisted RSVPs from prefetched data."""
-    return sum(1 for r in event.rsvps.all() if r.status == RSVPStatus.WAITLISTED)
+    """Count waitlisted spots incl. plus-ones, matching _attending_headcount."""
+    return sum(
+        1 + (1 if r.has_plus_one else 0)
+        for r in event.rsvps.all()
+        if r.status == RSVPStatus.WAITLISTED
+    )
 
 
 def _maybe_count(event: Event) -> int:

--- a/backend/tests/test_event_capacity.py
+++ b/backend/tests/test_event_capacity.py
@@ -204,6 +204,16 @@ class TestCapacityCounts:
         assert resp.status_code == 200
         assert resp.json()["waitlisted_count"] == 1
 
+    def test_waitlisted_count_includes_plus_ones(  # noqa: PLR0913
+        self, api_client, capped_event, headers1, headers2, headers3, auth_headers
+    ):
+        _rsvp(api_client, capped_event, headers1)
+        _rsvp(api_client, capped_event, headers2)
+        _rsvp(api_client, capped_event, headers3, has_plus_one=True)  # waitlisted w/ +1
+        resp = api_client.get(f"/api/community/events/{capped_event.id}/", **auth_headers)
+        assert resp.status_code == 200
+        assert resp.json()["waitlisted_count"] == 2  # 1 person + 1 guest
+
     def test_counts_in_list_endpoint(self, api_client, capped_event, headers1, auth_headers):
         _rsvp(api_client, capped_event, headers1)
         resp = api_client.get("/api/community/events/", **auth_headers)


### PR DESCRIPTION
## Summary

Fixes #1070 — "on the going maybe etc bar it looks correct but the tag above it doesnt seem to take into account +1s"

**Root cause:** `_waitlisted_count()` in `backend/community/_rsvp_counts.py` counted `1` per waitlisted RSVP row, ignoring `has_plus_one`. Meanwhile `_attending_headcount()` (used for the "going" count) already summed `1 + has_plus_one` per attending row. Waitlisted RSVPs deliberately keep `has_plus_one` set (so promotion off the waitlist seats the pair together — see `_event_rsvps.py`), so a waitlisted attendee with a +1 guest was undercounted by 1 in `event.waitlistedCount`.

This value feeds the small "waitlisted" summary pill in `RsvpSection.tsx`'s `Summary` component (the "tag" above the guest-list tab bar) — which is entirely separate from `RsvpGuestList.tsx`'s tab-count logic, which already correctly summed plus-ones client-side from `event.guests`. That's why the guest-list bar looked right while the summary tag above it did not.

**Fix:** `_waitlisted_count()` now sums `1 + (1 if has_plus_one else 0)` per waitlisted RSVP, matching `_attending_headcount()`. This is the single shared function behind all three waitlist-count call sites (event detail serializer, event list serializer, host stats endpoint), so the fix applies everywhere consistently.

## Test plan

- [x] Extended `backend/tests/test_event_capacity.py::TestCapacityCounts` with `test_waitlisted_count_includes_plus_ones` — 2 users fill capacity, a 3rd RSVPs with a +1 and is waitlisted; asserts `waitlisted_count == 2`.
- [x] `uv run pytest tests/test_event_capacity.py -q` — 20 passed
- [x] `make agent-lint` — clean
- [x] `make agent-typecheck` — clean