### PR TITLE
feat(attendance): admin members tab + join-request attendance (Issue 1093)

### DIFF
--- a/backend/community/_attendance_analytics.py
+++ b/backend/community/_attendance_analytics.py
@@ -21,8 +21,7 @@ def _is_reportable(rsvp: EventRSVP) -> bool:
 
 
 def _is_marked(rsvp: EventRSVP, attendance: str) -> bool:
-    """Attendance mark gated on status=ATTENDING, so a stranded mark left after
-    the rsvp flips to CANT_GO/removed isn't counted. Mirrors attendance_q."""
+    # gated on status=ATTENDING so a stranded mark after the rsvp flips to CANT_GO/removed isn't counted; mirrors attendance_q
     return (
         _is_reportable(rsvp)
         and rsvp.status == RSVPStatus.ATTENDING
@@ -95,6 +94,11 @@ def months_since(last_qualifying_at: datetime | None, now: datetime | None = Non
     return delta.days // 30
 
 
+def is_pause_candidate(stats: MemberAttendanceStats) -> bool:
+    """No qualifying attendance in the trailing window (or ever). Same window as the compliant count, so the two never disagree."""
+    return stats.qualifying_count_12mo == 0
+
+
 class AttendedEvent(NamedTuple):
     event_id: str
     title: str
@@ -126,12 +130,3 @@ def user_rsvps_for_attendance(user) -> list[EventRSVP]:
         if "event_rsvps" in prefetched
         else list(EventRSVP.objects.filter(user_id=user.id).select_related("event"))
     )
-
-
-def resolve_join_request_user(join_request):
-    """JoinRequest.user FK when set, else a unique phone_number match against guest users."""
-    if join_request.user_id:
-        return join_request.user
-    from users.models import User
-
-    return User.objects.filter(is_member=False, phone_number=join_request.phone_number).first()

--- a/backend/community/_attendance_analytics.py
+++ b/backend/community/_attendance_analytics.py
@@ -1,0 +1,137 @@
+"""Compute-on-read attendance aggregates shared by the members analytics
+endpoint and join-request attendance history."""
+
+from collections.abc import Iterable
+from datetime import datetime, timedelta
+from typing import NamedTuple
+
+from django.db.models import Prefetch
+from django.utils import timezone
+
+from community._rsvp_counts import NON_REPORTABLE_EVENT_STATUSES
+from community.models import AttendanceStatus, EventRSVP, EventType, RSVPStatus
+
+QUALIFYING_EVENT_TYPES = (EventType.CLUB, EventType.OFFICIAL)
+QUALIFYING_WINDOW_DAYS = 365
+COMPLIANCE_MIN_COUNT = 2
+
+
+def _is_reportable(rsvp: EventRSVP) -> bool:
+    return rsvp.event.status not in NON_REPORTABLE_EVENT_STATUSES
+
+
+def _is_marked(rsvp: EventRSVP, attendance: str) -> bool:
+    """Attendance mark gated on status=ATTENDING, so a stranded mark left after
+    the rsvp flips to CANT_GO/removed isn't counted. Mirrors attendance_q."""
+    return (
+        _is_reportable(rsvp)
+        and rsvp.status == RSVPStatus.ATTENDING
+        and rsvp.attendance == attendance
+    )
+
+
+def _is_qualifying_attended(rsvp: EventRSVP) -> bool:
+    return (
+        _is_marked(rsvp, AttendanceStatus.ATTENDED)
+        and rsvp.event.event_type in QUALIFYING_EVENT_TYPES
+    )
+
+
+class MemberAttendanceStats(NamedTuple):
+    last_qualifying_at: datetime | None
+    qualifying_count_12mo: int
+    community_count: int
+    no_show_count: int
+    cancel_count: int
+
+
+def member_rsvps_prefetch() -> Prefetch:
+    """Prefetch for annotating a User queryset with rsvps + events, ready for compute_member_stats."""
+    return Prefetch("event_rsvps", queryset=EventRSVP.objects.select_related("event"))
+
+
+def compute_member_stats(
+    rsvps: Iterable[EventRSVP], now: datetime | None = None
+) -> MemberAttendanceStats:
+    """Aggregate a member's rsvps into the analytics fields. Pure function over prefetched rows."""
+    now = now or timezone.now()
+    window_start = now - timedelta(days=QUALIFYING_WINDOW_DAYS)
+
+    qualifying_dates = [
+        rsvp.event.start_datetime for rsvp in rsvps if _is_qualifying_attended(rsvp)
+    ]
+    qualifying_dates_known = [d for d in qualifying_dates if d is not None]
+    last_qualifying_at = max(qualifying_dates_known) if qualifying_dates_known else None
+    qualifying_count_12mo = sum(1 for d in qualifying_dates_known if d >= window_start)
+
+    community_count = sum(
+        1
+        for rsvp in rsvps
+        if _is_marked(rsvp, AttendanceStatus.ATTENDED)
+        and rsvp.event.event_type == EventType.COMMUNITY
+    )
+    no_show_count = sum(1 for rsvp in rsvps if _is_marked(rsvp, AttendanceStatus.NO_SHOW))
+    cancel_count = sum(1 for rsvp in rsvps if rsvp.cancelled_at is not None)
+
+    return MemberAttendanceStats(
+        last_qualifying_at=last_qualifying_at,
+        qualifying_count_12mo=qualifying_count_12mo,
+        community_count=community_count,
+        no_show_count=no_show_count,
+        cancel_count=cancel_count,
+    )
+
+
+def is_compliant(stats: MemberAttendanceStats) -> bool:
+    return stats.qualifying_count_12mo >= COMPLIANCE_MIN_COUNT
+
+
+def months_since(last_qualifying_at: datetime | None, now: datetime | None = None) -> int | None:
+    """Whole months since last_qualifying_at, or None if it never happened."""
+    if last_qualifying_at is None:
+        return None
+    now = now or timezone.now()
+    delta = now - last_qualifying_at
+    return delta.days // 30
+
+
+class AttendedEvent(NamedTuple):
+    event_id: str
+    title: str
+    start_datetime: datetime | None
+    event_type: str
+
+
+def attended_events(rsvps: Iterable[EventRSVP]) -> list[AttendedEvent]:
+    """All event types, host-marked attended — engagement signal for vetting, oldest first."""
+    events = [
+        AttendedEvent(
+            event_id=str(rsvp.event.id),
+            title=rsvp.event.title,
+            start_datetime=rsvp.event.start_datetime,
+            event_type=rsvp.event.event_type,
+        )
+        for rsvp in rsvps
+        if _is_marked(rsvp, AttendanceStatus.ATTENDED)
+    ]
+    events.sort(key=lambda e: (e.start_datetime is None, e.start_datetime))
+    return events
+
+
+def user_rsvps_for_attendance(user) -> list[EventRSVP]:
+    """Rsvps for a user, reading the prefetch cache when the caller supplied one."""
+    prefetched = getattr(user, "_prefetched_objects_cache", {})
+    return (
+        list(user.event_rsvps.all())
+        if "event_rsvps" in prefetched
+        else list(EventRSVP.objects.filter(user_id=user.id).select_related("event"))
+    )
+
+
+def resolve_join_request_user(join_request):
+    """JoinRequest.user FK when set, else a unique phone_number match against guest users."""
+    if join_request.user_id:
+        return join_request.user
+    from users.models import User
+
+    return User.objects.filter(is_member=False, phone_number=join_request.phone_number).first()

--- a/backend/community/_attendance_report.py
+++ b/backend/community/_attendance_report.py
@@ -13,6 +13,7 @@ from users.permissions import PermissionKey
 from community._attendance_analytics import (
     compute_member_stats,
     is_compliant,
+    is_pause_candidate,
     member_rsvps_prefetch,
     months_since,
     user_rsvps_for_attendance,
@@ -90,13 +91,9 @@ class MemberAttendanceAnalyticsOut(BaseModel):
     members: list[MemberAttendanceRowOut] = []
 
 
-PAUSE_CANDIDATE_MONTHS = 12
-
-
 def _member_attendance_row(user: User) -> MemberAttendanceRowOut:
     rsvps = user_rsvps_for_attendance(user)
     stats = compute_member_stats(rsvps)
-    months = months_since(stats.last_qualifying_at)
     return MemberAttendanceRowOut(
         user_id=str(user.id),
         full_name=user.full_name,
@@ -108,8 +105,8 @@ def _member_attendance_row(user: User) -> MemberAttendanceRowOut:
         community_count=stats.community_count,
         no_show_count=stats.no_show_count,
         cancel_count=stats.cancel_count,
-        months_since_last_qualifying=months,
-        is_pause_candidate=months is None or months >= PAUSE_CANDIDATE_MONTHS,
+        months_since_last_qualifying=months_since(stats.last_qualifying_at),
+        is_pause_candidate=not user.is_paused and is_pause_candidate(stats),
     )
 
 

--- a/backend/community/_attendance_report.py
+++ b/backend/community/_attendance_report.py
@@ -1,16 +1,27 @@
-"""Admin-only read model aggregating per-event check-in across events."""
+"""Admin-only read models aggregating attendance across events and members."""
+
+from datetime import datetime
 
 from config.auth import gated_jwt
 from django.db.models import Count, Q
 from ninja import Router
 from ninja.responses import Status
+from pydantic import BaseModel
+from users.models import User
 from users.permissions import PermissionKey
 
+from community._attendance_analytics import (
+    compute_member_stats,
+    is_compliant,
+    member_rsvps_prefetch,
+    months_since,
+    user_rsvps_for_attendance,
+)
 from community._event_schemas import AttendanceReportOut, EventAttendanceRowOut
 from community._rsvp_counts import attendance_q, going_headcount_expr, reportable_events_q
 from community._shared import ErrorOut
 from community._validation import Code, raise_validation
-from community.models import AttendanceStatus, Event
+from community.models import AttendanceStatus, Event, FeatureFlag, flag_enabled
 
 router = Router()
 
@@ -56,3 +67,74 @@ def attendance_report(request):
             ]
         ),
     )
