### PR TITLE
feat(attendance): host check-in report + csv export (Issue 1092)

### DIFF
--- a/backend/community/_event_report.py
+++ b/backend/community/_event_report.py
@@ -1,0 +1,142 @@
+import csv
+import io
+from uuid import UUID
+
+from config.auth import gated_jwt
+from django.http import HttpResponse
+from ninja import Router
+from ninja.responses import Status
+from users._helpers import visible_display_name
+
+from community._event_helpers import _can_see_phones, load_event_with_stats_prefetch
+from community._event_report_schemas import (
+    REPORT_CSV_COLUMNS,
+    AttendedPersonOut,
+    CanceledPersonOut,
+    CheckInReportOut,
+    CheckInReportPersonOut,
+)
+from community._events import _can_edit_event
+from community._shared import ErrorOut
+from community._validation import Code, raise_validation
+from community.models import AttendanceStatus, Event, FeatureFlag, RSVPStatus, flag_enabled
+
+router = Router()
+
+
+def _load_and_authorize(request, event_id: UUID) -> Event:
+    event = load_event_with_stats_prefetch(event_id)
+    if event is None:
+        raise_validation(Code.Event.NOT_FOUND, status_code=404)
+    if not _can_edit_event(request.auth, event):
+        raise_validation(Code.Perm.DENIED, status_code=403, action="check_in_report")
+    if not flag_enabled(FeatureFlag.HOST_ATTENDANCE_REPORT):
+        raise_validation(Code.Event.NOT_FOUND, status_code=404)
+    if not event.is_past:
+        raise_validation(Code.Event.CHECK_IN_REPORT_NOT_YET_AVAILABLE, status_code=400)
+    return event
+
+
+def _person(rsvp, can_see_phones: bool) -> CheckInReportPersonOut:
+    return CheckInReportPersonOut(
+        user_id=str(rsvp.user_id),
+        name=visible_display_name(rsvp.user, None),
+        phone=rsvp.user.phone_number if can_see_phones else None,
+        is_member=rsvp.user.is_member,
+    )
+
+
+def _build_report(event: Event, viewer) -> CheckInReportOut:
+    creator = event.created_by
+    co_host_ids = {str(c.id) for c in event.co_hosts.all()}
+    can_see_phones = _can_see_phones(viewer, creator, co_host_ids)
+
+    attended, no_shows, canceled, unmarked = [], [], [], []
+    for rsvp in event.rsvps.all():
+        base = _person(rsvp, can_see_phones)
+        if rsvp.status == RSVPStatus.CANT_GO:
+            canceled.append(
+                CanceledPersonOut(
+                    **base.model_dump(), cancelled_at=rsvp.cancelled_at or rsvp.updated_at
+                )
+            )
+        elif rsvp.status == RSVPStatus.ATTENDING and rsvp.attendance == AttendanceStatus.ATTENDED:
+            attended.append(
+                AttendedPersonOut(**base.model_dump(), checked_in_at=rsvp.checked_in_at)
+            )
+        elif rsvp.status == RSVPStatus.ATTENDING and rsvp.attendance == AttendanceStatus.NO_SHOW:
+            no_shows.append(base)
+        elif rsvp.status == RSVPStatus.ATTENDING:
+            unmarked.append(base)
+
+    return CheckInReportOut(
+        attended_count=len(attended),
+        no_show_count=len(no_shows),
+        canceled_count=len(canceled),
+        unmarked_count=len(unmarked),
+        attended=attended,
+        no_shows=no_shows,
+        canceled=canceled,
+        unmarked=unmarked,
+    )
+
+
+@router.get(
+    "/events/{event_id}/report/",
+    response={200: CheckInReportOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut},
+    auth=gated_jwt,
+)
+def get_check_in_report(request, event_id: UUID):
+    event = _load_and_authorize(request, event_id)
+    return Status(200, _build_report(event, request.auth))
+
+
+def _csv_row(rsvp, can_see_phones: bool, columns: list[str]) -> list[str]:
+    values = {
+        "name": visible_display_name(rsvp.user, None),
+        "phone": (rsvp.user.phone_number or "") if can_see_phones else "",
+        "rsvp_status": rsvp.status,
+        "attendance": rsvp.attendance,
+        "checked_in_at": rsvp.checked_in_at.isoformat() if rsvp.checked_in_at else "",
+        "cancelled_at": rsvp.cancelled_at.isoformat() if rsvp.cancelled_at else "",
+        "plus_one": "yes" if rsvp.has_plus_one else "no",
+    }
+    return [values[c] for c in columns]
+
+
+def _parse_columns(raw: str) -> list[str]:
+    columns = [c.strip() for c in raw.split(",") if c.strip()]
+    for column in columns:
+        if column not in REPORT_CSV_COLUMNS:
+            raise_validation(
+                Code.Event.CHECK_IN_REPORT_INVALID_COLUMN, status_code=422, column=column
+            )
+    return columns
+
+
+def _report_csv_filename(event: Event) -> str:
+    return f"check-in-report-{event.id}.csv"
+
+
+@router.get(
+    "/events/{event_id}/report.csv",
+    response={400: ErrorOut, 403: ErrorOut, 404: ErrorOut, 422: ErrorOut},
+    auth=gated_jwt,
+)
+def get_check_in_report_csv(request, event_id: UUID, columns: str = ",".join(REPORT_CSV_COLUMNS)):
+    event = _load_and_authorize(request, event_id)
+    selected = _parse_columns(columns)
+
+    creator = event.created_by
+    co_host_ids = {str(c.id) for c in event.co_hosts.all()}
+    can_see_phones = _can_see_phones(request.auth, creator, co_host_ids)
+
+    buf = io.StringIO()
+    writer = csv.writer(buf)
+    writer.writerow(selected)
+    for rsvp in event.rsvps.all():
+        writer.writerow(_csv_row(rsvp, can_see_phones, selected))
+
+    response = HttpResponse(buf.getvalue(), content_type="text/csv")
+    response["Content-Disposition"] = f'attachment; filename="{_report_csv_filename(event)}"'
+    return response

--- a/backend/community/_event_report.py
+++ b/backend/community/_event_report.py
@@ -37,10 +37,16 @@ def _load_and_authorize(request, event_id: UUID) -> Event:
     return event
 
 
-def _person(rsvp, can_see_phones: bool) -> CheckInReportPersonOut:
+def _report_rsvps(event: Event):
+    # REMOVED RSVPs are soft-deleted off the guest list; every other status is
+    # a real attendee the report must account for.
+    return [r for r in event.rsvps.all() if r.status != RSVPStatus.REMOVED]
+
+
+def _person(rsvp, viewer, can_see_phones: bool) -> CheckInReportPersonOut:
     return CheckInReportPersonOut(
         user_id=str(rsvp.user_id),
-        name=visible_display_name(rsvp.user, None),
+        name=visible_display_name(rsvp.user, viewer),
         phone=rsvp.user.phone_number if can_see_phones else None,
         is_member=rsvp.user.is_member,
     )
@@ -52,8 +58,8 @@ def _build_report(event: Event, viewer) -> CheckInReportOut:
     can_see_phones = _can_see_phones(viewer, creator, co_host_ids)
 
     attended, no_shows, canceled, unmarked = [], [], [], []
