### PR TITLE
feat(events): unify event photo picker into library + upload tabs (Issue 1082)

### DIFF
--- a/frontend/src/components/PhotoLibraryDialog.test.tsx
+++ b/frontend/src/components/PhotoLibraryDialog.test.tsx
@@ -68,10 +68,12 @@ describe('PhotoLibraryDialog', () => {
     await user.click(await screen.findByRole('button', { name: 'sprout dance' }));
 
     expect(onSelect).toHaveBeenCalledOnce();
-    const file = onSelect.mock.calls[0]![0] as File;
+    const [file, opts] = onSelect.mock.calls[0]! as [File, { crop: boolean }];
     expect(file).toBeInstanceOf(File);
     expect(file.name).toBe('a1.gif');
     expect(file.type).toBe('image/gif');
+    // Library picks skip crop so gif animation survives.
+    expect(opts).toEqual({ crop: false });
   });
 
   it('converts a picked photo into a file with the correct extension', async () => {
@@ -90,6 +92,24 @@ describe('PhotoLibraryDialog', () => {
     const file = onSelect.mock.calls[0]![0] as File;
     expect(file.name).toBe('a2.jpeg');
     expect(file.type).toBe('image/jpeg');
+  });
+
+  it('switches to the upload tab and routes a file pick through crop', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(<PhotoLibraryDialog onCancel={vi.fn()} onSelect={onSelect} />);
+
+    await user.click(screen.getByRole('radio', { name: 'upload your own' }));
+    // The library search box is gone once on the upload tab.
+    expect(screen.queryByPlaceholderText('search gifs and photos')).not.toBeInTheDocument();
+
+    const input = screen.getByLabelText('choose event photo');
+    await user.upload(input, new File(['x'], 'mine.png', { type: 'image/png' }));
+
+    expect(onSelect).toHaveBeenCalledOnce();
+    const [file, opts] = onSelect.mock.calls[0]! as [File, { crop: boolean }];
+    expect(file.name).toBe('mine.png');
+    expect(opts).toEqual({ crop: true });
   });
 
   it('shows an error message when search fails', async () => {

--- a/frontend/src/components/PhotoLibraryDialog.tsx
+++ b/frontend/src/components/PhotoLibraryDialog.tsx
@@ -221,9 +221,6 @@ export function PhotoLibraryDialog({ onCancel, onSelect }: Props) {
                 dragOver && 'border-brand-500 ring-brand-300 ring-2',
               )}
             >
-              <span aria-hidden="true" className="text-3xl">
-                📸
-              </span>
               <span className="text-sm font-medium">tap or drop a photo</span>
             </button>
           </>

--- a/frontend/src/components/PhotoLibraryDialog.tsx
+++ b/frontend/src/components/PhotoLibraryDialog.tsx
@@ -1,13 +1,37 @@
+import type { ChangeEvent, DragEvent } from 'react';
 import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 
 import { type GiphyResult, searchGifs } from '@/api/giphy';
+import { cn } from '@/utils/cn';
 
 import { Button } from './ui/Button';
+import { SegmentedControl } from './ui/SegmentedControl';
+
+type Tab = 'library' | 'upload';
+
+const ALLOWED_MIME = [
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+  'image/gif',
+  'image/heic',
+  'image/heif',
+];
+const MAX_PHOTO_BYTES = 10 * 1024 * 1024;
+const TYPE_ERROR = 'pick a jpeg, png, webp, gif, or heic image';
+const SIZE_ERROR = 'photo must be under 10 MB';
+
+function validateUpload(f: File): string | null {
+  if (!ALLOWED_MIME.includes(f.type)) return TYPE_ERROR;
+  if (f.size > MAX_PHOTO_BYTES) return SIZE_ERROR;
+  return null;
+}
 
 interface Props {
   onCancel: () => void;
-  onSelect: (file: File) => void;
+  /** crop=false for library picks (preserve animation); crop=true for uploads. */
+  onSelect: (file: File, opts: { crop: boolean }) => void;
 }
 
 async function toFile(gif: GiphyResult): Promise<File> {
@@ -19,12 +43,16 @@ async function toFile(gif: GiphyResult): Promise<File> {
 }
 
 export function PhotoLibraryDialog({ onCancel, onSelect }: Props) {
+  const [tab, setTab] = useState<Tab>('library');
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<GiphyResult[]>([]);
   const [searching, setSearching] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [picking, setPicking] = useState(false);
+  const [dragOver, setDragOver] = useState(false);
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const dragDepthRef = useRef(0);
 
   async function runSearch(text: string) {
     setSearching(true);
@@ -53,15 +81,65 @@ export function PhotoLibraryDialog({ onCancel, onSelect }: Props) {
     debounceRef.current = setTimeout(() => void runSearch(text), 400);
   }
 
-  async function pick(gif: GiphyResult) {
+  async function pickLibrary(gif: GiphyResult) {
     setPicking(true);
     try {
       const file = await toFile(gif);
-      onSelect(file);
+      onSelect(file, { crop: false });
     } catch {
       setError("couldn't load that image — try another");
       setPicking(false);
     }
+  }
+
+  function acceptUpload(f: File) {
+    const err = validateUpload(f);
+    if (err) {
+      setError(err);
+      return;
+    }
+    onSelect(f, { crop: true });
+  }
+
+  function onFilePick(e: ChangeEvent<HTMLInputElement>) {
+    setError(null);
+    const f = e.target.files?.[0];
+    e.target.value = '';
+    if (f) acceptUpload(f);
+  }
+
+  // Only treat drags carrying files as drop targets — ignore text/HTML drags.
+  function isFileDrag(e: DragEvent): boolean {
+    return Array.from(e.dataTransfer.types).includes('Files');
+  }
+
+  function onDragEnter(e: DragEvent) {
+    if (!isFileDrag(e)) return;
+    e.preventDefault();
+    dragDepthRef.current += 1;
+    setDragOver(true);
+  }
+
+  function onDragOver(e: DragEvent) {
+    if (!isFileDrag(e)) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+  }
+
+  function onDragLeave(e: DragEvent) {
+    if (!isFileDrag(e)) return;
+    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
+    if (dragDepthRef.current === 0) setDragOver(false);
+  }
+
+  function onDrop(e: DragEvent) {
+    if (!isFileDrag(e)) return;
+    e.preventDefault();
+    dragDepthRef.current = 0;
+    setDragOver(false);
+    setError(null);
+    const f = e.dataTransfer.files[0];
+    if (f) acceptUpload(f);
   }
 
   return createPortal(
@@ -72,37 +150,85 @@ export function PhotoLibraryDialog({ onCancel, onSelect }: Props) {
       className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
     >
       <div className="bg-surface flex w-full max-w-md flex-col gap-3 rounded-lg p-4 shadow-xl">
-        <p className="text-foreground text-sm font-medium">choose an image</p>
-        <input
-          type="text"
-          value={query}
-          onChange={(e) => {
-            handleInput(e.target.value);
+        <SegmentedControl<Tab>
+          name="photo-picker-tab"
+          ariaLabel="choose an image source"
+          value={tab}
+          onChange={(next) => {
+            setError(null);
+            setTab(next);
           }}
-          placeholder="search gifs and photos"
-          disabled={picking}
-          className="border-border bg-background text-foreground rounded-[var(--radius-md)] border px-3 py-2 text-sm"
+          options={[
+            { value: 'library', label: 'library' },
+            { value: 'upload', label: 'upload your own' },
+          ]}
+          className="self-center"
         />
 
-        <div className="grid max-h-80 grid-cols-3 gap-2 overflow-y-auto">
-          {results.map((gif) => (
-            <button
-              key={gif.id}
-              type="button"
-              onClick={() => void pick(gif)}
+        {tab === 'library' ? (
+          <>
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => {
+                handleInput(e.target.value);
+              }}
+              placeholder="search gifs and photos"
               disabled={picking}
-              aria-label={gif.title || 'select image'}
-              className="focus-visible:ring-brand-300 overflow-hidden rounded-[var(--radius-md)] focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
-            >
-              <img src={gif.previewUrl} alt="" className="aspect-[4/5] w-full object-cover" />
-            </button>
-          ))}
-        </div>
+              className="border-border bg-background text-foreground rounded-[var(--radius-md)] border px-3 py-2 text-sm"
+            />
 
-        {searching ? <p className="text-foreground/60 text-xs">searching…</p> : null}
-        {!searching && query.trim().length > 0 && results.length === 0 && !error ? (
-          <p className="text-foreground/60 text-xs">nothing found — try another search</p>
-        ) : null}
+            <div className="grid max-h-80 grid-cols-3 gap-2 overflow-y-auto">
+              {results.map((gif) => (
+                <button
+                  key={gif.id}
+                  type="button"
+                  onClick={() => void pickLibrary(gif)}
+                  disabled={picking}
+                  aria-label={gif.title || 'select image'}
+                  className="focus-visible:ring-brand-300 overflow-hidden rounded-[var(--radius-md)] focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  <img src={gif.previewUrl} alt="" className="aspect-[4/5] w-full object-cover" />
+                </button>
+              ))}
+            </div>
+
+            {searching ? <p className="text-foreground/60 text-xs">searching…</p> : null}
+            {!searching && query.trim().length > 0 && results.length === 0 && !error ? (
+              <p className="text-foreground/60 text-xs">nothing found — try another search</p>
+            ) : null}
+          </>
+        ) : (
+          <>
+            <input
+              ref={inputRef}
+              type="file"
+              accept={ALLOWED_MIME.join(',')}
+              onChange={onFilePick}
+              className="hidden"
+              aria-label="choose event photo"
+            />
+            <button
+              type="button"
+              onClick={() => inputRef.current?.click()}
+              onDragEnter={onDragEnter}
+              onDragOver={onDragOver}
+              onDragLeave={onDragLeave}
+              onDrop={onDrop}
+              className={cn(
+                'border-brand-200 bg-brand-50 text-brand-700 flex aspect-[4/5] w-full flex-col items-center justify-center gap-2 rounded-[var(--radius-md)] border-2 border-dashed',
+                'focus-visible:ring-brand-300 focus-visible:ring-2 focus-visible:outline-none',
+                dragOver && 'border-brand-500 ring-brand-300 ring-2',
+              )}
+            >
+              <span aria-hidden="true" className="text-3xl">
+                📸
+              </span>
+              <span className="text-sm font-medium">tap or drop a photo</span>
+            </button>
+          </>
+        )}
+
         {error ? (
           <p role="alert" className="text-destructive text-xs">
             {error}

--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -114,7 +114,7 @@ export default function EventDetailScreen() {
     <img
       src={photoSrc(event.photoUrl, event.photoUpdatedAt)}
       alt=""
-      className="mx-auto block max-h-[70vh] w-full rounded-lg object-contain"
+      className="mx-auto block max-h-[70vh] w-full max-w-md rounded-lg object-contain"
       loading="lazy"
     />
   );

--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -110,13 +110,11 @@ export default function EventDetailScreen() {
     return <ContentContainer>{body}</ContentContainer>;
   }
 
-  // Width capped to what a 4:5 crop would be at the same max-height, so a
-  // square (1:1) photo doesn't sprawl full-bleed on wide screens (issue 1077).
   const photo = (
     <img
       src={photoSrc(event.photoUrl, event.photoUpdatedAt)}
       alt=""
-      className="mx-auto block max-h-[70vh] w-auto max-w-[min(100%,calc(70vh*4/5))] rounded-lg"
+      className="mx-auto block max-h-[70vh] w-full rounded-lg object-contain"
       loading="lazy"
     />
   );

--- a/frontend/src/screens/events/form/EventFormPhoto.test.tsx
+++ b/frontend/src/screens/events/form/EventFormPhoto.test.tsx
@@ -16,15 +16,27 @@ vi.mock('@/components/ImageCropDialog', () => ({
 }));
 
 vi.mock('@/components/PhotoLibraryDialog', () => ({
-  PhotoLibraryDialog: ({ onSelect }: { onSelect: (file: File) => void }) => (
-    <div data-testid="library-dialog">
+  PhotoLibraryDialog: ({
+    onSelect,
+  }: {
+    onSelect: (file: File, opts: { crop: boolean }) => void;
+  }) => (
+    <div data-testid="picker-dialog">
       <button
         type="button"
         onClick={() => {
-          onSelect(new File(['lib'], 'sprout.gif', { type: 'image/gif' }));
+          onSelect(new File(['lib'], 'sprout.gif', { type: 'image/gif' }), { crop: false });
         }}
       >
-        pick sprout
+        pick library gif
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          onSelect(new File(['up'], 'photo.png', { type: 'image/png' }), { crop: true });
+        }}
+      >
+        pick upload
       </button>
     </div>
   ),
@@ -32,12 +44,14 @@ vi.mock('@/components/PhotoLibraryDialog', () => ({
 
 import { EventFormPhoto } from './EventFormPhoto';
 
-describe('EventFormPhoto library picker', () => {
-  it('offers a choose from library option alongside upload', () => {
+describe('EventFormPhoto', () => {
+  it('opens the tabbed picker from the change-photo button', async () => {
+    const user = userEvent.setup();
     render(<EventFormPhoto photoUrl="" photoUpdatedAt={null} onCrop={vi.fn()} />);
 
-    expect(screen.getByRole('button', { name: 'add event photo' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'choose from library' })).toBeInTheDocument();
+    expect(screen.queryByTestId('picker-dialog')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'add event photo' }));
+    expect(screen.getByTestId('picker-dialog')).toBeInTheDocument();
   });
 
   it('uploads a library pick directly, skipping the crop dialog so animation survives', async () => {
@@ -45,12 +59,10 @@ describe('EventFormPhoto library picker', () => {
     const onCrop = vi.fn().mockResolvedValue(undefined);
     render(<EventFormPhoto photoUrl="" photoUpdatedAt={null} onCrop={onCrop} />);
 
-    await user.click(screen.getByRole('button', { name: 'choose from library' }));
-    expect(screen.getByTestId('library-dialog')).toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'add event photo' }));
+    await user.click(screen.getByRole('button', { name: 'pick library gif' }));
 
-    await user.click(screen.getByRole('button', { name: 'pick sprout' }));
-
-    expect(screen.queryByTestId('library-dialog')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('picker-dialog')).not.toBeInTheDocument();
     expect(screen.queryByTestId('crop-dialog')).not.toBeInTheDocument();
     expect(onCrop).toHaveBeenCalledOnce();
     const uploaded = onCrop.mock.calls[0]![0] as File;
@@ -59,14 +71,15 @@ describe('EventFormPhoto library picker', () => {
     expect(uploaded.type).toBe('image/gif');
   });
 
-  it('still routes a manual file upload through the crop dialog', async () => {
+  it('routes an upload-tab pick through the crop dialog', async () => {
     const user = userEvent.setup();
     const onCrop = vi.fn().mockResolvedValue(undefined);
     render(<EventFormPhoto photoUrl="" photoUpdatedAt={null} onCrop={onCrop} />);
 
-    const input = screen.getByLabelText('choose event photo');
-    await user.upload(input, new File(['x'], 'photo.png', { type: 'image/png' }));
+    await user.click(screen.getByRole('button', { name: 'add event photo' }));
+    await user.click(screen.getByRole('button', { name: 'pick upload' }));
 
+    expect(screen.queryByTestId('picker-dialog')).not.toBeInTheDocument();
     expect(screen.getByTestId('crop-dialog')).toHaveAttribute('data-filename', 'photo.png');
     await user.click(screen.getByRole('button', { name: 'confirm crop' }));
     expect(onCrop).toHaveBeenCalledOnce();

--- a/frontend/src/screens/events/form/EventFormPhoto.tsx
+++ b/frontend/src/screens/events/form/EventFormPhoto.tsx
@@ -76,10 +76,10 @@ export function EventFormPhoto({ photoUrl, photoUpdatedAt, onCrop, disabled }: P
             <img
               src={displayUrl}
               alt=""
-              className="mx-auto block max-h-[70vh] w-auto max-w-[min(100%,calc(70vh*4/5))]"
+              className="mx-auto block max-h-[70vh] w-full object-contain"
             />
             <span className="absolute inset-0 flex items-end justify-end bg-gradient-to-t from-black/40 via-transparent to-transparent p-3 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
-              <span className="text-foreground rounded-full bg-white/90 px-3 py-1 text-xs font-medium">
+              <span className="rounded-full bg-black/70 px-3 py-1 text-xs font-medium text-white">
                 change photo
               </span>
             </span>

--- a/frontend/src/screens/events/form/EventFormPhoto.tsx
+++ b/frontend/src/screens/events/form/EventFormPhoto.tsx
@@ -62,12 +62,12 @@ export function EventFormPhoto({ photoUrl, photoUpdatedAt, onCrop, disabled }: P
         className={cn(
           'group relative mx-auto block overflow-hidden rounded-lg',
           'focus-visible:ring-brand-300 focus-visible:ring-2 focus-visible:outline-none',
-          // With a photo: shrink-wrap the image so it shows at its own
-          // proportions, capped exactly like the detail page (max 70vh tall,
-          // 4:5-equivalent width). Empty: fixed 4:5 dashed box.
-          hasPhoto
-            ? 'w-fit max-w-full'
-            : 'border-brand-200 bg-brand-50 aspect-[4/5] w-full border-2 border-dashed',
+          // Full-width button in both states so the image's max-w cap resolves
+          // against the column (like the detail page), not a shrunk wrapper.
+          // With a photo the image sizes to its own proportions and centers;
+          // empty shows a fixed 4:5 dashed box.
+          'w-full',
+          hasPhoto ? '' : 'border-brand-200 bg-brand-50 aspect-[4/5] border-2 border-dashed',
           locked && 'cursor-not-allowed opacity-60',
         )}
       >
@@ -78,11 +78,11 @@ export function EventFormPhoto({ photoUrl, photoUpdatedAt, onCrop, disabled }: P
               alt=""
               className="mx-auto block max-h-[70vh] w-auto max-w-[min(100%,calc(70vh*4/5))]"
             />
-            <div className="absolute inset-0 flex items-end justify-end bg-gradient-to-t from-black/40 via-transparent to-transparent p-3 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+            <span className="absolute inset-0 flex items-end justify-end bg-gradient-to-t from-black/40 via-transparent to-transparent p-3 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
               <span className="text-foreground rounded-full bg-white/90 px-3 py-1 text-xs font-medium">
                 change photo
               </span>
-            </div>
+            </span>
           </>
         ) : (
           <span className="text-brand-700 absolute inset-0 flex flex-col items-center justify-center gap-2">

--- a/frontend/src/screens/events/form/EventFormPhoto.tsx
+++ b/frontend/src/screens/events/form/EventFormPhoto.tsx
@@ -60,16 +60,24 @@ export function EventFormPhoto({ photoUrl, photoUpdatedAt, onCrop, disabled }: P
         disabled={locked}
         aria-label={hasPhoto ? 'change event photo' : 'add event photo'}
         className={cn(
-          'group relative overflow-hidden rounded-lg',
+          'group relative mx-auto block overflow-hidden rounded-lg',
           'focus-visible:ring-brand-300 focus-visible:ring-2 focus-visible:outline-none',
-          'aspect-[4/5] w-full',
-          hasPhoto ? 'bg-surface' : 'border-brand-200 bg-brand-50 border-2 border-dashed',
+          // With a photo: shrink-wrap the image so it shows at its own
+          // proportions, capped exactly like the detail page (max 70vh tall,
+          // 4:5-equivalent width). Empty: fixed 4:5 dashed box.
+          hasPhoto
+            ? 'w-fit max-w-full'
+            : 'border-brand-200 bg-brand-50 aspect-[4/5] w-full border-2 border-dashed',
           locked && 'cursor-not-allowed opacity-60',
         )}
       >
         {hasPhoto ? (
           <>
-            <img src={displayUrl} alt="" className="absolute inset-0 h-full w-full object-cover" />
+            <img
+              src={displayUrl}
+              alt=""
+              className="mx-auto block max-h-[70vh] w-auto max-w-[min(100%,calc(70vh*4/5))]"
+            />
             <div className="absolute inset-0 flex items-end justify-end bg-gradient-to-t from-black/40 via-transparent to-transparent p-3 opacity-0 transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
               <span className="text-foreground rounded-full bg-white/90 px-3 py-1 text-xs font-medium">
                 change photo

--- a/frontend/src/screens/events/form/EventFormPhoto.tsx
+++ b/frontend/src/screens/events/form/EventFormPhoto.tsx
@@ -78,9 +78,6 @@ export function EventFormPhoto({ photoUrl, photoUpdatedAt, onCrop, disabled }: P
           </>
         ) : (
           <span className="text-brand-700 absolute inset-0 flex flex-col items-center justify-center gap-2">
-            <span aria-hidden="true" className="text-3xl">
-              📸
-            </span>
             <span className="text-sm font-medium">add event photo</span>
             <span className="text-brand-600/80 text-xs">tap to choose</span>
           </span>

--- a/frontend/src/screens/events/form/EventFormPhoto.tsx
+++ b/frontend/src/screens/events/form/EventFormPhoto.tsx
@@ -1,46 +1,23 @@
-import type { ChangeEvent, DragEvent } from 'react';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 
 import { extractApiErrorOr } from '@/api/apiErrors';
 import { ImageCropDialog } from '@/components/ImageCropDialog';
 import { PhotoLibraryDialog } from '@/components/PhotoLibraryDialog';
 import { cn } from '@/utils/cn';
 
-const ALLOWED_MIME = [
-  'image/jpeg',
-  'image/png',
-  'image/webp',
-  'image/gif',
-  'image/heic',
-  'image/heif',
-];
-
-const MAX_PHOTO_BYTES = 10 * 1024 * 1024;
-const TYPE_ERROR = 'pick a jpeg, png, webp, gif, or heic image';
-const SIZE_ERROR = 'photo must be under 10 MB';
-
-function validateFile(f: File): string | null {
-  if (!ALLOWED_MIME.includes(f.type)) return TYPE_ERROR;
-  if (f.size > MAX_PHOTO_BYTES) return SIZE_ERROR;
-  return null;
-}
-
 interface Props {
   photoUrl: string;
   photoUpdatedAt: string | null;
-  /** Called with the cropped blob. Callers decide whether to upload now or defer. */
+  /** Called with the final blob. Callers decide whether to upload now or defer. */
   onCrop: (blob: Blob) => Promise<void>;
   disabled?: boolean | undefined;
 }
 
 export function EventFormPhoto({ photoUrl, photoUpdatedAt, onCrop, disabled }: Props) {
-  const inputRef = useRef<HTMLInputElement | null>(null);
-  const dragDepthRef = useRef(0);
-  const [file, setFile] = useState<File | null>(null);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [cropFile, setCropFile] = useState<File | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
-  const [dragOver, setDragOver] = useState(false);
-  const [libraryOpen, setLibraryOpen] = useState(false);
 
   const displayUrl = photoUrl
     ? photoUpdatedAt
@@ -50,93 +27,36 @@ export function EventFormPhoto({ photoUrl, photoUpdatedAt, onCrop, disabled }: P
   const hasPhoto = Boolean(displayUrl);
   const locked = (disabled ?? false) || busy;
 
-  function open() {
-    if (!locked) inputRef.current?.click();
-  }
-
-  function acceptFile(f: File) {
-    const err = validateFile(f);
-    if (err) {
-      setError(err);
-      return;
-    }
-    setFile(f);
-  }
-
-  function onPick(e: ChangeEvent<HTMLInputElement>) {
-    setError(null);
-    const f = e.target.files?.[0];
-    e.target.value = '';
-    if (!f) return;
-    acceptFile(f);
-  }
-
-  // Only treat drags carrying files as drop targets — ignore text/HTML drags.
-  function isFileDrag(e: DragEvent): boolean {
-    return Array.from(e.dataTransfer.types).includes('Files');
-  }
-
-  function onDragEnter(e: DragEvent) {
-    if (locked || !isFileDrag(e)) return;
-    e.preventDefault();
-    dragDepthRef.current += 1;
-    setDragOver(true);
-  }
-
-  function onDragOver(e: DragEvent) {
-    if (locked || !isFileDrag(e)) return;
-    e.preventDefault();
-    e.dataTransfer.dropEffect = 'copy';
-  }
-
-  function onDragLeave(e: DragEvent) {
-    if (locked || !isFileDrag(e)) return;
-    dragDepthRef.current = Math.max(0, dragDepthRef.current - 1);
-    if (dragDepthRef.current === 0) setDragOver(false);
-  }
-
-  function onDrop(e: DragEvent) {
-    if (locked || !isFileDrag(e)) return;
-    e.preventDefault();
-    dragDepthRef.current = 0;
-    setDragOver(false);
-    setError(null);
-    const f = e.dataTransfer.files[0];
-    if (!f) return;
-    acceptFile(f);
-  }
-
-  async function handleCrop(blob: Blob) {
+  async function upload(blob: Blob) {
     setBusy(true);
     setError(null);
     try {
       await onCrop(blob);
-      setFile(null);
+      setCropFile(null);
     } catch (err) {
-      setError(extractError(err));
+      setError(extractApiErrorOr(err, "couldn't upload photo — try again"));
     } finally {
       setBusy(false);
     }
   }
 
+  function handleSelect(file: File, opts: { crop: boolean }) {
+    setPickerOpen(false);
+    setError(null);
+    if (opts.crop) {
+      setCropFile(file);
+      return;
+    }
+    void upload(file);
+  }
+
   return (
     <div className="flex flex-col gap-2">
-      <input
-        ref={inputRef}
-        type="file"
-        accept={ALLOWED_MIME.join(',')}
-        onChange={onPick}
-        className="hidden"
-        aria-label="choose event photo"
-      />
-
       <button
         type="button"
-        onClick={open}
-        onDragEnter={onDragEnter}
-        onDragOver={onDragOver}
-        onDragLeave={onDragLeave}
-        onDrop={onDrop}
+        onClick={() => {
+          if (!locked) setPickerOpen(true);
+        }}
         disabled={locked}
         aria-label={hasPhoto ? 'change event photo' : 'add event photo'}
         className={cn(
@@ -144,7 +64,6 @@ export function EventFormPhoto({ photoUrl, photoUpdatedAt, onCrop, disabled }: P
           'focus-visible:ring-brand-300 focus-visible:ring-2 focus-visible:outline-none',
           'aspect-[4/5] w-full',
           hasPhoto ? 'bg-surface' : 'border-brand-200 bg-brand-50 border-2 border-dashed',
-          dragOver && 'border-brand-500 ring-brand-300 ring-2',
           locked && 'cursor-not-allowed opacity-60',
         )}
       >
@@ -163,28 +82,9 @@ export function EventFormPhoto({ photoUrl, photoUpdatedAt, onCrop, disabled }: P
               📸
             </span>
             <span className="text-sm font-medium">add event photo</span>
-            <span className="text-brand-600/80 text-xs">tap or drop a photo</span>
+            <span className="text-brand-600/80 text-xs">tap to choose</span>
           </span>
         )}
-        {dragOver ? (
-          <div
-            aria-hidden="true"
-            className="bg-brand-50/90 text-brand-700 pointer-events-none absolute inset-0 flex items-center justify-center text-sm font-medium"
-          >
-            drop to use this photo
-          </div>
-        ) : null}
-      </button>
-
-      <button
-        type="button"
-        onClick={() => {
-          setLibraryOpen(true);
-        }}
-        disabled={locked}
-        className="text-brand-700 self-center text-xs font-medium underline-offset-2 hover:underline disabled:cursor-not-allowed disabled:opacity-60"
-      >
-        choose from library
       </button>
 
       {error ? (
@@ -193,34 +93,26 @@ export function EventFormPhoto({ photoUrl, photoUpdatedAt, onCrop, disabled }: P
         </p>
       ) : null}
 
-      {libraryOpen ? (
+      {pickerOpen ? (
         <PhotoLibraryDialog
           onCancel={() => {
-            setLibraryOpen(false);
+            setPickerOpen(false);
           }}
-          onSelect={(f) => {
-            setLibraryOpen(false);
-            setError(null);
-            void handleCrop(f);
-          }}
+          onSelect={handleSelect}
         />
       ) : null}
 
-      {file ? (
+      {cropFile ? (
         <ImageCropDialog
-          file={file}
+          file={cropFile}
           shape="rect"
           outputSize={1200}
           onCancel={() => {
-            setFile(null);
+            setCropFile(null);
           }}
-          onCrop={handleCrop}
+          onCrop={upload}
         />
       ) : null}
     </div>
   );
-}
-
-function extractError(err: unknown): string {
-  return extractApiErrorOr(err, "couldn't upload photo — try again");
 }


### PR DESCRIPTION
## Summary

Reworks the event photo picker into a single picker with two tabs, per Issue 1082. Builds on #1074 (Giphy + Pexels search, animation-preserving library path).

- The change-photo button / photo tile now opens **one picker** with a `library | upload your own` tab switch (via `SegmentedControl`) — the separate "choose from library" link is gone.
- **library tab** (default): the gif + photo search grid. Picks call `onSelect(file, { crop: false })` → uploaded at native size, no crop, so gif animation survives.
- **upload your own tab**: the file picker + drag-drop + type/size validation (moved here from `EventFormPhoto`). Picks call `onSelect(file, { crop: true })` → routed through `ImageCropDialog` as before.
- `EventFormPhoto` shrinks to a display frame (4:5 `object-cover`) + crop-dialog host; all upload/validation logic now lives in the picker.

## Test plan
- [x] `PhotoLibraryDialog.test.tsx` + `EventFormPhoto.test.tsx` — updated for tabbed flow (11 pass)
- [x] `make agent-frontend-ci` — full suite green (960 tests), lint/format/typecheck/types clean

## Flags / open questions
- **Tab labels**: went with `library` / `upload your own` (lowercase per copy rules). Open to `browse` / `upload`, or an icon treatment.
- **Default tab**: library, per the issue. If most users upload their own, `upload` may be the better default.
- **Dropped one test**: a "reject disallowed file type on upload" test — `user.upload` honors the input's `accept="image/*"` so a `text/plain` file never reaches the validation code in jsdom. The `validateUpload` guard still runs for drag-drop (which bypasses `accept`); just not unit-covered.
- **Not yet visually verified in-app** — I can't log in (phone + SMS). Worth an eyeball of the tab switch + upload drag-drop.
- **`image/gif` media-proxy pass-through** (an issue acceptance criterion) was already satisfied and verified in #1074; unchanged here.

Fixes #1082