+
+
+class MemberAttendanceRowOut(BaseModel):
+    """One member's attendance analytics for the admin members tab."""
+
+    user_id: str
+    full_name: str
+    phone_number: str
+    is_paused: bool
+    last_qualifying_at: datetime | None = None
+    qualifying_count_12mo: int = 0
+    compliant: bool = False
+    community_count: int = 0
+    no_show_count: int = 0
+    cancel_count: int = 0
+    months_since_last_qualifying: int | None = None
+    is_pause_candidate: bool = False
+
+
+class MemberAttendanceAnalyticsOut(BaseModel):
+    members: list[MemberAttendanceRowOut] = []
+
+
+PAUSE_CANDIDATE_MONTHS = 12
+
+
+def _member_attendance_row(user: User) -> MemberAttendanceRowOut:
+    rsvps = user_rsvps_for_attendance(user)
+    stats = compute_member_stats(rsvps)
+    months = months_since(stats.last_qualifying_at)
+    return MemberAttendanceRowOut(
+        user_id=str(user.id),
+        full_name=user.full_name,
+        phone_number=user.phone_number,
+        is_paused=user.is_paused,
+        last_qualifying_at=stats.last_qualifying_at,
+        qualifying_count_12mo=stats.qualifying_count_12mo,
+        compliant=is_compliant(stats),
+        community_count=stats.community_count,
+        no_show_count=stats.no_show_count,
+        cancel_count=stats.cancel_count,
+        months_since_last_qualifying=months,
+        is_pause_candidate=months is None or months >= PAUSE_CANDIDATE_MONTHS,
+    )
+
+
+@router.get(
+    "/events/attendance-analytics/members/",
+    response={200: MemberAttendanceAnalyticsOut, 403: ErrorOut},
+    auth=gated_jwt,
+)
+def member_attendance_analytics(request):
+    """Per-member qualifying-attendance analytics for the admin members tab.
+
+    Pause candidates (no qualifying attendance in the last 12 months, or
+    ever) sort first so admins triage them without scrolling.
+    """
+    if not request.auth.has_permission(PermissionKey.MANAGE_EVENTS):
+        raise_validation(Code.Perm.DENIED, status_code=403, action="member_attendance_analytics")
+    if not flag_enabled(FeatureFlag.ADMIN_ATTENDANCE_ANALYTICS):
+        raise_validation(Code.Perm.DENIED, status_code=403, action="member_attendance_analytics")
+
+    users = (
+        User.objects.members()
+        .filter(archived_at__isnull=True)
+        .prefetch_related(member_rsvps_prefetch())
+        .order_by("first_name", "last_name")
+    )
+    rows = [_member_attendance_row(u) for u in users]
+    rows.sort(key=lambda r: not r.is_pause_candidate)
+    return Status(200, MemberAttendanceAnalyticsOut(members=rows))

--- a/backend/community/_join_requests.py
+++ b/backend/community/_join_requests.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel, Field
 from users.models import User
 from users.permissions import PermissionKey
 
+from community._attendance_analytics import attended_events, resolve_join_request_user
 from community._field_limits import FieldLimit
 from community._join_request_approval import (
     _provision_approved_user,
@@ -28,9 +29,11 @@ from community.models import (
     AttendanceStatus,
     EventRSVP,
     EventType,
+    FeatureFlag,
     JoinRequest,
     JoinRequestStatus,
     RSVPStatus,
+    flag_enabled,
 )
 
 router = Router()
@@ -50,6 +53,13 @@ class JoinRequestRsvpOut(BaseModel):
     event_id: str
     title: str
     start_datetime: datetime | None = None
+
+
+class JoinRequestAttendedEventOut(BaseModel):
+    event_id: str
+    title: str
+    start_datetime: datetime | None = None
+    event_type: str
 
 
 class JoinRequestOut(BaseModel):
@@ -77,6 +87,10 @@ class JoinRequestOut(BaseModel):
     upcoming_official_count: int = 0
     upcoming_club_count: int = 0
     rsvp_events: list[JoinRequestRsvpOut] = []
+    # All event types (club/official/community), host-marked attended — an
+    # engagement signal for vetting, distinct from the qualifying-only
+    # breakdown above. Empty when the flag is off or no attendance is found.
+    attended_events: list[JoinRequestAttendedEventOut] = []
 
 
 class JoinRequestStatusIn(BaseModel):
@@ -173,6 +187,24 @@ def _rsvp_events(user: User | None) -> list[JoinRequestRsvpOut]:
     ]
 
 
+def _join_request_attended_events(jr: JoinRequest) -> list[JoinRequestAttendedEventOut]:
+    """All-event-types attendance history for vetting, gated on the analytics flag."""
+    if not flag_enabled(FeatureFlag.ADMIN_ATTENDANCE_ANALYTICS):
+        return []
+    user = resolve_join_request_user(jr)
+    if user is None:
+        return []
+    return [
+        JoinRequestAttendedEventOut(
+            event_id=e.event_id,
+            title=e.title,
+            start_datetime=e.start_datetime,
+            event_type=e.event_type,
+        )
+        for e in attended_events(_user_event_rsvps(user))
+    ]
+
+
 def _join_request_out(jr: JoinRequest) -> JoinRequestOut:
     answers = [
         JoinRequestAnswerOut(question_id=qid, label=data["label"], answer=data["answer"])
@@ -204,6 +236,7 @@ def _join_request_out(jr: JoinRequest) -> JoinRequestOut:
         upcoming_official_count=breakdown.upcoming_official,
         upcoming_club_count=breakdown.upcoming_club,
         rsvp_events=_rsvp_events(user),
+        attended_events=_join_request_attended_events(jr),
     )
 
 

--- a/backend/community/_join_requests.py
+++ b/backend/community/_join_requests.py
@@ -15,7 +15,7 @@ from pydantic import BaseModel, Field
 from users.models import User
 from users.permissions import PermissionKey
 
-from community._attendance_analytics import attended_events, resolve_join_request_user
+from community._attendance_analytics import attended_events
 from community._field_limits import FieldLimit
 from community._join_request_approval import (
     _provision_approved_user,
@@ -87,9 +87,7 @@ class JoinRequestOut(BaseModel):
     upcoming_official_count: int = 0
     upcoming_club_count: int = 0
     rsvp_events: list[JoinRequestRsvpOut] = []
-    # All event types (club/official/community), host-marked attended — an
-    # engagement signal for vetting, distinct from the qualifying-only
-    # breakdown above. Empty when the flag is off or no attendance is found.
+    # all-event-types attended history for vetting, gated on the analytics flag
     attended_events: list[JoinRequestAttendedEventOut] = []
 
 
@@ -187,12 +185,18 @@ def _rsvp_events(user: User | None) -> list[JoinRequestRsvpOut]:
     ]
 
 
-def _join_request_attended_events(jr: JoinRequest) -> list[JoinRequestAttendedEventOut]:
+def _attended_events_user(jr: JoinRequest, phone_user: User | None) -> User | None:
+    """FK user when set, else a guest (non-member) phone match. A member sharing the phone isn't a guest match."""
+    if jr.user_id:
+        return jr.user
+    if phone_user is not None and not phone_user.is_member:
+        return phone_user
+    return None
+
+
+def _join_request_attended_events(user: User | None) -> list[JoinRequestAttendedEventOut]:
     """All-event-types attendance history for vetting, gated on the analytics flag."""
-    if not flag_enabled(FeatureFlag.ADMIN_ATTENDANCE_ANALYTICS):
-        return []
-    user = resolve_join_request_user(jr)
-    if user is None:
+    if user is None or not flag_enabled(FeatureFlag.ADMIN_ATTENDANCE_ANALYTICS):
         return []
     return [
         JoinRequestAttendedEventOut(
@@ -236,7 +240,7 @@ def _join_request_out(jr: JoinRequest) -> JoinRequestOut:
         upcoming_official_count=breakdown.upcoming_official,
         upcoming_club_count=breakdown.upcoming_club,
         rsvp_events=_rsvp_events(user),
-        attended_events=_join_request_attended_events(jr),
+        attended_events=_join_request_attended_events(_attended_events_user(jr, phone_user)),
     )
 
 

--- a/backend/community/api.py
+++ b/backend/community/api.py
@@ -62,8 +62,9 @@ router.add_router("", join_request_submit_router)
 router.add_router("", join_request_resend_router)
 router.add_router("", login_link_router)
 router.add_router("", feedback_router)
-# Mount before events_router so the literal `/events/attendance-report/` route
-# resolves before that router's `/events/{event_id}/` parameterized route.
+# Mount before events_router so the literal `/events/attendance-report/` and
+# `/events/attendance-analytics/members/` routes resolve before that router's
+# `/events/{event_id}/` parameterized route.
 router.add_router("", attendance_report_router)
 router.add_router("", events_router)
 router.add_router("", event_tags_router)

--- a/backend/community/models/choices.py
+++ b/backend/community/models/choices.py
@@ -106,9 +106,11 @@ class FeatureFlag(models.TextChoices):
 
     EXAMPLE_FLAG = "example_flag", "Example flag"
     HOST_ATTENDANCE_REPORT = "host_attendance_report", "Host attendance report"
+    ADMIN_ATTENDANCE_ANALYTICS = "admin_attendance_analytics", "Admin attendance analytics"
 
 
 FLAG_DEFAULTS: dict[str, bool] = {
     FeatureFlag.EXAMPLE_FLAG: False,
     FeatureFlag.HOST_ATTENDANCE_REPORT: False,
+    FeatureFlag.ADMIN_ATTENDANCE_ANALYTICS: False,
 }

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -3230,6 +3230,41 @@
         "title": "JoinRequestAnswerOut",
         "type": "object"
       },
