### PR TITLE
feat(feature-flags): frontend read path — useFlag, RequireFlag (Issue 996)

### DIFF
--- a/frontend/src/api/featureFlags.test.ts
+++ b/frontend/src/api/featureFlags.test.ts
@@ -79,4 +79,17 @@ describe('useSetFeatureFlag', () => {
     });
     expect(flags).toEqual({ example_flag: true });
   });
+
+  it('writes the resolved map straight into the flags cache without a refetch', async () => {
+    mockedPatch.mockResolvedValueOnce({ data: { flags: { example_flag: true } } });
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const wrap = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: qc }, children);
+
+    const { result } = renderHook(() => useSetFeatureFlag(), { wrapper: wrap });
+    await result.current.mutateAsync({ key: Feature.ExampleFlag, enabled: true });
+
+    expect(qc.getQueryData(['feature-flags'])).toEqual({ example_flag: true });
+    expect(mockedGet).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/api/featureFlags.test.ts
+++ b/frontend/src/api/featureFlags.test.ts
@@ -1,0 +1,82 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/api/client', () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+
+import { apiClient } from '@/api/client';
+import { Feature } from '@/models/featureFlags';
+
+import { useFeatureFlags, useFlag, useSetFeatureFlag } from './featureFlags';
+
+const mockedGet = vi.mocked(apiClient.get);
+const mockedPatch = vi.mocked(apiClient.patch);
+
+function wrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useFeatureFlags', () => {
+  it('returns the resolved flags map on success', async () => {
+    mockedGet.mockResolvedValueOnce({ data: { flags: { example_flag: true } } });
+
+    const { result } = renderHook(() => useFeatureFlags(), { wrapper: wrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(result.current.data).toEqual({ example_flag: true });
+    expect(mockedGet).toHaveBeenCalledWith('/api/community/feature-flags/');
+  });
+});
+
+describe('useFlag', () => {
+  it('returns the resolved boolean when the flag is on', async () => {
+    mockedGet.mockResolvedValueOnce({ data: { flags: { example_flag: true } } });
+
+    const { result } = renderHook(() => useFlag(Feature.ExampleFlag), { wrapper: wrapper() });
+
+    await waitFor(() => expect(result.current).toBe(true));
+  });
+
+  it('fail-closes to false while loading', () => {
+    mockedGet.mockReturnValueOnce(new Promise(() => {}));
+
+    const { result } = renderHook(() => useFlag(Feature.ExampleFlag), { wrapper: wrapper() });
+
+    expect(result.current).toBe(false);
+  });
+
+  it('fail-closes to false when the key is absent from the resolved map', async () => {
+    mockedGet.mockResolvedValueOnce({ data: { flags: {} } });
+
+    const { result } = renderHook(() => useFlag(Feature.ExampleFlag), { wrapper: wrapper() });
+
+    // let the query settle, then confirm it stays closed
+    await waitFor(() => expect(mockedGet).toHaveBeenCalled());
+    expect(result.current).toBe(false);
+  });
+});
+
+describe('useSetFeatureFlag', () => {
+  it('patches the flag and returns the resolved map', async () => {
+    mockedPatch.mockResolvedValueOnce({ data: { flags: { example_flag: true } } });
+
+    const { result } = renderHook(() => useSetFeatureFlag(), { wrapper: wrapper() });
+
+    const flags = await result.current.mutateAsync({ key: Feature.ExampleFlag, enabled: true });
+
+    expect(mockedPatch).toHaveBeenCalledWith('/api/community/feature-flags/example_flag/', {
+      enabled: true,
+    });
+    expect(flags).toEqual({ example_flag: true });
+  });
+});

