### PR TITLE
fix(attendance): don't attribute a different guest's attendance to a join-request applicant (Issue 1107)

### DIFF
--- a/backend/community/_join_requests.py
+++ b/backend/community/_join_requests.py
@@ -186,15 +186,6 @@ def _rsvp_events(user: User | None) -> list[JoinRequestRsvpOut]:
     ]
 
 
-def _attended_events_user(jr: JoinRequest, phone_user: User | None) -> User | None:
-    """FK user when set, else a guest (non-member) phone match. A member sharing the phone isn't a guest match."""
-    if jr.user_id:
-        return jr.user
-    if phone_user is not None and not phone_user.is_member:
-        return phone_user
-    return None
-
-
 def _join_request_attended_events(user: User | None) -> list[JoinRequestAttendedEventOut]:
     """All-event-types attendance history for vetting, gated on the analytics flag."""
     if user is None or not flag_enabled(FeatureFlag.ADMIN_ATTENDANCE_ANALYTICS):
@@ -241,7 +232,9 @@ def _join_request_out(jr: JoinRequest) -> JoinRequestOut:
         upcoming_official_count=breakdown.upcoming_official,
         upcoming_club_count=breakdown.upcoming_club,
         rsvp_events=_rsvp_events(user),
-        attended_events=_join_request_attended_events(_attended_events_user(jr, phone_user)),
+        # Only attribute per-event attendance history to a confidently-linked
+        # account. A bare phone match could be a different guest (Issue 1107).
+        attended_events=_join_request_attended_events(jr.user),
     )
 
 

--- a/backend/tests/test_join_request_attendance.py
+++ b/backend/tests/test_join_request_attendance.py
@@ -70,12 +70,12 @@ class TestJoinRequestAttendedEvents:
         row = response.json()[0]
         assert row["attended_events"] == []
 
-    def test_all_event_types_included_via_phone_fallback(
+    def test_all_event_types_included_when_account_linked(
         self, api_client, vettor_headers, flag_on, host_user
     ):
         from users.models import User
 
-        guest = User.objects.create_user(
+        applicant = User.objects.create_user(
             phone_number="+16505551234", password="x", first_name="Guest", is_member=False
         )
         community_event = _make_event(
@@ -85,18 +85,71 @@ class TestJoinRequestAttendedEvents:
         for ev in (community_event, club_event):
             EventRSVP.objects.create(
                 event=ev,
-                user=guest,
+                user=applicant,
                 status=RSVPStatus.ATTENDING,
                 attendance=AttendanceStatus.ATTENDED,
             )
         JoinRequest.objects.create(
-            first_name="Sprout", last_name="Seedling", phone_number="+16505551234"
+            first_name="Sprout",
+            last_name="Seedling",
+            phone_number="+16505551234",
+            user=applicant,
         )
 
         response = api_client.get(JOIN_REQUESTS_URL, **vettor_headers)
         row = response.json()[0]
         titles = {e["title"]: e["event_type"] for e in row["attended_events"]}
         assert titles == {"Community Meetup": "community", "Club Night": "club"}
+
+    def test_no_history_without_linked_account(
+        self, api_client, vettor_headers, flag_on, host_user
+    ):
+        """A bare phone match to a guest row must not surface that guest's history."""
+        from users.models import User
+
+        guest = User.objects.create_user(
+            phone_number="+16505551234", password="x", first_name="Guest", is_member=False
+        )
+        event = _make_event(
+            host_user, "Community Meetup", days_ago=5, event_type=EventType.COMMUNITY
+        )
+        EventRSVP.objects.create(
+            event=event,
+            user=guest,
+            status=RSVPStatus.ATTENDING,
+            attendance=AttendanceStatus.ATTENDED,
+        )
+        JoinRequest.objects.create(
+            first_name="Sprout", last_name="Seedling", phone_number="+16505551234"
+        )
+
+        response = api_client.get(JOIN_REQUESTS_URL, **vettor_headers)
+        row = response.json()[0]
+        assert row["attended_events"] == []
+
+    def test_two_guests_same_phone_not_attributed(
+        self, api_client, vettor_headers, flag_on, host_user
+    ):
+        """Guest A's attendance must not appear on unlinked applicant B who shares A's phone."""
+        from users.models import User
+
+        guest_a = User.objects.create_user(
+            phone_number="+16505551234", password="x", first_name="GuestA", is_member=False
+        )
+        event = _make_event(host_user, "Club Night", days_ago=10, event_type=EventType.CLUB)
+        EventRSVP.objects.create(
+            event=event,
+            user=guest_a,
+            status=RSVPStatus.ATTENDING,
+            attendance=AttendanceStatus.ATTENDED,
+        )
+        JoinRequest.objects.create(
+            first_name="Applicant", last_name="Bee", phone_number="+16505551234"
+        )
+
+        response = api_client.get(JOIN_REQUESTS_URL, **vettor_headers)
+        row = response.json()[0]
+        assert row["attended_events"] == []
 
     def test_resolves_via_join_request_user_fk(
         self, api_client, vettor_headers, flag_on, host_user


### PR DESCRIPTION
## Summary

The join-request vetting card was attributing a **different guest's** attendance history to an applicant who has no linked account (Issue 1107).

- **Root cause**: `_join_request_out` in `backend/community/_join_requests.py` resolved a phone-only match (`User.objects.filter(phone_number=jr.phone_number).first()`) and, via `_attended_events_user`, fed that guest's full attended-events history into the applicant's card whenever the request had no linked user. Two different guests sharing a phone number (recycled, shared, or mistyped) meant guest A's history showed up on unlinked applicant B's card, and `.first()` made the match nondeterministic. A vettor would read A's engagement as B's.
- **Fix**: Only attribute per-event attendance history when the join request has an **actually-linked account** (`jr.user`). A bare phone match is no longer trusted to be the same person, so it no longer surfaces attended events. Removed the now-dead `_attended_events_user` helper; the call site passes `jr.user` directly (which is `None` when unlinked).
- **Scope**: This changes only the per-event `attended_events` vetting list. The aggregate counts (`attended_*_count`, `upcoming_*_count`), `rsvp_events`, `previously_archived`, and `user_id` still use the existing phone fallback and are untouched — the API contract (`attended_events: []` when unlinked) is unchanged, so no frontend change is needed.

## Test plan

- [x] `backend/tests/test_join_request_attendance.py` — 7 passed. Reshaped `test_all_event_types_included_via_phone_fallback` into `test_all_event_types_included_when_account_linked` (linked account still surfaces history), and added:
  - `test_no_history_without_linked_account` — a bare phone match to a guest row surfaces no history.
  - `test_two_guests_same_phone_not_attributed` — guest A's attendance does not appear on unlinked applicant B who shares A's phone (the reported failure).
- [x] Sibling join-request suites (`test_join_request_conflicts`, `test_join_request_submission`, `test_join_request_resend`, `test_join_form_admin`, `test_community`) — 76 passed.
- [x] `make agent-typecheck` clean; ruff check + format clean on the changed files.

Closes #1107
