### PR TITLE
feat: tentative-approval rsvp link (Issue 1103, Issue 1104)

### DIFF
--- a/backend/community/_join_request_approval.py
+++ b/backend/community/_join_request_approval.py
@@ -103,12 +103,13 @@ def send_join_approval(*, to: str, display_name: str, first_name: str, magic_tok
         logging.getLogger(__name__).warning("join approval email failed", exc_info=True)
 
 
-def _provision_tentative_user(join_request, requesting_user) -> User:
+def _provision_tentative_user(join_request, requesting_user) -> tuple[User, str]:
     """Provision the non-member User backing a tentatively-approved join request.
 
     Reuses a non-member already linked or matched by phone; else creates one. A
-    scoped RSVP token is minted so they can RSVP without being a member. No member
-    role, no login email — those wait for full approval.
+    scoped RSVP token is minted (or reused, if still valid) so they can RSVP
+    without being a member. No member role, no login email — those wait for
+    full approval. Returns the user and the RSVP manage-link token string.
     """
     user = join_request.user or User.objects.filter(phone_number=join_request.phone_number).first()
     if user is None:
@@ -126,8 +127,8 @@ def _provision_tentative_user(join_request, requesting_user) -> User:
         join_request.user = user
         join_request.save(update_fields=["user"])
 
-    NonMemberRsvpToken.issue_or_extend(user)
-    return user
+    rsvp_token = NonMemberRsvpToken.issue_or_extend(user)
+    return user, rsvp_token.token
 
 
 def _maybe_promote_tentative(user, event, actor) -> str | None:

--- a/backend/community/_join_requests.py
+++ b/backend/community/_join_requests.py
@@ -90,6 +90,7 @@ class ApproveJoinRequestOut(BaseModel):
     phone_number: str
     status: str
     magic_link_token: str | None = None
+    rsvp_link_token: str | None = None
     user_id: str | None = None
 
 
@@ -264,11 +265,12 @@ _DECISION_ACTIONS = {
 
 def _apply_status_transition(
     id: UUID, status: str, actor
-) -> tuple[JoinRequest, str | None, bool, bool]:
+) -> tuple[JoinRequest, str | None, str | None, bool, bool]:
     """Stamp + provision inside one locked transaction.
 
-    Returns ``(join_request, magic_token, user_created, promoted_from_tentative)``.
-    select_for_update() serializes concurrent approvals so only one provisions.
+    Returns ``(join_request, magic_token, rsvp_link_token, user_created,
+    promoted_from_tentative)``. select_for_update() serializes concurrent
+    approvals so only one provisions.
     """
     with transaction.atomic():
         try:
@@ -284,12 +286,12 @@ def _apply_status_transition(
         was_tentative = join_request.status == JoinRequestStatus.TENTATIVE
         _stamp_decision(join_request, status, actor)
         if status == JoinRequestStatus.TENTATIVE:
-            _provision_tentative_user(join_request, actor)
-            return join_request, None, False, False
+            _, rsvp_link_token = _provision_tentative_user(join_request, actor)
+            return join_request, None, rsvp_link_token, False, False
         if status == JoinRequestStatus.APPROVED:
             magic_token, user_created = _provision_approved_user(join_request, actor)
-            return join_request, magic_token, user_created, was_tentative
-    return join_request, None, False, False
+            return join_request, magic_token, None, user_created, was_tentative
+    return join_request, None, None, False, False
 
 
 @router.patch(
@@ -331,7 +333,7 @@ def update_join_request_status(request, id: UUID, payload: JoinRequestStatusIn):
             allowed=valid_statuses,
         )
 
-    join_request, magic_token, user_created, promoted = _apply_status_transition(
+    join_request, magic_token, rsvp_link_token, user_created, promoted = _apply_status_transition(
         id, payload.status, request.auth
     )
 
@@ -368,6 +370,7 @@ def update_join_request_status(request, id: UUID, payload: JoinRequestStatusIn):
             phone_number=join_request.phone_number,
             status=join_request.status,
             magic_link_token=magic_token,
+            rsvp_link_token=rsvp_link_token,
             user_id=str(approved_user.id) if approved_user else None,
         ),
     )

--- a/backend/community/models/content.py
+++ b/backend/community/models/content.py
@@ -134,7 +134,8 @@ class TentativeApprovalMessageTemplate(models.Model):
 
     Plain-text body for the sms/whatsapp message a vetter sends right after
     tentatively approving a join request. Placeholders ${FIRST_NAME},
-    ${SENDER_NAME}, ${WHATSAPP_LINK} are substituted client-side when rendered.
+    ${SENDER_NAME}, ${WHATSAPP_LINK}, ${RSVP_LINK} are substituted client-side
+    when rendered.
     """
 
     body = models.TextField(default="", max_length=4000)

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -58,6 +58,17 @@
             "title": "Phone Number",
             "type": "string"
           },
+          "rsvp_link_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rsvp Link Token"
+          },
           "status": {
             "title": "Status",
             "type": "string"

--- a/backend/tests/test_join_request_tentative.py
+++ b/backend/tests/test_join_request_tentative.py
@@ -86,6 +86,33 @@ class TestTentativeApprove:
         )
         assert response.json()["magic_link_token"] is None
 
+    def test_tentative_response_rsvp_link_token_resolves_to_linked_user(
+        self, api_client, vettor_headers, sample_join_request
+    ):
+        response = api_client.patch(
+            f"/api/community/join-requests/{sample_join_request.id}/",
+            {"status": JoinRequestStatus.TENTATIVE},
+            content_type="application/json",
+            **vettor_headers,
+        )
+        token = response.json()["rsvp_link_token"]
+        assert token
+        sample_join_request.refresh_from_db()
+        resolved = NonMemberRsvpToken.resolve_user(token)
+        assert resolved is not None
+        assert resolved.id == sample_join_request.user_id
+
+    def test_approved_response_has_no_rsvp_link_token(
+        self, api_client, vettor_headers, sample_join_request
+    ):
+        response = api_client.patch(
+            f"/api/community/join-requests/{sample_join_request.id}/",
+            {"status": JoinRequestStatus.APPROVED},
+            content_type="application/json",
+            **vettor_headers,
+        )
+        assert response.json()["rsvp_link_token"] is None
+
     def test_tentative_requires_permission(self, api_client, auth_headers, sample_join_request):
         response = api_client.patch(
             f"/api/community/join-requests/{sample_join_request.id}/",

--- a/frontend/src/api/join.ts
+++ b/frontend/src/api/join.ts
@@ -321,6 +321,8 @@ export interface JoinRequestDecision {
   status: JoinRequestStatus;
   /** Present only when the decision created a brand-new user. */
   magicLinkToken: string | null;
+  /** Present only on a tentative-approval decision. */
+  rsvpLinkToken: string | null;
   userId: string | null;
 }
 
@@ -331,6 +333,7 @@ interface WireDecision {
   phone_number: string;
   status: JoinRequestStatus;
   magic_link_token: string | null;
+  rsvp_link_token: string | null;
   user_id: string | null;
 }
 
@@ -355,6 +358,7 @@ export function useDecideJoinRequest() {
         phoneNumber: data.phone_number,
         status: data.status,
         magicLinkToken: data.magic_link_token,
+        rsvpLinkToken: data.rsvp_link_token,
         userId: data.user_id,
       } satisfies JoinRequestDecision;
     },
@@ -389,6 +393,7 @@ export function useResendMagicLink() {
         phoneNumber: data.phone_number,
         status: data.status,
         magicLinkToken: data.magic_link_token,
+        rsvpLinkToken: data.rsvp_link_token,
         userId: data.user_id,
       } satisfies JoinRequestDecision;
     },

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -1943,6 +1943,8 @@ export interface components {
             magic_link_token?: string | null;
             /** Phone Number */
             phone_number: string;
+            /** Rsvp Link Token */
+            rsvp_link_token?: string | null;
             /** Status */
             status: string;
             /** User Id */

--- a/frontend/src/screens/admin/JoinRequestsScreen.test.tsx
+++ b/frontend/src/screens/admin/JoinRequestsScreen.test.tsx
@@ -249,6 +249,7 @@ describe('JoinRequestsScreen pending actions', () => {
       firstName: 'Ada',
       phoneNumber: '+16505550001',
       magicLinkToken: null,
+      rsvpLinkToken: 'rsvp-tok',
     });
     vi.mocked(useDecideJoinRequest).mockReturnValue({
       mutateAsync,
@@ -273,6 +274,7 @@ describe('JoinRequestsScreen pending actions', () => {
       firstName: 'Ada',
       phoneNumber: '+16505550001',
       magicLinkToken: null,
+      rsvpLinkToken: 'rsvp-tok',
     });
     vi.mocked(useDecideJoinRequest).mockReturnValue({
       mutateAsync,

--- a/frontend/src/screens/admin/JoinRequestsScreen.tsx
+++ b/frontend/src/screens/admin/JoinRequestsScreen.tsx
@@ -55,6 +55,7 @@ export default function JoinRequestsScreen() {
     fullName: string;
     firstName: string;
     phoneNumber: string;
+    rsvpLinkToken: string | null;
   } | null>(null);
   const [memberPromotionMessageFor, setMemberPromotionMessageFor] = useState<{
     fullName: string;
@@ -103,6 +104,7 @@ export default function JoinRequestsScreen() {
           fullName: result.fullName,
           firstName: result.firstName,
           phoneNumber: result.phoneNumber,
+          rsvpLinkToken: result.rsvpLinkToken,
         });
       }
     } catch (err) {
@@ -236,6 +238,7 @@ export default function JoinRequestsScreen() {
           fullName={tentativeMessageFor.fullName}
           firstName={tentativeMessageFor.firstName}
           phoneNumber={tentativeMessageFor.phoneNumber}
+          rsvpLinkToken={tentativeMessageFor.rsvpLinkToken}
         />
       ) : null}
       {memberPromotionMessageFor ? (

--- a/frontend/src/screens/admin/TentativeApprovalMessageDialog.test.tsx
+++ b/frontend/src/screens/admin/TentativeApprovalMessageDialog.test.tsx
@@ -17,7 +17,7 @@ vi.mock('@/api/client', () => ({
 vi.mock('@/api/content', () => ({
   useTentativeApprovalMessage: () => ({
     data: {
-      body: 'hi ${FIRST_NAME}, from ${SENDER_NAME} — you are tentatively in',
+      body: 'hi ${FIRST_NAME}, from ${SENDER_NAME} — you are tentatively in. rsvp: ${RSVP_LINK}',
       updatedAt: '2026-01-01',
     },
     isPending: false,
@@ -46,7 +46,7 @@ beforeEach(() => {
   useAuthStore.setState({ status: 'idle', user: null, accessToken: null });
 });
 
-function renderDialog(user: User | null) {
+function renderDialog(user: User | null, rsvpLinkToken: string | null = null) {
   useAuthStore.setState({
     status: user ? 'authed' : 'idle',
     user,
@@ -61,6 +61,7 @@ function renderDialog(user: User | null) {
         fullName="Sam Vetterson"
         firstName="Sam"
         phoneNumber="+12025551234"
+        rsvpLinkToken={rsvpLinkToken}
       />
     </QueryClientProvider>,
   );
@@ -78,6 +79,20 @@ describe('TentativeApprovalMessageDialog', () => {
     expect(wa?.getAttribute('href')).toContain('https://wa.me/12025551234?text=');
     expect(screen.queryByText(/magic-login/i)).toBeNull();
     expect(screen.queryByRole('button', { name: /copy link/i })).toBeNull();
+  });
+
+  it('substitutes ${RSVP_LINK} into the sms body when a token is present', () => {
+    renderDialog(makeUser(), 'tok123');
+    const sms = screen.getByText('send via sms').closest('a');
+    expect(sms?.getAttribute('href')).toContain(
+      encodeURIComponent(`${window.location.origin}/my-rsvps?token=tok123`),
+    );
+  });
+
+  it('renders an empty rsvp link when no token is present', () => {
+    renderDialog(makeUser(), null);
+    const sms = screen.getByText('send via sms').closest('a');
+    expect(sms?.getAttribute('href')).toContain(encodeURIComponent('rsvp: '));
   });
 
   it('hides edit-template trigger without permission', () => {

--- a/frontend/src/screens/admin/TentativeApprovalMessageDialog.tsx
+++ b/frontend/src/screens/admin/TentativeApprovalMessageDialog.tsx
@@ -6,7 +6,12 @@ import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import { hasPermission, Permission } from '@/models/permissions';
 import { formatPhone } from '@/utils/formatPhone';
-import { buildSmsHref, buildWhatsAppHref, renderWelcomeMessage } from '@/utils/welcomeMessage';
+import {
+  buildRsvpLinkUrl,
+  buildSmsHref,
+  buildWhatsAppHref,
+  renderWelcomeMessage,
+} from '@/utils/welcomeMessage';
 
 import { TentativeApprovalMessageEditorDialog } from './TentativeApprovalMessageEditorDialog';
 
@@ -16,6 +21,7 @@ interface Props {
   fullName: string;
   firstName: string;
   phoneNumber: string;
+  rsvpLinkToken: string | null;
 }
 
 const DEFAULT_TENTATIVE_MESSAGE =
@@ -27,6 +33,7 @@ export function TentativeApprovalMessageDialog({
   fullName,
   firstName,
   phoneNumber,
+  rsvpLinkToken,
 }: Props) {
   const [editorOpen, setEditorOpen] = useState(false);
   const currentUser = useAuthStore((s) => s.user);
@@ -38,6 +45,7 @@ export function TentativeApprovalMessageDialog({
   const message = renderWelcomeMessage(body, {
     name: firstName,
     senderName,
+    rsvpLink: rsvpLinkToken ? buildRsvpLinkUrl(rsvpLinkToken) : '',
     whatsappLink: whatsappLinkQ.data?.link ?? '',
   });
   const smsHref = buildSmsHref(phoneNumber, message);

--- a/frontend/src/screens/admin/TentativeApprovalMessageEditorDialog.tsx
+++ b/frontend/src/screens/admin/TentativeApprovalMessageEditorDialog.tsx
@@ -59,7 +59,8 @@ function EditorForm({ initialBody, onClose }: { initialBody: string; onClose: ()
         available placeholders:{' '}
         <code className="bg-surface-dim rounded px-1">{'${FIRST_NAME}'}</code> (recipient's first
         name), <code className="bg-surface-dim rounded px-1">{'${SENDER_NAME}'}</code>,{' '}
-        <code className="bg-surface-dim rounded px-1">{'${WHATSAPP_LINK}'}</code>
+        <code className="bg-surface-dim rounded px-1">{'${RSVP_LINK}'}</code> (their rsvp manage
+        link), <code className="bg-surface-dim rounded px-1">{'${WHATSAPP_LINK}'}</code>
       </p>
       <textarea
         value={body}

--- a/frontend/src/utils/welcomeMessage.test.ts
+++ b/frontend/src/utils/welcomeMessage.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  buildRsvpLinkUrl,
   buildSmsHref,
   buildWelcomeMessage,
   buildWhatsAppHref,
@@ -58,18 +59,19 @@ describe('buildWelcomeMessage', () => {
 });
 
 describe('renderWelcomeMessage', () => {
-  it('substitutes all four placeholders', () => {
+  it('substitutes all five placeholders', () => {
     const out = renderWelcomeMessage(
-      'hi ${FIRST_NAME}, this is ${SENDER_NAME}, sign in: ${MAGIC_LINK}, chat: ${WHATSAPP_LINK}',
+      'hi ${FIRST_NAME}, this is ${SENDER_NAME}, sign in: ${MAGIC_LINK}, rsvp: ${RSVP_LINK}, chat: ${WHATSAPP_LINK}',
       {
         name: 'Sam',
         senderName: 'Vetter',
         magicLink: 'https://pda.test/m/abc',
+        rsvpLink: 'https://pda.test/my-rsvps?token=xyz',
         whatsappLink: 'https://chat.whatsapp.com/xyz',
       },
     );
     expect(out).toBe(
-      'hi Sam, this is Vetter, sign in: https://pda.test/m/abc, chat: https://chat.whatsapp.com/xyz',
+      'hi Sam, this is Vetter, sign in: https://pda.test/m/abc, rsvp: https://pda.test/my-rsvps?token=xyz, chat: https://chat.whatsapp.com/xyz',
     );
   });
 
@@ -101,6 +103,21 @@ describe('renderWelcomeMessage', () => {
       whatsappLink: '',
     });
     expect(out).toBe('hi ada!');
+  });
+
+  it('leaves ${RSVP_LINK} empty when no rsvpLink is supplied', () => {
+    const out = renderWelcomeMessage('x${RSVP_LINK}y', {
+      name: 'ada',
+      senderName: 'sender',
+      whatsappLink: '',
+    });
+    expect(out).toBe('xy');
+  });
+});
+
+describe('buildRsvpLinkUrl', () => {
+  it('builds a /my-rsvps manage url from a token', () => {
+    expect(buildRsvpLinkUrl('abc123')).toBe(`${window.location.origin}/my-rsvps?token=abc123`);
   });
 });
 

--- a/frontend/src/utils/welcomeMessage.ts
+++ b/frontend/src/utils/welcomeMessage.ts
@@ -2,6 +2,10 @@ export function buildMagicLinkUrl(token: string): string {
   return `${window.location.origin}/magic-login/${token}`;
 }
 
+export function buildRsvpLinkUrl(token: string): string {
+  return `${window.location.origin}/my-rsvps?token=${token}`;
+}
+
 // Legacy hardcoded body — still used by member-create / bulk-create /
 // member-detail flows. The join-request approval flow uses the editable
 // template via renderWelcomeMessage instead.
@@ -15,6 +19,7 @@ export interface WelcomeMessageVars {
   name: string;
   senderName: string;
   magicLink?: string;
+  rsvpLink?: string;
   whatsappLink: string;
 }
 
@@ -23,6 +28,7 @@ export function renderWelcomeMessage(template: string, vars: WelcomeMessageVars)
     .replaceAll('${FIRST_NAME}', vars.name)
     .replaceAll('${SENDER_NAME}', vars.senderName)
     .replaceAll('${MAGIC_LINK}', vars.magicLink ?? '')
+    .replaceAll('${RSVP_LINK}', vars.rsvpLink ?? '')
     .replaceAll('${WHATSAPP_LINK}', vars.whatsappLink);
 }
 


### PR DESCRIPTION
## Overview

Tentative approval already mints a `NonMemberRsvpToken` for the applicant but discards it, and the `/my-rsvps` manage screen already lets a token holder RSVP to any open event without re-typing their info. This PR surfaces that token as `rsvp_link_token` and adds a `${RSVP_LINK}` placeholder to the tentative-approval SMS/WhatsApp message, mirroring the existing `${MAGIC_LINK}` flow on the member-promotion message — so a vetter can hand a tentatively-approved applicant their RSVP link right away.

Same token the public-RSVP flow issues (`NonMemberRsvpToken.issue_or_extend` reuses the newest valid token) — no new token type, no migration, no change to the `rsvp-phone-check` privacy surface or the member-promotion templates.

Closes #1103
Closes #1104

## Test plan

- [x] `_provision_tentative_user` returns a token that `NonMemberRsvpToken.resolve_user` resolves to the linked non-member (backend test)
- [x] `PATCH .../join-requests/{id}/` tentative response includes `rsvp_link_token`; approved response has it `null`
- [x] `renderWelcomeMessage` substitutes `${RSVP_LINK}`, empty when no token supplied
- [x] `TentativeApprovalMessageDialog` renders the `/my-rsvps?token=...` link when a token is present
- [x] Backend: targeted pytest subset (23/23 passed) + `ty check` clean
- [x] Frontend: `tsc --noEmit` clean, `eslint` clean, touched Vitest files (38/38 + 9/9 passed)
- [ ] Full `make agent-ci` / `make agent-frontend-test` suite (skipped per request — run before merge)
