### PR TITLE
fix: cap event form photo column width on desktop

### DIFF
--- a/frontend/src/screens/events/form/EventForm.tsx
+++ b/frontend/src/screens/events/form/EventForm.tsx
@@ -242,8 +242,8 @@ export function EventForm({ existing }: Props) {
           scroll-up drift. Height is 100vh minus twice that offset so the flex
           box centers the photo on the true viewport middle (89 + (100vh-178)/2
           = 50vh), not the middle of the space below the header. */}
-      <div className="lg:sticky lg:top-[89px] lg:flex lg:h-[calc(100vh-178px)] lg:w-full lg:flex-1 lg:items-center lg:self-start">
-        <div className="w-full">
+      <div className="lg:sticky lg:top-[89px] lg:flex lg:h-[calc(100vh-178px)] lg:w-full lg:flex-1 lg:items-center lg:justify-center lg:self-start">
+        <div className="mx-auto w-full max-w-md">
           <EventFormPhoto
             photoUrl={existing?.photoUrl ?? pendingPhotoUrl ?? ''}
             photoUpdatedAt={existing?.photoUpdatedAt ?? null}


### PR DESCRIPTION
## Overview

The sticky photo column in the event editor was `lg:flex-1` with no width cap, so the `aspect-[4/5]` photo box grew to fill an entire half of the form on desktop — reported as the event photo being "too big" on staging. Caps the photo container at `max-w-md` and centers it, keeping the sticky vertical centering behavior intact.

## Test plan

- [ ] TODO
