### PR TITLE
fix(events): remove caution icon from delete button

### DIFF
--- a/frontend/src/screens/events/EventAdminActions.tsx
+++ b/frontend/src/screens/events/EventAdminActions.tsx
@@ -121,7 +121,7 @@ function AdminActionRow({
             }}
             className="border-red-300 font-medium text-red-700 hover:bg-red-50"
           >
-            ⚠ delete
+            delete
           </Button>
         ) : null}
       </div>


### PR DESCRIPTION
## overview

removes the ⚠ prefix from the event delete button label in `EventAdminActions.tsx`, so it now reads just `delete`.

## changes
- `frontend/src/screens/events/EventAdminActions.tsx` — drop the `⚠ ` prefix on the delete button

## notes
- tests match the button by accessible name `/delete$/i`, which still passes since the label ends in `delete`