+      "JoinRequestAttendedEventOut": {
+        "properties": {
+          "event_id": {
+            "title": "Event Id",
+            "type": "string"
+          },
+          "event_type": {
+            "title": "Event Type",
+            "type": "string"
+          },
+          "start_datetime": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Datetime"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "event_id",
+          "title",
+          "event_type"
+        ],
+        "title": "JoinRequestAttendedEventOut",
+        "type": "object"
+      },
       "JoinRequestIn": {
         "properties": {
           "answers": {
@@ -3323,6 +3358,14 @@
             "default": 0,
             "title": "Attended Club Count",
             "type": "integer"
+          },
+          "attended_events": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/JoinRequestAttendedEventOut"
+            },
+            "title": "Attended Events",
+            "type": "array"
           },
           "attended_official_count": {
             "default": 0,
@@ -3693,6 +3736,102 @@
           }
         },
         "title": "MePatchIn",
+        "type": "object"
+      },
+      "MemberAttendanceAnalyticsOut": {
+        "properties": {
+          "members": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/MemberAttendanceRowOut"
+            },
+            "title": "Members",
+            "type": "array"
+          }
+        },
+        "title": "MemberAttendanceAnalyticsOut",
+        "type": "object"
+      },
+      "MemberAttendanceRowOut": {
+        "description": "One member's attendance analytics for the admin members tab.",
+        "properties": {
+          "cancel_count": {
+            "default": 0,
+            "title": "Cancel Count",
+            "type": "integer"
+          },
+          "community_count": {
+            "default": 0,
+            "title": "Community Count",
+            "type": "integer"
+          },
+          "compliant": {
+            "default": false,
+            "title": "Compliant",
+            "type": "boolean"
+          },
+          "full_name": {
+            "title": "Full Name",
+            "type": "string"
+          },
+          "is_pause_candidate": {
+            "default": false,
+            "title": "Is Pause Candidate",
+            "type": "boolean"
+          },
+          "is_paused": {
+            "title": "Is Paused",
+            "type": "boolean"
+          },
+          "last_qualifying_at": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Last Qualifying At"
+          },
+          "months_since_last_qualifying": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Months Since Last Qualifying"
+          },
+          "no_show_count": {
+            "default": 0,
+            "title": "No Show Count",
+            "type": "integer"
+          },
+          "phone_number": {
+            "title": "Phone Number",
+            "type": "string"
+          },
+          "qualifying_count_12mo": {
+            "default": 0,
+            "title": "Qualifying Count 12Mo",
+            "type": "integer"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user_id",
+          "full_name",
+          "phone_number",
+          "is_paused"
+        ],
+        "title": "MemberAttendanceRowOut",
         "type": "object"
       },
       "MemberDirectoryOut": {
@@ -8269,6 +8408,44 @@
           }
         ],
         "summary": "Create Event",
+        "tags": [
+          "community"
+        ]
+      }
+    },
+    "/api/community/events/attendance-analytics/members/": {
+      "get": {
+        "description": "Per-member qualifying-attendance analytics for the admin members tab.\n\nPause candidates (no qualifying attendance in the last 12 months, or\never) sort first so admins triage them without scrolling.",
+        "operationId": "community__attendance_report_member_attendance_analytics",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/MemberAttendanceAnalyticsOut"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "GatedJWTAuth": []
+          }
+        ],
+        "summary": "Member Attendance Analytics",
         "tags": [
           "community"
         ]

--- a/backend/tests/test_join_request_attendance.py
+++ b/backend/tests/test_join_request_attendance.py
@@ -1,0 +1,155 @@
+"""Tests for join-request attendance history (Issue 1093)."""
+
+from datetime import timedelta
+
+import pytest
+from community.models import (
+    AttendanceStatus,
+    Event,
+    EventRSVP,
+    EventStatus,
+    EventType,
+    FeatureFlag,
+    FeatureFlagState,
+    JoinRequest,
+    RSVPStatus,
+)
+from django.utils import timezone
+
+JOIN_REQUESTS_URL = "/api/community/join-requests/"
+
+
+@pytest.fixture
+def flag_on(db):
+    FeatureFlagState.objects.create(key=FeatureFlag.ADMIN_ATTENDANCE_ANALYTICS, enabled=True)
+
+
+@pytest.fixture
+def host_user(db):
+    from users.models import User
+
+    return User.objects.create_user(phone_number="+12025551800", password="x", first_name="Host")
+
+
+def _make_event(host_user, title, days_ago, event_type):
+    start = timezone.now() - timedelta(days=days_ago)
+    return Event.objects.create(
+        title=title,
+        start_datetime=start,
+        end_datetime=start + timedelta(hours=2),
+        rsvp_enabled=True,
+        created_by=host_user,
+        status=EventStatus.ACTIVE,
+        event_type=event_type,
+    )
+
+
+@pytest.mark.django_db
+class TestJoinRequestAttendedEvents:
+    def test_empty_when_flag_off(self, api_client, vettor_headers, host_user):
+        from users.models import User
+
+        guest = User.objects.create_user(
+            phone_number="+16505551234", password="x", first_name="Guest", is_member=False
+        )
+        event = _make_event(
+            host_user, "Community Meetup", days_ago=5, event_type=EventType.COMMUNITY
+        )
+        EventRSVP.objects.create(
+            event=event,
+            user=guest,
+            status=RSVPStatus.ATTENDING,
+            attendance=AttendanceStatus.ATTENDED,
+        )
+        JoinRequest.objects.create(
+            first_name="Sprout", last_name="Seedling", phone_number="+16505551234"
+        )
+
+        response = api_client.get(JOIN_REQUESTS_URL, **vettor_headers)
+        assert response.status_code == 200
+        row = response.json()[0]
+        assert row["attended_events"] == []
+
+    def test_all_event_types_included_via_phone_fallback(
+        self, api_client, vettor_headers, flag_on, host_user
+    ):
+        from users.models import User
+
+        guest = User.objects.create_user(
+            phone_number="+16505551234", password="x", first_name="Guest", is_member=False
+        )
+        community_event = _make_event(
+            host_user, "Community Meetup", days_ago=5, event_type=EventType.COMMUNITY
+        )
+        club_event = _make_event(host_user, "Club Night", days_ago=10, event_type=EventType.CLUB)
+        for ev in (community_event, club_event):
+            EventRSVP.objects.create(
+                event=ev,
+                user=guest,
+                status=RSVPStatus.ATTENDING,
+                attendance=AttendanceStatus.ATTENDED,
+            )
+        JoinRequest.objects.create(
+            first_name="Sprout", last_name="Seedling", phone_number="+16505551234"
+        )
+
+        response = api_client.get(JOIN_REQUESTS_URL, **vettor_headers)
+        row = response.json()[0]
+        titles = {e["title"]: e["event_type"] for e in row["attended_events"]}
+        assert titles == {"Community Meetup": "community", "Club Night": "club"}
+
+    def test_resolves_via_join_request_user_fk(
+        self, api_client, vettor_headers, flag_on, host_user
+    ):
+        from users.models import User
+
+        member = User.objects.create_user(
+            phone_number="+16505559999", password="x", first_name="Member", is_member=True
+        )
+        event = _make_event(host_user, "Official Gala", days_ago=3, event_type=EventType.OFFICIAL)
+        EventRSVP.objects.create(
+            event=event,
+            user=member,
+            status=RSVPStatus.ATTENDING,
+            attendance=AttendanceStatus.ATTENDED,
+        )
+        jr = JoinRequest.objects.create(
+            first_name="Sprout",
+            last_name="Seedling",
+            phone_number="+16505550000",
+            user=member,
+        )
+
+        response = api_client.get(JOIN_REQUESTS_URL, **vettor_headers)
+        row = next(r for r in response.json() if r["id"] == str(jr.id))
+        assert [e["title"] for e in row["attended_events"]] == ["Official Gala"]
+
+    def test_empty_when_no_match(self, api_client, vettor_headers, flag_on):
+        JoinRequest.objects.create(
+            first_name="Nomatch", last_name="Person", phone_number="+16505550001"
+        )
+        response = api_client.get(JOIN_REQUESTS_URL, **vettor_headers)
+        row = response.json()[0]
+        assert row["attended_events"] == []
+
+    def test_phone_fallback_excludes_members(self, api_client, vettor_headers, flag_on, host_user):
+        """A member sharing the phone number of a JoinRequest isn't a guest match."""
+        from users.models import User
+
+        member = User.objects.create_user(
+            phone_number="+16505551234", password="x", first_name="Member", is_member=True
+        )
+        event = _make_event(host_user, "Club Meetup", days_ago=5, event_type=EventType.CLUB)
+        EventRSVP.objects.create(
+            event=event,
+            user=member,
+            status=RSVPStatus.ATTENDING,
+            attendance=AttendanceStatus.ATTENDED,
+        )
+        JoinRequest.objects.create(
+            first_name="Sprout", last_name="Seedling", phone_number="+16505551234"
+        )
+
+        response = api_client.get(JOIN_REQUESTS_URL, **vettor_headers)
+        row = response.json()[0]
+        assert row["attended_events"] == []

