### PR TITLE
fix(dev): make backend dev port configurable (Issue 1075)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,9 +7,7 @@ DATABASE_URL=postgresql://pda:pda@localhost:5432/pda
 # `make dev-pg` / `make run-pg` — they read credentials from DATABASE_URL but
 # target a gitignored per-worktree database name. See CLAUDE.md > Development.
 
-# Backend dev server port. `make run`/`make run-sqlite`/`make run-pg` default to
-# 8000; `make dev`/`make dev-sqlite`/`make dev-pg` auto-pick a free port starting
-# here if it's taken (e.g. running multiple worktrees concurrently).
+# Backend dev server port. `make dev*` targets auto-pick a free port starting here.
 BACKEND_PORT=8000
 
 # Django

--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,11 @@ DATABASE_URL=postgresql://pda:pda@localhost:5432/pda
 # `make dev-pg` / `make run-pg` — they read credentials from DATABASE_URL but
 # target a gitignored per-worktree database name. See CLAUDE.md > Development.
 
+# Backend dev server port. `make run`/`make run-sqlite`/`make run-pg` default to
+# 8000; `make dev`/`make dev-sqlite`/`make dev-pg` auto-pick a free port starting
+# here if it's taken (e.g. running multiple worktrees concurrently).
+BACKEND_PORT=8000
+
 # Django
 DEBUG=True
 SECRET_KEY=

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ export
 SQLITE_DB := $(abspath $(CURDIR)/dev.db)
 SQLITE_DATABASE_URL = sqlite:///$(SQLITE_DB)
 
+# Overridable so multiple `make run*`/`make dev*` instances (e.g. across worktrees)
+# don't collide on the same port. dev.sh exports its own free-port pick for dev targets.
+BACKEND_PORT ?= 8000
+
 # DB the agent-* backend targets run against. Locally this overrides .env's shared
 # Postgres with an isolated per-worktree SQLite DB. In GitHub Actions (CI=true,
 # set automatically by Actions) it falls through to the job's own isolated Postgres
@@ -96,7 +100,7 @@ install:
 	cd frontend && pnpm install
 
 run:
-	cd backend && uv run uvicorn config.asgi:application --host 0.0.0.0 --port 8000 --reload
+	cd backend && uv run uvicorn config.asgi:application --host 0.0.0.0 --port $(BACKEND_PORT) --reload
 
 test:
 	cd backend && uv run python -m pytest tests/ -v
@@ -168,7 +172,7 @@ dev-db-reset:
 
 # Run the backend against the per-worktree SQLite DB (auto-migrates + seeds).
 run-sqlite: dev-db-ensure
-	cd backend && DATABASE_URL="$(SQLITE_DATABASE_URL)" uv run uvicorn config.asgi:application --host 0.0.0.0 --port 8000 --reload
+	cd backend && DATABASE_URL="$(SQLITE_DATABASE_URL)" uv run uvicorn config.asgi:application --host 0.0.0.0 --port $(BACKEND_PORT) --reload
 
 # Concurrent backend (SQLite) + Vite. Same as `make dev` but no Docker/Postgres.
 dev-sqlite: dev-db-ensure
@@ -187,7 +191,7 @@ dev-pg-db-reset:
 
 run-pg: dev-pg-db-ensure
 	@url=$$(./scripts/dev_pg_db.sh url); \
-	cd backend && DATABASE_URL="$$url" uv run uvicorn config.asgi:application --host 0.0.0.0 --port 8000 --reload
+	cd backend && DATABASE_URL="$$url" uv run uvicorn config.asgi:application --host 0.0.0.0 --port $(BACKEND_PORT) --reload
 
 dev-pg: dev-pg-db-ensure
 	@url=$$(./scripts/dev_pg_db.sh url); \

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,7 @@ export
 SQLITE_DB := $(abspath $(CURDIR)/dev.db)
 SQLITE_DATABASE_URL = sqlite:///$(SQLITE_DB)
 
-# Overridable so multiple `make run*`/`make dev*` instances (e.g. across worktrees)
-# don't collide on the same port. dev.sh exports its own free-port pick for dev targets.
+# dev.sh overrides this with its own free-port pick
 BACKEND_PORT ?= 8000
 
 # DB the agent-* backend targets run against. Locally this overrides .env's shared

