### PR TITLE
fix(attendance): render events-tab rows as links only when host_attendance_report is on (Issue 1106)

### DIFF
--- a/frontend/src/screens/admin/AttendanceReportScreen.test.tsx
+++ b/frontend/src/screens/admin/AttendanceReportScreen.test.tsx
@@ -17,12 +17,21 @@ vi.mock('./MemberAttendanceTab', () => ({
 
 import { useAttendanceReport } from '@/api/attendanceReport';
 import { useFlag } from '@/api/featureFlags';
+import { Feature } from '@/models/featureFlags';
 import { makeRow } from '@/test/fixtures';
 
 import AttendanceReportScreen from './AttendanceReportScreen';
 
 const mockUseReport = vi.mocked(useAttendanceReport);
 const mockUseFlag = vi.mocked(useFlag);
+
+function mockFlags({ analytics = false, report = false } = {}) {
+  mockUseFlag.mockImplementation((key) => {
+    if (key === Feature.AdminAttendanceAnalytics) return analytics;
+    if (key === Feature.HostAttendanceReport) return report;
+    return false;
+  });
+}
 
 function mockResult(overrides: Partial<ReturnType<typeof useAttendanceReport>>) {
   mockUseReport.mockReturnValue({
@@ -46,12 +55,13 @@ function renderScreen() {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockUseFlag.mockReturnValue(false);
+  mockFlags();
 });
 
 describe('AttendanceReportScreen', () => {
   it('renders per-event attended / no-show / going counts', () => {
     mockResult({ data: [makeRow()] });
+    mockFlags({ report: true });
 
     renderScreen();
 
@@ -61,6 +71,25 @@ describe('AttendanceReportScreen', () => {
     expect(row).toHaveTextContent('1 no-show');
     expect(row).toHaveTextContent('6 going');
     expect(row).toHaveAttribute('href', '/events/e1/report');
+  });
+
+  it('links each event row to its check-in report when host_attendance_report is on', () => {
+    mockResult({ data: [makeRow()] });
+    mockFlags({ analytics: true, report: true });
+
+    renderScreen();
+
+    expect(screen.getByRole('link')).toHaveAttribute('href', '/events/e1/report');
+  });
+
+  it('renders event rows as plain text (no link) when host_attendance_report is off', () => {
+    mockResult({ data: [makeRow()] });
+    mockFlags({ analytics: true, report: false });
+
+    renderScreen();
+
+    expect(screen.getByText('potluck')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
   });
 
   it('shows the empty state when nothing is marked', () => {
@@ -89,7 +118,7 @@ describe('AttendanceReportScreen', () => {
 
   it('hides the members tab when the flag is off', () => {
     mockResult({ data: [] });
-    mockUseFlag.mockReturnValue(false);
+    mockFlags({ analytics: false });
 
     renderScreen();
 
@@ -98,7 +127,7 @@ describe('AttendanceReportScreen', () => {
 
   it('switches to the members tab when the flag is on', async () => {
     mockResult({ data: [] });
-    mockUseFlag.mockReturnValue(true);
+    mockFlags({ analytics: true });
     const user = userEvent.setup();
 
     renderScreen();

--- a/frontend/src/screens/admin/AttendanceReportScreen.tsx
+++ b/frontend/src/screens/admin/AttendanceReportScreen.tsx
@@ -80,6 +80,9 @@ function TabButton({
 
 function EventsTab() {
   const { data = [], isPending, isError } = useAttendanceReport();
+  // The per-event report at /events/:id/report is behind its own flag; only
+  // link rows there when it's on, otherwise the row dead-links to /calendar.
+  const reportEnabled = useFlag(Feature.HostAttendanceReport);
 
   if (isPending) return <ContentLoading />;
   if (isError) return <ContentError message="couldn't load attendance — try refreshing" />;
@@ -90,19 +93,16 @@ function EventsTab() {
     <ul className="flex flex-col gap-2">
       {data.map((row) => (
         <li key={row.eventId}>
-          <AttendanceRow row={row} />
+          <AttendanceRow row={row} linkable={reportEnabled} />
         </li>
       ))}
     </ul>
   );
 }
 
-function AttendanceRow({ row }: { row: EventAttendanceRow }) {
-  return (
-    <Link
-      to={`/events/${row.eventId}/report`}
-      className="border-border bg-surface hover:bg-surface-dim flex items-center justify-between gap-3 rounded-lg border p-3 transition-colors"
-    >
+function AttendanceRow({ row, linkable }: { row: EventAttendanceRow; linkable: boolean }) {
+  const content = (
+    <>
       <div className="min-w-0 flex-1">
         <p className="text-foreground truncate text-sm font-medium">{row.title.toLowerCase()}</p>
         <p className="text-foreground-tertiary truncate text-xs">
@@ -116,6 +116,23 @@ function AttendanceRow({ row }: { row: EventAttendanceRow }) {
         <Stat label="no-show" value={row.noShowCount} />
         <Stat label="going (heads)" value={row.goingCount} />
       </div>
+    </>
+  );
+
+  if (!linkable) {
+    return (
+      <div className="border-border bg-surface flex items-center justify-between gap-3 rounded-lg border p-3">
+        {content}
+      </div>
+    );
+  }
+
+  return (
+    <Link
+      to={`/events/${row.eventId}/report`}
+      className="border-border bg-surface hover:bg-surface-dim flex items-center justify-between gap-3 rounded-lg border p-3 transition-colors"
+    >
+      {content}
     </Link>
   );
 }


### PR DESCRIPTION
## what & why

Closes #1106

The admin attendance **events tab** (`/admin/attendance`) is reachable whenever `admin_attendance_analytics` is on. But every events-tab row linked to `/events/:id/report`, a route gated by the **separate** `host_attendance_report` flag. The two flags are independent and can legitimately be `analytics on / report off`.

In that state, an admin clicking any event row was silently bounced to `/calendar` — `RequireFlag` fail-closes with `<Navigate to="/calendar" replace />`. Confusing dead-link.

## fix (Option A)

Only render an events-tab row as a link when `host_attendance_report` is also on. Otherwise render the row as plain, non-clickable text (same layout, minus the hover/link affordance). The per-event report stays strictly behind its own flag.

This matches the existing correct pattern in `EventDetailKebabMenu.tsx`, which already gates its "check-in report" link on `useFlag(Feature.HostAttendanceReport)`. `AttendanceReportScreen` was the only unguarded caller — confirmed no other links to `/report`.

## tests

- Updated `AttendanceReportScreen.test.tsx`: flag mock is now key-aware, and two new cases assert (a) rows link to `/events/:id/report` when `host_attendance_report` is on, (b) rows render as plain text (no link) when it's off.
- The e2e "known bug" probe lives on a separate branch/PR (#1108 `attendance-e2e`, which also owns the `attendance-analytics` seed + fixture). It currently documents the buggy `/calendar` bounce and must flip once this merges: on the `attendance-analytics` scenario (`host_attendance_report` off), assert the row is **not** a link (`a[href*="/report"]` absent) and interacting does **not** navigate to `/calendar`. Not changed here to keep this PR self-contained and avoid tangling with #1108.

## local checks

- `make agent-frontend-typecheck` — pass
- `make agent-frontend-lint` — pass
- `make agent-frontend-test` — 1003 passed, 1 skipped