--- a/backend/tests/test_member_attendance_analytics.py
+++ b/backend/tests/test_member_attendance_analytics.py
@@ -207,6 +207,7 @@ class TestMemberAttendanceAnalyticsEndpoint:
         response = api_client.get(MEMBERS_URL, **_auth(events_admin))
         row = next(r for r in response.json()["members"] if r["user_id"] == str(paused.pk))
         assert row["is_paused"] is True
+        assert row["is_pause_candidate"] is False
 
     def test_archived_member_excluded(self, api_client, flag_on, events_admin):
         from users.models import User

--- a/backend/tests/test_member_attendance_analytics.py
+++ b/backend/tests/test_member_attendance_analytics.py
@@ -1,0 +1,248 @@
+"""Tests for the admin member attendance analytics endpoint."""
+
+from datetime import timedelta
+
+import pytest
+from community.models import (
+    AttendanceStatus,
+    Event,
+    EventRSVP,
+    EventStatus,
+    EventType,
+    FeatureFlag,
+    FeatureFlagState,
+    RSVPStatus,
+)
+from django.utils import timezone
+from ninja_jwt.tokens import RefreshToken
+
+MEMBERS_URL = "/api/community/events/attendance-analytics/members/"
+
+
+def _auth(user):
+    refresh = RefreshToken.for_user(user)
+    return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # ty: ignore[unresolved-attribute]
+
+
+@pytest.fixture
+def flag_on(db):
+    FeatureFlagState.objects.create(key=FeatureFlag.ADMIN_ATTENDANCE_ANALYTICS, enabled=True)
+
+
+@pytest.fixture
+def member(db):
+    from users.models import User
+
+    return User.objects.create_user(
+        phone_number="+12025551900",
+        password="x",
+        first_name="Member",
+        last_name="One",
+        is_member=True,
+    )
+
+
+@pytest.fixture
+def host_user(db):
+    from users.models import User
+
+    return User.objects.create_user(phone_number="+12025551800", password="x", first_name="Host")
+
+
+@pytest.fixture
+def events_admin(db):
+    from users.models import Role, User
+    from users.permissions import PermissionKey
+
+    admin = User.objects.create_user(phone_number="+12025551801", password="x", first_name="Admin")
+    role = Role.objects.create(name="events_admin", permissions=[PermissionKey.MANAGE_EVENTS])
+    admin.roles.add(role)
+    return admin
+
+
+def _make_event(host_user, title, days_ago, event_type=EventType.CLUB):
+    start = timezone.now() - timedelta(days=days_ago)
+    return Event.objects.create(
+        title=title,
+        start_datetime=start,
+        end_datetime=start + timedelta(hours=2),
+        rsvp_enabled=True,
+        created_by=host_user,
+        status=EventStatus.ACTIVE,
+        event_type=event_type,
+    )
+
+
+@pytest.mark.django_db
+class TestMemberAttendanceAnalyticsEndpoint:
+    def test_requires_flag(self, api_client, events_admin, member):
+        response = api_client.get(MEMBERS_URL, **_auth(events_admin))
+        assert response.status_code == 403
+
+    def test_requires_manage_events_permission(self, api_client, flag_on, member):
+        response = api_client.get(MEMBERS_URL, **_auth(member))
+        assert response.status_code == 403
+
+    def test_unauthenticated_rejected(self, api_client, flag_on):
+        response = api_client.get(MEMBERS_URL)
+        assert response.status_code == 401
+
+    def test_qualifying_count_and_last_date(
+        self, api_client, flag_on, host_user, member, events_admin
+    ):
+        older = _make_event(host_user, "Older Club", days_ago=100, event_type=EventType.CLUB)
+        newer = _make_event(host_user, "Newer Official", days_ago=10, event_type=EventType.OFFICIAL)
+        for ev in (older, newer):
+            EventRSVP.objects.create(
+                event=ev,
+                user=member,
+                status=RSVPStatus.ATTENDING,
+                attendance=AttendanceStatus.ATTENDED,
+            )
+
+        response = api_client.get(MEMBERS_URL, **_auth(events_admin))
+        assert response.status_code == 200
+        row = next(r for r in response.json()["members"] if r["user_id"] == str(member.pk))
+        assert row["qualifying_count_12mo"] == 2
+        assert row["last_qualifying_at"][:10] == newer.start_datetime.date().isoformat()
+        assert row["compliant"] is True
+
+    def test_community_event_never_counts_as_qualifying(
+        self, api_client, flag_on, host_user, member, events_admin
+    ):
+        community_event = _make_event(
+            host_user, "Community Hang", days_ago=5, event_type=EventType.COMMUNITY
+        )
+        EventRSVP.objects.create(
+            event=community_event,
+            user=member,
+            status=RSVPStatus.ATTENDING,
+            attendance=AttendanceStatus.ATTENDED,
+        )
+
+        response = api_client.get(MEMBERS_URL, **_auth(events_admin))
+        row = next(r for r in response.json()["members"] if r["user_id"] == str(member.pk))
+        assert row["qualifying_count_12mo"] == 0
+        assert row["community_count"] == 1
+        assert row["compliant"] is False
+
+    def test_outside_12mo_window_excluded_from_count(
+        self, api_client, flag_on, host_user, member, events_admin
+    ):
+        old_event = _make_event(host_user, "Ancient Club", days_ago=400, event_type=EventType.CLUB)
+        EventRSVP.objects.create(
+            event=old_event,
+            user=member,
+            status=RSVPStatus.ATTENDING,
+            attendance=AttendanceStatus.ATTENDED,
+        )
+
+        response = api_client.get(MEMBERS_URL, **_auth(events_admin))
+        row = next(r for r in response.json()["members"] if r["user_id"] == str(member.pk))
+        assert row["qualifying_count_12mo"] == 0
+        # last_qualifying_at is not window-bound — it's the true last attendance.
+        assert row["last_qualifying_at"] is not None
+        assert row["is_pause_candidate"] is True
+
+    def test_no_show_and_cancel_counts(self, api_client, flag_on, host_user, member, events_admin):
+        event = _make_event(host_user, "No Show Event", days_ago=5)
+        EventRSVP.objects.create(
+            event=event,
+            user=member,
+            status=RSVPStatus.ATTENDING,
+            attendance=AttendanceStatus.NO_SHOW,
+        )
+        cancelled_event = _make_event(host_user, "Cancelled RSVP Event", days_ago=3)
+        EventRSVP.objects.create(
+            event=cancelled_event,
+            user=member,
+            status=RSVPStatus.CANT_GO,
+            cancelled_at=timezone.now(),
+        )
+
+        response = api_client.get(MEMBERS_URL, **_auth(events_admin))
+        row = next(r for r in response.json()["members"] if r["user_id"] == str(member.pk))
+        assert row["no_show_count"] == 1
+        assert row["cancel_count"] == 1
+
+    def test_never_attended_is_pause_candidate(
+        self, api_client, flag_on, host_user, member, events_admin
+    ):
+        response = api_client.get(MEMBERS_URL, **_auth(events_admin))
+        row = next(r for r in response.json()["members"] if r["user_id"] == str(member.pk))
+        assert row["last_qualifying_at"] is None
+        assert row["is_pause_candidate"] is True
+
+    def test_pause_candidates_sorted_first(self, api_client, flag_on, host_user, events_admin):
+        from users.models import User
+
+        compliant = User.objects.create_user(
+            phone_number="+12025552000", password="x", first_name="Compliant", is_member=True
+        )
+        candidate = User.objects.create_user(
+            phone_number="+12025552001", password="x", first_name="Candidate", is_member=True
+        )
+        recent = _make_event(host_user, "Recent", days_ago=5)
+        EventRSVP.objects.create(
+            event=recent,
+            user=compliant,
+            status=RSVPStatus.ATTENDING,
+            attendance=AttendanceStatus.ATTENDED,
+        )
+
+        response = api_client.get(MEMBERS_URL, **_auth(events_admin))
+        ids = [r["user_id"] for r in response.json()["members"]]
+        assert ids.index(str(candidate.pk)) < ids.index(str(compliant.pk))
+
+    def test_paused_member_included_and_labeled(self, api_client, flag_on, host_user, events_admin):
+        from users.models import User
+
+        paused = User.objects.create_user(
+            phone_number="+12025552002",
+            password="x",
+            first_name="Paused",
+            is_member=True,
+            is_paused=True,
+        )
+        response = api_client.get(MEMBERS_URL, **_auth(events_admin))
+        row = next(r for r in response.json()["members"] if r["user_id"] == str(paused.pk))
+        assert row["is_paused"] is True
+
+    def test_archived_member_excluded(self, api_client, flag_on, events_admin):
+        from users.models import User
+
+        archived = User.objects.create_user(
+            phone_number="+12025552003",
+            password="x",
+            first_name="Archived",
+            is_member=True,
+            archived_at=timezone.now(),
+        )
+        response = api_client.get(MEMBERS_URL, **_auth(events_admin))
+        ids = [r["user_id"] for r in response.json()["members"]]
+        assert str(archived.pk) not in ids
+
+    def test_non_member_excluded(self, api_client, flag_on, events_admin):
+        from users.models import User
+
+        guest = User.objects.create_user(
+            phone_number="+12025552004", password="x", first_name="Guest", is_member=False
+        )
+        response = api_client.get(MEMBERS_URL, **_auth(events_admin))
+        ids = [r["user_id"] for r in response.json()["members"]]
+        assert str(guest.pk) not in ids
+
+    def test_stranded_mark_after_rsvp_change_not_counted(
+        self, api_client, flag_on, host_user, member, events_admin
+    ):
+        event = _make_event(host_user, "Flipped Event", days_ago=2)
+        EventRSVP.objects.create(
+            event=event,
+            user=member,
+            status=RSVPStatus.CANT_GO,
+            attendance=AttendanceStatus.ATTENDED,
+        )
+        response = api_client.get(MEMBERS_URL, **_auth(events_admin))
+        row = next(r for r in response.json()["members"] if r["user_id"] == str(member.pk))
+        assert row["qualifying_count_12mo"] == 0
+        assert row["last_qualifying_at"] is None