-    for rsvp in event.rsvps.all():
-        base = _person(rsvp, can_see_phones)
+    for rsvp in _report_rsvps(event):
+        base = _person(rsvp, viewer, can_see_phones)
         if rsvp.status == RSVPStatus.CANT_GO:
             canceled.append(
                 CanceledPersonOut(
@@ -66,7 +72,7 @@ def _build_report(event: Event, viewer) -> CheckInReportOut:
             )
         elif rsvp.status == RSVPStatus.ATTENDING and rsvp.attendance == AttendanceStatus.NO_SHOW:
             no_shows.append(base)
-        elif rsvp.status == RSVPStatus.ATTENDING:
+        else:
             unmarked.append(base)
 
     return CheckInReportOut(
@@ -91,10 +97,18 @@ def get_check_in_report(request, event_id: UUID):
     return Status(200, _build_report(event, request.auth))
 
 
-def _csv_row(rsvp, can_see_phones: bool, columns: list[str]) -> list[str]:
+def _csv_safe(value: str) -> str:
+    # Prefix a leading apostrophe so spreadsheet apps don't execute
+    # attendee-controlled names/phones as formulas (CSV injection).
+    if value and value[0] in ("=", "+", "-", "@", "\t", "\r"):
+        return "'" + value
+    return value
+
+
+def _csv_row(rsvp, viewer, can_see_phones: bool, columns: list[str]) -> list[str]:
     values = {
-        "name": visible_display_name(rsvp.user, None),
-        "phone": (rsvp.user.phone_number or "") if can_see_phones else "",
+        "name": _csv_safe(visible_display_name(rsvp.user, viewer)),
+        "phone": _csv_safe((rsvp.user.phone_number or "") if can_see_phones else ""),
         "rsvp_status": rsvp.status,
         "attendance": rsvp.attendance,
         "checked_in_at": rsvp.checked_in_at.isoformat() if rsvp.checked_in_at else "",
@@ -134,8 +148,8 @@ def get_check_in_report_csv(request, event_id: UUID, columns: str = ",".join(REP
     buf = io.StringIO()
     writer = csv.writer(buf)
     writer.writerow(selected)
-    for rsvp in event.rsvps.all():
-        writer.writerow(_csv_row(rsvp, can_see_phones, selected))
+    for rsvp in _report_rsvps(event):
+        writer.writerow(_csv_row(rsvp, request.auth, can_see_phones, selected))
 
     response = HttpResponse(buf.getvalue(), content_type="text/csv")
     response["Content-Disposition"] = f'attachment; filename="{_report_csv_filename(event)}"'

--- a/backend/community/_event_report_schemas.py
+++ b/backend/community/_event_report_schemas.py
@@ -1,0 +1,40 @@
+from datetime import datetime
+
+from pydantic import BaseModel
+
+
+class CheckInReportPersonOut(BaseModel):
+    user_id: str
+    name: str
+    phone: str | None = None
+    is_member: bool = True
+
+
+class AttendedPersonOut(CheckInReportPersonOut):
+    checked_in_at: datetime | None = None
+
+
+class CanceledPersonOut(CheckInReportPersonOut):
+    cancelled_at: datetime
+
+
+class CheckInReportOut(BaseModel):
+    attended_count: int = 0
+    no_show_count: int = 0
+    canceled_count: int = 0
+    unmarked_count: int = 0
+    attended: list[AttendedPersonOut] = []
+    no_shows: list[CheckInReportPersonOut] = []
+    canceled: list[CanceledPersonOut] = []
+    unmarked: list[CheckInReportPersonOut] = []
+
+
+REPORT_CSV_COLUMNS = (
+    "name",
+    "phone",
+    "rsvp_status",
+    "attendance",
+    "checked_in_at",
+    "cancelled_at",
+    "plus_one",
+)

--- a/backend/community/_validation.py
+++ b/backend/community/_validation.py
@@ -35,6 +35,10 @@ class Code:
         BLAST_INVALID_AUDIENCE = "event.blast_invalid_audience"
         BLAST_NO_RECIPIENTS = "event.blast_no_recipients"
         WOULD_REMOVE_NON_MEMBERS = "event.would_remove_non_members"  # params: { count: int }
+        CHECK_IN_REPORT_NOT_YET_AVAILABLE = "event.check_in_report_not_yet_available"
+        CHECK_IN_REPORT_INVALID_COLUMN = (
+            "event.check_in_report_invalid_column"  # params: { column: str }
+        )
 
     class Poll:
         NOT_FOUND = "poll.not_found"

--- a/backend/community/api.py
+++ b/backend/community/api.py
@@ -18,6 +18,7 @@ from community._event_helpers import (  # noqa: F401
 )
 from community._event_host_actions import router as event_host_actions_router
 from community._event_invitations import router as event_invitations_router
+from community._event_report import router as event_report_router
 from community._event_rsvps import router as event_rsvps_router
 from community._event_schemas import EventPatchIn  # noqa: F401
 from community._event_tags import router as event_tags_router
@@ -68,6 +69,7 @@ router.add_router("", events_router)
 router.add_router("", event_tags_router)
 router.add_router("", event_rsvps_router)
 router.add_router("", event_host_actions_router)
+router.add_router("", event_report_router)
 router.add_router("", public_rsvp_submit_router)
 # Mount resend before manage so the literal `/public/my-rsvps/resend/` route
 # resolves before that router's `/public/my-rsvps/{event_id}/` parameterized route.

--- a/backend/community/models/choices.py
+++ b/backend/community/models/choices.py
@@ -105,8 +105,10 @@ class FeatureFlag(models.TextChoices):
     """Registry of feature flags; pair each member with a default in FLAG_DEFAULTS."""
 
     EXAMPLE_FLAG = "example_flag", "Example flag"
+    HOST_ATTENDANCE_REPORT = "host_attendance_report", "Host attendance report"
 
 
 FLAG_DEFAULTS: dict[str, bool] = {
     FeatureFlag.EXAMPLE_FLAG: False,
+    FeatureFlag.HOST_ATTENDANCE_REPORT: False,
 }

--- a/backend/community/validation_codes.json
+++ b/backend/community/validation_codes.json
@@ -154,6 +154,18 @@
         "params": [
           "count"
         ]
+      },
+      {
+        "name": "CHECK_IN_REPORT_NOT_YET_AVAILABLE",
+        "value": "event.check_in_report_not_yet_available",
+        "params": []
+      },
+      {
+        "name": "CHECK_IN_REPORT_INVALID_COLUMN",
+        "value": "event.check_in_report_invalid_column",
+        "params": [
+          "column"
+        ]
       }
     ],
     "Poll": [

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -117,6 +117,52 @@
         "title": "AttendanceStatus",
         "type": "string"
       },
+      "AttendedPersonOut": {
+        "properties": {
+          "checked_in_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Checked In At"
+          },
+          "is_member": {
+            "default": true,
+            "title": "Is Member",
+            "type": "boolean"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "phone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phone"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user_id",
+          "name"
+        ],
+        "title": "AttendedPersonOut",
+        "type": "object"
+      },
       "BirthdayIn": {
         "properties": {
           "day": {
@@ -286,6 +332,46 @@
         "title": "CalendarTokenOut",
         "type": "object"
       },
+      "CanceledPersonOut": {
+        "properties": {
+          "cancelled_at": {
+            "format": "date-time",
+            "title": "Cancelled At",
+            "type": "string"
+          },
+          "is_member": {
+            "default": true,
+            "title": "Is Member",
+            "type": "boolean"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "phone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phone"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user_id",
+          "name",
+          "cancelled_at"
+        ],
+        "title": "CanceledPersonOut",
+        "type": "object"
+      },
       "CancellationOut": {
         "properties": {
           "cancelled_at": {
@@ -333,6 +419,98 @@
           "new_password"
         ],
         "title": "ChangePasswordIn",
+        "type": "object"
+      },
+      "CheckInReportOut": {
+        "properties": {
+          "attended": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/AttendedPersonOut"
+            },
+            "title": "Attended",
+            "type": "array"
+          },
+          "attended_count": {
+            "default": 0,
+            "title": "Attended Count",
+            "type": "integer"
+          },
+          "canceled": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/CanceledPersonOut"
+            },
+            "title": "Canceled",
+            "type": "array"
+          },
+          "canceled_count": {
+            "default": 0,
+            "title": "Canceled Count",
+            "type": "integer"
+          },
+          "no_show_count": {
+            "default": 0,
+            "title": "No Show Count",
+            "type": "integer"
+          },
+          "no_shows": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/CheckInReportPersonOut"
+            },
+            "title": "No Shows",
+            "type": "array"
+          },
+          "unmarked": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/CheckInReportPersonOut"
+            },
+            "title": "Unmarked",
+            "type": "array"
+          },
+          "unmarked_count": {
+            "default": 0,
+            "title": "Unmarked Count",
+            "type": "integer"
+          }
+        },
+        "title": "CheckInReportOut",
+        "type": "object"
+      },
+      "CheckInReportPersonOut": {
+        "properties": {
+          "is_member": {
+            "default": true,
+            "title": "Is Member",
+            "type": "boolean"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "phone": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Phone"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user_id",
+          "name"
+        ],
+        "title": "CheckInReportPersonOut",
         "type": "object"
       },
       "CheckPhoneIn": {
@@ -9954,6 +10132,152 @@
           }
         ],
         "summary": "Vote On Event Poll",
