### PR TITLE
fix(ui): simplify calendar header and fade footer background (Issue 1076)

### DIFF
--- a/frontend/src/layout/AppShell.tsx
+++ b/frontend/src/layout/AppShell.tsx
@@ -14,8 +14,8 @@ export function AppShell() {
 
   return (
     <div className="bg-background flex min-h-screen flex-col">
-      <header className="border-border bg-surface sticky top-0 z-10 border-b">
-        <div className="mx-auto flex h-14 max-w-6xl items-center justify-between gap-4 px-4">
+      <header className="sticky top-0 z-10">
+        <div className="mx-auto flex h-10 max-w-6xl items-center justify-between gap-4 px-4">
           <button
             type="button"
             aria-label="open menu"

--- a/frontend/src/layout/BottomNav.tsx
+++ b/frontend/src/layout/BottomNav.tsx
@@ -21,7 +21,7 @@ export function BottomNav() {
   return (
     <nav
       aria-label="primary"
-      className="border-border bg-surface fixed inset-x-0 bottom-0 z-20 border-t pb-[env(safe-area-inset-bottom)]"
+      className="from-surface/60 to-surface fixed inset-x-0 bottom-0 z-20 bg-gradient-to-b pb-[env(safe-area-inset-bottom)]"
     >
       <div className="mx-auto grid h-14 max-w-6xl grid-cols-5">
         <NavItem to="/calendar" label="calendar">


### PR DESCRIPTION
## Summary
- Removed the header's separator line and distinct background color; reduced its height (h-14 → h-10) so it takes up less space.
- Removed the footer/bottom-nav's separator line; replaced its solid background with a top-to-bottom gradient (`from-surface/60 to-surface`) so the top edge is translucent, matching the "see through it a lil bit" request.

Both `AppShell` (header) and `BottomNav` (footer) are shared chrome used across all screens, not calendar-specific, so this affects the whole app.

## Test plan
- [x] `make agent-frontend-typecheck` passes
- [x] Verified visually on `/calendar` at mobile viewport (375x812): header has no border/background distinction and is shorter; footer has no top border and shows a translucent-to-solid gradient

Closes #1076