### PR TITLE
fix(events): stop gif thumbnails squishing on mobile (Issue 1085)

### DIFF
--- a/frontend/src/components/PhotoLibraryDialog.tsx
+++ b/frontend/src/components/PhotoLibraryDialog.tsx
@@ -186,9 +186,13 @@ export function PhotoLibraryDialog({ onCancel, onSelect }: Props) {
                   onClick={() => void pickLibrary(gif)}
                   disabled={picking}
                   aria-label={gif.title || 'select image'}
-                  className="focus-visible:ring-brand-300 overflow-hidden rounded-[var(--radius-md)] focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
+                  className="focus-visible:ring-brand-300 relative aspect-[4/5] w-full overflow-hidden rounded-[var(--radius-md)] focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-60"
                 >
-                  <img src={gif.previewUrl} alt="" className="aspect-[4/5] w-full object-cover" />
+                  <img
+                    src={gif.previewUrl}
+                    alt=""
+                    className="absolute inset-0 h-full w-full object-cover"
+                  />
                 </button>
               ))}
             </div>


### PR DESCRIPTION
## Summary
- gif thumbnails in the photo library picker were squished on mobile (ios safari/brave), not scrollable
- root cause: `aspect-[4/5]` was set directly on the `<img>`. aspect-ratio on a replaced element is unreliable on ios — the browser honored each gif's intrinsic wide ratio, squishing landscape gifs into the narrow grid cells
- fix: move `aspect-[4/5]` onto the tile button and absolutely position the img with `object-cover`, matching the proven pattern already used in `EventFormPhoto`

Closes #1085

## Test plan
- [ ] on an iphone (safari/brave), open `/events/add` → photo picker → library tab; gifs render as clean 4:5 tiles, no squish, grid scrolls
- [x] `make agent-frontend-typecheck` passes
- [x] `make agent-frontend-lint` passes
- [x] `PhotoLibraryDialog.test.tsx` passes (8/8)