+        "tags": [
+          "community"
+        ]
+      }
+    },
+    "/api/community/events/{event_id}/report.csv": {
+      "get": {
+        "operationId": "community__event_report_get_check_in_report_csv",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "event_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Event Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "query",
+            "name": "columns",
+            "required": false,
+            "schema": {
+              "default": "name,phone,rsvp_status,attendance,checked_in_at,cancelled_at,plus_one",
+              "title": "Columns",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Unprocessable Content"
+          }
+        },
+        "security": [
+          {
+            "GatedJWTAuth": []
+          }
+        ],
+        "summary": "Get Check In Report Csv",
+        "tags": [
+          "community"
+        ]
+      }
+    },
+    "/api/community/events/{event_id}/report/": {
+      "get": {
+        "operationId": "community__event_report_get_check_in_report",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "event_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Event Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CheckInReportOut"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Not Found"
+          }
+        },
+        "security": [
+          {
+            "GatedJWTAuth": []
+          }
+        ],
+        "summary": "Get Check In Report",
         "tags": [
           "community"
         ]

--- a/backend/tests/test_event_check_in_report.py
+++ b/backend/tests/test_event_check_in_report.py
@@ -180,6 +180,44 @@ class TestCheckInReportEndpoint:
         )
         assert response.status_code == 404
 
+    def test_maybe_and_waitlisted_land_in_unmarked(
+        self, api_client, past_event, members, host_user
+    ):
+        EventRSVP.objects.create(event=past_event, user=members[0], status=RSVPStatus.MAYBE)
+        EventRSVP.objects.create(event=past_event, user=members[1], status=RSVPStatus.WAITLISTED)
+        response = api_client.get(
+            f"/api/community/events/{past_event.id}/report/", **_auth(host_user)
+        )
+        data = response.json()
+        assert data["unmarked_count"] == 2
+        assert {r["user_id"] for r in data["unmarked"]} == {
+            str(members[0].pk),
+            str(members[1].pk),
+        }
+
+    def test_removed_rsvps_excluded(self, api_client, past_event, members, host_user):
+        EventRSVP.objects.create(event=past_event, user=members[0], status=RSVPStatus.REMOVED)
+        response = api_client.get(
+            f"/api/community/events/{past_event.id}/report/", **_auth(host_user)
+        )
+        data = response.json()
+        total = (
+            data["attended_count"]
+            + data["no_show_count"]
+            + data["canceled_count"]
+            + data["unmarked_count"]
+        )
+        assert total == 0
+
+    def test_own_row_shows_full_name_despite_hide_last_name(self, api_client, past_event):
+        host = past_event.created_by
+        host.first_name, host.last_name, host.hide_last_name = "Ada", "Lovelace", True
+        host.save(update_fields=["first_name", "last_name", "hide_last_name"])
+        EventRSVP.objects.create(event=past_event, user=host, status=RSVPStatus.ATTENDING)
+        response = api_client.get(f"/api/community/events/{past_event.id}/report/", **_auth(host))
+        row = next(r for r in response.json()["unmarked"] if r["user_id"] == str(host.pk))
+        assert row["name"] == "Ada Lovelace"
+
 
 @pytest.mark.django_db
 class TestCheckInReportCsvEndpoint:
@@ -229,3 +267,37 @@ class TestCheckInReportCsvEndpoint:
             f"/api/community/events/{stocked_event.id}/report.csv", **_auth(host_user)
         )
         assert response.status_code == 404
+
+    def test_csv_matches_report_row_count(self, api_client, past_event, members, host_user):
+        EventRSVP.objects.create(event=past_event, user=members[0], status=RSVPStatus.ATTENDING)
+        EventRSVP.objects.create(event=past_event, user=members[1], status=RSVPStatus.MAYBE)
+        EventRSVP.objects.create(event=past_event, user=members[2], status=RSVPStatus.REMOVED)
+        report = api_client.get(
+            f"/api/community/events/{past_event.id}/report/", **_auth(host_user)
+        ).json()
+        csv_body = api_client.get(
+            f"/api/community/events/{past_event.id}/report.csv", **_auth(host_user)
+        ).content.decode()
+        data_rows = [line for line in csv_body.splitlines()[1:] if line]
+        report_total = (
+            report["attended_count"]
+            + report["no_show_count"]
+            + report["canceled_count"]
+            + report["unmarked_count"]
+        )
+        assert len(data_rows) == report_total == 2
+
+    def test_csv_escapes_formula_injection(self, api_client, past_event, host_user):
+        attacker = User.objects.create_user(
+            phone_number="+12025559500",
+            password="x",
+            first_name="=HYPERLINK(1)",
+            is_member=False,
+        )
+        EventRSVP.objects.create(event=past_event, user=attacker, status=RSVPStatus.ATTENDING)
+        response = api_client.get(
+            f"/api/community/events/{past_event.id}/report.csv?columns=name", **_auth(host_user)
+        )
+        body = response.content.decode()
+        assert "'=HYPERLINK(1)" in body
+        assert "\n=HYPERLINK(1)" not in body.replace("\r", "")

