### PR TITLE
chore(feature-flags): remove example flag

### DIFF
--- a/backend/community/models/choices.py
+++ b/backend/community/models/choices.py
@@ -104,13 +104,11 @@ class FeedbackType(models.TextChoices):
 class FeatureFlag(models.TextChoices):
     """Registry of feature flags; pair each member with a default in FLAG_DEFAULTS."""
 
-    EXAMPLE_FLAG = "example_flag", "Example flag"
     HOST_ATTENDANCE_REPORT = "host_attendance_report", "Host attendance report"
     ADMIN_ATTENDANCE_ANALYTICS = "admin_attendance_analytics", "Admin attendance analytics"
 
 
 FLAG_DEFAULTS: dict[str, bool] = {
-    FeatureFlag.EXAMPLE_FLAG: False,
     FeatureFlag.HOST_ATTENDANCE_REPORT: False,
     FeatureFlag.ADMIN_ATTENDANCE_ANALYTICS: False,
 }

--- a/backend/tests/test_feature_flags.py
+++ b/backend/tests/test_feature_flags.py
@@ -32,12 +32,12 @@ class TestGetFeatureFlags:
     def test_get_flags_unauthenticated(self, api_client):
         response = api_client.get("/api/community/feature-flags/")
         assert response.status_code == 200
-        assert response.json()["flags"][FeatureFlag.EXAMPLE_FLAG] is False
+        assert response.json()["flags"][FeatureFlag.HOST_ATTENDANCE_REPORT] is False
 
     def test_get_flags_resolves_db_override(self, api_client, db):
-        FeatureFlagState.objects.create(key=FeatureFlag.EXAMPLE_FLAG, enabled=True)
+        FeatureFlagState.objects.create(key=FeatureFlag.HOST_ATTENDANCE_REPORT, enabled=True)
         response = api_client.get("/api/community/feature-flags/")
-        assert response.json()["flags"][FeatureFlag.EXAMPLE_FLAG] is True
+        assert response.json()["flags"][FeatureFlag.HOST_ATTENDANCE_REPORT] is True
 
     def test_resolve_flags_ignores_unknown_keys(self, db):
         FeatureFlagState.objects.create(key="not_a_real_flag", enabled=True)
@@ -48,18 +48,18 @@ class TestGetFeatureFlags:
 class TestUpdateFeatureFlag:
     def test_update_flag_with_permission(self, api_client, manage_flags_headers):
         response = api_client.patch(
-            f"/api/community/feature-flags/{FeatureFlag.EXAMPLE_FLAG}/",
+            f"/api/community/feature-flags/{FeatureFlag.HOST_ATTENDANCE_REPORT}/",
             data={"enabled": True},
             content_type="application/json",
             **manage_flags_headers,
         )
         assert response.status_code == 200
