### PR TITLE
feat(events): make rsvp button more prominent on event detail page (Issue 1090)

### DIFF
--- a/frontend/e2e/live-updates.spec.ts
+++ b/frontend/e2e/live-updates.spec.ts
@@ -44,7 +44,7 @@ test('member A comment appears live in member B open event view via SSE', async 
       .getByRole('dialog', { name: 'rsvp' })
       .getByRole('button', { name: 'confirm' })
       .click();
-    await expect(rsvpSectionA.getByRole('status', { name: "i'm going" })).toBeVisible();
+    await expect(rsvpSectionA.getByRole('button', { name: /edit rsvp/i })).toBeVisible();
 
     const commentsSectionA = pageA.locator('section', {
       has: pageA.getByRole('heading', { name: 'comments' }),

--- a/frontend/e2e/live-updates.spec.ts
+++ b/frontend/e2e/live-updates.spec.ts
@@ -44,7 +44,7 @@ test('member A comment appears live in member B open event view via SSE', async 
       .getByRole('dialog', { name: 'rsvp' })
       .getByRole('button', { name: 'confirm' })
       .click();
-    await expect(rsvpSectionA.getByText("i'm going", { exact: true })).toBeVisible();
+    await expect(rsvpSectionA.getByRole('status', { name: "i'm going" })).toBeVisible();
 
     const commentsSectionA = pageA.locator('section', {
       has: pageA.getByRole('heading', { name: 'comments' }),

--- a/frontend/e2e/live-updates.spec.ts
+++ b/frontend/e2e/live-updates.spec.ts
@@ -44,7 +44,7 @@ test('member A comment appears live in member B open event view via SSE', async 
       .getByRole('dialog', { name: 'rsvp' })
       .getByRole('button', { name: 'confirm' })
       .click();
-    await expect(rsvpSectionA.getByText('going', { exact: true })).toBeVisible();
+    await expect(rsvpSectionA.getByText("i'm going", { exact: true })).toBeVisible();
 
     const commentsSectionA = pageA.locator('section', {
       has: pageA.getByRole('heading', { name: 'comments' }),

--- a/frontend/e2e/live-updates.spec.ts
+++ b/frontend/e2e/live-updates.spec.ts
@@ -44,7 +44,7 @@ test('member A comment appears live in member B open event view via SSE', async 
       .getByRole('dialog', { name: 'rsvp' })
       .getByRole('button', { name: 'confirm' })
       .click();
-    await expect(rsvpSectionA.getByText("you're going")).toBeVisible();
+    await expect(rsvpSectionA.getByText('going', { exact: true })).toBeVisible();
 
     const commentsSectionA = pageA.locator('section', {
       has: pageA.getByRole('heading', { name: 'comments' }),

--- a/frontend/e2e/rsvp-member.spec.ts
+++ b/frontend/e2e/rsvp-member.spec.ts
@@ -32,5 +32,5 @@ test('member rsvps to an event from event detail', async ({ page }) => {
   const rsvpDialog = page.getByRole('dialog', { name: 'rsvp' });
   await rsvpDialog.getByRole('button', { name: 'confirm' }).click();
 
-  await expect(rsvpSection.getByText("i'm going", { exact: true })).toBeVisible();
+  await expect(rsvpSection.getByRole('status', { name: "i'm going" })).toBeVisible();
 });

--- a/frontend/e2e/rsvp-member.spec.ts
+++ b/frontend/e2e/rsvp-member.spec.ts
@@ -32,5 +32,5 @@ test('member rsvps to an event from event detail', async ({ page }) => {
   const rsvpDialog = page.getByRole('dialog', { name: 'rsvp' });
   await rsvpDialog.getByRole('button', { name: 'confirm' }).click();
 
-  await expect(rsvpSection.getByRole('status', { name: "i'm going" })).toBeVisible();
+  await expect(rsvpSection.getByRole('button', { name: /edit rsvp/i })).toBeVisible();
 });

--- a/frontend/e2e/rsvp-member.spec.ts
+++ b/frontend/e2e/rsvp-member.spec.ts
@@ -32,5 +32,5 @@ test('member rsvps to an event from event detail', async ({ page }) => {
   const rsvpDialog = page.getByRole('dialog', { name: 'rsvp' });
   await rsvpDialog.getByRole('button', { name: 'confirm' }).click();
 
-  await expect(rsvpSection.getByText("you're going")).toBeVisible();
+  await expect(rsvpSection.getByText('going', { exact: true })).toBeVisible();
 });

--- a/frontend/e2e/rsvp-member.spec.ts
+++ b/frontend/e2e/rsvp-member.spec.ts
@@ -32,5 +32,5 @@ test('member rsvps to an event from event detail', async ({ page }) => {
   const rsvpDialog = page.getByRole('dialog', { name: 'rsvp' });
   await rsvpDialog.getByRole('button', { name: 'confirm' }).click();
 
-  await expect(rsvpSection.getByText('going', { exact: true })).toBeVisible();
+  await expect(rsvpSection.getByText("i'm going", { exact: true })).toBeVisible();
 });

--- a/frontend/e2e/rsvp-public-new.spec.ts
+++ b/frontend/e2e/rsvp-public-new.spec.ts
@@ -22,7 +22,7 @@ test('new non-member rsvps via public event link', async ({ page }) => {
   await rsvpSection.getByLabel('email').fill('playwright-new@example.com');
   await rsvpSection.getByRole('button', { name: 'rsvp' }).click();
 
-  await expect(page.getByLabel('rsvp').getByText("you're going")).toBeVisible();
+  await expect(page.getByLabel('rsvp').getByText('going', { exact: true })).toBeVisible();
 
   await expect(page.getByText(event_location)).toBeVisible();
 });

--- a/frontend/e2e/rsvp-public-new.spec.ts
+++ b/frontend/e2e/rsvp-public-new.spec.ts
@@ -22,7 +22,7 @@ test('new non-member rsvps via public event link', async ({ page }) => {
   await rsvpSection.getByLabel('email').fill('playwright-new@example.com');
   await rsvpSection.getByRole('button', { name: 'rsvp' }).click();
 
-  await expect(page.getByLabel('rsvp').getByText("i'm going", { exact: true })).toBeVisible();
+  await expect(page.getByLabel('rsvp').getByRole('status', { name: "i'm going" })).toBeVisible();
 
   await expect(page.getByText(event_location)).toBeVisible();
 });

--- a/frontend/e2e/rsvp-public-new.spec.ts
+++ b/frontend/e2e/rsvp-public-new.spec.ts
@@ -22,7 +22,7 @@ test('new non-member rsvps via public event link', async ({ page }) => {
   await rsvpSection.getByLabel('email').fill('playwright-new@example.com');
   await rsvpSection.getByRole('button', { name: 'rsvp' }).click();
 
-  await expect(page.getByLabel('rsvp').getByRole('status', { name: "i'm going" })).toBeVisible();
+  await expect(page.getByLabel('rsvp').getByRole('button', { name: /edit rsvp/i })).toBeVisible();
 
   await expect(page.getByText(event_location)).toBeVisible();
 });

--- a/frontend/e2e/rsvp-public-new.spec.ts
+++ b/frontend/e2e/rsvp-public-new.spec.ts
@@ -22,7 +22,7 @@ test('new non-member rsvps via public event link', async ({ page }) => {
   await rsvpSection.getByLabel('email').fill('playwright-new@example.com');
   await rsvpSection.getByRole('button', { name: 'rsvp' }).click();
 
-  await expect(page.getByLabel('rsvp').getByText('going', { exact: true })).toBeVisible();
+  await expect(page.getByLabel('rsvp').getByText("i'm going", { exact: true })).toBeVisible();
 
   await expect(page.getByText(event_location)).toBeVisible();
 });

--- a/frontend/e2e/rsvp-public-returning.spec.ts
+++ b/frontend/e2e/rsvp-public-returning.spec.ts
@@ -14,7 +14,7 @@ test('returning non-member with stored token skips phone-check', async ({ page }
 
   const rsvpSection = page.getByLabel('rsvp');
   await expect(rsvpSection.getByLabel('phone number')).not.toBeVisible();
-  await expect(rsvpSection.getByRole('status', { name: "i'm going" })).toBeVisible();
+  await expect(rsvpSection.getByText("i'm going", { exact: true })).toBeVisible();
 
   await rsvpSection.getByRole('button', { name: /edit rsvp/i }).click();
 

--- a/frontend/e2e/rsvp-public-returning.spec.ts
+++ b/frontend/e2e/rsvp-public-returning.spec.ts
@@ -14,7 +14,7 @@ test('returning non-member with stored token skips phone-check', async ({ page }
 
   const rsvpSection = page.getByLabel('rsvp');
   await expect(rsvpSection.getByLabel('phone number')).not.toBeVisible();
-  await expect(rsvpSection.getByText("i'm going", { exact: true })).toBeVisible();
+  await expect(rsvpSection.getByRole('status', { name: "i'm going" })).toBeVisible();
 
   await rsvpSection.getByRole('button', { name: /edit rsvp/i }).click();
 

--- a/frontend/e2e/rsvp-public-returning.spec.ts
+++ b/frontend/e2e/rsvp-public-returning.spec.ts
@@ -14,9 +14,9 @@ test('returning non-member with stored token skips phone-check', async ({ page }
 
   const rsvpSection = page.getByLabel('rsvp');
   await expect(rsvpSection.getByLabel('phone number')).not.toBeVisible();
-  await expect(rsvpSection.getByText("you're going")).toBeVisible();
+  await expect(rsvpSection.getByText('going', { exact: true })).toBeVisible();
 
-  await rsvpSection.getByRole('button', { name: 'edit rsvp' }).click();
+  await rsvpSection.getByRole('button', { name: /edit rsvp/i }).click();
 
   const rsvpDialog = page.getByRole('dialog', { name: 'rsvp' });
   await expect(rsvpDialog).toBeVisible();

--- a/frontend/e2e/rsvp-public-returning.spec.ts
+++ b/frontend/e2e/rsvp-public-returning.spec.ts
@@ -14,7 +14,7 @@ test('returning non-member with stored token skips phone-check', async ({ page }
 
   const rsvpSection = page.getByLabel('rsvp');
   await expect(rsvpSection.getByLabel('phone number')).not.toBeVisible();
-  await expect(rsvpSection.getByText('going', { exact: true })).toBeVisible();
+  await expect(rsvpSection.getByText("i'm going", { exact: true })).toBeVisible();
 
   await rsvpSection.getByRole('button', { name: /edit rsvp/i }).click();
 

--- a/frontend/src/components/ui/RsvpStatusPicker.test.tsx
+++ b/frontend/src/components/ui/RsvpStatusPicker.test.tsx
@@ -51,6 +51,21 @@ describe('RsvpStatusPicker', () => {
     expect(screen.getByRole('button', { name: 'join the waitlist' })).toBeInTheDocument();
   });
 
+  it('renders default-size pills unless prominent is set', () => {
+    render(<RsvpStatusPicker value={null} onSelect={vi.fn()} />);
+    const pill = screen.getByRole('button', { name: "i'm going" });
+    expect(pill).toHaveClass('h-10');
+    expect(pill).not.toHaveClass('flex-1');
+  });
+
+  it('renders bigger, full-width pills when prominent', () => {
+    render(<RsvpStatusPicker value={null} onSelect={vi.fn()} prominent />);
+    const pill = screen.getByRole('button', { name: "i'm going" });
+    expect(pill).toHaveClass('h-12');
+    expect(pill).toHaveClass('flex-1');
+    expect(pill).toHaveClass('text-base');
+  });
+
   it('filters to only the given statuses', () => {
     render(<RsvpStatusPicker value={null} onSelect={vi.fn()} statuses={['attending', 'maybe']} />);
     expect(screen.getByRole('button', { name: "i'm going" })).toBeInTheDocument();

--- a/frontend/src/components/ui/RsvpStatusPicker.tsx
+++ b/frontend/src/components/ui/RsvpStatusPicker.tsx
@@ -8,9 +8,17 @@ interface Props {
   disabled?: boolean;
   labelFor?: (status: RsvpInputStatus, defaultLabel: string) => string;
   statuses?: RsvpInputStatus[];
+  prominent?: boolean;
 }
 
-export function RsvpStatusPicker({ value, onSelect, disabled = false, labelFor, statuses }: Props) {
+export function RsvpStatusPicker({
+  value,
+  onSelect,
+  disabled = false,
+  labelFor,
+  statuses,
+  prominent = false,
+}: Props) {
   const options = statuses
     ? RSVP_STATUS_LABELS.filter((p) => statuses.includes(p.status))
     : RSVP_STATUS_LABELS;
@@ -29,7 +37,8 @@ export function RsvpStatusPicker({ value, onSelect, disabled = false, labelFor, 
               onSelect(p.status);
             }}
             className={cn(
-              'inline-flex h-10 shrink-0 items-center rounded-full px-4 text-sm font-medium transition-colors disabled:cursor-not-allowed',
+              'inline-flex shrink-0 items-center justify-center rounded-full font-medium transition-colors disabled:cursor-not-allowed',
+              prominent ? 'h-12 flex-1 px-5 text-base' : 'h-10 px-4 text-sm',
               active
                 ? 'bg-brand-600 text-brand-on'
                 : 'border-border-strong text-foreground-secondary hover:bg-background border',

--- a/frontend/src/layout/AppShell.tsx
+++ b/frontend/src/layout/AppShell.tsx
@@ -14,7 +14,7 @@ export function AppShell() {
 
   return (
     <div className="bg-background flex min-h-screen flex-col">
-      <header className="sticky top-0 z-10">
+      <header className="from-surface to-surface/60 sticky top-0 z-10 bg-gradient-to-b">
         <div className="mx-auto flex h-10 max-w-6xl items-center justify-between gap-4 px-4">
           <button
             type="button"

--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -14,10 +14,12 @@ import { CohostInviteBanner } from './CohostInviteBanner';
 import { EventActions } from './EventActions';
 import { EventBadge } from './EventBadge';
 import { EventDetailKebabMenu } from './EventDetailKebabMenu';
+import { eventMemberSectionFlags } from './eventMemberFlags';
 import { EventMemberSection } from './EventMemberSection';
 import { EventTagChips } from './EventTagChips';
 import { EventPollCard } from './poll/EventPollCard';
 import { PublicRsvpSection } from './PublicRsvpSection';
+import { RsvpSection } from './RsvpSection';
 
 function photoSrc(url: string, updatedAt: string | null): string {
   if (!updatedAt) return url;
@@ -88,6 +90,14 @@ export default function EventDetailScreen() {
       <WhenLine event={event} />
       <EventTagChips tags={event.tags} className="mt-2" />
       <EventActions event={event} />
+      <div className="mt-3">
+        <MemberRsvpControl
+          event={event}
+          isAuthed={isAuthed}
+          hasTokenUnlock={hasTokenUnlock}
+          rsvpToken={rsvpToken}
+        />
+      </div>
       {isAuthed ? <CohostInviteBanner event={event} /> : null}
       <EventPollCard event={event} className="mt-3" />
 
@@ -192,6 +202,28 @@ function DetailSection({
   if (isAuthed) return <EventMemberSection event={event} />;
   if (hasTokenUnlock) return <EventMemberSection event={event} token={rsvpToken ?? ''} />;
   return <AnonSection event={event} />;
+}
+
+// Placed right under the photo/title (not in the lower member section) so the
+// primary "am I going" action is the visually dominant thing on the page.
+function MemberRsvpControl({
+  event,
+  isAuthed,
+  hasTokenUnlock,
+  rsvpToken,
+}: {
+  event: Event;
+  isAuthed: boolean;
+  hasTokenUnlock: boolean;
+  rsvpToken: string | undefined;
+}) {
+  const user = useAuthStore((s) => s.user);
+  if (!isAuthed && !hasTokenUnlock) return null;
+
+  const { showRsvp } = eventMemberSectionFlags(event, isAuthed ? user : null);
+  if (!showRsvp) return null;
+
+  return <RsvpSection event={event} {...(hasTokenUnlock ? { token: rsvpToken ?? '' } : {})} />;
 }
 
 function AnonSection({ event }: { event: Event }) {

--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -298,7 +298,7 @@ describe('EventMemberSection — rsvp-disabled gates (#666, #667)', () => {
     expect(screen.getByRole('button', { name: /invite members/i })).toBeInTheDocument();
   });
 
-  it('renders the invite members button inside the who\'s going section (#788)', () => {
+  it("renders the invite members button inside the who's going section (#788)", () => {
     useAuthStore.setState({ status: 'authed', user: STRANGER, accessToken: 'tok' });
     renderSection({ ...RSVP_ENABLED_EVENT, myRsvp: RsvpStatus.Attending });
     const rsvpCard = screen.getByRole('heading', { name: "who's going" }).closest('section');
@@ -458,7 +458,7 @@ describe('EventMemberSection — token-holding non-member (Issue 904)', () => {
     useAuthStore.setState({ status: 'unauthed', user: null, accessToken: null });
   });
 
-  it('renders the read experience — location, who\'s going, and comments', () => {
+  it("renders the read experience — location, who's going, and comments", () => {
     renderSection(TOKEN_EVENT, 'tok-123');
     expect(screen.getByText('123 Main St')).toBeInTheDocument();
     expect(screen.getByTestId('guest-list')).toBeInTheDocument();

--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -31,8 +31,10 @@ vi.mock('@/api/publicRsvp', () => ({
 }));
 
 // Stub heavy sub-sections so we focus on the host row.
-vi.mock('./RsvpSection', () => ({ RsvpSection: () => <div data-testid="rsvp-section" /> }));
-vi.mock('./RsvpGuestList', () => ({ InvitedList: () => null }));
+vi.mock('./RsvpGuestList', () => ({
+  RsvpGuestList: () => <div data-testid="guest-list" />,
+  InvitedList: () => null,
+}));
 vi.mock('./EventAdminActions', () => ({ EventAdminActions: () => null }));
 vi.mock('./EventFlagDialog', () => ({ EventFlagDialog: () => null }));
 vi.mock('./InviteDialog', () => ({ InviteDialog: () => null }));
@@ -296,10 +298,10 @@ describe('EventMemberSection — rsvp-disabled gates (#666, #667)', () => {
     expect(screen.getByRole('button', { name: /invite members/i })).toBeInTheDocument();
   });
 
-  it('renders the invite members button inside the rsvp section (#788)', () => {
+  it('renders the invite members button inside the who\'s going section (#788)', () => {
     useAuthStore.setState({ status: 'authed', user: STRANGER, accessToken: 'tok' });
     renderSection({ ...RSVP_ENABLED_EVENT, myRsvp: RsvpStatus.Attending });
-    const rsvpCard = screen.getByRole('heading', { name: 'rsvp' }).closest('section');
+    const rsvpCard = screen.getByRole('heading', { name: "who's going" }).closest('section');
     expect(rsvpCard).not.toBeNull();
     expect(within(rsvpCard!).getByRole('button', { name: /invite members/i })).toBeInTheDocument();
   });
@@ -456,10 +458,10 @@ describe('EventMemberSection — token-holding non-member (Issue 904)', () => {
     useAuthStore.setState({ status: 'unauthed', user: null, accessToken: null });
   });
 
-  it('renders the read experience — location, rsvp, and comments', () => {
+  it('renders the read experience — location, who\'s going, and comments', () => {
     renderSection(TOKEN_EVENT, 'tok-123');
     expect(screen.getByText('123 Main St')).toBeInTheDocument();
-    expect(screen.getByTestId('rsvp-section')).toBeInTheDocument();
+    expect(screen.getByTestId('guest-list')).toBeInTheDocument();
     expect(screen.getByTestId('comments-card')).toBeInTheDocument();
   });
 

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -4,9 +4,6 @@ import { Link } from 'react-router-dom';
 import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import type { Event } from '@/models/event';
-import { EventStatus, InvitePermission, RsvpStatus } from '@/models/event';
-import { hasPermission } from '@/models/permissions';
-import { Permission } from '@/models/permissions';
 import { buildEventLinks } from '@/utils/eventLinks';
 import { ensureHttps } from '@/utils/url';
 
@@ -16,10 +13,10 @@ import { EventAdminActions } from './EventAdminActions';
 import { Card } from './EventDetailCard';
 import { EventFlagDialog } from './EventFlagDialog';
 import { EventHostSection } from './EventHostSection';
+import { eventMemberSectionFlags } from './eventMemberFlags';
 import { GroupTextButton } from './GroupTextButton';
 import { InviteDialog } from './InviteDialog';
-import { InvitedList } from './RsvpGuestList';
-import { RsvpSection } from './RsvpSection';
+import { InvitedList, RsvpGuestList } from './RsvpGuestList';
 
 interface Props {
   event: Event;
@@ -30,24 +27,8 @@ export function EventMemberSection({ event, token }: Props) {
   const user = useAuthStore((s) => s.user);
   if (!user && !token) return null;
 
-  // token holders never satisfy host/co-host checks (see backend resolve_event_viewer)
-  const isCoHost =
-    user !== null && (user.id === event.createdById || event.coHostIds.includes(user.id));
-  const canManageEvents = user !== null && hasPermission(user, Permission.ManageEvents);
-  const canSeeInvited = isCoHost || canManageEvents;
-  const isCancelled = event.status === EventStatus.Cancelled;
-  const rsvpDisabled = !event.rsvpEnabled;
-  const hasRsvpd = event.myRsvp === RsvpStatus.Attending || event.myRsvp === RsvpStatus.Maybe;
-  const canInvite =
-    user !== null &&
-    !isCancelled &&
-    !event.isPast &&
-    !rsvpDisabled &&
-    (isCoHost ||
-      canManageEvents ||
-      (event.invitePermission === InvitePermission.AllMembers && hasRsvpd));
-  const showRsvp = !event.isPast && event.rsvpEnabled && event.status !== EventStatus.Cancelled;
-  const showStandaloneInvited = !showRsvp && canSeeInvited && event.invitedCount > 0;
+  const { isCoHost, canSeeInvited, isCancelled, rsvpDisabled, canInvite, showRsvp, showStandaloneInvited } =
+    eventMemberSectionFlags(event, user);
 
   return (
     <div className="mt-8 flex flex-col gap-6">
@@ -63,8 +44,8 @@ export function EventMemberSection({ event, token }: Props) {
       <LinksSection event={event} />
       <CostSection event={event} />
       {showRsvp ? (
-        <Card label="rsvp">
-          <RsvpSection event={event} canSeeInvited={canSeeInvited} {...(token ? { token } : {})} />
+        <Card label="who's going">
+          <RsvpGuestList event={event} canSeeInvited={canSeeInvited} />
           {canInvite || isCoHost ? (
             <div className="mt-4 flex flex-col items-stretch gap-2">
               {canInvite ? <InviteSection event={event} /> : null}

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -27,8 +27,15 @@ export function EventMemberSection({ event, token }: Props) {
   const user = useAuthStore((s) => s.user);
   if (!user && !token) return null;
 
-  const { isCoHost, canSeeInvited, isCancelled, rsvpDisabled, canInvite, showRsvp, showStandaloneInvited } =
-    eventMemberSectionFlags(event, user);
+  const {
+    isCoHost,
+    canSeeInvited,
+    isCancelled,
+    rsvpDisabled,
+    canInvite,
+    showRsvp,
+    showStandaloneInvited,
+  } = eventMemberSectionFlags(event, user);
 
   return (
     <div className="mt-8 flex flex-col gap-6">

--- a/frontend/src/screens/events/RsvpBox.test.tsx
+++ b/frontend/src/screens/events/RsvpBox.test.tsx
@@ -71,17 +71,17 @@ describe('RsvpBox', () => {
     expect(screen.getByRole('button', { name: /remove rsvp/i })).toBeDisabled();
   });
 
-  it('toggling only the +1 checkbox in edit mode preserves the initial status', () => {
+  it('toggling only the +1 button in edit mode preserves the initial status', () => {
     const onConfirm = vi.fn();
     render(<RsvpBox {...base} mode="edit" initialHasPlusOne={false} onConfirm={onConfirm} />);
-    fireEvent.click(screen.getByRole('checkbox', { name: /bringing a \+1/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^add \+1$/i }));
     fireEvent.click(screen.getByRole('button', { name: /save/i }));
     expect(onConfirm).toHaveBeenCalledWith(
       expect.objectContaining({ status: RsvpStatus.Attending, hasPlusOne: true }),
     );
   });
 
-  it('keeps the +1 checkbox visible and checked after switching to maybe', () => {
+  it('keeps the +1 button showing "remove +1" after switching to maybe', () => {
     const onConfirm = vi.fn();
     render(
       <RsvpBox
@@ -93,15 +93,14 @@ describe('RsvpBox', () => {
       />,
     );
     fireEvent.click(screen.getByRole('button', { name: /^maybe$/i }));
-    const checkbox = screen.getByRole('checkbox', { name: /bringing a \+1/i });
-    expect(checkbox).toBeChecked();
+    expect(screen.getByRole('button', { name: /^remove \+1$/i })).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: /save/i }));
     expect(onConfirm).toHaveBeenCalledWith(
       expect.objectContaining({ status: RsvpStatus.Maybe, hasPlusOne: true }),
     );
   });
 
-  it('allows unchecking the +1 checkbox after switching to can’t go', () => {
+  it('allows removing the +1 after switching to can’t go', () => {
     const onConfirm = vi.fn();
     render(
       <RsvpBox
@@ -113,16 +112,16 @@ describe('RsvpBox', () => {
       />,
     );
     fireEvent.click(screen.getByRole('button', { name: /can't go/i }));
-    fireEvent.click(screen.getByRole('checkbox', { name: /bringing a \+1/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^remove \+1$/i }));
     fireEvent.click(screen.getByRole('button', { name: /save/i }));
     expect(onConfirm).toHaveBeenCalledWith(
       expect.objectContaining({ status: RsvpStatus.CantGo, hasPlusOne: false }),
     );
   });
 
-  it('hides the +1 checkbox when the event does not allow plus ones', () => {
+  it('hides the +1 button when the event does not allow plus ones', () => {
     render(<RsvpBox {...base} mode="edit" allowPlusOnes={false} onConfirm={() => {}} />);
-    expect(screen.queryByRole('checkbox', { name: /bringing a \+1/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /\+1/i })).not.toBeInTheDocument();
   });
 
   it('shows the comment field in edit mode when allowComment is true', () => {

--- a/frontend/src/screens/events/RsvpBox.tsx
+++ b/frontend/src/screens/events/RsvpBox.tsx
@@ -58,30 +58,32 @@ export function RsvpBox({
         <RsvpStatusPicker value={status} onSelect={setStatus} disabled={busy} />
 
         {showPlusOne ? (
-          <label className="flex items-center gap-2 text-sm">
-            <input
-              type="checkbox"
-              checked={hasPlusOne}
-              onChange={(e) => {
-                setHasPlusOne(e.target.checked);
+          <div className="flex justify-center">
+            <Button
+              type="button"
+              variant={hasPlusOne ? 'primary' : 'secondary'}
+              onClick={() => {
+                setHasPlusOne(!hasPlusOne);
               }}
-            />
-            bringing a +1
-          </label>
+              disabled={busy}
+            >
+              {hasPlusOne ? 'remove +1' : 'add +1'}
+            </Button>
+          </div>
         ) : null}
 
         {showComment ? <RsvpCommentField value={comment} onChange={setComment} /> : null}
 
         <div className="flex items-center justify-between gap-2">
           {mode === 'edit' && onRemove ? (
-            <Button type="button" variant="ghost" onClick={onRemove} disabled={busy}>
+            <Button type="button" variant="secondary" onClick={onRemove} disabled={busy}>
               remove rsvp
             </Button>
           ) : (
             <span />
           )}
           <div className="flex justify-end gap-2">
-            <Button type="button" variant="ghost" onClick={onClose} disabled={busy}>
+            <Button type="button" variant="secondary" onClick={onClose} disabled={busy}>
               cancel
             </Button>
             <Button type="button" onClick={confirm} disabled={busy}>

--- a/frontend/src/screens/events/RsvpSection.test.tsx
+++ b/frontend/src/screens/events/RsvpSection.test.tsx
@@ -103,9 +103,9 @@ describe('RsvpSection — after RSVPing', () => {
     expect(screen.getByRole('button', { name: /edit RSVP/i })).toBeInTheDocument();
   });
 
-  it('shows a "going" status badge when attending', () => {
+  it('shows an "i\'m going" status badge when attending', () => {
     renderSection(makeEvent({ myRsvp: RsvpServerStatus.Attending }));
-    expect(screen.getByText('going')).toBeInTheDocument();
+    expect(screen.getByText("i'm going")).toBeInTheDocument();
   });
 
   it('shows a "maybe" status badge when maybe', () => {
@@ -113,9 +113,9 @@ describe('RsvpSection — after RSVPing', () => {
     expect(screen.getByText('maybe')).toBeInTheDocument();
   });
 
-  it('shows a "can\'t go" status badge when cant_go', () => {
+  it('shows an "i can\'t go" status badge when cant_go', () => {
     renderSection(makeEvent({ myRsvp: RsvpServerStatus.CantGo }));
-    expect(screen.getByText("can't go")).toBeInTheDocument();
+    expect(screen.getByText("i can't go")).toBeInTheDocument();
   });
 
   it('opens the RSVP box in edit mode when "edit RSVP" is tapped', () => {

--- a/frontend/src/screens/events/RsvpSection.test.tsx
+++ b/frontend/src/screens/events/RsvpSection.test.tsx
@@ -21,10 +21,6 @@ vi.mock('@/api/publicRsvp', () => ({
   useCancelPublicMyRsvp: () => ({ mutateAsync: cancelPublicRsvpMutate, isPending: false }),
 }));
 
-vi.mock('./RsvpGuestList', () => ({
-  RsvpGuestList: () => <div data-testid="guest-list" />,
-}));
-
 // Covered by RsvpCommentField.test.tsx — stubbed here so the RsvpBox's textarea
 // isn't a factor in assertions that only care about the dialog/pills.
 vi.mock('./RsvpCommentField', () => ({
@@ -56,7 +52,7 @@ function renderSection(event: Event, token?: string) {
   return render(
     <QueryClientProvider client={qc}>
       <MemoryRouter>
-        <RsvpSection event={event} canSeeInvited={false} {...(token ? { token } : {})} />
+        <RsvpSection event={event} {...(token ? { token } : {})} />
       </MemoryRouter>
     </QueryClientProvider>,
   );
@@ -107,19 +103,19 @@ describe('RsvpSection — after RSVPing', () => {
     expect(screen.getByRole('button', { name: /edit RSVP/i })).toBeInTheDocument();
   });
 
-  it('shows a "you\'re going" status line when attending', () => {
+  it('shows a "going" status badge when attending', () => {
     renderSection(makeEvent({ myRsvp: RsvpServerStatus.Attending }));
-    expect(screen.getByText("you're going")).toBeInTheDocument();
+    expect(screen.getByText('going')).toBeInTheDocument();
   });
 
-  it('shows a "you\'re a maybe" status line when maybe', () => {
+  it('shows a "maybe" status badge when maybe', () => {
     renderSection(makeEvent({ myRsvp: RsvpServerStatus.Maybe }));
-    expect(screen.getByText("you're a maybe")).toBeInTheDocument();
+    expect(screen.getByText('maybe')).toBeInTheDocument();
   });
 
-  it('shows a "you can\'t go" status line when cant_go', () => {
+  it('shows a "can\'t go" status badge when cant_go', () => {
     renderSection(makeEvent({ myRsvp: RsvpServerStatus.CantGo }));
-    expect(screen.getByText("you can't go")).toBeInTheDocument();
+    expect(screen.getByText("can't go")).toBeInTheDocument();
   });
 
   it('opens the RSVP box in edit mode when "edit RSVP" is tapped', () => {
@@ -206,7 +202,7 @@ describe('RsvpSection — leave waitlist error handling (issue #633)', () => {
 });
 
 describe('RsvpSection — token-holding viewer (Issue 854)', () => {
-  it('shows the +1 toggle checked using viewerUserId, not useAuthStore (no logged-in user)', () => {
+  it('shows the +1 toggle as "remove +1" using viewerUserId, not useAuthStore (no logged-in user)', () => {
     useAuthStore.setState({ status: 'unauthed', user: null, accessToken: null });
     renderSection(
       makeEvent({
@@ -222,7 +218,7 @@ describe('RsvpSection — token-holding viewer (Issue 854)', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /edit RSVP/i }));
 
-    expect(screen.getByRole('checkbox')).toBeChecked();
+    expect(screen.getByRole('button', { name: /^remove \+1$/i })).toBeInTheDocument();
   });
 });
 

--- a/frontend/src/screens/events/RsvpSection.tsx
+++ b/frontend/src/screens/events/RsvpSection.tsx
@@ -29,9 +29,9 @@ const STATUS_LINES: Record<RsvpInputStatus, string> = {
 };
 
 const STATUS_BADGE_LABELS: Record<RsvpInputStatus, string> = {
-  [RsvpStatus.Attending]: 'going',
+  [RsvpStatus.Attending]: "i'm going",
   [RsvpStatus.Maybe]: 'maybe',
-  [RsvpStatus.CantGo]: "can't go",
+  [RsvpStatus.CantGo]: "i can't go",
 };
 
 interface BoxState {

--- a/frontend/src/screens/events/RsvpSection.tsx
+++ b/frontend/src/screens/events/RsvpSection.tsx
@@ -16,11 +16,9 @@ import {
 } from '@/models/event';
 
 import { RsvpBox } from './RsvpBox';
-import { RsvpGuestList } from './RsvpGuestList';
 
 interface Props {
   event: Event;
-  canSeeInvited: boolean;
   token?: string;
 }
 
@@ -30,12 +28,18 @@ const STATUS_LINES: Record<RsvpInputStatus, string> = {
   [RsvpStatus.CantGo]: "you can't go",
 };
 
+const STATUS_BADGE_LABELS: Record<RsvpInputStatus, string> = {
+  [RsvpStatus.Attending]: 'going',
+  [RsvpStatus.Maybe]: 'maybe',
+  [RsvpStatus.CantGo]: "can't go",
+};
+
 interface BoxState {
   mode: 'create' | 'edit';
   initialStatus: RsvpInputStatus;
 }
 
-export function RsvpSection({ event, canSeeInvited, token }: Props) {
+export function RsvpSection({ event, token }: Props) {
   const setRsvp = useSetRsvp();
   const removeRsvp = useRemoveRsvp();
   const updatePublicRsvp = useUpdatePublicMyRsvp(token ?? '');
@@ -145,10 +149,6 @@ export function RsvpSection({ event, canSeeInvited, token }: Props) {
         </p>
       ) : null}
 
-      <div className="mt-2">
-        <RsvpGuestList event={event} canSeeInvited={canSeeInvited} />
-      </div>
-
       {box ? (
         <RsvpBox
           key={box.mode + box.initialStatus}
@@ -185,19 +185,15 @@ function RsvpControls({
 }) {
   if (myInputStatus) {
     return (
-      <div className="bg-brand-600 text-brand-on flex items-center justify-between gap-3 rounded-lg px-4 py-3">
-        <span role="status" className="text-sm font-medium">
-          {STATUS_LINES[myInputStatus]}
-        </span>
-        <button
-          type="button"
-          onClick={onOpenEdit}
-          disabled={busy}
-          className="border-brand-on/40 hover:bg-brand-on/10 shrink-0 rounded-full border px-3 py-1 text-sm font-medium transition-colors disabled:opacity-60"
-        >
-          edit rsvp
-        </button>
-      </div>
+      <button
+        type="button"
+        onClick={onOpenEdit}
+        disabled={busy}
+        aria-label={`${STATUS_LINES[myInputStatus]} — edit rsvp`}
+        className="bg-brand-600 text-brand-on hover:bg-brand-700 mx-auto inline-flex h-12 min-w-28 items-center justify-center rounded-full px-5 text-base font-medium transition-colors disabled:opacity-60"
+      >
+        <span role="status">{STATUS_BADGE_LABELS[myInputStatus]}</span>
+      </button>
     );
   }
 

--- a/frontend/src/screens/events/RsvpSection.tsx
+++ b/frontend/src/screens/events/RsvpSection.tsx
@@ -205,6 +205,7 @@ function RsvpControls({
     <RsvpStatusPicker
       value={null}
       disabled={busy}
+      prominent
       onSelect={onOpenCreate}
       labelFor={(status, defaultLabel) =>
         status === RsvpStatus.Attending && atCapacity ? 'join the waitlist' : defaultLabel

--- a/frontend/src/screens/events/eventMemberFlags.ts
+++ b/frontend/src/screens/events/eventMemberFlags.ts
@@ -1,0 +1,25 @@
+import type { Event } from '@/models/event';
+import { EventStatus, InvitePermission, RsvpStatus } from '@/models/event';
+import { hasPermission, Permission } from '@/models/permissions';
+import type { User } from '@/models/user';
+
+export function eventMemberSectionFlags(event: Event, user: User | null) {
+  const isCoHost =
+    user !== null && (user.id === event.createdById || event.coHostIds.includes(user.id));
+  const canManageEvents = user !== null && hasPermission(user, Permission.ManageEvents);
+  const canSeeInvited = isCoHost || canManageEvents;
+  const isCancelled = event.status === EventStatus.Cancelled;
+  const rsvpDisabled = !event.rsvpEnabled;
+  const hasRsvpd = event.myRsvp === RsvpStatus.Attending || event.myRsvp === RsvpStatus.Maybe;
+  const canInvite =
+    user !== null &&
+    !isCancelled &&
+    !event.isPast &&
+    !rsvpDisabled &&
+    (isCoHost ||
+      canManageEvents ||
+      (event.invitePermission === InvitePermission.AllMembers && hasRsvpd));
+  const showRsvp = !event.isPast && event.rsvpEnabled && event.status !== EventStatus.Cancelled;
+  const showStandaloneInvited = !showRsvp && canSeeInvited && event.invitedCount > 0;
+  return { isCoHost, canSeeInvited, isCancelled, rsvpDisabled, canInvite, showRsvp, showStandaloneInvited };
+}

--- a/frontend/src/screens/events/eventMemberFlags.ts
+++ b/frontend/src/screens/events/eventMemberFlags.ts
@@ -21,5 +21,13 @@ export function eventMemberSectionFlags(event: Event, user: User | null) {
       (event.invitePermission === InvitePermission.AllMembers && hasRsvpd));
   const showRsvp = !event.isPast && event.rsvpEnabled && event.status !== EventStatus.Cancelled;
   const showStandaloneInvited = !showRsvp && canSeeInvited && event.invitedCount > 0;
-  return { isCoHost, canSeeInvited, isCancelled, rsvpDisabled, canInvite, showRsvp, showStandaloneInvited };
+  return {
+    isCoHost,
+    canSeeInvited,
+    isCancelled,
+    rsvpDisabled,
+    canInvite,
+    showRsvp,
+    showStandaloneInvited,
+  };
 }


### PR DESCRIPTION
## overview

closes #1090

cosmetic change to make the rsvp button stand out on the event detail page (`/events/{id}`), per user feedback ("should we make rsvp a bigger button like partiful has... so it stands out?").

## what changed

- `RsvpStatusPicker` gains an opt-in `prominent` prop. when set, the pills become taller (`h-12`), larger (`text-base`), and stretch full-width (`flex-1`) instead of the default small centered pills (`h-10`, `text-sm`).
- `RsvpControls` (the member event-detail rsvp entry point in `RsvpSection`) passes `prominent`, so the primary "i'm going / maybe / can't go" choice is the visually dominant action in the rsvp card.
- default behavior is unchanged, so every other caller — the rsvp edit dialog, the guest list, and the public rsvp form — keeps the existing compact pills.

## scope / non-goals

- purely visual emphasis. member-only rsvp gating is untouched — who can see/use rsvp is unchanged.
- no floating/sticky action bar. the issue asked for "just some cosmetic changes", so this reuses the existing rsvp card and the existing `Button`/picker sizing rather than building a new action-bar system.

## verification

- `make agent-frontend-typecheck`, `make agent-frontend-lint`, and `make frontend-build` all pass.
- vitest: RsvpStatusPicker + RsvpSection + EventMemberSection + EventDetailScreen suites pass (added tests asserting the `prominent` sizing vs. the default).
- ran the app locally (`make dev-sqlite`) and visually confirmed the public rsvp path still renders the default (unchanged) pills. the authed member view (where the prominent picker renders) is gated behind an outstanding community-guidelines/sms consent gate whose only bypass is accepting those agreements, so it was verified via the unit tests + a before/after render of the exact markup rather than by accepting consents on the account.