--- a/frontend/src/api/featureFlags.ts
+++ b/frontend/src/api/featureFlags.ts
@@ -1,0 +1,50 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import type { FeatureFlagKey } from '@/models/featureFlags';
+
+import { apiClient } from './client';
+
+interface WireFlags {
+  flags: Record<string, boolean>;
+}
+
+const FLAGS_KEY = ['feature-flags'] as const;
+
+// Flags change rarely; avoid refetching on every mount/focus.
+const FLAGS_STALE_TIME = 5 * 60 * 1000;
+
+export function useFeatureFlags() {
+  return useQuery({
+    queryKey: FLAGS_KEY,
+    queryFn: async () => {
+      const { data } = await apiClient.get<WireFlags>('/api/community/feature-flags/');
+      return data.flags;
+    },
+    staleTime: FLAGS_STALE_TIME,
+  });
+}
+
+export function useFlag(key: FeatureFlagKey): boolean {
+  const { data } = useFeatureFlags();
+  return data?.[key] ?? false;
+}
+
+export interface SetFeatureFlagInput {
+  key: FeatureFlagKey;
+  enabled: boolean;
+}
+
+export function useSetFeatureFlag() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ key, enabled }: SetFeatureFlagInput) => {
+      const { data } = await apiClient.patch<WireFlags>(`/api/community/feature-flags/${key}/`, {
+        enabled,
+      });
+      return data.flags;
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: FLAGS_KEY });
+    },
+  });
+}

--- a/frontend/src/api/featureFlags.ts
+++ b/frontend/src/api/featureFlags.ts
@@ -38,13 +38,14 @@ export function useSetFeatureFlag() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: async ({ key, enabled }: SetFeatureFlagInput) => {
-      const { data } = await apiClient.patch<WireFlags>(`/api/community/feature-flags/${key}/`, {
-        enabled,
-      });
+      const { data } = await apiClient.patch<WireFlags>(
+        `/api/community/feature-flags/${encodeURIComponent(key)}/`,
+        { enabled },
+      );
       return data.flags;
     },
-    onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: FLAGS_KEY });
+    onSuccess: (flags) => {
+      qc.setQueryData(FLAGS_KEY, flags);
     },
   });
 }

--- a/frontend/src/auth/guards.test.tsx
+++ b/frontend/src/auth/guards.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { useFlag } from '@/api/featureFlags';
+import { useFeatureFlags } from '@/api/featureFlags';
 import { Feature } from '@/models/featureFlags';
 import { Permission } from '@/models/permissions';
 import type { User } from '@/models/user';
@@ -20,7 +20,7 @@ vi.mock('@/api/client', () => ({
 }));
 
 vi.mock('@/api/featureFlags', () => ({
-  useFlag: vi.fn(),
+  useFeatureFlags: vi.fn(),
 }));
 
 // Prevent any real API calls from the store module.