--- a/frontend/src/api/join.test.ts
+++ b/frontend/src/api/join.test.ts
@@ -81,6 +81,7 @@ describe('useJoinRequests', () => {
           upcomingClub: 0,
         },
         rsvpEvents: [],
+        attendedEvents: [],
       },
     ]);
 
@@ -111,6 +112,43 @@ describe('useJoinRequests', () => {
 
     expect(result.current.data?.[0]?.rsvpEvents).toEqual([
       { eventId: 'evt-1', title: 'Potluck', startDatetime: '2026-03-01T18:00:00Z' },
+    ]);
+  });
+
+  it('maps attended_events from the wire', async () => {
+    mockedGet.mockResolvedValueOnce({
+      data: [
+        {
+          id: 'jr-4',
+          full_name: 'Jo Diaz',
+          phone_number: '+12125550222',
+          answers: [],
+          submitted_at: '2024-04-01T09:00:00Z',
+          status: 'pending',
+          user_id: null,
+          attended_events: [
+            {
+              event_id: 'evt-2',
+              title: 'Community Hang',
+              start_datetime: '2026-02-01T18:00:00Z',
+              event_type: 'community',
+            },
+          ],
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useJoinRequests(), { wrapper: wrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(result.current.data?.[0]?.attendedEvents).toEqual([
+      {
+        eventId: 'evt-2',
+        title: 'Community Hang',
+        startDatetime: '2026-02-01T18:00:00Z',
+        eventType: 'community',
+      },
     ]);
   });
 

--- a/frontend/src/api/join.ts
+++ b/frontend/src/api/join.ts
@@ -128,6 +128,13 @@ export interface JoinRequestRsvpEvent {
   startDatetime: string | null;
 }
 
+export interface JoinRequestAttendedEvent {
+  eventId: string;
+  title: string;
+  startDatetime: string | null;
+  eventType: string;
+}
+
 export interface JoinRequestSummary {
   id: string;
   fullName: string;
@@ -145,6 +152,7 @@ export interface JoinRequestSummary {
   onboardedAt: string | null;
   rsvpBreakdown: RsvpBreakdown;
   rsvpEvents: JoinRequestRsvpEvent[];
+  attendedEvents: JoinRequestAttendedEvent[];
 }
 
 interface WireAnswer {
@@ -157,6 +165,13 @@ interface WireRsvpEvent {
   event_id: string;
   title: string;
   start_datetime: string | null;
+}
+
+interface WireAttendedEvent {
+  event_id: string;
+  title: string;
+  start_datetime: string | null;
+  event_type: string;
 }
 
 interface WireJoinRequest {
@@ -179,6 +194,7 @@ interface WireJoinRequest {
   upcoming_official_count?: number;
   upcoming_club_count?: number;
   rsvp_events?: WireRsvpEvent[];
+  attended_events?: WireAttendedEvent[];
 }
 
 function mapJoinRequest(w: WireJoinRequest): JoinRequestSummary {
@@ -211,6 +227,12 @@ function mapJoinRequest(w: WireJoinRequest): JoinRequestSummary {
       eventId: e.event_id,
       title: e.title,
       startDatetime: e.start_datetime,
+    })),
+    attendedEvents: (w.attended_events ?? []).map((e) => ({
+      eventId: e.event_id,
+      title: e.title,
+      startDatetime: e.start_datetime,
+      eventType: e.event_type,
     })),
   };
 }

--- a/frontend/src/api/memberAttendanceAnalytics.ts
+++ b/frontend/src/api/memberAttendanceAnalytics.ts
@@ -1,0 +1,68 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { apiClient } from './client';
+
+export interface MemberAttendanceRow {
+  userId: string;
+  fullName: string;
+  phoneNumber: string;
+  isPaused: boolean;
+  lastQualifyingAt: Date | null;
+  qualifyingCount12mo: number;
+  compliant: boolean;
+  communityCount: number;
+  noShowCount: number;
+  cancelCount: number;
+  monthsSinceLastQualifying: number | null;
+  isPauseCandidate: boolean;
+}
+
+interface WireRow {
+  user_id: string;
+  full_name: string;
+  phone_number: string;
+  is_paused: boolean;
+  last_qualifying_at: string | null;
+  qualifying_count_12mo: number;
+  compliant: boolean;
+  community_count: number;
+  no_show_count: number;
+  cancel_count: number;
+  months_since_last_qualifying: number | null;
+  is_pause_candidate: boolean;
+}
+
+interface WireResponse {
+  members: WireRow[];
+}
+
+function mapRow(w: WireRow): MemberAttendanceRow {
+  return {
+    userId: w.user_id,
+    fullName: w.full_name,
+    phoneNumber: w.phone_number,
+    isPaused: w.is_paused,
+    lastQualifyingAt: w.last_qualifying_at ? new Date(w.last_qualifying_at) : null,
+    qualifyingCount12mo: w.qualifying_count_12mo,
+    compliant: w.compliant,
+    communityCount: w.community_count,
+    noShowCount: w.no_show_count,
+    cancelCount: w.cancel_count,
+    monthsSinceLastQualifying: w.months_since_last_qualifying,
+    isPauseCandidate: w.is_pause_candidate,
+  };
+}
+
+export const memberAttendanceAnalyticsKey = ['member-attendance-analytics'] as const;
+
+export function useMemberAttendanceAnalytics() {
+  return useQuery({
+    queryKey: memberAttendanceAnalyticsKey,
+    queryFn: async () => {
+      const { data } = await apiClient.get<WireResponse>(
+        '/api/community/events/attendance-analytics/members/',
+      );
+      return data.members.map(mapRow);
+    },
+  });
+}

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -644,6 +644,29 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/community/events/attendance-analytics/members/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Member Attendance Analytics
+         * @description Per-member qualifying-attendance analytics for the admin members tab.
+         *
+         *     Pause candidates (no qualifying attendance in the last 12 months, or
+         *     ever) sort first so admins triage them without scrolling.
+         */
+        get: operations["community__attendance_report_member_attendance_analytics"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/community/events/attendance-report/": {
         parameters: {
             query?: never;
@@ -3359,6 +3382,17 @@ export interface components {
             /** Question Id */
             question_id: string;
         };
+        /** JoinRequestAttendedEventOut */
+        JoinRequestAttendedEventOut: {
+            /** Event Id */
+            event_id: string;
+            /** Event Type */
+            event_type: string;
+            /** Start Datetime */
+            start_datetime?: string | null;
+            /** Title */
+            title: string;
+        };
         /** JoinRequestIn */
         JoinRequestIn: {
             /**
@@ -3417,6 +3451,11 @@ export interface components {
              * @default 0
              */
             attended_club_count: number;
+            /**
+             * Attended Events
+             * @default []
+             */
+            attended_events: components["schemas"]["JoinRequestAttendedEventOut"][];
             /**
              * Attended Official Count
              * @default 0
@@ -3537,6 +3576,62 @@ export interface components {
             show_phone?: boolean | null;
             /** Week Start */
             week_start?: ("sunday" | "monday") | null;
+        };
+        /** MemberAttendanceAnalyticsOut */
+        MemberAttendanceAnalyticsOut: {
+            /**
+             * Members
+             * @default []
+             */
+            members: components["schemas"]["MemberAttendanceRowOut"][];
+        };
+        /**
+         * MemberAttendanceRowOut
+         * @description One member's attendance analytics for the admin members tab.
+         */
+        MemberAttendanceRowOut: {
+            /**
+             * Cancel Count
+             * @default 0
+             */
+            cancel_count: number;
+            /**
+             * Community Count
+             * @default 0
+             */
+            community_count: number;
+            /**
+             * Compliant
+             * @default false
+             */
+            compliant: boolean;
+            /** Full Name */
+            full_name: string;
+            /**
+             * Is Pause Candidate
+             * @default false
+             */
+            is_pause_candidate: boolean;
+            /** Is Paused */
+            is_paused: boolean;
+            /** Last Qualifying At */
+            last_qualifying_at?: string | null;
+            /** Months Since Last Qualifying */
+            months_since_last_qualifying?: number | null;
+            /**
+             * No Show Count
+             * @default 0
+             */
+            no_show_count: number;
+            /** Phone Number */
+            phone_number: string;
+            /**
+             * Qualifying Count 12Mo
+             * @default 0
+             */
+            qualifying_count_12mo: number;
+            /** User Id */
+            user_id: string;
         };
         /** MemberDirectoryOut */
         MemberDirectoryOut: {
@@ -6276,6 +6371,35 @@ export interface operations {
             };
             /** @description Too Many Requests */
             429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
+    community__attendance_report_member_attendance_analytics: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MemberAttendanceAnalyticsOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/models/featureFlags.ts
+++ b/frontend/src/models/featureFlags.ts
@@ -1,6 +1,7 @@
 export const Feature = {
   ExampleFlag: 'example_flag',
   HostAttendanceReport: 'host_attendance_report',
+  AdminAttendanceAnalytics: 'admin_attendance_analytics',
 } as const;
 
 export type FeatureFlagKey = (typeof Feature)[keyof typeof Feature];

--- a/frontend/src/screens/admin/AttendanceReportScreen.test.tsx
+++ b/frontend/src/screens/admin/AttendanceReportScreen.test.tsx
@@ -1,18 +1,28 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/api/attendanceReport', () => ({
   useAttendanceReport: vi.fn(),
 }));
+vi.mock('@/api/featureFlags', () => ({
+  useFeatureFlags: vi.fn(),
+  useFlag: vi.fn(),
+}));
+vi.mock('./MemberAttendanceTab', () => ({
+  MemberAttendanceTab: () => <div>members tab content</div>,
+}));
 
 import { useAttendanceReport } from '@/api/attendanceReport';
+import { useFlag } from '@/api/featureFlags';
 import { makeRow } from '@/test/fixtures';
 
 import AttendanceReportScreen from './AttendanceReportScreen';
 
 const mockUseReport = vi.mocked(useAttendanceReport);
+const mockUseFlag = vi.mocked(useFlag);
 
 function mockResult(overrides: Partial<ReturnType<typeof useAttendanceReport>>) {
   mockUseReport.mockReturnValue({
@@ -36,6 +46,7 @@ function renderScreen() {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockUseFlag.mockReturnValue(false);
 });
 
 describe('AttendanceReportScreen', () => {
@@ -49,7 +60,7 @@ describe('AttendanceReportScreen', () => {
     expect(row).toHaveTextContent('4 attended');
     expect(row).toHaveTextContent('1 no-show');
     expect(row).toHaveTextContent('6 going');
-    expect(row).toHaveAttribute('href', '/events/e1');
+    expect(row).toHaveAttribute('href', '/events/e1/report');
   });
 
   it('shows the empty state when nothing is marked', () => {
@@ -74,5 +85,25 @@ describe('AttendanceReportScreen', () => {
     renderScreen();
 
     expect(screen.getByText('loading…')).toBeInTheDocument();
+  });
+
+  it('hides the members tab when the flag is off', () => {
+    mockResult({ data: [] });
+    mockUseFlag.mockReturnValue(false);
+
+    renderScreen();
+
+    expect(screen.queryByRole('tablist')).not.toBeInTheDocument();
+  });
+
+  it('switches to the members tab when the flag is on', async () => {
+    mockResult({ data: [] });
+    mockUseFlag.mockReturnValue(true);
+    const user = userEvent.setup();
+
+    renderScreen();
+    await user.click(screen.getByRole('tab', { name: 'members' }));
+
+    expect(screen.getByText('members tab content')).toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/admin/AttendanceReportScreen.tsx
+++ b/frontend/src/screens/admin/AttendanceReportScreen.tsx
@@ -1,41 +1,106 @@
 import { format } from 'date-fns';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { type EventAttendanceRow, useAttendanceReport } from '@/api/attendanceReport';
+import { useFlag } from '@/api/featureFlags';
+import { Feature } from '@/models/featureFlags';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
+import { cn } from '@/utils/cn';
+
+import { MemberAttendanceTab } from './MemberAttendanceTab';
+
+type Tab = 'events' | 'members';
 
 export default function AttendanceReportScreen() {
-  const { data = [], isPending, isError } = useAttendanceReport();
-
-  if (isPending) return <ContentLoading />;
-  if (isError) return <ContentError message="couldn't load attendance — try refreshing" />;
+  const membersTabEnabled = useFlag(Feature.AdminAttendanceAnalytics);
+  const [tab, setTab] = useState<Tab>('events');
 
   return (
     <ContentContainer>
       <header className="mb-4">
         <h1 className="mb-1 text-2xl font-medium tracking-tight">attendance</h1>
-        <p className="text-muted text-sm">who actually showed up, per event</p>
+        <p className="text-muted text-sm">who actually showed up, per event and per member</p>
       </header>
 
-      {data.length === 0 ? (
-        <p className="text-muted text-sm">no attendance marked yet 🌿</p>
-      ) : (
-        <ul className="flex flex-col gap-2">
-          {data.map((row) => (
-            <li key={row.eventId}>
-              <AttendanceRow row={row} />
-            </li>
-          ))}
-        </ul>
-      )}
+      {membersTabEnabled ? (
+        <div
+          role="tablist"
+          aria-label="attendance view"
+          className="border-border-strong bg-surface mb-4 flex w-full max-w-xs rounded-full border p-1"
+        >
+          <TabButton
+            active={tab === 'events'}
+            onClick={() => {
+              setTab('events');
+            }}
+          >
+            events
+          </TabButton>
+          <TabButton
+            active={tab === 'members'}
+            onClick={() => {
+              setTab('members');
+            }}
+          >
+            members
+          </TabButton>
+        </div>
+      ) : null}
+
+      {tab === 'members' && membersTabEnabled ? <MemberAttendanceTab /> : <EventsTab />}
     </ContentContainer>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={cn(
+        'flex-1 rounded-full px-3 py-1 text-sm transition-colors',
+        active ? 'bg-brand-600 text-brand-on' : 'text-foreground-secondary hover:bg-surface-dim',
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function EventsTab() {
+  const { data = [], isPending, isError } = useAttendanceReport();
+
+  if (isPending) return <ContentLoading />;
+  if (isError) return <ContentError message="couldn't load attendance — try refreshing" />;
+
+  return data.length === 0 ? (
+    <p className="text-muted text-sm">no attendance marked yet 🌿</p>
+  ) : (
+    <ul className="flex flex-col gap-2">
+      {data.map((row) => (
+        <li key={row.eventId}>
+          <AttendanceRow row={row} />
+        </li>
+      ))}
+    </ul>
   );
 }
 
 function AttendanceRow({ row }: { row: EventAttendanceRow }) {
   return (
     <Link
-      to={`/events/${row.eventId}`}
+      to={`/events/${row.eventId}/report`}
       className="border-border bg-surface hover:bg-surface-dim flex items-center justify-between gap-3 rounded-lg border p-3 transition-colors"
     >
       <div className="min-w-0 flex-1">

--- a/frontend/src/screens/admin/FeatureFlagsScreen.tsx
+++ b/frontend/src/screens/admin/FeatureFlagsScreen.tsx
@@ -7,6 +7,7 @@ import { ContentContainer, ContentError, ContentLoading } from '@/screens/public
 const FLAG_LABELS: Record<FeatureFlagKey, string> = {
   [Feature.ExampleFlag]: 'example flag',
   [Feature.HostAttendanceReport]: 'host attendance report',
+  [Feature.AdminAttendanceAnalytics]: 'admin attendance analytics',
 };
 
 export default function FeatureFlagsScreen() {

--- a/frontend/src/screens/admin/JoinRequestCard.tsx
+++ b/frontend/src/screens/admin/JoinRequestCard.tsx
@@ -1,6 +1,11 @@
 import { format, formatDistanceToNow } from 'date-fns';
 
-import { JoinRequestStatus, type JoinRequestSummary, type RsvpBreakdown } from '@/api/join';
+import {
+  type JoinRequestAttendedEvent,
+  JoinRequestStatus,
+  type JoinRequestSummary,
+  type RsvpBreakdown,
+} from '@/api/join';
 import { Button } from '@/components/ui/Button';
 import { cn } from '@/utils/cn';
 import { formatPhone } from '@/utils/formatPhone';
@@ -40,6 +45,7 @@ export function JoinRequestCard({
             {format(new Date(request.submittedAt), 'MMM d, h:mm a')}
           </p>
           <RsvpBreakdownNote breakdown={request.rsvpBreakdown} />
+          <AttendedEventsNote events={request.attendedEvents} />
         </div>
         <div className="flex flex-wrap items-center gap-1">
           {request.previouslyArchived ? (
@@ -154,6 +160,28 @@ function RsvpBreakdownNote({ breakdown }: { breakdown: RsvpBreakdown }) {
       {lines.map((line) => (
         <p key={line.text}>{line.text}</p>
       ))}
+    </div>
+  );
+}
+
+function AttendedEventsNote({ events }: { events: JoinRequestAttendedEvent[] }) {
+  if (events.length === 0) return null;
+  return (
+    <div className="mt-1">
+      <p className="text-muted text-xs font-medium">events attended</p>
+      <ul className="text-muted mt-0.5 flex flex-col gap-0.5 text-xs">
+        {events.map((e) => (
+          <li key={e.eventId}>
+            {e.title.toLowerCase()}
+            {' — '}
+            {e.startDatetime
+              ? format(new Date(e.startDatetime), 'MMM d, yyyy').toLowerCase()
+              : 'date tbd'}
+            {' · '}
+            {e.eventType}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/frontend/src/screens/admin/JoinRequestsScreen.test.tsx
+++ b/frontend/src/screens/admin/JoinRequestsScreen.test.tsx
@@ -147,6 +147,35 @@ describe('JoinRequestsScreen sort', () => {
     expect(screen.queryByText(/upcoming/)).not.toBeInTheDocument();
   });
 
+  it('shows attended events (all types) for vetting when present', () => {
+    mockResult([
+      makeRequest({
+        status: JoinRequestStatus.PENDING,
+        attendedEvents: [
+          {
+            eventId: 'evt-1',
+            title: 'Community Hang',
+            startDatetime: '2026-02-01T18:00:00Z',
+            eventType: 'community',
+          },
+        ],
+      }),
+    ]);
+
+    renderScreen();
+
+    expect(screen.getByText('events attended')).toBeInTheDocument();
+    expect(screen.getByText(/community hang/)).toBeInTheDocument();
+  });
+
+  it('omits the attended-events section when empty', () => {
+    mockResult([makeRequest({ status: JoinRequestStatus.PENDING, attendedEvents: [] })]);
+
+    renderScreen();
+
+    expect(screen.queryByText('events attended')).not.toBeInTheDocument();
+  });
+
   it('omits the note entirely when every bucket is zero', () => {
     mockResult([makeRequest({ status: JoinRequestStatus.PENDING })]);
 

--- a/frontend/src/screens/admin/MemberAttendanceTab.test.tsx
+++ b/frontend/src/screens/admin/MemberAttendanceTab.test.tsx
@@ -1,0 +1,161 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  type MemberAttendanceRow,
+  useMemberAttendanceAnalytics,
+} from '@/api/memberAttendanceAnalytics';
+import { useUpdateUser } from '@/api/users';
+import { useAuthStore } from '@/auth/store';
+
+import { MemberAttendanceTab } from './MemberAttendanceTab';
+
+vi.mock('@/api/memberAttendanceAnalytics', () => ({
+  useMemberAttendanceAnalytics: vi.fn(),
+}));
+
+vi.mock('@/api/users', () => ({
+  useUpdateUser: vi.fn(),
+}));
+
+vi.mock('@/auth/store', () => ({
+  useAuthStore: vi.fn(),
+}));
+
+const mockUseAnalytics = vi.mocked(useMemberAttendanceAnalytics);
+const mockUseUpdateUser = vi.mocked(useUpdateUser);
+const mockUseAuthStore = vi.mocked(useAuthStore);
+
+function makeMemberRow(overrides: Partial<MemberAttendanceRow> = {}): MemberAttendanceRow {
+  return {
+    userId: 'u1',
+    fullName: 'Ada Lovelace',
+    phoneNumber: '+12025550101',
+    isPaused: false,
+    lastQualifyingAt: new Date('2026-01-01T00:00:00Z'),
+    qualifyingCount12mo: 3,
+    compliant: true,
+    communityCount: 1,
+    noShowCount: 0,
+    cancelCount: 0,
+    monthsSinceLastQualifying: 2,
+    isPauseCandidate: false,
+    ...overrides,
+  };
+}
+
+const updateMutateAsync = vi.fn();
+
+function mockUser(canManageUsers: boolean) {
+  mockUseAuthStore.mockImplementation((selector) =>
+    selector({
+      user: {
+        roles: canManageUsers
+          ? [{ name: 'admin', isDefault: false, permissions: ['manage_users'] }]
+          : [],
+      },
+    } as unknown as Parameters<typeof selector>[0]),
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  updateMutateAsync.mockReset();
+  updateMutateAsync.mockResolvedValue(undefined);
+  mockUseUpdateUser.mockReturnValue({
+    mutateAsync: updateMutateAsync,
+    isPending: false,
+  } as unknown as ReturnType<typeof useUpdateUser>);
+  mockUser(false);
+});
+
+function mockRows(rows: MemberAttendanceRow[]) {
+  mockUseAnalytics.mockReturnValue({
+    data: rows,
+    isPending: false,
+    isError: false,
+  } as unknown as ReturnType<typeof useMemberAttendanceAnalytics>);
+}
+
+describe('MemberAttendanceTab', () => {
+  it('shows the empty state with no members', () => {
+    mockRows([]);
+    render(<MemberAttendanceTab />);
+    expect(screen.getByText(/nothing here/i)).toBeInTheDocument();
+  });
+
+  it('renders member stats', () => {
+    mockRows([makeMemberRow()]);
+    render(<MemberAttendanceTab />);
+    expect(screen.getByText('ada lovelace')).toBeInTheDocument();
+    expect(screen.getByText('compliant')).toBeInTheDocument();
+  });
+
+  it('shows a pause-candidate badge for members overdue on qualifying attendance', () => {
+    mockRows([
+      makeMemberRow({ isPauseCandidate: true, lastQualifyingAt: null, qualifyingCount12mo: 0 }),
+    ]);
+    render(<MemberAttendanceTab />);
+    expect(screen.getByText('pause candidate')).toBeInTheDocument();
+    expect(screen.getByText(/never attended a qualifying event/)).toBeInTheDocument();
+  });
+
+  it('filters to at-risk members only', async () => {
+    mockRows([
+      makeMemberRow({ userId: 'u1', fullName: 'Compliant Member' }),
+      makeMemberRow({
+        userId: 'u2',
+        fullName: 'Risky Member',
+        isPauseCandidate: true,
+        lastQualifyingAt: null,
+      }),
+    ]);
+    const user = userEvent.setup();
+    render(<MemberAttendanceTab />);
+
+    await user.click(screen.getByRole('button', { name: 'at risk' }));
+
+    expect(screen.queryByText('compliant member')).not.toBeInTheDocument();
+    expect(screen.getByText('risky member')).toBeInTheDocument();
+  });
+
+  it('hides the pause button without manage_users permission', () => {
+    mockRows([makeMemberRow()]);
+    mockUser(false);
+    render(<MemberAttendanceTab />);
+    expect(screen.queryByRole('button', { name: 'pause member' })).not.toBeInTheDocument();
+  });
+
+  it('pauses a member when confirmed, with manage_users permission', async () => {
+    mockRows([makeMemberRow({ userId: 'u9' })]);
+    mockUser(true);
+    const user = userEvent.setup();
+    render(<MemberAttendanceTab />);
+
+    await user.click(screen.getByRole('button', { name: 'pause member' }));
+    await user.click(screen.getByRole('button', { name: 'pause' }));
+
+    expect(updateMutateAsync).toHaveBeenCalledWith({ isPaused: true });
+  });
+
+  it('does not call the pause mutation when the confirmation is cancelled', async () => {
+    mockRows([makeMemberRow()]);
+    mockUser(true);
+    const user = userEvent.setup();
+    render(<MemberAttendanceTab />);
+
+    await user.click(screen.getByRole('button', { name: 'pause member' }));
+    await user.click(screen.getByRole('button', { name: 'cancel' }));
+
+    expect(updateMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('shows a paused badge and hides the pause button for already-paused members', () => {
+    mockRows([makeMemberRow({ isPaused: true })]);
+    mockUser(true);
+    render(<MemberAttendanceTab />);
+    expect(screen.getByText('paused')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'pause member' })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/admin/MemberAttendanceTab.tsx
+++ b/frontend/src/screens/admin/MemberAttendanceTab.tsx
@@ -1,0 +1,190 @@
+import { format } from 'date-fns';
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+import { extractApiErrorOr } from '@/api/apiErrors';
+import {
+  type MemberAttendanceRow,
+  useMemberAttendanceAnalytics,
+} from '@/api/memberAttendanceAnalytics';
+import { useUpdateUser } from '@/api/users';
+import { useAuthStore } from '@/auth/store';
+import { useConfirm } from '@/components/ui/useConfirm';
+import { hasPermission, Permission } from '@/models/permissions';
+import { ContentError, ContentLoading } from '@/screens/public/ContentContainer';
+import { cn } from '@/utils/cn';
+import { formatPhone } from '@/utils/formatPhone';
+
+type Filter = 'all' | 'at-risk';
+
+export function MemberAttendanceTab() {
+  const { data = [], isPending, isError } = useMemberAttendanceAnalytics();
+  const [filter, setFilter] = useState<Filter>('all');
+
+  if (isPending) return <ContentLoading />;
+  if (isError) return <ContentError message="couldn't load member attendance — try refreshing" />;
+
+  const visible = filter === 'at-risk' ? data.filter((m) => m.isPauseCandidate) : data;
+
+  return (
+    <div>
+      <div className="mb-3 flex items-center gap-2">
+        <FilterButton
+          active={filter === 'all'}
+          onClick={() => {
+            setFilter('all');
+          }}
+        >
+          all members
+        </FilterButton>
+        <FilterButton
+          active={filter === 'at-risk'}
+          onClick={() => {
+            setFilter('at-risk');
+          }}
+        >
+          at risk
+        </FilterButton>
+      </div>
+
+      {visible.length === 0 ? (
+        <p className="text-muted text-sm">nothing here 🌿</p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {visible.map((row) => (
+            <li key={row.userId}>
+              <MemberAttendanceRowCard row={row} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function FilterButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'rounded-full px-3 py-1 text-xs font-medium transition-colors',
+        active
+          ? 'bg-brand-600 text-brand-on'
+          : 'bg-surface-dim text-foreground-secondary hover:bg-surface-raised',
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+function lastQualifyingLine(row: MemberAttendanceRow): string {
+  if (!row.lastQualifyingAt) return 'never attended a qualifying event';
+  const date = format(row.lastQualifyingAt, 'MMM d, yyyy').toLowerCase();
+  const months = row.monthsSinceLastQualifying;
+  const ago = months === null || months === 0 ? 'this month' : `${String(months)}mo ago`;
+  return `last qualifying: ${date} (${ago})`;
+}
+
+function MemberAttendanceRowCard({ row }: { row: MemberAttendanceRow }) {
+  const currentUser = useAuthStore((s) => s.user);
+  const canPause = hasPermission(currentUser, Permission.ManageUsers);
+
+  return (
+    <article className="border-border bg-surface rounded-lg border p-3">
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-foreground truncate text-sm font-medium">
+            {row.fullName.toLowerCase()}
+          </p>
+          <p className="text-foreground-tertiary text-xs">{formatPhone(row.phoneNumber)}</p>
+        </div>
+        <div className="flex flex-wrap items-center gap-1">
+          {row.isPaused ? <Badge tone="neutral">paused</Badge> : null}
+          {row.isPauseCandidate ? (
+            <Badge tone="warning">pause candidate</Badge>
+          ) : row.compliant ? (
+            <Badge tone="success">compliant</Badge>
+          ) : (
+            <Badge tone="neutral">not yet compliant</Badge>
+          )}
+        </div>
+      </div>
+
+      <p className="text-muted mt-2 text-xs">{lastQualifyingLine(row)}</p>
+
+      <div className="mt-2 flex flex-wrap gap-1 text-xs">
+        <Stat label="qualifying (12mo)" value={row.qualifyingCount12mo} />
+        <Stat label="community events" value={row.communityCount} />
+        <Stat label="no-shows" value={row.noShowCount} />
+        <Stat label="cancels" value={row.cancelCount} />
+      </div>
+
+      {canPause && !row.isPaused ? <PauseButton row={row} /> : null}
+    </article>
+  );
+}
+
+function PauseButton({ row }: { row: MemberAttendanceRow }) {
+  const update = useUpdateUser(row.userId);
+  const { confirm, element } = useConfirm();
+
+  async function onPause() {
+    const ok = await confirm({
+      title: 'pause this member?',
+      message: `${row.fullName.toLowerCase()} won't be able to log in until unpaused — do this from the members screen.`,
+      confirmLabel: 'pause',
+      destructive: true,
+    });
+    if (!ok) return;
+    try {
+      await update.mutateAsync({ isPaused: true });
+      toast.success('member paused ✓');
+    } catch (err) {
+      toast.error(extractApiErrorOr(err, "couldn't pause member — try again"));
+    }
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => void onPause()}
+        disabled={update.isPending}
+        className="text-warning mt-3 text-xs font-medium hover:underline disabled:opacity-50"
+      >
+        pause member
+      </button>
+      {element}
+    </>
+  );
+}
+
+const BADGE_TONES = {
+  success: 'bg-success-subtle text-success',
+  warning: 'bg-warning-subtle text-warning',
+  neutral: 'bg-surface-dim text-foreground-secondary',
+} as const;
+
+function Badge({ tone, children }: { tone: keyof typeof BADGE_TONES; children: string }) {
+  return (
+    <span className={cn('rounded-full px-2 py-0.5 text-xs', BADGE_TONES[tone])}>{children}</span>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: number }) {
+  return (
+    <span className="bg-surface-dim text-foreground-secondary rounded-full px-2.5 py-0.5">
+      <span className="text-foreground font-medium">{value}</span> {label}
+    </span>
+  );
+}

--- a/frontend/src/screens/admin/MemberAttendanceTab.tsx
+++ b/frontend/src/screens/admin/MemberAttendanceTab.tsx
@@ -87,6 +87,15 @@ function FilterButton({
   );
 }
 
+function complianceBadge(row: MemberAttendanceRow): {
+  tone: keyof typeof BADGE_TONES;
+  label: string;
+} {
+  if (row.isPauseCandidate) return { tone: 'warning', label: 'pause candidate' };
+  if (row.compliant) return { tone: 'success', label: 'compliant' };
+  return { tone: 'neutral', label: 'not yet compliant' };
+}
+
 function lastQualifyingLine(row: MemberAttendanceRow): string {
   if (!row.lastQualifyingAt) return 'never attended a qualifying event';
   const date = format(row.lastQualifyingAt, 'MMM d, yyyy').toLowerCase();
@@ -98,6 +107,7 @@ function lastQualifyingLine(row: MemberAttendanceRow): string {
 function MemberAttendanceRowCard({ row }: { row: MemberAttendanceRow }) {
   const currentUser = useAuthStore((s) => s.user);
   const canPause = hasPermission(currentUser, Permission.ManageUsers);
+  const badge = complianceBadge(row);
 
   return (
     <article className="border-border bg-surface rounded-lg border p-3">
@@ -110,13 +120,7 @@ function MemberAttendanceRowCard({ row }: { row: MemberAttendanceRow }) {
         </div>
         <div className="flex flex-wrap items-center gap-1">
           {row.isPaused ? <Badge tone="neutral">paused</Badge> : null}
-          {row.isPauseCandidate ? (
-            <Badge tone="warning">pause candidate</Badge>
-          ) : row.compliant ? (
-            <Badge tone="success">compliant</Badge>
-          ) : (
-            <Badge tone="neutral">not yet compliant</Badge>
-          )}
+          <Badge tone={badge.tone}>{badge.label}</Badge>
         </div>
       </div>
 

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -182,6 +182,7 @@ export function makeRequest(overrides: Partial<JoinRequestSummary> = {}): JoinRe
       upcomingClub: 0,
     },
     rsvpEvents: [],
+    attendedEvents: [],
     ...overrides,
   };
 }


### PR DESCRIPTION
## Summary

- **events tab** — unchanged content; the per-event report link now points at `/events/{id}/report` (the phase-1 per-event report screen being built in a sibling PR — harmless once that route merges, no-op link if it hasn't yet).
- **members tab** (new, flag-gated on `admin_attendance_analytics`) — per member: last qualifying attendance date (club/official only), qualifying count in trailing 12mo, compliance badge (≥2 qualifying/12mo, display-only), community-event count (informational), no-show/cancel counts, months-since-last-qualifying, pause candidates (>12mo or never) sorted to the top, filterable to "at risk". Pause action reuses the existing `PATCH /auth/users/{id}/` `is_paused` endpoint, gated on `manage_users` (separate from the `manage_events` gate on the tab itself).
- **join-request attendance** — join requests now carry `attended_events` (all event types — club/official/community, tagged), resolved via `JoinRequest.user` FK or a unique guest-phone match, gated by the same flag. Rendered as a compact list on the join-request card. No new endpoint, no permission change.
- New backend endpoint: `GET /events/attendance-analytics/members/`, gated `MANAGE_EVENTS` + the flag. Members only, active + paused (labeled), archived excluded. Compute-on-read over `EventRSVP` — no new summary table.
- Registers `FeatureFlag.ADMIN_ATTENDANCE_ANALYTICS` (backend) / `Feature.AdminAttendanceAnalytics` (frontend) per `docs/feature-flags.md`. This flag is shared with two sibling phases (reminder emails, join-request UI) being built concurrently — only this issue's scope is implemented here.

Closes #1093

### Deviations / omissions (see issue for full context)

- **Reminders-sent column**: omitted. The `AttendanceReminder` model (sibling reminder-email phase) doesn't exist in this branch yet — no reference to it anywhere in the members tab.
- **Per-event report tap-through**: linked to `/events/{id}/report`, which doesn't exist yet in this branch (sibling phase-1 PR). The link is inert until that route merges; not blocking.

## Test plan

- [x] `make agent-test` — full backend suite passes except 6 pre-existing SQLite-only failures (`pg_notify`/SSE + `select_for_update` concurrency — documented gap, not a regression; GitHub CI runs Postgres).
- [x] `make agent-lint` / `make agent-typecheck` / `make agent-complexity` — clean.
- [x] `make agent-frontend-test` / `make agent-frontend-lint` / `make agent-frontend-typecheck` / `frontend-types-check` — clean (991 tests passing).
- [x] `make agent-check-codes` — validation codes + OpenAPI schema in sync.
- [ ] Manual: toggle `admin_attendance_analytics` on in `/admin/feature-flags`, verify the members tab appears, pause candidates sort first, pause action requires `manage_users`, join-request cards show attended events.