--- a/backend/tests/test_event_check_in_report.py
+++ b/backend/tests/test_event_check_in_report.py
@@ -1,0 +1,231 @@
+"""Tests for the host-only per-event check-in report + CSV export."""
+
+from datetime import timedelta
+
+import pytest
+from community.models import (
+    AttendanceStatus,
+    Event,
+    EventRSVP,
+    FeatureFlag,
+    FeatureFlagState,
+    RSVPStatus,
+)
+from django.utils import timezone
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
+
+
+def _auth(user):
+    refresh = RefreshToken.for_user(user)
+    return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # ty: ignore[unresolved-attribute]
+
+
+@pytest.fixture(autouse=True)
+def _flag_on(db):
+    FeatureFlagState.objects.create(key=FeatureFlag.HOST_ATTENDANCE_REPORT, enabled=True)
+
+
+@pytest.fixture
+def host_user(db):
+    return User.objects.create_user(phone_number="+12025559000", password="x", first_name="Host")
+
+
+@pytest.fixture
+def members(db):
+    return [
+        User.objects.create_user(
+            phone_number=f"+1202555910{i}", password="x", first_name=f"Member {i}"
+        )
+        for i in range(1, 5)
+    ]
+
+
+@pytest.fixture
+def guest_user(db):
+    return User.objects.create_user(
+        phone_number="+12025559200", password="x", first_name="Guest", is_member=False
+    )
+
+
+@pytest.fixture
+def other_member(db):
+    return User.objects.create_user(phone_number="+12025559300", password="x", first_name="Other")
+
+
+@pytest.fixture
+def past_event(db, host_user):
+    return Event.objects.create(
+        title="Past Potluck",
+        start_datetime=timezone.now() - timedelta(days=2),
+        end_datetime=timezone.now() - timedelta(days=2, hours=-2),
+        rsvp_enabled=True,
+        created_by=host_user,
+    )
+
+
+@pytest.fixture
+def future_event(db, host_user):
+    return Event.objects.create(
+        title="Future Potluck",
+        start_datetime=timezone.now() + timedelta(days=2),
+        end_datetime=timezone.now() + timedelta(days=2, hours=2),
+        rsvp_enabled=True,
+        created_by=host_user,
+    )
+
+
+@pytest.fixture
+def stocked_event(past_event, members, guest_user):
+    EventRSVP.objects.create(
+        event=past_event,
+        user=members[0],
+        status=RSVPStatus.ATTENDING,
+        attendance=AttendanceStatus.ATTENDED,
+        checked_in_at=timezone.now() - timedelta(days=2),
+    )
+    EventRSVP.objects.create(
+        event=past_event,
+        user=guest_user,
+        status=RSVPStatus.ATTENDING,
+        attendance=AttendanceStatus.ATTENDED,
+        checked_in_at=timezone.now() - timedelta(days=2),
+    )
+    EventRSVP.objects.create(
+        event=past_event,
+        user=members[1],
+        status=RSVPStatus.ATTENDING,
+        attendance=AttendanceStatus.NO_SHOW,
+    )
+    EventRSVP.objects.create(
+        event=past_event,
+        user=members[2],
+        status=RSVPStatus.CANT_GO,
+        cancelled_at=past_event.start_datetime - timedelta(days=1),
+    )
+    EventRSVP.objects.create(
+        event=past_event,
+        user=members[3],
+        status=RSVPStatus.ATTENDING,
+    )
+    return past_event
+
+
+@pytest.mark.django_db
+class TestCheckInReportEndpoint:
+    def test_host_gets_report(self, api_client, stocked_event, host_user):
+        response = api_client.get(
+            f"/api/community/events/{stocked_event.id}/report/", **_auth(host_user)
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["attended_count"] == 2
+        assert data["no_show_count"] == 1
+        assert data["canceled_count"] == 1
+        assert data["unmarked_count"] == 1
+
+    def test_guest_rsvp_tagged_not_member(self, api_client, stocked_event, host_user, guest_user):
+        response = api_client.get(
+            f"/api/community/events/{stocked_event.id}/report/", **_auth(host_user)
+        )
+        attended = response.json()["attended"]
+        guest_row = next(r for r in attended if r["user_id"] == str(guest_user.pk))
+        assert guest_row["is_member"] is False
+
+    def test_canceled_includes_cancelled_at(self, api_client, stocked_event, host_user):
+        response = api_client.get(
+            f"/api/community/events/{stocked_event.id}/report/", **_auth(host_user)
+        )
+        canceled = response.json()["canceled"]
+        assert len(canceled) == 1
+        assert canceled[0]["cancelled_at"] is not None
+
+    def test_attended_includes_checked_in_at(self, api_client, stocked_event, host_user):
+        response = api_client.get(
+            f"/api/community/events/{stocked_event.id}/report/", **_auth(host_user)
+        )
+        attended = response.json()["attended"]
+        assert all(r["checked_in_at"] is not None for r in attended)
+
+    def test_non_host_forbidden(self, api_client, stocked_event, other_member):
+        response = api_client.get(
+            f"/api/community/events/{stocked_event.id}/report/", **_auth(other_member)
+        )
+        assert response.status_code == 403
+
+    def test_unauthenticated_rejected(self, api_client, stocked_event):
+        response = api_client.get(f"/api/community/events/{stocked_event.id}/report/")
+        assert response.status_code == 401
+
+    def test_not_found(self, api_client, host_user):
+        response = api_client.get(
+            "/api/community/events/00000000-0000-0000-0000-000000000000/report/",
+            **_auth(host_user),
+        )
+        assert response.status_code == 404
+
+    def test_event_not_ended_rejected(self, api_client, future_event, host_user):
+        response = api_client.get(
+            f"/api/community/events/{future_event.id}/report/", **_auth(host_user)
+        )
+        assert response.status_code == 400
+        assert response.json()["detail"][0]["code"] == "event.check_in_report_not_yet_available"
+
+    def test_flag_off_not_found(self, api_client, stocked_event, host_user):
+        FeatureFlagState.objects.filter(key=FeatureFlag.HOST_ATTENDANCE_REPORT).update(
+            enabled=False
+        )
+        response = api_client.get(
+            f"/api/community/events/{stocked_event.id}/report/", **_auth(host_user)
+        )
+        assert response.status_code == 404
+
+
+@pytest.mark.django_db
+class TestCheckInReportCsvEndpoint:
+    def test_host_downloads_csv(self, api_client, stocked_event, host_user):
+        response = api_client.get(
+            f"/api/community/events/{stocked_event.id}/report.csv", **_auth(host_user)
+        )
+        assert response.status_code == 200
+        assert response["Content-Type"] == "text/csv"
+        assert "attachment" in response["Content-Disposition"]
+        body = response.content.decode()
+        assert "name" in body.splitlines()[0]
+
+    def test_column_selection_respected(self, api_client, stocked_event, host_user):
+        response = api_client.get(
+            f"/api/community/events/{stocked_event.id}/report.csv?columns=name,attendance",
+            **_auth(host_user),
+        )
+        header = response.content.decode().splitlines()[0]
+        assert header == "name,attendance"
+
+    def test_unknown_column_rejected(self, api_client, stocked_event, host_user):
+        response = api_client.get(
+            f"/api/community/events/{stocked_event.id}/report.csv?columns=name,not_a_column",
+            **_auth(host_user),
+        )
+        assert response.status_code == 422
+        assert response.json()["detail"][0]["code"] == "event.check_in_report_invalid_column"
+
+    def test_non_host_forbidden(self, api_client, stocked_event, other_member):
+        response = api_client.get(
+            f"/api/community/events/{stocked_event.id}/report.csv", **_auth(other_member)
+        )
+        assert response.status_code == 403
+
+    def test_event_not_ended_rejected(self, api_client, future_event, host_user):
+        response = api_client.get(
+            f"/api/community/events/{future_event.id}/report.csv", **_auth(host_user)
+        )
+        assert response.status_code == 400
+
+    def test_flag_off_not_found(self, api_client, stocked_event, host_user):
+        FeatureFlagState.objects.filter(key=FeatureFlag.HOST_ATTENDANCE_REPORT).update(
+            enabled=False
+        )
+        response = api_client.get(
+            f"/api/community/events/{stocked_event.id}/report.csv", **_auth(host_user)
+        )
+        assert response.status_code == 404

--- a/frontend/src/api/eventCheckInReport.ts
+++ b/frontend/src/api/eventCheckInReport.ts
@@ -1,0 +1,133 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { apiClient } from './client';
+
+export interface CheckInReportPerson {
+  userId: string;
+  name: string;
+  phone: string | null;
+  isMember: boolean;
+}
+
+export interface AttendedPerson extends CheckInReportPerson {
+  checkedInAt: Date | null;
+}
+
+export interface CanceledPerson extends CheckInReportPerson {
+  cancelledAt: Date;
+}
+
+export interface CheckInReport {
+  attendedCount: number;
+  noShowCount: number;
+  canceledCount: number;
+  unmarkedCount: number;
+  attended: AttendedPerson[];
+  noShows: CheckInReportPerson[];
+  canceled: CanceledPerson[];
+  unmarked: CheckInReportPerson[];
+}
+
+interface WirePerson {
+  user_id: string;
+  name: string;
+  phone: string | null;
+  is_member: boolean;
+}
+
+interface WireAttendedPerson extends WirePerson {
+  checked_in_at: string | null;
+}
+
+interface WireCanceledPerson extends WirePerson {
+  cancelled_at: string;
+}
+
+interface WireReport {
+  attended_count: number;
+  no_show_count: number;
+  canceled_count: number;
+  unmarked_count: number;
+  attended: WireAttendedPerson[];
+  no_shows: WirePerson[];
+  canceled: WireCanceledPerson[];
+  unmarked: WirePerson[];
+}
+
+function mapReport(w: WireReport): CheckInReport {
+  return {
+    attendedCount: w.attended_count,
+    noShowCount: w.no_show_count,
+    canceledCount: w.canceled_count,
+    unmarkedCount: w.unmarked_count,
+    attended: w.attended.map((p) => ({
+      userId: p.user_id,
+      name: p.name,
+      phone: p.phone,
+      isMember: p.is_member,
+      checkedInAt: p.checked_in_at ? new Date(p.checked_in_at) : null,
+    })),
+    noShows: w.no_shows.map((p) => ({
+      userId: p.user_id,
+      name: p.name,
+      phone: p.phone,
+      isMember: p.is_member,
+    })),
+    canceled: w.canceled.map((p) => ({
+      userId: p.user_id,
+      name: p.name,
+      phone: p.phone,
+      isMember: p.is_member,
+      cancelledAt: new Date(p.cancelled_at),
+    })),
+    unmarked: w.unmarked.map((p) => ({
+      userId: p.user_id,
+      name: p.name,
+      phone: p.phone,
+      isMember: p.is_member,
+    })),
+  };
+}
+
+export const CSV_COLUMNS = [
+  { key: 'name', label: 'name' },
+  { key: 'phone', label: 'phone' },
+  { key: 'rsvp_status', label: 'rsvp status' },
+  { key: 'attendance', label: 'attendance' },
+  { key: 'checked_in_at', label: 'checked-in time' },
+  { key: 'cancelled_at', label: 'canceled time' },
+  { key: 'plus_one', label: 'plus-one' },
+] as const;
+
+export const checkInReportKeys = {
+  detail: (eventId: string) => ['event-check-in-report', eventId] as const,
+};
+
+export function useCheckInReport(eventId: string | undefined) {
+  const id = eventId ?? '';
+  return useQuery({
+    queryKey: checkInReportKeys.detail(id),
+    queryFn: async () => {
+      const { data } = await apiClient.get<WireReport>(
+        `/api/community/events/${id}/report/`,
+      );
+      return mapReport(data);
+    },
+    enabled: Boolean(eventId),
+  });
+}
+
+export async function downloadCheckInReportCsv(eventId: string, columns: string[]): Promise<void> {
+  const { data } = await apiClient.get<Blob>(`/api/community/events/${eventId}/report.csv`, {
+    params: { columns: columns.join(',') },
+    responseType: 'blob',
+  });
+  const url = URL.createObjectURL(data);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `check-in-report-${eventId}.csv`;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}

--- a/frontend/src/api/eventCheckInReport.ts
+++ b/frontend/src/api/eventCheckInReport.ts
@@ -108,9 +108,7 @@ export function useCheckInReport(eventId: string | undefined) {
   return useQuery({
     queryKey: checkInReportKeys.detail(id),
     queryFn: async () => {
-      const { data } = await apiClient.get<WireReport>(
-        `/api/community/events/${id}/report/`,
-      );
+      const { data } = await apiClient.get<WireReport>(`/api/community/events/${id}/report/`);
       return mapReport(data);
     },
     enabled: Boolean(eventId),

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -987,6 +987,40 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/community/events/{event_id}/report.csv": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Check In Report Csv */
+        get: operations["community__event_report_get_check_in_report_csv"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/community/events/{event_id}/report/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** Get Check In Report */
+        get: operations["community__event_report_get_check_in_report"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/community/events/{event_id}/rsvp/": {
         parameters: {
             query?: never;
@@ -1965,6 +1999,22 @@ export interface components {
          * @enum {string}
          */
         AttendanceStatus: "unknown" | "attended" | "no_show";
+        /** AttendedPersonOut */
+        AttendedPersonOut: {
+            /** Checked In At */
+            checked_in_at?: string | null;
+            /**
+             * Is Member
+             * @default true
+             */
+            is_member: boolean;
+            /** Name */
+            name: string;
+            /** Phone */
+            phone?: string | null;
+            /** User Id */
+            user_id: string;
+        };
         /** BirthdayIn */
         BirthdayIn: {
             /** Day */
@@ -2017,6 +2067,25 @@ export interface components {
             /** Token */
             token: string;
         };
+        /** CanceledPersonOut */
+        CanceledPersonOut: {
+            /**
+             * Cancelled At
+             * Format: date-time
+             */
+            cancelled_at: string;
+            /**
+             * Is Member
+             * @default true
+             */
+            is_member: boolean;
+            /** Name */
+            name: string;
+            /** Phone */
+            phone?: string | null;
+            /** User Id */
+            user_id: string;
+        };
         /** CancellationOut */
         CancellationOut: {
             /**
@@ -2037,6 +2106,63 @@ export interface components {
             current_password: string;
             /** New Password */
             new_password: string;
+        };
+        /** CheckInReportOut */
+        CheckInReportOut: {
+            /**
+             * Attended
+             * @default []
+             */
+            attended: components["schemas"]["AttendedPersonOut"][];
+            /**
+             * Attended Count
+             * @default 0
+             */
+            attended_count: number;
+            /**
+             * Canceled
+             * @default []
+             */
+            canceled: components["schemas"]["CanceledPersonOut"][];
+            /**
+             * Canceled Count
+             * @default 0
+             */
+            canceled_count: number;
+            /**
+             * No Show Count
+             * @default 0
+             */
+            no_show_count: number;
+            /**
+             * No Shows
+             * @default []
+             */
+            no_shows: components["schemas"]["CheckInReportPersonOut"][];
+            /**
+             * Unmarked
+             * @default []
+             */
+            unmarked: components["schemas"]["CheckInReportPersonOut"][];
+            /**
+             * Unmarked Count
+             * @default 0
+             */
+            unmarked_count: number;
+        };
+        /** CheckInReportPersonOut */
+        CheckInReportPersonOut: {
+            /**
+             * Is Member
+             * @default true
+             */
+            is_member: boolean;
+            /** Name */
+            name: string;
+            /** Phone */
+            phone?: string | null;
+            /** User Id */
+            user_id: string;
         };
         /** CheckPhoneIn */
         CheckPhoneIn: {
@@ -7429,6 +7555,106 @@ export interface operations {
             };
             /** @description Too Many Requests */
             429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
+    community__event_report_get_check_in_report_csv: {
+        parameters: {
+            query?: {
+                columns?: string;
+            };
+            header?: never;
+            path: {
+                event_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Unprocessable Content */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
+    community__event_report_get_check_in_report: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                event_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CheckInReportOut"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/api/validationCodes.gen.ts
+++ b/frontend/src/api/validationCodes.gen.ts
@@ -37,6 +37,8 @@ export const Code = {
     BlastInvalidAudience: 'event.blast_invalid_audience',
     BlastNoRecipients: 'event.blast_no_recipients',
     WouldRemoveNonMembers: 'event.would_remove_non_members',
+    CheckInReportNotYetAvailable: 'event.check_in_report_not_yet_available',
+    CheckInReportInvalidColumn: 'event.check_in_report_invalid_column',
   },
   Poll: {
     NotFound: 'poll.not_found',
@@ -252,6 +254,8 @@ export type ValidationCode =
   | 'event.blast_invalid_audience'
   | 'event.blast_no_recipients'
   | 'event.would_remove_non_members'
+  | 'event.check_in_report_not_yet_available'
+  | 'event.check_in_report_invalid_column'
   | 'poll.not_found'
   | 'poll.options_required'
   | 'poll.options_must_be_future'
@@ -409,6 +413,8 @@ export const CODE_PARAMS: Record<ValidationCode, readonly string[]> = {
   'event.blast_invalid_audience': [],
   'event.blast_no_recipients': [],
   'event.would_remove_non_members': ['count'],
+  'event.check_in_report_not_yet_available': [],
+  'event.check_in_report_invalid_column': ['column'],
   'poll.not_found': [],
   'poll.options_required': [],
   'poll.options_must_be_future': [],

--- a/frontend/src/api/validationCodes.ts
+++ b/frontend/src/api/validationCodes.ts
@@ -108,6 +108,10 @@ function messageForKnownCode(code: KnownCode, err: FieldError): string {
       return 'no attendees in that audience have an email — nothing to send';
     case Code.Event.WouldRemoveNonMembers:
       return "this change would remove non-members rsvp'd on this event";
+    case Code.Event.CheckInReportNotYetAvailable:
+      return 'the check-in report is available once the event has ended';
+    case Code.Event.CheckInReportInvalidColumn:
+      return "one of those csv columns isn't recognized";
 
     // Poll
     case Code.Poll.NotFound:

--- a/frontend/src/models/featureFlags.ts
+++ b/frontend/src/models/featureFlags.ts
@@ -1,5 +1,6 @@
 export const Feature = {
   ExampleFlag: 'example_flag',
+  HostAttendanceReport: 'host_attendance_report',
 } as const;
 
 export type FeatureFlagKey = (typeof Feature)[keyof typeof Feature];

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -1,7 +1,15 @@
 import { createBrowserRouter } from 'react-router-dom';
 
-import { AuthBoot, EmailGate, OnboardingGate, RequireAuth, RequirePermission } from '@/auth/guards';
+import {
+  AuthBoot,
+  EmailGate,
+  OnboardingGate,
+  RequireAuth,
+  RequireFlag,
+  RequirePermission,
+} from '@/auth/guards';
 import { AppShell } from '@/layout/AppShell';
+import { Feature } from '@/models/featureFlags';
 import { Permission } from '@/models/permissions';
 
 import { lazyEl as el, lazyWithRetry } from './lazyRoute';
@@ -26,6 +34,9 @@ const EventDetail = lazyWithRetry(() => import('@/screens/events/EventDetailScre
 const EventCreate = lazyWithRetry(() => import('@/screens/events/EventCreateScreen'));
 const EventEdit = lazyWithRetry(() => import('@/screens/events/EventEditScreen'));
 const EventAttendance = lazyWithRetry(() => import('@/screens/events/EventAttendanceScreen'));
+const EventCheckInReport = lazyWithRetry(
+  () => import('@/screens/events/EventCheckInReportScreen'),
+);
 const MyEvents = lazyWithRetry(() => import('@/screens/events/MyEventsScreen'));
 const PublicRsvps = lazyWithRetry(() => import('@/screens/events/PublicRsvpsScreen'));
 const Notifications = lazyWithRetry(() => import('@/screens/notifications/NotificationsScreen'));
@@ -105,6 +116,13 @@ export const router = createBrowserRouter([
                   { path: '/events/:id/attendance', element: el(<EventAttendance />) },
                   { path: '/members', element: el(<MembersDirectory />) },
                   { path: '/members/:userId', element: el(<MemberProfile />) },
+                ],
+              },
+
+              {
+                element: <RequireFlag flag={Feature.HostAttendanceReport} />,
+                children: [
+                  { path: '/events/:id/report', element: el(<EventCheckInReport />) },
                 ],
               },
 

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -34,9 +34,7 @@ const EventDetail = lazyWithRetry(() => import('@/screens/events/EventDetailScre
 const EventCreate = lazyWithRetry(() => import('@/screens/events/EventCreateScreen'));
 const EventEdit = lazyWithRetry(() => import('@/screens/events/EventEditScreen'));
 const EventAttendance = lazyWithRetry(() => import('@/screens/events/EventAttendanceScreen'));
-const EventCheckInReport = lazyWithRetry(
-  () => import('@/screens/events/EventCheckInReportScreen'),
-);
+const EventCheckInReport = lazyWithRetry(() => import('@/screens/events/EventCheckInReportScreen'));
 const MyEvents = lazyWithRetry(() => import('@/screens/events/MyEventsScreen'));
 const PublicRsvps = lazyWithRetry(() => import('@/screens/events/PublicRsvpsScreen'));
 const Notifications = lazyWithRetry(() => import('@/screens/notifications/NotificationsScreen'));
@@ -121,9 +119,7 @@ export const router = createBrowserRouter([
 
               {
                 element: <RequireFlag flag={Feature.HostAttendanceReport} />,
-                children: [
-                  { path: '/events/:id/report', element: el(<EventCheckInReport />) },
-                ],
+                children: [{ path: '/events/:id/report', element: el(<EventCheckInReport />) }],
               },
 
               // ---- admin hub: any authed user can visit; the hub itself shows

--- a/frontend/src/screens/admin/FeatureFlagsScreen.tsx
+++ b/frontend/src/screens/admin/FeatureFlagsScreen.tsx
@@ -6,6 +6,7 @@ import { ContentContainer, ContentError, ContentLoading } from '@/screens/public
 
 const FLAG_LABELS: Record<FeatureFlagKey, string> = {
   [Feature.ExampleFlag]: 'example flag',
+  [Feature.HostAttendanceReport]: 'host attendance report',
 };
 
 export default function FeatureFlagsScreen() {

--- a/frontend/src/screens/events/CheckInReportCsvSheet.tsx
+++ b/frontend/src/screens/events/CheckInReportCsvSheet.tsx
@@ -1,0 +1,74 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+import { CSV_COLUMNS, downloadCheckInReportCsv } from '@/api/eventCheckInReport';
+import { Button } from '@/components/ui/Button';
+import { Dialog } from '@/components/ui/Dialog';
+
+const DEFAULT_COLUMNS = new Set<string>(CSV_COLUMNS.map((c) => c.key));
+
+interface Props {
+  eventId: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function CheckInReportCsvSheet({ eventId, open, onClose }: Props) {
+  const [selected, setSelected] = useState<Set<string>>(DEFAULT_COLUMNS);
+  const [isDownloading, setIsDownloading] = useState(false);
+
+  function toggle(key: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  async function handleDownload() {
+    setIsDownloading(true);
+    try {
+      await downloadCheckInReportCsv(eventId, [...selected]);
+      onClose();
+    } catch {
+      toast.error("couldn't download the csv — try again");
+    } finally {
+      setIsDownloading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} title="download csv">
+      <fieldset className="mb-4 flex flex-col gap-2">
+        <legend className="sr-only">columns to include</legend>
+        {CSV_COLUMNS.map((col) => (
+          <label key={col.key} className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={selected.has(col.key)}
+              onChange={() => {
+                toggle(col.key);
+              }}
+              className="h-4 w-4"
+            />
+            {col.label}
+          </label>
+        ))}
+      </fieldset>
+      <div className="flex justify-end gap-2">
+        <Button variant="secondary" onClick={onClose}>
+          cancel
+        </Button>
+        <Button
+          onClick={() => {
+            void handleDownload();
+          }}
+          disabled={selected.size === 0 || isDownloading}
+        >
+          {isDownloading ? 'downloading…' : 'download'}
+        </Button>
+      </div>
+    </Dialog>
+  );
+}

--- a/frontend/src/screens/events/EventCheckInReportScreen.test.tsx
+++ b/frontend/src/screens/events/EventCheckInReportScreen.test.tsx
@@ -1,0 +1,75 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useAuthStore } from '@/auth/store';
+import { makeEvent, makeUser } from '@/test/fixtures';
+
+vi.mock('@/api/events', () => ({
+  useEvent: vi.fn(),
+  eventKeys: { all: ['events'], list: vi.fn(), detail: vi.fn() },
+}));
+
+vi.mock('@/api/eventCheckInReport', () => ({
+  useCheckInReport: vi.fn().mockReturnValue({ data: undefined, isLoading: true, isError: false }),
+  downloadCheckInReportCsv: vi.fn(),
+  CSV_COLUMNS: [
+    { key: 'name', label: 'name' },
+    { key: 'attendance', label: 'attendance' },
+  ],
+}));
+
+import { useEvent } from '@/api/events';
+
+import EventCheckInReportScreen from './EventCheckInReportScreen';
+
+const BASE_EVENT = makeEvent({
+  title: 'Spring Potluck',
+  createdById: 'user-creator',
+  isPast: true,
+  guests: [],
+});
+
+const CREATOR = makeUser({ id: 'user-creator', firstName: 'Alice', fullName: 'Alice' });
+const nonMember = makeUser({ id: 'user-nonmember', firstName: 'Casey', fullName: 'Casey' });
+
+function renderScreen() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/events/ev1/report']}>
+        <Routes>
+          <Route path="/events/:id/report" element={<EventCheckInReportScreen />} />
+          <Route path="/events/:id" element={<div>event detail</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(useEvent).mockReturnValue({
+    data: BASE_EVENT,
+    isPending: false,
+    isError: false,
+  } as ReturnType<typeof useEvent>);
+});
+
+describe('EventCheckInReportScreen', () => {
+  it('renders the report heading for the event creator', () => {
+    useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
+    renderScreen();
+
+    expect(screen.getByRole('heading', { name: /check-in report/i })).toBeInTheDocument();
+    expect(screen.getByText(BASE_EVENT.title)).toBeInTheDocument();
+  });
+
+  it('blocks non-host members with a forbidden notice', () => {
+    useAuthStore.setState({ status: 'authed', user: nonMember, accessToken: 'tok' });
+    renderScreen();
+
+    expect(screen.getByText(/only the host or a co-host/i)).toBeInTheDocument();
+    expect(screen.queryByText(BASE_EVENT.title)).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/events/EventCheckInReportScreen.tsx
+++ b/frontend/src/screens/events/EventCheckInReportScreen.tsx
@@ -1,0 +1,208 @@
+import { type ReactNode, useState } from 'react';
+import { Link, useParams } from 'react-router-dom';
+
+import { extractApiError, getApiStatus } from '@/api/apiErrors';
+import type { AttendedPerson, CanceledPerson, CheckInReportPerson } from '@/api/eventCheckInReport';
+import { useCheckInReport } from '@/api/eventCheckInReport';
+import { useEvent } from '@/api/events';
+import { useAuthStore } from '@/auth/store';
+import { Button } from '@/components/ui/Button';
+import { canManageEvent } from '@/models/event';
+import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
+import { formatShortDateTime } from '@/utils/datetime';
+
+import { CheckInReportCsvSheet } from './CheckInReportCsvSheet';
+
+export default function EventCheckInReportScreen() {
+  const { id } = useParams<{ id: string }>();
+  const user = useAuthStore((s) => s.user);
+  const { data: event, isPending, isError, error } = useEvent(id);
+  const [csvOpen, setCsvOpen] = useState(false);
+
+  const isHost = event ? canManageEvent(event, user) : false;
+  const report = useCheckInReport(isHost ? id : undefined);
+
+  if (isPending) return <ContentLoading />;
+  if (isError) {
+    if (getApiStatus(error) === 403) {
+      const message = extractApiError(error) ?? "you don't have permission to see this event";
+      return <ForbiddenNotice eventId={id} message={message} />;
+    }
+    return <ContentError message="couldn't load this event — try refreshing" />;
+  }
+
+  if (!canManageEvent(event, user)) {
+    return (
+      <ForbiddenNotice
+        eventId={event.id}
+        message="only the host or a co-host can see the check-in report"
+      />
+    );
+  }
+
+  return (
+    <ContentContainer>
+      <BackLink eventId={event.id} />
+      <div className="mb-6 flex items-start justify-between gap-2">
+        <div>
+          <h1 className="mb-1 text-2xl font-medium tracking-tight">check-in report</h1>
+          <p className="text-foreground-secondary text-sm">{event.title}</p>
+        </div>
+        <Button
+          variant="secondary"
+          onClick={() => {
+            setCsvOpen(true);
+          }}
+        >
+          export csv
+        </Button>
+      </div>
+
+      {report.isLoading ? <p className="text-muted text-sm">loading report…</p> : null}
+      {report.isError ? (
+        <p className="text-sm text-red-600">couldn't load the report — try refreshing</p>
+      ) : null}
+      {report.data ? <ReportBody report={report.data} /> : null}
+
+      <CheckInReportCsvSheet
+        eventId={event.id}
+        open={csvOpen}
+        onClose={() => {
+          setCsvOpen(false);
+        }}
+      />
+    </ContentContainer>
+  );
+}
+
+function ReportBody({
+  report,
+}: {
+  report: NonNullable<ReturnType<typeof useCheckInReport>['data']>;
+}) {
+  return (
+    <div className="flex flex-col gap-6">
+      <div className="flex flex-wrap gap-2 text-xs">
+        <Pill label="attended" value={report.attendedCount} />
+        <Pill label="no-show" value={report.noShowCount} />
+        <Pill label="canceled" value={report.canceledCount} />
+        <Pill label="unmarked" value={report.unmarkedCount} />
+      </div>
+
+      <PersonSection title="attended" people={report.attended} empty="nobody checked in">
+        {(p) => <AttendedRow key={p.userId} person={p} />}
+      </PersonSection>
+
+      <PersonSection title="no-shows" people={report.noShows} empty="no no-shows">
+        {(p) => <PersonRow key={p.userId} person={p} />}
+      </PersonSection>
+
+      <PersonSection title="canceled" people={report.canceled} empty="nobody canceled">
+        {(p) => <CanceledRow key={p.userId} person={p} />}
+      </PersonSection>
+
+      <PersonSection title="unmarked" people={report.unmarked} empty="everyone got marked">
+        {(p) => <PersonRow key={p.userId} person={p} />}
+      </PersonSection>
+    </div>
+  );
+}
+
+function Pill({ label, value }: { label: string; value: number }) {
+  return (
+    <span className="bg-surface-dim text-foreground-secondary rounded-full px-3 py-1">
+      <span className="text-foreground font-medium">{value}</span> {label}
+    </span>
+  );
+}
+
+function PersonSection<T extends CheckInReportPerson>({
+  title,
+  people,
+  empty,
+  children,
+}: {
+  title: string;
+  people: T[];
+  empty: string;
+  children: (person: T) => ReactNode;
+}) {
+  return (
+    <section>
+      <h2 className="text-muted mb-2 text-xs font-medium">{title}</h2>
+      {people.length === 0 ? (
+        <p className="text-muted text-xs">{empty}</p>
+      ) : (
+        <ul className="flex flex-col gap-2">{people.map(children)}</ul>
+      )}
+    </section>
+  );
+}
+
+function GuestBadge() {
+  return <span className="bg-surface-dim text-foreground-secondary rounded px-1.5 py-0.5">guest</span>;
+}
+
+function PersonRow({ person }: { person: CheckInReportPerson }) {
+  return (
+    <li className="border-border flex items-center justify-between gap-2 rounded-md border p-2 text-sm">
+      <span className="flex items-center gap-2">
+        {person.name}
+        {!person.isMember ? <GuestBadge /> : null}
+      </span>
+    </li>
+  );
+}
+
+function AttendedRow({ person }: { person: AttendedPerson }) {
+  return (
+    <li className="border-border flex items-center justify-between gap-2 rounded-md border p-2 text-sm">
+      <span className="flex items-center gap-2">
+        {person.name}
+        {!person.isMember ? <GuestBadge /> : null}
+      </span>
+      {person.checkedInAt ? (
+        <span className="text-muted text-xs">{formatShortDateTime(person.checkedInAt)}</span>
+      ) : null}
+    </li>
+  );
+}
+
+function CanceledRow({ person }: { person: CanceledPerson }) {
+  return (
+    <li className="border-border flex items-center justify-between gap-2 rounded-md border p-2 text-sm">
+      <span className="flex items-center gap-2">
+        {person.name}
+        {!person.isMember ? <GuestBadge /> : null}
+      </span>
+      <span className="text-muted text-xs">canceled {formatShortDateTime(person.cancelledAt)}</span>
+    </li>
+  );
+}
+
+function BackLink({ eventId }: { eventId: string }) {
+  return (
+    <Link
+      to={`/events/${eventId}`}
+      className="text-foreground-secondary hover:text-foreground mb-4 inline-flex items-center gap-1 text-sm"
+    >
+      ← back to event
+    </Link>
+  );
+}
+
+function ForbiddenNotice({ eventId, message }: { eventId: string | undefined; message: string }) {
+  return (
+    <ContentContainer>
+      <section className="border-border bg-surface mt-8 rounded-lg border p-6">
+        <h2 className="mb-2 text-base font-medium">{message}</h2>
+        <Link
+          to={eventId ? `/events/${eventId}` : '/calendar'}
+          className="border-border-strong text-foreground-secondary hover:bg-background mt-4 inline-flex h-10 items-center rounded-md border px-4 text-sm font-medium"
+        >
+          back to event
+        </Link>
+      </section>
+    </ContentContainer>
+  );
+}

--- a/frontend/src/screens/events/EventCheckInReportScreen.tsx
+++ b/frontend/src/screens/events/EventCheckInReportScreen.tsx
@@ -140,7 +140,9 @@ function PersonSection<T extends CheckInReportPerson>({
 }
 
 function GuestBadge() {
-  return <span className="bg-surface-dim text-foreground-secondary rounded px-1.5 py-0.5">guest</span>;
+  return (
+    <span className="bg-surface-dim text-foreground-secondary rounded px-1.5 py-0.5">guest</span>
+  );
 }
 
 function PersonRow({ person }: { person: CheckInReportPerson }) {

--- a/frontend/src/screens/events/EventDetailKebabMenu.test.tsx
+++ b/frontend/src/screens/events/EventDetailKebabMenu.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/api/featureFlags', () => ({
+  useFlag: vi.fn(),
+}));
+
+import { useFlag } from '@/api/featureFlags';
+
+import { EventDetailKebabMenu } from './EventDetailKebabMenu';
+
+function renderMenu(overrides: { eventHasEnded?: boolean } = {}) {
+  return render(
+    <MemoryRouter>
+      <EventDetailKebabMenu eventId="ev1" eventHasEnded={overrides.eventHasEnded ?? false} />
+    </MemoryRouter>,
+  );
+}
+
+async function openMenu() {
+  await userEvent.click(screen.getByRole('button', { name: /event settings/i }));
+}
+
+describe('EventDetailKebabMenu', () => {
+  it('shows a check-in item linking to the attendance route', async () => {
+    vi.mocked(useFlag).mockReturnValue(false);
+    renderMenu();
+    await openMenu();
+
+    const checkIn = screen.getByRole('menuitem', { name: 'check-in' });
+    expect(checkIn).toHaveAttribute('href', '/events/ev1/attendance');
+  });
+
+  it('hides check-in report when the event has not ended', async () => {
+    vi.mocked(useFlag).mockReturnValue(true);
+    renderMenu({ eventHasEnded: false });
+    await openMenu();
+
+    expect(screen.queryByRole('menuitem', { name: /check-in report/i })).not.toBeInTheDocument();
+  });
+
+  it('hides check-in report when the flag is off', async () => {
+    vi.mocked(useFlag).mockReturnValue(false);
+    renderMenu({ eventHasEnded: true });
+    await openMenu();
+
+    expect(screen.queryByRole('menuitem', { name: /check-in report/i })).not.toBeInTheDocument();
+  });
+
+  it('shows check-in report when the event ended and the flag is on', async () => {
+    vi.mocked(useFlag).mockReturnValue(true);
+    renderMenu({ eventHasEnded: true });
+    await openMenu();
+
+    const reportLink = screen.getByRole('menuitem', { name: 'check-in report' });
+    expect(reportLink).toHaveAttribute('href', '/events/ev1/report');
+  });
+});

--- a/frontend/src/screens/events/EventDetailKebabMenu.tsx
+++ b/frontend/src/screens/events/EventDetailKebabMenu.tsx
@@ -1,13 +1,19 @@
 import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 
+import { useFlag } from '@/api/featureFlags';
+import { Feature } from '@/models/featureFlags';
+
 interface Props {
   eventId: string;
+  eventHasEnded: boolean;
 }
 
-export function EventDetailKebabMenu({ eventId }: Props) {
+export function EventDetailKebabMenu({ eventId, eventHasEnded }: Props) {
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
+  const reportFlagOn = useFlag(Feature.HostAttendanceReport);
+  const showCheckInReport = eventHasEnded && reportFlagOn;
 
   useEffect(() => {
     if (!open) return;
@@ -46,19 +52,48 @@ export function EventDetailKebabMenu({ eventId }: Props) {
           role="menu"
           className="border-border bg-surface absolute right-0 z-10 mt-1 w-44 overflow-hidden rounded-md border text-sm shadow-lg"
         >
-          <Link
+          <MenuLink
             to={`/events/${eventId}/attendance`}
-            role="menuitem"
-            className="text-foreground hover:bg-surface-dim block px-3 py-2"
-            onClick={() => {
+            onSelect={() => {
               setOpen(false);
             }}
           >
-            attendance
-          </Link>
+            check-in
+          </MenuLink>
+          {showCheckInReport ? (
+            <MenuLink
+              to={`/events/${eventId}/report`}
+              onSelect={() => {
+                setOpen(false);
+              }}
+            >
+              check-in report
+            </MenuLink>
+          ) : null}
         </div>
       ) : null}
     </div>
+  );
+}
+
+function MenuLink({
+  to,
+  onSelect,
+  children,
+}: {
+  to: string;
+  onSelect: () => void;
+  children: string;
+}) {
+  return (
+    <Link
+      to={to}
+      role="menuitem"
+      className="text-foreground hover:bg-surface-dim block px-3 py-2"
+      onClick={onSelect}
+    >
+      {children}
+    </Link>
   );
 }
 

--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -76,7 +76,7 @@ export default function EventDetailScreen() {
         <EventBadge event={event} />
         {showKebab ? (
           <div className="ml-auto">
-            <EventDetailKebabMenu eventId={event.id} />
+            <EventDetailKebabMenu eventId={event.id} eventHasEnded={event.isPast} />
           </div>
         ) : null}
       </div>

--- a/frontend/src/utils/datetime.ts
+++ b/frontend/src/utils/datetime.ts
@@ -20,6 +20,10 @@ export function formatDayHeader(date: Date): string {
   return format(date, 'EEEE, MMMM d');
 }
 
+export function formatShortDateTime(date: Date): string {
+  return format(date, 'MMM d, h:mma').toLowerCase();
+}
+
 export function parseIsoDate(iso: string): Date {
   // Backend serializes DateTimeField as ISO 8601 with timezone; Date constructor
   // parses that natively.


### PR DESCRIPTION
## Summary
- Registers the `host_attendance_report` feature flag (backend `FeatureFlag.HOST_ATTENDANCE_REPORT` / frontend `Feature.HostAttendanceReport`, both `"host_attendance_report"`) using the real flag system from Issue 995/996/997 — the design doc's `is_feature_enabled()` stub is obsolete and not used.
- Backend: `GET /events/{event_id}/report/` (JSON breakdown — summary counts + attended/no-show/canceled/unmarked person lists, non-member RSVPs tagged `is_member: false`) and `GET /events/{event_id}/report.csv?columns=...` (column-selectable export, unknown column → 422). Both gated by `_can_edit_event` + event-ended + the flag.
- Frontend: kebab menu's "attendance" item renamed to "check-in" (route unchanged); new "check-in report" item shown only to hosts once the event has ended and the flag is on. New `/events/:id/report` screen (mobile-first): summary pills, attended/no-shows/canceled/unmarked sections, and a csv column-picker sheet that downloads via the new endpoint.

Closes #1092

## Test plan
- [x] `make agent-lint` / `make agent-typecheck` / `make agent-complexity` / `make agent-check-codes` all pass
- [x] `make agent-frontend-lint` / `make agent-frontend-typecheck` / `make agent-frontend-test` all pass (128 files, 984 tests)
- [x] Backend suite passes (1665/1665) excluding 6 pre-existing SQLite-incompatible failures in `test_sse.py`/`test_rsvp_capacity_race.py` (require Postgres `pg_notify`/row locking, unrelated to this change)
- [x] New backend tests cover: host/non-host/unauth gating, event-not-ended (400), flag-off (404), guest tagging, cancellation/checked-in timestamps, csv column selection + unknown-column 422
- [x] New frontend tests cover: kebab menu gating (event-ended × flag), report screen host gating
- [ ] Manual smoke test on staging once deployed