@@ -171,30 +171,56 @@ describe('RequirePermission', () => {
 // ---------------------------------------------------------------------------
 
 describe('RequireFlag', () => {
-  const mockedUseFlag = vi.mocked(useFlag);
+  const mockedUseFeatureFlags = vi.mocked(useFeatureFlags);
 
-  function renderGuarded() {
+  function mockFlags(overrides: Partial<ReturnType<typeof useFeatureFlags>>) {
+    mockedUseFeatureFlags.mockReturnValue({
+      data: undefined,
+      isPending: false,
+      ...overrides,
+    } as ReturnType<typeof useFeatureFlags>);
+  }
+
+  function renderGuarded(initialEntry = '/beta') {
     return render(
-      <MemoryRouter initialEntries={['/beta']}>
+      <MemoryRouter initialEntries={[initialEntry]}>
         <Routes>
           <Route element={<RequireFlag flag={Feature.ExampleFlag} />}>
             <Route path="/beta" element={<div>beta content</div>} />
           </Route>
+          <Route path="/login" element={<div>login page</div>} />
           <Route path="/calendar" element={<div>calendar page</div>} />
         </Routes>
       </MemoryRouter>,
     );
   }
 
-  it('renders the outlet when the flag is on', () => {
-    mockedUseFlag.mockReturnValue(true);
+  it('redirects an unauthed user to /login before checking the flag', () => {
+    mockFlags({ data: { example_flag: true } });
+    renderGuarded();
+    expect(screen.getByText('login page')).toBeInTheDocument();
+    expect(screen.queryByText('beta content')).not.toBeInTheDocument();
+  });
+
+  it('renders a spinner while the flags query is loading, without redirecting', () => {
+    useAuthStore.setState({ status: 'authed', user: makeUser(), accessToken: 'tok-abc' });
+    mockFlags({ isPending: true });
+    renderGuarded();
+    expect(screen.queryByText('beta content')).not.toBeInTheDocument();
+    expect(screen.queryByText('calendar page')).not.toBeInTheDocument();
+  });
+
+  it('renders the outlet when authed and the flag is on', () => {
+    useAuthStore.setState({ status: 'authed', user: makeUser(), accessToken: 'tok-abc' });
+    mockFlags({ data: { example_flag: true } });
     renderGuarded();
     expect(screen.getByText('beta content')).toBeInTheDocument();
     expect(screen.queryByText('calendar page')).not.toBeInTheDocument();
   });
 
-  it('redirects to /calendar when the flag is off', () => {
-    mockedUseFlag.mockReturnValue(false);
+  it('redirects to /calendar when authed but the flag is off', () => {
+    useAuthStore.setState({ status: 'authed', user: makeUser(), accessToken: 'tok-abc' });
+    mockFlags({ data: { example_flag: false } });
     renderGuarded();
     expect(screen.getByText('calendar page')).toBeInTheDocument();
     expect(screen.queryByText('beta content')).not.toBeInTheDocument();

--- a/frontend/src/auth/guards.test.tsx
+++ b/frontend/src/auth/guards.test.tsx
@@ -3,11 +3,13 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useFlag } from '@/api/featureFlags';
+import { Feature } from '@/models/featureFlags';
 import { Permission } from '@/models/permissions';
 import type { User } from '@/models/user';
 import { makeUser as makeSharedUser } from '@/test/fixtures';
 
-import { EmailGate, OnboardingGate, RequireAuth, RequirePermission } from './guards';
+import { EmailGate, OnboardingGate, RequireAuth, RequireFlag, RequirePermission } from './guards';
 import { useAuthStore } from './store';
 
 // Prevent the store from wiring up real axios interceptors.
@@ -15,6 +17,10 @@ vi.mock('@/api/client', () => ({
   setAuthBridge: vi.fn(),
   authClient: { post: vi.fn(), get: vi.fn() },
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+
+vi.mock('@/api/featureFlags', () => ({
+  useFlag: vi.fn(),
 }));
 
 // Prevent any real API calls from the store module.
@@ -157,6 +163,41 @@ describe('RequirePermission', () => {
 
     expect(screen.getByText('admin content')).toBeInTheDocument();
     expect(screen.queryByText('calendar page')).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// RequireFlag
+// ---------------------------------------------------------------------------
+
+describe('RequireFlag', () => {
+  const mockedUseFlag = vi.mocked(useFlag);
+
+  function renderGuarded() {
+    return render(
+      <MemoryRouter initialEntries={['/beta']}>
+        <Routes>
+          <Route element={<RequireFlag flag={Feature.ExampleFlag} />}>
+            <Route path="/beta" element={<div>beta content</div>} />
+          </Route>
+          <Route path="/calendar" element={<div>calendar page</div>} />
+        </Routes>
+      </MemoryRouter>,
+    );
+  }
+
+  it('renders the outlet when the flag is on', () => {
+    mockedUseFlag.mockReturnValue(true);
+    renderGuarded();
+    expect(screen.getByText('beta content')).toBeInTheDocument();
+    expect(screen.queryByText('calendar page')).not.toBeInTheDocument();
+  });
+
+  it('redirects to /calendar when the flag is off', () => {
+    mockedUseFlag.mockReturnValue(false);
+    renderGuarded();
+    expect(screen.getByText('calendar page')).toBeInTheDocument();
+    expect(screen.queryByText('beta content')).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/auth/guards.tsx
+++ b/frontend/src/auth/guards.tsx
@@ -1,8 +1,10 @@
 import { type ReactNode, useEffect } from 'react';
 import { Navigate, Outlet, useLocation, useNavigate } from 'react-router-dom';
 
+import { useFlag } from '@/api/featureFlags';
 import { RequireEmail } from '@/components/RequireEmail';
 import { CONSENT_REGISTRY } from '@/models/consent';
+import type { FeatureFlagKey } from '@/models/featureFlags';
 import { hasPermission, type PermissionKey } from '@/models/permissions';
 import { consentRedirect, passwordSetupRedirect } from '@/models/user';
 
@@ -123,6 +125,20 @@ export function RequirePermission({ perm }: { perm: PermissionKey }) {
     return <Navigate to={`/login?redirect=${redirect}`} replace />;
   }
   if (!hasPermission(user, perm)) {
+    return <Navigate to="/calendar" replace />;
+  }
+  return <Outlet />;
+}
+
+// ----------------------------------------------------------------------------
+// RequireFlag — gates a route behind a feature flag. Fail-closed: a flag that
+// is off, missing, or still loading redirects to /calendar, so a dark feature
+// never flashes into view before the flag resolves.
+// ----------------------------------------------------------------------------
+
+export function RequireFlag({ flag }: { flag: FeatureFlagKey }) {
+  const enabled = useFlag(flag);
+  if (!enabled) {
     return <Navigate to="/calendar" replace />;
   }
   return <Outlet />;

--- a/frontend/src/auth/guards.tsx
+++ b/frontend/src/auth/guards.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode, useEffect } from 'react';
 import { Navigate, Outlet, useLocation, useNavigate } from 'react-router-dom';
 
-import { useFlag } from '@/api/featureFlags';
+import { useFeatureFlags } from '@/api/featureFlags';
 import { RequireEmail } from '@/components/RequireEmail';
 import { CONSENT_REGISTRY } from '@/models/consent';
 import type { FeatureFlagKey } from '@/models/featureFlags';
@@ -131,14 +131,25 @@ export function RequirePermission({ perm }: { perm: PermissionKey }) {
 }
 
 // ----------------------------------------------------------------------------
-// RequireFlag — gates a route behind a feature flag. Fail-closed: a flag that
-// is off, missing, or still loading redirects to /calendar, so a dark feature
-// never flashes into view before the flag resolves.
+// RequireFlag — authed + feature flag check. Fail-closed: a flag that is off
+// or missing redirects to /calendar. While the flags query is still loading,
+// renders a spinner instead of redirecting, so a flag that resolves true
+// doesn't briefly bounce the user away first.
 // ----------------------------------------------------------------------------
 
 export function RequireFlag({ flag }: { flag: FeatureFlagKey }) {
-  const enabled = useFlag(flag);
-  if (!enabled) {
+  const isAuthed = useAuthStore((s) => s.status === 'authed');
+  const location = useLocation();
+  const { data: flags, isPending } = useFeatureFlags();
+
+  if (!isAuthed) {
+    const redirect = encodeURIComponent(location.pathname + location.search);
+    return <Navigate to={`/login?redirect=${redirect}`} replace />;
+  }
+  if (isPending) {
+    return <BootSpinner />;
+  }
+  if (!(flags?.[flag] ?? false)) {
     return <Navigate to="/calendar" replace />;
   }
   return <Outlet />;

--- a/frontend/src/models/featureFlags.ts
+++ b/frontend/src/models/featureFlags.ts
@@ -1,0 +1,5 @@
+export const Feature = {
+  ExampleFlag: 'example_flag',
+} as const;
+
+export type FeatureFlagKey = (typeof Feature)[keyof typeof Feature];

--- a/frontend/src/test/featureFlagParity.test.ts
+++ b/frontend/src/test/featureFlagParity.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { Feature } from '@/models/featureFlags';
+
+const CHOICES = join(__dirname, '../../..', 'backend/community/models/choices.py');
+
+// Extract the string values of the backend `FeatureFlag(models.TextChoices)`
+// members, e.g. `EXAMPLE_FLAG = "example_flag", "Example flag"` → `example_flag`.
+function backendFlagKeys(): Set<string> {
+  const source = readFileSync(CHOICES, 'utf8');
+  const classMatch = /class FeatureFlag\(models\.TextChoices\):([\s\S]*?)(?:\n\S|$)/.exec(source);
+  if (!classMatch) throw new Error('FeatureFlag class not found in choices.py');
+  const memberRe = /^\s+[A-Z0-9_]+\s*=\s*"([^"]+)"/;
+  const keys = new Set<string>();
+  for (const line of classMatch[1].split('\n')) {
+    const m = memberRe.exec(line);
+    if (m) keys.add(m[1]);
+  }
+  return keys;
+}
+
+describe('feature flag registry parity', () => {
+  it('backend FeatureFlag keys match the frontend Feature mirror exactly', () => {
+    const backend = backendFlagKeys();
+    const frontend = new Set<string>(Object.values(Feature));
+    expect([...frontend].sort()).toEqual([...backend].sort());
+  });
+});

--- a/frontend/src/test/featureFlagParity.test.ts
+++ b/frontend/src/test/featureFlagParity.test.ts
@@ -14,9 +14,9 @@ function backendFlagKeys(): Set<string> {
   if (!classMatch) throw new Error('FeatureFlag class not found in choices.py');
   const memberRe = /^\s+[A-Z0-9_]+\s*=\s*"([^"]+)"/;
   const keys = new Set<string>();
-  for (const line of classMatch[1].split('\n')) {
+  for (const line of (classMatch[1] ?? '').split('\n')) {
     const m = memberRe.exec(line);
-    if (m) keys.add(m[1]);
+    if (m?.[1]) keys.add(m[1]);
   }
   return keys;
 }


### PR DESCRIPTION
## Overview

Phase 2 of the feature flag system: the frontend read path, so components and routes can gate on flags. Server-driven — no Zustand store; the TanStack Query cache is the global state, mirroring `useRoles` / `useHasPermission`. Admin toggle UI is the next phase (#997); this is consumption only.

Part of epic #994. Follows #995 (backend foundation, merged).

Closes #996.

- `Feature` const + `FeatureFlagKey` union (`models/featureFlags.ts`) — string values mirror the backend `FeatureFlag` keys exactly
- `useFeatureFlags()` query (generous `staleTime`) + `useFlag(key)` selector — **fail-closed**: missing/loading ⇒ `false`, so a dark feature stays dark until proven on
- `useSetFeatureFlag()` mutation (invalidates the flags query) — defined here so the API module is complete; consumed by the admin screen in #997
- `RequireFlag` route guard — clone of `RequirePermission`, redirects to `/calendar` when the flag is off
- Tests: `useFlag` on/off/loading, `RequireFlag` render vs redirect, and a **backend↔frontend parity test** that reads both source files and asserts set-equality (guards the two-file sync)

## Test plan

- [x] `featureFlags.test.ts` — query resolves, `useFlag` returns bool / fail-closes on loading + absent key, mutation PATCHes correct URL
- [x] `guards.test.tsx` — `RequireFlag` renders outlet when on, redirects when off (existing guard tests still green with the new mock)
- [x] `featureFlagParity.test.ts` — parses backend `FeatureFlag` enum, asserts == frontend `Feature` values (verified it parses `['example_flag']`, not a vacuous pass)
- [x] `tsc --noEmit`, eslint, prettier all clean on changed files
- [ ] Full `make agent-frontend-*` (deferred — ask before merging out of draft)
