### PR TITLE
feat(feature-flags): admin toggle UI, all environments (Issue 997)

### DIFF
--- a/frontend/src/api/version.test.ts
+++ b/frontend/src/api/version.test.ts
@@ -1,0 +1,44 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/api/client', () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+
+import { apiClient } from '@/api/client';
+
+import { useVersion } from './version';
+
+const mockedGet = vi.mocked(apiClient.get);
+
+function wrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('useVersion', () => {
+  it('returns the mapped version info', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: { commit_sha: 'abcdef123', commit_sha_short: 'abcdef1', environment: 'production' },
+    });
+
+    const { result } = renderHook(() => useVersion(), { wrapper: wrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data).toEqual({
+      commitSha: 'abcdef123',
+      commitShaShort: 'abcdef1',
+      environment: 'production',
+    });
+    expect(mockedGet).toHaveBeenCalledWith('/api/community/version/');
+  });
+});

--- a/frontend/src/api/version.ts
+++ b/frontend/src/api/version.ts
@@ -1,0 +1,30 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { apiClient } from './client';
+
+export interface Version {
+  commitSha: string;
+  commitShaShort: string;
+  environment: string;
+}
+
+interface WireVersion {
+  commit_sha: string;
+  commit_sha_short: string;
+  environment: string;
+}
+
+export function useVersion() {
+  return useQuery({
+    queryKey: ['version'],
+    queryFn: async (): Promise<Version> => {
+      const { data } = await apiClient.get<WireVersion>('/api/community/version/');
+      return {
+        commitSha: data.commit_sha,
+        commitShaShort: data.commit_sha_short,
+        environment: data.environment,
+      };
+    },
+    staleTime: Infinity,
+  });
+}