-        assert response.json()["flags"][FeatureFlag.EXAMPLE_FLAG] is True
-        assert FeatureFlagState.objects.get(key=FeatureFlag.EXAMPLE_FLAG).enabled is True
+        assert response.json()["flags"][FeatureFlag.HOST_ATTENDANCE_REPORT] is True
+        assert FeatureFlagState.objects.get(key=FeatureFlag.HOST_ATTENDANCE_REPORT).enabled is True
 
     def test_update_flag_without_permission(self, api_client, auth_headers):
         response = api_client.patch(
-            f"/api/community/feature-flags/{FeatureFlag.EXAMPLE_FLAG}/",
+            f"/api/community/feature-flags/{FeatureFlag.HOST_ATTENDANCE_REPORT}/",
             data={"enabled": True},
             content_type="application/json",
             **auth_headers,
@@ -68,7 +68,7 @@ class TestUpdateFeatureFlag:
 
     def test_update_flag_unauthenticated(self, api_client):
         response = api_client.patch(
-            f"/api/community/feature-flags/{FeatureFlag.EXAMPLE_FLAG}/",
+            f"/api/community/feature-flags/{FeatureFlag.HOST_ATTENDANCE_REPORT}/",
             data={"enabled": True},
             content_type="application/json",
         )
@@ -77,7 +77,7 @@ class TestUpdateFeatureFlag:
     def test_update_flag_allowed_on_production(self, api_client, manage_flags_headers, monkeypatch):
         monkeypatch.setenv("RAILWAY_ENVIRONMENT_NAME", "production")
         response = api_client.patch(
-            f"/api/community/feature-flags/{FeatureFlag.EXAMPLE_FLAG}/",
+            f"/api/community/feature-flags/{FeatureFlag.HOST_ATTENDANCE_REPORT}/",
             data={"enabled": True},
             content_type="application/json",
             **manage_flags_headers,

--- a/frontend/src/api/featureFlags.test.ts
+++ b/frontend/src/api/featureFlags.test.ts
@@ -28,21 +28,21 @@ beforeEach(() => {
 
 describe('useFeatureFlags', () => {
   it('returns the resolved flags map on success', async () => {
-    mockedGet.mockResolvedValueOnce({ data: { flags: { example_flag: true } } });
+    mockedGet.mockResolvedValueOnce({ data: { flags: { host_attendance_report: true } } });
 
     const { result } = renderHook(() => useFeatureFlags(), { wrapper: wrapper() });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(result.current.data).toEqual({ example_flag: true });
+    expect(result.current.data).toEqual({ host_attendance_report: true });
     expect(mockedGet).toHaveBeenCalledWith('/api/community/feature-flags/');
   });
 });
 
 describe('useFlag', () => {
   it('returns the resolved boolean when the flag is on', async () => {
-    mockedGet.mockResolvedValueOnce({ data: { flags: { example_flag: true } } });
+    mockedGet.mockResolvedValueOnce({ data: { flags: { host_attendance_report: true } } });
 
-    const { result } = renderHook(() => useFlag(Feature.ExampleFlag), { wrapper: wrapper() });
+    const { result } = renderHook(() => useFlag(Feature.HostAttendanceReport), { wrapper: wrapper() });
 
     await waitFor(() => expect(result.current).toBe(true));
   });
@@ -50,7 +50,7 @@ describe('useFlag', () => {
   it('fail-closes to false while loading', () => {
     mockedGet.mockReturnValueOnce(new Promise(() => {}));
 
-    const { result } = renderHook(() => useFlag(Feature.ExampleFlag), { wrapper: wrapper() });
+    const { result } = renderHook(() => useFlag(Feature.HostAttendanceReport), { wrapper: wrapper() });
 
     expect(result.current).toBe(false);
   });
@@ -58,7 +58,7 @@ describe('useFlag', () => {
   it('fail-closes to false when the key is absent from the resolved map', async () => {
     mockedGet.mockResolvedValueOnce({ data: { flags: {} } });
 
-    const { result } = renderHook(() => useFlag(Feature.ExampleFlag), { wrapper: wrapper() });
+    const { result } = renderHook(() => useFlag(Feature.HostAttendanceReport), { wrapper: wrapper() });
 
     // let the query settle, then confirm it stays closed
     await waitFor(() => expect(mockedGet).toHaveBeenCalled());
@@ -68,28 +68,28 @@ describe('useFlag', () => {
 
 describe('useSetFeatureFlag', () => {
   it('patches the flag and returns the resolved map', async () => {
-    mockedPatch.mockResolvedValueOnce({ data: { flags: { example_flag: true } } });
+    mockedPatch.mockResolvedValueOnce({ data: { flags: { host_attendance_report: true } } });
 
     const { result } = renderHook(() => useSetFeatureFlag(), { wrapper: wrapper() });
 
-    const flags = await result.current.mutateAsync({ key: Feature.ExampleFlag, enabled: true });
+    const flags = await result.current.mutateAsync({ key: Feature.HostAttendanceReport, enabled: true });
 
-    expect(mockedPatch).toHaveBeenCalledWith('/api/community/feature-flags/example_flag/', {
+    expect(mockedPatch).toHaveBeenCalledWith('/api/community/feature-flags/host_attendance_report/', {
       enabled: true,
     });
-    expect(flags).toEqual({ example_flag: true });
+    expect(flags).toEqual({ host_attendance_report: true });
   });
 
   it('writes the resolved map straight into the flags cache without a refetch', async () => {
-    mockedPatch.mockResolvedValueOnce({ data: { flags: { example_flag: true } } });
+    mockedPatch.mockResolvedValueOnce({ data: { flags: { host_attendance_report: true } } });
     const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
     const wrap = ({ children }: { children: ReactNode }) =>
       createElement(QueryClientProvider, { client: qc }, children);
 
     const { result } = renderHook(() => useSetFeatureFlag(), { wrapper: wrap });
-    await result.current.mutateAsync({ key: Feature.ExampleFlag, enabled: true });
+    await result.current.mutateAsync({ key: Feature.HostAttendanceReport, enabled: true });
 
-    expect(qc.getQueryData(['feature-flags'])).toEqual({ example_flag: true });
+    expect(qc.getQueryData(['feature-flags'])).toEqual({ host_attendance_report: true });
     expect(mockedGet).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/api/featureFlags.test.ts
+++ b/frontend/src/api/featureFlags.test.ts
@@ -42,7 +42,9 @@ describe('useFlag', () => {
   it('returns the resolved boolean when the flag is on', async () => {
     mockedGet.mockResolvedValueOnce({ data: { flags: { host_attendance_report: true } } });
 
-    const { result } = renderHook(() => useFlag(Feature.HostAttendanceReport), { wrapper: wrapper() });
+    const { result } = renderHook(() => useFlag(Feature.HostAttendanceReport), {
+      wrapper: wrapper(),
+    });
 
     await waitFor(() => expect(result.current).toBe(true));
   });
@@ -50,7 +52,9 @@ describe('useFlag', () => {
   it('fail-closes to false while loading', () => {
     mockedGet.mockReturnValueOnce(new Promise(() => {}));
 
-    const { result } = renderHook(() => useFlag(Feature.HostAttendanceReport), { wrapper: wrapper() });
+    const { result } = renderHook(() => useFlag(Feature.HostAttendanceReport), {
+      wrapper: wrapper(),
+    });
 
     expect(result.current).toBe(false);
   });
@@ -58,7 +62,9 @@ describe('useFlag', () => {
   it('fail-closes to false when the key is absent from the resolved map', async () => {
     mockedGet.mockResolvedValueOnce({ data: { flags: {} } });
 
-    const { result } = renderHook(() => useFlag(Feature.HostAttendanceReport), { wrapper: wrapper() });
+    const { result } = renderHook(() => useFlag(Feature.HostAttendanceReport), {
+      wrapper: wrapper(),
+    });
 
     // let the query settle, then confirm it stays closed
     await waitFor(() => expect(mockedGet).toHaveBeenCalled());
@@ -72,11 +78,17 @@ describe('useSetFeatureFlag', () => {
 
     const { result } = renderHook(() => useSetFeatureFlag(), { wrapper: wrapper() });
 
-    const flags = await result.current.mutateAsync({ key: Feature.HostAttendanceReport, enabled: true });
-
-    expect(mockedPatch).toHaveBeenCalledWith('/api/community/feature-flags/host_attendance_report/', {
+    const flags = await result.current.mutateAsync({
+      key: Feature.HostAttendanceReport,
       enabled: true,
     });
+
+    expect(mockedPatch).toHaveBeenCalledWith(
+      '/api/community/feature-flags/host_attendance_report/',
+      {
+        enabled: true,
+      },
+    );
     expect(flags).toEqual({ host_attendance_report: true });
   });
 

--- a/frontend/src/auth/guards.test.tsx
+++ b/frontend/src/auth/guards.test.tsx
@@ -185,7 +185,7 @@ describe('RequireFlag', () => {
     return render(
       <MemoryRouter initialEntries={[initialEntry]}>
         <Routes>
-          <Route element={<RequireFlag flag={Feature.ExampleFlag} />}>
+          <Route element={<RequireFlag flag={Feature.HostAttendanceReport} />}>
             <Route path="/beta" element={<div>beta content</div>} />
           </Route>
           <Route path="/login" element={<div>login page</div>} />
@@ -196,7 +196,7 @@ describe('RequireFlag', () => {
   }
 
   it('redirects an unauthed user to /login before checking the flag', () => {
-    mockFlags({ data: { example_flag: true } });
+    mockFlags({ data: { host_attendance_report: true } });
     renderGuarded();
     expect(screen.getByText('login page')).toBeInTheDocument();
     expect(screen.queryByText('beta content')).not.toBeInTheDocument();
@@ -212,7 +212,7 @@ describe('RequireFlag', () => {
 
   it('renders the outlet when authed and the flag is on', () => {
     useAuthStore.setState({ status: 'authed', user: makeUser(), accessToken: 'tok-abc' });
-    mockFlags({ data: { example_flag: true } });
+    mockFlags({ data: { host_attendance_report: true } });
     renderGuarded();
     expect(screen.getByText('beta content')).toBeInTheDocument();
     expect(screen.queryByText('calendar page')).not.toBeInTheDocument();
@@ -220,7 +220,7 @@ describe('RequireFlag', () => {
 
   it('redirects to /calendar when authed but the flag is off', () => {
     useAuthStore.setState({ status: 'authed', user: makeUser(), accessToken: 'tok-abc' });
-    mockFlags({ data: { example_flag: false } });
+    mockFlags({ data: { host_attendance_report: false } });
     renderGuarded();
     expect(screen.getByText('calendar page')).toBeInTheDocument();
     expect(screen.queryByText('beta content')).not.toBeInTheDocument();

--- a/frontend/src/models/featureFlags.ts
+++ b/frontend/src/models/featureFlags.ts
@@ -1,5 +1,4 @@
 export const Feature = {
-  ExampleFlag: 'example_flag',
   HostAttendanceReport: 'host_attendance_report',
   AdminAttendanceAnalytics: 'admin_attendance_analytics',
 } as const;

--- a/frontend/src/screens/admin/FeatureFlagsScreen.test.tsx
+++ b/frontend/src/screens/admin/FeatureFlagsScreen.test.tsx
@@ -27,7 +27,7 @@ function mockFlagsResult(overrides: Partial<ReturnType<typeof useFeatureFlags>>)
   mockUseFlags.mockReturnValue({
     isPending: false,
     isError: false,
-    data: { example_flag: false },
+    data: { host_attendance_report: false },
     ...overrides,
   } as ReturnType<typeof useFeatureFlags>);
 }
@@ -56,16 +56,16 @@ beforeEach(() => {
 
 describe('FeatureFlagsScreen', () => {
   it('renders a toggle per flag and calls the mutation on change', async () => {
-    mockFlagsResult({ data: { example_flag: false } });
+    mockFlagsResult({ data: { host_attendance_report: false } });
 
     renderScreen();
 
-    const toggle = screen.getByRole('switch', { name: /example flag/i });
+    const toggle = screen.getByRole('switch', { name: /host attendance report/i });
     expect(toggle).toHaveAttribute('aria-checked', 'false');
 
     await userEvent.click(toggle);
 
-    expect(mockMutate).toHaveBeenCalledWith({ key: 'example_flag', enabled: true });
+    expect(mockMutate).toHaveBeenCalledWith({ key: 'host_attendance_report', enabled: true });
   });
 
   it('shows the current environment', () => {

--- a/frontend/src/screens/admin/FeatureFlagsScreen.tsx
+++ b/frontend/src/screens/admin/FeatureFlagsScreen.tsx
@@ -5,7 +5,6 @@ import { Feature, type FeatureFlagKey } from '@/models/featureFlags';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 
 const FLAG_LABELS: Record<FeatureFlagKey, string> = {
-  [Feature.ExampleFlag]: 'example flag',
   [Feature.HostAttendanceReport]: 'host attendance report',
   [Feature.AdminAttendanceAnalytics]: 'admin attendance analytics',
 };

--- a/frontend/src/test/featureFlagParity.test.ts
+++ b/frontend/src/test/featureFlagParity.test.ts
@@ -7,7 +7,7 @@ import { Feature } from '@/models/featureFlags';
 const CHOICES = join(__dirname, '../../..', 'backend/community/models/choices.py');
 
 // Extract the string values of the backend `FeatureFlag(models.TextChoices)`
-// members, e.g. `EXAMPLE_FLAG = "example_flag", "Example flag"` → `example_flag`.
+// members, e.g. `HOST_ATTENDANCE_REPORT = "host_attendance_report", "..."` → `host_attendance_report`.
 function backendFlagKeys(): Set<string> {
   const source = readFileSync(CHOICES, 'utf8');
   const classMatch = /class FeatureFlag\(models\.TextChoices\):([\s\S]*?)(?:\n\S|$)/.exec(source);


### PR DESCRIPTION
## Overview

Removes `EXAMPLE_FLAG` / `Feature.ExampleFlag` — the demo flag from the feature-flag registry (Issues 996/997/998). Tests that used it as their fixture flag now use the real `host_attendance_report` flag instead.

## Test plan

- [x] `make agent-frontend-typecheck` passes
- [x] `make agent-frontend-lint` passes
- [x] `make agent-frontend-test` — 1001 passed
- [x] `make agent-lint` passes
- [x] backend `test_feature_flags.py` — 8 passed
