### PR TITLE
fix(events): cap photo width to 4:5 and overlay title (Issue 1077)

### DIFF
--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -70,11 +70,9 @@ export default function EventDetailScreen() {
   const body = (
     <>
       <div className="mb-2 flex flex-wrap items-center gap-2">
-        {event.photoUrl ? null : (
-          <h1 className="text-2xl font-medium tracking-tight [overflow-wrap:anywhere] break-words">
-            {event.title}
-          </h1>
-        )}
+        <h1 className="text-2xl font-medium tracking-tight [overflow-wrap:anywhere] break-words">
+          {event.title}
+        </h1>
         <EventBadge event={event} />
         {showKebab ? (
           <div className="ml-auto">
@@ -115,17 +113,12 @@ export default function EventDetailScreen() {
   // Width capped to what a 4:5 crop would be at the same max-height, so a
   // square (1:1) photo doesn't sprawl full-bleed on wide screens (issue 1077).
   const photo = (
-    <div className="relative mx-auto">
-      <img
-        src={photoSrc(event.photoUrl, event.photoUpdatedAt)}
-        alt=""
-        className="mx-auto block max-h-[70vh] w-auto max-w-[min(100%,calc(70vh*4/5))] rounded-lg"
-        loading="lazy"
-      />
-      <h1 className="absolute inset-x-0 top-0 rounded-t-lg bg-gradient-to-b from-black/60 to-transparent p-4 text-2xl font-medium tracking-tight text-white [overflow-wrap:anywhere] break-words">
-        {event.title}
-      </h1>
-    </div>
+    <img
+      src={photoSrc(event.photoUrl, event.photoUpdatedAt)}
+      alt=""
+      className="mx-auto block max-h-[70vh] w-auto max-w-[min(100%,calc(70vh*4/5))] rounded-lg"
+      loading="lazy"
+    />
   );
 
   // desktop: photo sticks to the left while the narrow details column scrolls;

--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -70,9 +70,11 @@ export default function EventDetailScreen() {
   const body = (
     <>
       <div className="mb-2 flex flex-wrap items-center gap-2">
-        <h1 className="text-2xl font-medium tracking-tight [overflow-wrap:anywhere] break-words">
-          {event.title}
-        </h1>
+        {event.photoUrl ? null : (
+          <h1 className="text-2xl font-medium tracking-tight [overflow-wrap:anywhere] break-words">
+            {event.title}
+          </h1>
+        )}
         <EventBadge event={event} />
         {showKebab ? (
           <div className="ml-auto">
@@ -110,13 +112,20 @@ export default function EventDetailScreen() {
     return <ContentContainer>{body}</ContentContainer>;
   }
 
+  // Width capped to what a 4:5 crop would be at the same max-height, so a
+  // square (1:1) photo doesn't sprawl full-bleed on wide screens (issue 1077).
   const photo = (
-    <img
-      src={photoSrc(event.photoUrl, event.photoUpdatedAt)}
-      alt=""
-      className="mx-auto block max-h-[70vh] w-auto max-w-full rounded-lg"
-      loading="lazy"
-    />
+    <div className="relative mx-auto">
+      <img
+        src={photoSrc(event.photoUrl, event.photoUpdatedAt)}
+        alt=""
+        className="mx-auto block max-h-[70vh] w-auto max-w-[min(100%,calc(70vh*4/5))] rounded-lg"
+        loading="lazy"
+      />
+      <h1 className="absolute inset-x-0 top-0 rounded-t-lg bg-gradient-to-b from-black/60 to-transparent p-4 text-2xl font-medium tracking-tight text-white [overflow-wrap:anywhere] break-words">
+        {event.title}
+      </h1>
+    </div>
   );
 
   // desktop: photo sticks to the left while the narrow details column scrolls;


### PR DESCRIPTION
## summary
- event detail photo was capped only by height (`max-h-[70vh]`), so a square (1:1) crop rendered full-bleed wide on desktop. now the displayed width is also capped to what a 4:5-ratio photo would be at the same height (`max-w-[min(100%,calc(70vh*4/5))]`).
- the event title now overlays the top of the photo (dark gradient scrim) instead of sitting separately above the details column. for events with no photo, the title stays in its original spot in the header row.
- sticky/scroll behavior for the photo column is untouched.

closes #1077

## test plan
- [x] `pnpm run typecheck` — clean
- [x] `make agent-frontend-lint` — clean
- [x] `EventDetailScreen.test.tsx` — 20/20 passing
- [x] manual verification in browser: attached a real 1200x1200 test image to a seeded event, confirmed photo renders at capped width (504px at 900px viewport height, matching 70vh*4/5) instead of full column width, title overlays top of photo with readable gradient, and mobile layout stacks correctly