--- a/frontend/src/models/permissions.ts
+++ b/frontend/src/models/permissions.ts
@@ -12,6 +12,7 @@ export const Permission = {
   TagOfficialEvent: 'tag_official_event',
   TagClubEvent: 'tag_club_event',
   ManageDocuments: 'manage_documents',
+  ManageFeatureFlags: 'manage_feature_flags',
 } as const;
 
 export type PermissionKey = (typeof Permission)[keyof typeof Permission];

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -45,6 +45,7 @@ const JoinFormAdmin = lazyWithRetry(() => import('@/screens/admin/JoinFormAdminS
 const SurveyAdminList = lazyWithRetry(() => import('@/screens/admin/SurveyAdminListScreen'));
 const SurveyBuilder = lazyWithRetry(() => import('@/screens/admin/SurveyBuilderScreen'));
 const SurveyResponses = lazyWithRetry(() => import('@/screens/admin/SurveyResponsesScreen'));
+const FeatureFlags = lazyWithRetry(() => import('@/screens/admin/FeatureFlagsScreen'));
 const Members = lazyWithRetry(() => import('@/screens/admin/MembersScreen'));
 const MemberDetail = lazyWithRetry(() => import('@/screens/admin/MemberDetailScreen'));
 const MemberProfile = lazyWithRetry(() => import('@/screens/members/MemberProfileScreen'));
@@ -152,6 +153,10 @@ export const router = createBrowserRouter([
                   { path: '/admin/surveys/:id', element: el(<SurveyBuilder />) },
                   { path: '/admin/surveys/:id/responses', element: el(<SurveyResponses />) },
                 ],
+              },
+              {
+                element: <RequirePermission perm={Permission.ManageFeatureFlags} />,
+                children: [{ path: '/admin/feature-flags', element: el(<FeatureFlags />) }],
               },
 
               // ---- catch-all ----

--- a/frontend/src/screens/admin/AdminHubScreen.test.tsx
+++ b/frontend/src/screens/admin/AdminHubScreen.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import { useAuthStore } from '@/auth/store';
+import { Permission } from '@/models/permissions';
+import { makeUser } from '@/test/fixtures';
+
+import AdminHubScreen from './AdminHubScreen';
+
+function renderHub() {
+  return render(
+    <MemoryRouter>
+      <AdminHubScreen />
+    </MemoryRouter>,
+  );
+}
+
+describe('AdminHubScreen', () => {
+  it('shows the feature flags tile for a permitted user', () => {
+    const user = makeUser({
+      roles: [
+        {
+          id: 'r1',
+          name: 'flags-admin',
+          isDefault: true,
+          permissions: [Permission.ManageFeatureFlags],
+        },
+      ],
+    });
+    useAuthStore.setState({ status: 'authed', user, accessToken: 'tok-abc' });
+
+    renderHub();
+
+    expect(screen.getByText('feature flags')).toBeInTheDocument();
+  });
+
+  it('hides the feature flags tile for a user without the permission', () => {
+    const user = makeUser({ roles: [] });
+    useAuthStore.setState({ status: 'authed', user, accessToken: 'tok-abc' });
+
+    renderHub();
+
+    expect(screen.queryByText('feature flags')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/admin/AdminHubScreen.tsx
+++ b/frontend/src/screens/admin/AdminHubScreen.tsx
@@ -60,6 +60,12 @@ const TILES: Tile[] = [
     description: 'manage the shared document library',
     perm: Permission.ManageDocuments,
   },
+  {
+    to: '/admin/feature-flags',
+    label: 'feature flags',
+    description: 'toggle dark-launched features',
+    perm: Permission.ManageFeatureFlags,
+  },
 ];
 
 export default function AdminHubScreen() {

--- a/frontend/src/screens/admin/FeatureFlagsScreen.test.tsx
+++ b/frontend/src/screens/admin/FeatureFlagsScreen.test.tsx
@@ -1,0 +1,94 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/api/featureFlags', () => ({
+  useFeatureFlags: vi.fn(),
+  useSetFeatureFlag: vi.fn(),
+}));
+
+vi.mock('@/api/version', () => ({
+  useVersion: vi.fn(),
+}));
+
+import { useFeatureFlags, useSetFeatureFlag } from '@/api/featureFlags';
+import { useVersion } from '@/api/version';
+
+import FeatureFlagsScreen from './FeatureFlagsScreen';
+
+const mockUseFlags = vi.mocked(useFeatureFlags);
+const mockUseSetFlag = vi.mocked(useSetFeatureFlag);
+const mockUseVersion = vi.mocked(useVersion);
+const mockMutate = vi.fn();
+
+function mockFlagsResult(overrides: Partial<ReturnType<typeof useFeatureFlags>>) {
+  mockUseFlags.mockReturnValue({
+    isPending: false,
+    isError: false,
+    data: { example_flag: false },
+    ...overrides,
+  } as ReturnType<typeof useFeatureFlags>);
+}
+
+function renderScreen() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <FeatureFlagsScreen />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseVersion.mockReturnValue({
+    data: { commitSha: 'abc', commitShaShort: 'abc', environment: 'staging' },
+  } as ReturnType<typeof useVersion>);
+  mockUseSetFlag.mockReturnValue({
+    mutate: mockMutate,
+    isPending: false,
+  } as unknown as ReturnType<typeof useSetFeatureFlag>);
+});
+
+describe('FeatureFlagsScreen', () => {
+  it('renders a toggle per flag and calls the mutation on change', async () => {
+    mockFlagsResult({ data: { example_flag: false } });
+
+    renderScreen();
+
+    const toggle = screen.getByRole('switch', { name: /example flag/i });
+    expect(toggle).toHaveAttribute('aria-checked', 'false');
+
+    await userEvent.click(toggle);
+
+    expect(mockMutate).toHaveBeenCalledWith({ key: 'example_flag', enabled: true });
+  });
+
+  it('shows the current environment', () => {
+    mockFlagsResult({});
+
+    renderScreen();
+
+    expect(screen.getByText(/environment: staging/i)).toBeInTheDocument();
+  });
+
+  it('shows a loading state while pending', () => {
+    mockFlagsResult({ isPending: true, data: undefined });
+
+    renderScreen();
+
+    expect(screen.getByText('loading…')).toBeInTheDocument();
+  });
+
+  it('shows an error message when the query fails', () => {
+    mockFlagsResult({ isError: true, data: undefined });
+
+    renderScreen();
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/couldn't load feature flags/i);
+  });
+});

--- a/frontend/src/screens/admin/FeatureFlagsScreen.tsx
+++ b/frontend/src/screens/admin/FeatureFlagsScreen.tsx
@@ -1,0 +1,44 @@
+import { useFeatureFlags, useSetFeatureFlag } from '@/api/featureFlags';
+import { useVersion } from '@/api/version';
+import { Toggle } from '@/components/ui/Toggle';
+import { Feature, type FeatureFlagKey } from '@/models/featureFlags';
+import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
+
+const FLAG_LABELS: Record<FeatureFlagKey, string> = {
+  [Feature.ExampleFlag]: 'example flag',
+};
+
+export default function FeatureFlagsScreen() {
+  const { data: flags, isPending, isError } = useFeatureFlags();
+  const { data: version } = useVersion();
+  const setFlag = useSetFeatureFlag();
+
+  if (isPending) return <ContentLoading />;
+  if (isError) return <ContentError message="couldn't load feature flags — try refreshing" />;
+
+  return (
+    <ContentContainer>
+      <header className="mb-4">
+        <h1 className="mb-1 text-2xl font-medium tracking-tight">feature flags</h1>
+        <p className="text-muted text-sm">
+          {version ? `environment: ${version.environment}` : 'loading environment…'}
+        </p>
+      </header>
+
+      <ul className="border-border bg-surface divide-border flex flex-col divide-y rounded-lg border px-3">
+        {Object.values(Feature).map((key) => (
+          <li key={key}>
+            <Toggle
+              label={FLAG_LABELS[key]}
+              checked={flags[key] ?? false}
+              disabled={setFlag.isPending}
+              onChange={(enabled) => {
+                setFlag.mutate({ key, enabled });
+              }}
+            />
+          </li>
+        ))}
+      </ul>
+    </ContentContainer>
+  );
+}

--- a/frontend/src/screens/admin/RoleFormDialog.tsx
+++ b/frontend/src/screens/admin/RoleFormDialog.tsx
@@ -27,6 +27,7 @@ const PERMISSION_LABELS: Record<string, string> = {
   [Permission.TagOfficialEvent]: 'tag official events',
   [Permission.TagClubEvent]: 'tag club events',
   [Permission.ManageDocuments]: 'manage documents',
+  [Permission.ManageFeatureFlags]: 'manage feature flags',
 };
 
 export function RoleFormDialog({ open, onClose, initialRole: role }: Props) {


### PR DESCRIPTION
## Overview

Phase 3 of the feature flag system: the admin toggle UI. A screen listing every flag with an on/off switch, wired to the write endpoint from #995. Gated by `MANAGE_FEATURE_FLAGS` only — visible and usable on every environment, including production, so a flag can be flipped off immediately if something missed in staging surfaces after launch (see #994's decision log).

Part of epic #994. Depends on #995 (write endpoint + permission, merged) and #996 (`useFeatureFlags`/`useSetFeatureFlag`/`Feature` mirror, merged).

Closes #997.

- `useVersion()` — new hook reading `GET /api/community/version/`, used to *display* the environment for operator context (not to gate visibility)
- `FeatureFlagsScreen` — one `Toggle` per `Feature` member, wired to `useFeatureFlags`/`useSetFeatureFlag`, `ContentContainer`/`ContentLoading`/`ContentError` states, lowercase copy
- `AdminHub` tile + `/admin/feature-flags` route — gated by `Permission.ManageFeatureFlags` only, same pattern as every other tile (no environment check)
- RBAC mirror sync: `Permission.ManageFeatureFlags` in `models/permissions.ts` + `PERMISSION_LABELS` entry in `RoleFormDialog.tsx` (backend enum already had the key from #995)

## Test plan

- [x] `FeatureFlagsScreen.test.tsx` — toggle renders per flag, click calls `useSetFeatureFlag` with the right key/enabled, loading + error states
- [x] `AdminHubScreen.test.tsx` — tile shows for a permitted user, hidden for one without the permission (no environment branching exists to test — that's the point)
- [x] `version.test.ts` — wire → camelCase mapping
- [x] Existing `RoleFormDialog.test.tsx` / `guards.test.tsx` still pass with the new permission
- [x] `make agent-frontend-lint` / `agent-frontend-typecheck` / `agent-frontend-test` (126 files, 978 tests) all clean
- [x] `make agent-frontend-format` — no diff (already Prettier-clean)