--- a/dev.sh
+++ b/dev.sh
@@ -6,10 +6,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Auto-pick a free port starting at BACKEND_PORT (default 8000) so concurrent
-# `make dev`/`make dev-sqlite` instances across worktrees don't collide. Bind
-# (not connect) so an occupied port fails instantly instead of waiting on a
-# connect timeout.
+# bind (not connect) so an occupied port fails instantly, no timeout
 port="${BACKEND_PORT:-8000}"
 port_free() {
   python3 -c "

--- a/dev.sh
+++ b/dev.sh
@@ -6,7 +6,27 @@ cleanup() {
 }
 trap cleanup EXIT
 
-echo "🚀 Starting backend..."
+# Auto-pick a free port starting at BACKEND_PORT (default 8000) so concurrent
+# `make dev`/`make dev-sqlite` instances across worktrees don't collide. Bind
+# (not connect) so an occupied port fails instantly instead of waiting on a
+# connect timeout.
+port="${BACKEND_PORT:-8000}"
+port_free() {
+  python3 -c "
+import socket, sys
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+try:
+    s.bind(('127.0.0.1', int(sys.argv[1])))
+except OSError:
+    sys.exit(1)
+" "$1"
+}
+while ! port_free "$port"; do
+  port=$((port + 1))
+done
+export BACKEND_PORT="$port"
+
+echo "🚀 Starting backend on port $BACKEND_PORT..."
 make "${RUN_TARGET:-run}" &
 
 sleep 2

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,7 +2,6 @@ import path from 'node:path';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
-// Set by dev.sh to the backend's actual port (auto-picked if 8000 is taken).
 const backendTarget = `http://localhost:${process.env.BACKEND_PORT ?? 8000}`;
 
 export default defineConfig({

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -2,6 +2,9 @@ import path from 'node:path';
 import react from '@vitejs/plugin-react';
 import { defineConfig } from 'vite';
 
+// Set by dev.sh to the backend's actual port (auto-picked if 8000 is taken).
+const backendTarget = `http://localhost:${process.env.BACKEND_PORT ?? 8000}`;
+
 export default defineConfig({
   plugins: [react()],
   resolve: {
@@ -15,7 +18,7 @@ export default defineConfig({
       // SSE endpoint — disable proxy buffering so events stream through
       // in real time instead of getting held until connection close.
       '/api/notifications/stream': {
-        target: 'http://localhost:8000',
+        target: backendTarget,
         changeOrigin: true,
         selfHandleResponse: false,
         configure: (proxy) => {
@@ -26,11 +29,11 @@ export default defineConfig({
         },
       },
       '/api': {
-        target: 'http://localhost:8000',
+        target: backendTarget,
         changeOrigin: true,
       },
       '/media': {
-        target: 'http://localhost:8000',
+        target: backendTarget,
         changeOrigin: true,
       },
     },


### PR DESCRIPTION
## Summary
- Add a `BACKEND_PORT` env var (default `8000`) that `make run` / `make run-sqlite` / `make run-pg` pass through to `uvicorn --port`.
- `dev.sh` auto-picks a free port starting at `BACKEND_PORT` if it's taken (bind-probe, similar in spirit to Vite's own auto-port-selection), and exports the resolved port for both the backend process and Vite.
- `frontend/vite.config.ts`'s dev proxy (`/api`, `/api/notifications/stream`, `/media`) now targets `http://localhost:${BACKEND_PORT}` instead of a hardcoded `localhost:8000`, so it stays in sync with whatever port the backend actually bound to.
- Documented `BACKEND_PORT` in `.env.example`.

`make dev` / `make dev-sqlite` (which go through `dev.sh`) get the auto-picking behavior; `make run` / `make run-sqlite` / `make run-pg` keep defaulting to `8000` when `BACKEND_PORT` is unset, per the acceptance criteria.

## Test plan
- [x] `make agent-frontend-typecheck` passes (vite.config.ts change typechecks clean)
- [x] `bash -n dev.sh` — script syntax valid
- [x] Verified the free-port probe: with port 8000 (and 8001) occupied by unrelated local listeners, `dev.sh`'s picker correctly skipped both and resolved to `8002`
- [x] Ran `make dev-sqlite` end-to-end in this worktree with 8000/8001 occupied — backend started on the resolved port (`8002`), confirmed via `INFO: Uvicorn running on http://0.0.0.0:8002`
- [x] Confirmed the frontend correctly talks to its own backend: fetched `http://localhost:3000/api/openapi.json` through the Vite dev proxy and got a valid response proxied to the `:8002` backend (verified via browser tool, not just logs)
- [x] Confirmed via a Makefile precedence test that a pre-set `BACKEND_PORT` env var overrides the `?=` default, so `make run` / `make run-sqlite` still default to `8000` when unset
- [ ] Manually run two `make dev-sqlite` instances in two worktrees at once and confirm no port collision (spot-checked equivalent behavior above by pre-occupying ports; full two-worktree run not exercised in this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)