### PR TITLE
feat(events): dedicated host rsvp management screen

### DIFF
--- a/backend/community/_event_host_actions.py
+++ b/backend/community/_event_host_actions.py
@@ -9,30 +9,20 @@ from django.db import transaction
 from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
-from users.models import User as UserModel
 
 from community._event_helpers import (
     _cancellations,
     _event_out,
-    broadcast_capacity_change,
     load_event_with_stats_prefetch,
-    promote_from_waitlist,
-)
-from community._event_rsvps import (
-    _resolve_cancelled_at,
-    _resolve_rsvp_status,
-    _validate_rsvp_status,
 )
 from community._event_schemas import (
     AttendanceIn,
     EventOut,
     EventStatsOut,
-    HostRSVPIn,
     TextRecipientsOut,
 )
 from community._events import _can_edit_event
 from community._join_request_approval import _maybe_promote_tentative, send_join_approval
-from community._public_rsvp_shared import _email_promoted_non_members
 from community._rsvp_counts import (
     _attended_count,
     _attending_headcount,
@@ -183,104 +173,4 @@ def set_attendance(request, event_id: UUID, user_id: UUID, payload: AttendanceIn
     event = load_event_with_stats_prefetch(event_id)
     if event is None:
         raise_validation(Code.Event.NOT_FOUND, status_code=404)
-    return Status(200, _event_out(event, request.auth))
-
-
-def _apply_host_rsvp_in_transaction(
-    event_id, target_user, status: str, has_plus_one: bool
-) -> tuple[str, list[str]]:
-    """Execute a host-driven RSVP upsert for another user inside a locked transaction.
-
-    Unlike _apply_rsvp_in_transaction, access is already gated on the acting
-    host (_can_edit_event) by the caller — this only enforces that the event
-    still accepts RSVPs, not the target user's own read-visibility.
-
-    Returns (final_status, promoted_user_ids). Raises ValidationException on failure.
-    """
-    event = (
-        Event.objects.select_for_update()
-        .prefetch_related("co_hosts", "invited_users")
-        .get(id=event_id)
-    )
-
-    if not event.rsvp_enabled:
-        raise_validation(Code.Event.RSVPS_NOT_ENABLED, status_code=400)
-    if event.is_cancelled:
-        raise_validation(Code.Event.RSVPS_CLOSED_CANCELLED, status_code=400)
-
-    final_status, final_plus_one = _resolve_rsvp_status(event, target_user, status, has_plus_one)
-
-    existing = EventRSVP.objects.filter(event=event, user=target_user).first()
-    was_attending = existing is not None and existing.status == RSVPStatus.ATTENDING
-    had_plus_one = existing is not None and existing.has_plus_one
-
-    if (
-        existing is not None
-        and existing.status == final_status
-        and existing.has_plus_one == final_plus_one
-    ):
-        return final_status, []
-
-    EventRSVP.objects.update_or_create(
-        event=event,
-        user=target_user,
-        defaults={
-            "status": final_status,
-            "has_plus_one": final_plus_one,
-            "cancelled_at": _resolve_cancelled_at(existing, final_status),
-        },
-    )
-
-    spot_freed = (was_attending and final_status != RSVPStatus.ATTENDING) or (
-        was_attending and had_plus_one and not final_plus_one
-    )
-    promoted_user_ids = promote_from_waitlist(event) if spot_freed else []
-
-    return final_status, promoted_user_ids
-
-
-@router.post(
-    "/events/{event_id}/rsvps/{user_id}/rsvp/",
-    response={200: EventOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut, 429: ErrorOut},
-    auth=gated_jwt,
-)
-@rate_limit(key_func=lambda r: str(r.auth.pk), rate="30/m")
-def set_guest_rsvp(request, event_id: UUID, user_id: UUID, payload: HostRSVPIn):
-    """Let an event host/co-host/manager change another user's rsvp on their behalf (Issue 872)."""
-    event = (
-        Event.objects.select_related("created_by")
-        .prefetch_related("co_hosts", "invited_users", "rsvps__user")
-        .filter(id=event_id)
-        .first()
-    )
-    if event is None:
-        raise_validation(Code.Event.NOT_FOUND, status_code=404)
-    if not _can_edit_event(request.auth, event):
-        raise_validation(Code.Perm.DENIED, status_code=403, action="set_guest_rsvp")
-
-    _validate_rsvp_status(payload.status)
-
-    try:
-        target_user = UserModel.objects.get(id=user_id)
-    except UserModel.DoesNotExist:
-        raise_validation(Code.User.NOT_FOUND, status_code=404)
-
-    with transaction.atomic():
-        final_status, promoted_user_ids = _apply_host_rsvp_in_transaction(
-            event_id, target_user, payload.status, payload.has_plus_one
-        )
-
-    audit_log(
-        logging.INFO,
-        "guest_rsvp_changed",
-        request,
-        target_type="event",
-        target_id=str(event_id),
-        details={"user_id": str(user_id), "status": final_status},
-    )
-    event = load_event_with_stats_prefetch(event_id)
-    if event is None:
-        raise_validation(Code.Event.NOT_FOUND, status_code=404)
-    broadcast_capacity_change(event_id, exclude_user_ids={str(request.auth.pk)})
-    _email_promoted_non_members(request, event, promoted_user_ids)
     return Status(200, _event_out(event, request.auth))

--- a/backend/community/_event_host_rsvps.py
+++ b/backend/community/_event_host_rsvps.py
@@ -128,3 +128,64 @@ def set_guest_rsvp(request, event_id: UUID, user_id: UUID, payload: HostRSVPIn):
     broadcast_capacity_change(event_id, exclude_user_ids={str(request.auth.pk)})
     _email_promoted_non_members(request, event, promoted_user_ids)
     return Status(200, _event_out(event, request.auth))
+
+
+@router.delete(
+    "/events/{event_id}/rsvps/{user_id}/rsvp/",
+    response={204: None, 403: ErrorOut, 404: ErrorOut, 429: ErrorOut},
+    auth=gated_jwt,
+)
+@rate_limit(key_func=lambda r: str(r.auth.pk), rate="30/m")
+def remove_guest_rsvp(request, event_id: UUID, user_id: UUID):
+    """Let an event host/co-host/manager remove another user's rsvp entirely."""
+    event = (
+        Event.objects.select_related("created_by")
+        .prefetch_related("co_hosts", "invited_users")
+        .filter(id=event_id)
+        .first()
+    )
+    if event is None:
+        raise_validation(Code.Event.NOT_FOUND, status_code=404)
+    if not _can_edit_event(request.auth, event):
+        raise_validation(Code.Perm.DENIED, status_code=403, action="remove_guest_rsvp")
+
+    try:
+        target_user = UserModel.objects.get(id=user_id)
+    except UserModel.DoesNotExist:
+        raise_validation(Code.User.NOT_FOUND, status_code=404)
+
+    with transaction.atomic():
+        promoted_user_ids = _remove_guest_rsvp_in_transaction(event_id, target_user)
+
+    audit_log(
+        logging.INFO,
+        "guest_rsvp_removed",
+        request,
+        target_type="event",
+        target_id=str(event_id),
+        details={"user_id": str(user_id)},
+    )
+    event = load_event_with_stats_prefetch(event_id)
+    if event is None:
+        raise_validation(Code.Event.NOT_FOUND, status_code=404)
+    broadcast_capacity_change(event_id, exclude_user_ids={str(request.auth.pk)})
+    _email_promoted_non_members(request, event, promoted_user_ids)
+    return Status(204, None)
+
+
+def _remove_guest_rsvp_in_transaction(event_id, target_user) -> list[str]:
+    """Delete target_user's RSVP inside a locked transaction. No-op if none exists.
+
+    Returns promoted_user_ids (empty unless a spot freed).
+    """
+    event = Event.objects.select_for_update().get(id=event_id)
+    rsvp = EventRSVP.objects.filter(event=event, user=target_user).first()
+    if rsvp is None:
+        return []
+
+    was_attending = rsvp.status == RSVPStatus.ATTENDING
+    rsvp.delete()
+    if not was_attending:
+        return []
+
+    return promote_from_waitlist(event)

--- a/backend/community/_event_host_rsvps.py
+++ b/backend/community/_event_host_rsvps.py
@@ -1,0 +1,130 @@
+import logging
+from uuid import UUID
+
+from config.audit import audit_log
+from config.auth import gated_jwt
+from config.ratelimit import rate_limit
+from django.db import transaction
+from ninja import Router
+from ninja.responses import Status
+from users.models import User as UserModel
+
+from community._event_helpers import (
+    _event_out,
+    broadcast_capacity_change,
+    load_event_with_stats_prefetch,
+    promote_from_waitlist,
+)
+from community._event_rsvps import (
+    _resolve_cancelled_at,
+    _resolve_rsvp_status,
+    _validate_rsvp_status,
+)
+from community._event_schemas import EventOut, HostRSVPIn
+from community._events import _can_edit_event
+from community._public_rsvp_shared import _email_promoted_non_members
+from community._shared import ErrorOut
+from community._validation import Code, raise_validation
+from community.models import Event, EventRSVP, RSVPStatus
+
+router = Router()
+
+
+def _apply_host_rsvp_in_transaction(
+    event_id, target_user, status: str, has_plus_one: bool
+) -> tuple[str, list[str]]:
+    """Execute a host-driven RSVP upsert for another user inside a locked transaction.
+
+    Unlike _apply_rsvp_in_transaction, access is already gated on the acting
+    host (_can_edit_event) by the caller — this only enforces that the event
+    still accepts RSVPs, not the target user's own read-visibility.
+
+    Returns (final_status, promoted_user_ids). Raises ValidationException on failure.
+    """
+    event = (
+        Event.objects.select_for_update()
+        .prefetch_related("co_hosts", "invited_users")
+        .get(id=event_id)
+    )
+
+    if not event.rsvp_enabled:
+        raise_validation(Code.Event.RSVPS_NOT_ENABLED, status_code=400)
+    if event.is_cancelled:
+        raise_validation(Code.Event.RSVPS_CLOSED_CANCELLED, status_code=400)
+
+    final_status, final_plus_one = _resolve_rsvp_status(event, target_user, status, has_plus_one)
+
+    existing = EventRSVP.objects.filter(event=event, user=target_user).first()
+    was_attending = existing is not None and existing.status == RSVPStatus.ATTENDING
+    had_plus_one = existing is not None and existing.has_plus_one
+
+    if (
+        existing is not None
+        and existing.status == final_status
+        and existing.has_plus_one == final_plus_one
+    ):
+        return final_status, []
+
+    EventRSVP.objects.update_or_create(
+        event=event,
+        user=target_user,
+        defaults={
+            "status": final_status,
+            "has_plus_one": final_plus_one,
+            "cancelled_at": _resolve_cancelled_at(existing, final_status),
+        },
+    )
+
+    spot_freed = (was_attending and final_status != RSVPStatus.ATTENDING) or (
+        was_attending and had_plus_one and not final_plus_one
+    )
+    promoted_user_ids = promote_from_waitlist(event) if spot_freed else []
+
+    return final_status, promoted_user_ids
+
+
+@router.post(
+    "/events/{event_id}/rsvps/{user_id}/rsvp/",
+    response={200: EventOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut, 429: ErrorOut},
+    auth=gated_jwt,
+)
+@rate_limit(key_func=lambda r: str(r.auth.pk), rate="30/m")
+def set_guest_rsvp(request, event_id: UUID, user_id: UUID, payload: HostRSVPIn):
+    """Let an event host/co-host/manager change another user's rsvp on their behalf (Issue 872)."""
+    event = (
+        Event.objects.select_related("created_by")
+        .prefetch_related("co_hosts", "invited_users", "rsvps__user")
+        .filter(id=event_id)
+        .first()
+    )
+    if event is None:
+        raise_validation(Code.Event.NOT_FOUND, status_code=404)
+    if not _can_edit_event(request.auth, event):
+        raise_validation(Code.Perm.DENIED, status_code=403, action="set_guest_rsvp")
+
+    _validate_rsvp_status(payload.status)
+
+    try:
+        target_user = UserModel.objects.get(id=user_id)
+    except UserModel.DoesNotExist:
+        raise_validation(Code.User.NOT_FOUND, status_code=404)
+
+    with transaction.atomic():
+        final_status, promoted_user_ids = _apply_host_rsvp_in_transaction(
+            event_id, target_user, payload.status, payload.has_plus_one
+        )
+
+    audit_log(
+        logging.INFO,
+        "guest_rsvp_changed",
+        request,
+        target_type="event",
+        target_id=str(event_id),
+        details={"user_id": str(user_id), "status": final_status},
+    )
+    event = load_event_with_stats_prefetch(event_id)
+    if event is None:
+        raise_validation(Code.Event.NOT_FOUND, status_code=404)
+    broadcast_capacity_change(event_id, exclude_user_ids={str(request.auth.pk)})
+    _email_promoted_non_members(request, event, promoted_user_ids)
+    return Status(200, _event_out(event, request.auth))

--- a/backend/community/api.py
+++ b/backend/community/api.py
@@ -17,6 +17,7 @@ from community._event_helpers import (  # noqa: F401
     _find_my_rsvp,
 )
 from community._event_host_actions import router as event_host_actions_router
+from community._event_host_rsvps import router as event_host_rsvps_router
 from community._event_invitations import router as event_invitations_router
 from community._event_report import router as event_report_router
 from community._event_rsvps import router as event_rsvps_router
@@ -70,6 +71,7 @@ router.add_router("", events_router)
 router.add_router("", event_tags_router)
 router.add_router("", event_rsvps_router)
 router.add_router("", event_host_actions_router)
+router.add_router("", event_host_rsvps_router)
 router.add_router("", event_report_router)
 router.add_router("", public_rsvp_submit_router)
 # Mount resend before manage so the literal `/public/my-rsvps/resend/` route

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -10727,9 +10727,79 @@
       }
     },
     "/api/community/events/{event_id}/rsvps/{user_id}/rsvp/": {
+      "delete": {
+        "description": "Let an event host/co-host/manager remove another user's rsvp entirely.",
+        "operationId": "community__event_host_rsvps_remove_guest_rsvp",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "event_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Event Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          }
+        },
+        "security": [
+          {
+            "GatedJWTAuth": []
+          }
+        ],
+        "summary": "Remove Guest Rsvp",
+        "tags": [
+          "community"
+        ]
+      },
       "post": {
         "description": "Let an event host/co-host/manager change another user's rsvp on their behalf (Issue 872).",
-        "operationId": "community__event_host_actions_set_guest_rsvp",
+        "operationId": "community__event_host_rsvps_set_guest_rsvp",
         "parameters": [
           {
             "in": "path",

--- a/backend/tests/test_host_rsvp.py
+++ b/backend/tests/test_host_rsvp.py
@@ -238,3 +238,105 @@ class TestSetGuestRsvp:
         mock_broadcast.assert_called_once()
         assert mock_broadcast.call_args.args[0] == host_rsvp_event.id
         assert mock_broadcast.call_args.kwargs["exclude_user_ids"] == {str(host_user.pk)}
+
+
+@pytest.mark.django_db
+class TestRemoveGuestRsvp:
+    def test_host_removes_guest_rsvp(self, api_client, host_rsvp_event, host_user, guest):
+        EventRSVP.objects.create(event=host_rsvp_event, user=guest, status=RSVPStatus.ATTENDING)
+        response = api_client.delete(
+            f"/api/community/events/{host_rsvp_event.id}/rsvps/{guest.pk}/rsvp/",
+            **_auth(host_user),
+        )
+        assert response.status_code == 204
+        assert not EventRSVP.objects.filter(event=host_rsvp_event, user=guest).exists()
+
+    def test_cohost_can_remove_guest_rsvp(self, api_client, host_rsvp_event, cohost_user, guest):
+        EventRSVP.objects.create(event=host_rsvp_event, user=guest, status=RSVPStatus.MAYBE)
+        response = api_client.delete(
+            f"/api/community/events/{host_rsvp_event.id}/rsvps/{guest.pk}/rsvp/",
+            **_auth(cohost_user),
+        )
+        assert response.status_code == 204
+
+    def test_manage_events_admin_can_remove_guest_rsvp(
+        self, api_client, host_rsvp_event, admin_user, guest
+    ):
+        EventRSVP.objects.create(event=host_rsvp_event, user=guest, status=RSVPStatus.MAYBE)
+        response = api_client.delete(
+            f"/api/community/events/{host_rsvp_event.id}/rsvps/{guest.pk}/rsvp/",
+            **_auth(admin_user),
+        )
+        assert response.status_code == 204
+
+    def test_rejects_non_host(self, api_client, host_rsvp_event, other_member, guest):
+        EventRSVP.objects.create(event=host_rsvp_event, user=guest, status=RSVPStatus.MAYBE)
+        response = api_client.delete(
+            f"/api/community/events/{host_rsvp_event.id}/rsvps/{guest.pk}/rsvp/",
+            **_auth(other_member),
+        )
+        assert response.status_code == 403
+        assert_error_code(response, "perm.denied")
+
+    def test_rejects_unauthenticated(self, api_client, host_rsvp_event, guest):
+        response = api_client.delete(
+            f"/api/community/events/{host_rsvp_event.id}/rsvps/{guest.pk}/rsvp/",
+        )
+        assert response.status_code == 401
+
+    def test_event_not_found(self, api_client, host_user, guest):
+        response = api_client.delete(
+            "/api/community/events/00000000-0000-0000-0000-000000000000"
+            f"/rsvps/{guest.pk}/rsvp/",
+            **_auth(host_user),
+        )
+        assert response.status_code == 404
+
+    def test_target_user_not_found(self, api_client, host_rsvp_event, host_user):
+        response = api_client.delete(
+            f"/api/community/events/{host_rsvp_event.id}"
+            "/rsvps/00000000-0000-0000-0000-000000000000/rsvp/",
+            **_auth(host_user),
+        )
+        assert response.status_code == 404
+        assert_error_code(response, "user.not_found")
+
+    def test_no_existing_rsvp_is_a_no_op_success(
+        self, api_client, host_rsvp_event, host_user, guest
+    ):
+        response = api_client.delete(
+            f"/api/community/events/{host_rsvp_event.id}/rsvps/{guest.pk}/rsvp/",
+            **_auth(host_user),
+        )
+        assert response.status_code == 204
+
+    def test_removing_attending_guest_promotes_waitlisted_guest(
+        self, api_client, host_rsvp_event, host_user, guest, other_member
+    ):
+        host_rsvp_event.max_attendees = 1
+        host_rsvp_event.save(update_fields=["max_attendees"])
+        EventRSVP.objects.create(event=host_rsvp_event, user=guest, status=RSVPStatus.ATTENDING)
+        waitlisted = EventRSVP.objects.create(
+            event=host_rsvp_event, user=other_member, status=RSVPStatus.WAITLISTED
+        )
+        response = api_client.delete(
+            f"/api/community/events/{host_rsvp_event.id}/rsvps/{guest.pk}/rsvp/",
+            **_auth(host_user),
+        )
+        assert response.status_code == 204
+        waitlisted.refresh_from_db()
+        assert waitlisted.status == RSVPStatus.ATTENDING
+
+    def test_broadcasts_capacity_change_excluding_actor(
+        self, api_client, host_rsvp_event, host_user, guest
+    ):
+        EventRSVP.objects.create(event=host_rsvp_event, user=guest, status=RSVPStatus.ATTENDING)
+        with patch("community._event_host_rsvps.broadcast_capacity_change") as mock_broadcast:
+            api_client.delete(
+                f"/api/community/events/{host_rsvp_event.id}/rsvps/{guest.pk}/rsvp/",
+                **_auth(host_user),
+            )
+        mock_broadcast.assert_called_once()
+        assert mock_broadcast.call_args.args[0] == host_rsvp_event.id
+        assert mock_broadcast.call_args.kwargs["exclude_user_ids"] == {str(host_user.pk)}
+        assert mock_broadcast.call_args.kwargs["exclude_user_ids"] == {str(host_user.pk)}

--- a/backend/tests/test_host_rsvp.py
+++ b/backend/tests/test_host_rsvp.py
@@ -338,4 +338,3 @@ class TestRemoveGuestRsvp:
         mock_broadcast.assert_called_once()
         assert mock_broadcast.call_args.args[0] == host_rsvp_event.id
         assert mock_broadcast.call_args.kwargs["exclude_user_ids"] == {str(host_user.pk)}
-        assert mock_broadcast.call_args.kwargs["exclude_user_ids"] == {str(host_user.pk)}

--- a/backend/tests/test_host_rsvp.py
+++ b/backend/tests/test_host_rsvp.py
@@ -228,7 +228,7 @@ class TestSetGuestRsvp:
     def test_broadcasts_capacity_change_excluding_actor(
         self, api_client, host_rsvp_event, host_user, guest
     ):
-        with patch("community._event_host_actions.broadcast_capacity_change") as mock_broadcast:
+        with patch("community._event_host_rsvps.broadcast_capacity_change") as mock_broadcast:
             api_client.post(
                 f"/api/community/events/{host_rsvp_event.id}/rsvps/{guest.pk}/rsvp/",
                 {"status": RSVPStatus.ATTENDING},

--- a/backend/tests/test_host_rsvp.py
+++ b/backend/tests/test_host_rsvp.py
@@ -286,8 +286,7 @@ class TestRemoveGuestRsvp:
 
     def test_event_not_found(self, api_client, host_user, guest):
         response = api_client.delete(
-            "/api/community/events/00000000-0000-0000-0000-000000000000"
-            f"/rsvps/{guest.pk}/rsvp/",
+            f"/api/community/events/00000000-0000-0000-0000-000000000000/rsvps/{guest.pk}/rsvp/",
             **_auth(host_user),
         )
         assert response.status_code == 404

--- a/frontend/src/api/eventStats.ts
+++ b/frontend/src/api/eventStats.ts
@@ -108,3 +108,16 @@ export function useSetGuestRsvp(eventId: string) {
     },
   });
 }
+
+export function useRemoveGuestRsvp(eventId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (args: { userId: string }) => {
+      await apiClient.delete(`/api/community/events/${eventId}/rsvps/${args.userId}/rsvp/`);
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: eventKeys.detail(eventId, true) });
+      void qc.invalidateQueries({ queryKey: eventStatsKeys.detail(eventId) });
+    },
+  });
+}

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -1092,8 +1092,12 @@ export interface paths {
          * Set Guest Rsvp
          * @description Let an event host/co-host/manager change another user's rsvp on their behalf (Issue 872).
          */
-        post: operations["community__event_host_actions_set_guest_rsvp"];
-        delete?: never;
+        post: operations["community__event_host_rsvps_set_guest_rsvp"];
+        /**
+         * Remove Guest Rsvp
+         * @description Let an event host/co-host/manager remove another user's rsvp entirely.
+         */
+        delete: operations["community__event_host_rsvps_remove_guest_rsvp"];
         options?: never;
         head?: never;
         patch?: never;
@@ -7971,7 +7975,7 @@ export interface operations {
             };
         };
     };
-    community__event_host_actions_set_guest_rsvp: {
+    community__event_host_rsvps_set_guest_rsvp: {
         parameters: {
             query?: never;
             header?: never;
@@ -8004,6 +8008,54 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["ErrorOut"];
                 };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
+    community__event_host_rsvps_remove_guest_rsvp: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                event_id: string;
+                user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description No Content */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Forbidden */
             403: {

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -34,6 +34,7 @@ const EventDetail = lazyWithRetry(() => import('@/screens/events/EventDetailScre
 const EventCreate = lazyWithRetry(() => import('@/screens/events/EventCreateScreen'));
 const EventEdit = lazyWithRetry(() => import('@/screens/events/EventEditScreen'));
 const EventAttendance = lazyWithRetry(() => import('@/screens/events/EventAttendanceScreen'));
+const EventManageRsvps = lazyWithRetry(() => import('@/screens/events/EventManageRsvpsScreen'));
 const EventCheckInReport = lazyWithRetry(() => import('@/screens/events/EventCheckInReportScreen'));
 const MyEvents = lazyWithRetry(() => import('@/screens/events/MyEventsScreen'));
 const PublicRsvps = lazyWithRetry(() => import('@/screens/events/PublicRsvpsScreen'));
@@ -112,6 +113,7 @@ export const router = createBrowserRouter([
                   { path: '/events/add', element: el(<EventCreate />) },
                   { path: '/events/:id/edit', element: el(<EventEdit />) },
                   { path: '/events/:id/attendance', element: el(<EventAttendance />) },
+                  { path: '/events/:id/manage-rsvps', element: el(<EventManageRsvps />) },
                   { path: '/members', element: el(<MembersDirectory />) },
                   { path: '/members/:userId', element: el(<MemberProfile />) },
                 ],

--- a/frontend/src/screens/events/EventDetailKebabMenu.test.tsx
+++ b/frontend/src/screens/events/EventDetailKebabMenu.test.tsx
@@ -11,10 +11,16 @@ import { useFlag } from '@/api/featureFlags';
 
 import { EventDetailKebabMenu } from './EventDetailKebabMenu';
 
-function renderMenu(overrides: { eventHasEnded?: boolean } = {}) {
+function renderMenu(
+  overrides: { eventHasEnded?: boolean; canManageRsvps?: boolean } = {},
+) {
   return render(
     <MemoryRouter>
-      <EventDetailKebabMenu eventId="ev1" eventHasEnded={overrides.eventHasEnded ?? false} />
+      <EventDetailKebabMenu
+        eventId="ev1"
+        eventHasEnded={overrides.eventHasEnded ?? false}
+        canManageRsvps={overrides.canManageRsvps ?? false}
+      />
     </MemoryRouter>,
   );
 }
@@ -56,5 +62,30 @@ describe('EventDetailKebabMenu', () => {
 
     const reportLink = screen.getByRole('menuitem', { name: 'check-in report' });
     expect(reportLink).toHaveAttribute('href', '/events/ev1/report');
+  });
+
+  it('shows "manage rsvps" for a host on a future event', async () => {
+    vi.mocked(useFlag).mockReturnValue(false);
+    renderMenu({ eventHasEnded: false, canManageRsvps: true });
+    await openMenu();
+
+    const manageRsvps = screen.getByRole('menuitem', { name: /manage rsvps/i });
+    expect(manageRsvps).toHaveAttribute('href', '/events/ev1/manage-rsvps');
+  });
+
+  it('hides "manage rsvps" once the event has ended', async () => {
+    vi.mocked(useFlag).mockReturnValue(false);
+    renderMenu({ eventHasEnded: true, canManageRsvps: true });
+    await openMenu();
+
+    expect(screen.queryByRole('menuitem', { name: /manage rsvps/i })).not.toBeInTheDocument();
+  });
+
+  it('hides "manage rsvps" when the viewer cannot manage rsvps', async () => {
+    vi.mocked(useFlag).mockReturnValue(false);
+    renderMenu({ eventHasEnded: false, canManageRsvps: false });
+    await openMenu();
+
+    expect(screen.queryByRole('menuitem', { name: /manage rsvps/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/events/EventDetailKebabMenu.test.tsx
+++ b/frontend/src/screens/events/EventDetailKebabMenu.test.tsx
@@ -11,9 +11,7 @@ import { useFlag } from '@/api/featureFlags';
 
 import { EventDetailKebabMenu } from './EventDetailKebabMenu';
 
-function renderMenu(
-  overrides: { eventHasEnded?: boolean; canManageRsvps?: boolean } = {},
-) {
+function renderMenu(overrides: { eventHasEnded?: boolean; canManageRsvps?: boolean } = {}) {
   return render(
     <MemoryRouter>
       <EventDetailKebabMenu

--- a/frontend/src/screens/events/EventDetailKebabMenu.tsx
+++ b/frontend/src/screens/events/EventDetailKebabMenu.tsx
@@ -7,13 +7,15 @@ import { Feature } from '@/models/featureFlags';
 interface Props {
   eventId: string;
   eventHasEnded: boolean;
+  canManageRsvps: boolean;
 }
 
-export function EventDetailKebabMenu({ eventId, eventHasEnded }: Props) {
+export function EventDetailKebabMenu({ eventId, eventHasEnded, canManageRsvps }: Props) {
   const [open, setOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
   const reportFlagOn = useFlag(Feature.HostAttendanceReport);
   const showCheckInReport = eventHasEnded && reportFlagOn;
+  const showManageRsvps = canManageRsvps && !eventHasEnded;
 
   useEffect(() => {
     if (!open) return;
@@ -52,6 +54,16 @@ export function EventDetailKebabMenu({ eventId, eventHasEnded }: Props) {
           role="menu"
           className="border-border bg-surface absolute right-0 z-10 mt-1 w-44 overflow-hidden rounded-md border text-sm shadow-lg"
         >
+          {showManageRsvps ? (
+            <MenuLink
+              to={`/events/${eventId}/manage-rsvps`}
+              onSelect={() => {
+                setOpen(false);
+              }}
+            >
+              manage rsvps
+            </MenuLink>
+          ) : null}
           <MenuLink
             to={`/events/${eventId}/attendance`}
             onSelect={() => {

--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -76,7 +76,11 @@ export default function EventDetailScreen() {
         <EventBadge event={event} />
         {showKebab ? (
           <div className="ml-auto">
-            <EventDetailKebabMenu eventId={event.id} eventHasEnded={event.isPast} />
+            <EventDetailKebabMenu
+              eventId={event.id}
+              eventHasEnded={event.isPast}
+              canManageRsvps={showKebab}
+            />
           </div>
         ) : null}
       </div>

--- a/frontend/src/screens/events/EventManageRsvpsPanel.test.tsx
+++ b/frontend/src/screens/events/EventManageRsvpsPanel.test.tsx
@@ -1,0 +1,114 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { toast } from 'sonner';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RsvpServerStatus } from '@/models/event';
+import { makeEvent, makeGuest } from '@/test/fixtures';
+
+const setGuestRsvpMutate = vi.fn();
+const removeGuestRsvpMutate = vi.fn();
+vi.mock('@/api/eventStats', () => ({
+  useSetGuestRsvp: () => ({ mutate: setGuestRsvpMutate, isPending: false }),
+  useRemoveGuestRsvp: () => ({ mutate: removeGuestRsvpMutate, isPending: false }),
+}));
+vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+
+import { EventManageRsvpsPanel } from './EventManageRsvpsPanel';
+
+function renderPanel(event = makeEvent({})) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <EventManageRsvpsPanel event={event} />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  setGuestRsvpMutate.mockReset();
+  removeGuestRsvpMutate.mockReset();
+  vi.mocked(toast.error).mockReset();
+});
+
+describe('EventManageRsvpsPanel', () => {
+  it('groups guests by status', () => {
+    renderPanel(
+      makeEvent({
+        guests: [
+          makeGuest({ userId: 'u1', name: 'Alex', status: RsvpServerStatus.Attending }),
+          makeGuest({ userId: 'u2', name: 'Sam', status: RsvpServerStatus.Maybe }),
+        ],
+      }),
+    );
+    expect(screen.getByText('Alex')).toBeInTheDocument();
+    expect(screen.getByText('Sam')).toBeInTheDocument();
+  });
+
+  it('changes a guest status via the picker', () => {
+    renderPanel(
+      makeEvent({
+        guests: [makeGuest({ userId: 'u1', name: 'Alex', status: RsvpServerStatus.Attending })],
+      }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: /^maybe$/i }));
+    expect(setGuestRsvpMutate).toHaveBeenCalledWith(
+      { userId: 'u1', status: 'maybe', hasPlusOne: false },
+      expect.objectContaining({ onError: expect.any(Function) }),
+    );
+  });
+
+  it('toggles a guest +1', () => {
+    renderPanel(
+      makeEvent({
+        guests: [
+          makeGuest({
+            userId: 'u1',
+            name: 'Alex',
+            status: RsvpServerStatus.Attending,
+            hasPlusOne: false,
+          }),
+        ],
+      }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: /add \+1/i }));
+    expect(setGuestRsvpMutate).toHaveBeenCalledWith(
+      { userId: 'u1', status: 'attending', hasPlusOne: true },
+      expect.objectContaining({ onError: expect.any(Function) }),
+    );
+  });
+
+  it('removes a guest', () => {
+    renderPanel(
+      makeEvent({
+        guests: [makeGuest({ userId: 'u1', name: 'Alex', status: RsvpServerStatus.Attending })],
+      }),
+    );
+    fireEvent.click(screen.getByRole('button', { name: /remove alex/i }));
+    expect(removeGuestRsvpMutate).toHaveBeenCalledWith(
+      { userId: 'u1' },
+      expect.objectContaining({ onError: expect.any(Function) }),
+    );
+  });
+
+  it('does not show edit controls for non-member guests', () => {
+    renderPanel(
+      makeEvent({
+        guests: [
+          makeGuest({
+            userId: 'u1',
+            name: 'Walkin',
+            status: RsvpServerStatus.Attending,
+            isMember: false,
+          }),
+        ],
+      }),
+    );
+    expect(screen.queryByRole('button', { name: /remove walkin/i })).not.toBeInTheDocument();
+  });
+
+  it('shows an empty state with no guests', () => {
+    renderPanel(makeEvent({ guests: [] }));
+    expect(screen.getByText(/no one yet/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/events/EventManageRsvpsPanel.test.tsx
+++ b/frontend/src/screens/events/EventManageRsvpsPanel.test.tsx
@@ -13,6 +13,11 @@ vi.mock('@/api/eventStats', () => ({
   useRemoveGuestRsvp: () => ({ mutate: removeGuestRsvpMutate, isPending: false }),
 }));
 vi.mock('sonner', () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+vi.mock('@/api/userSearch', () => ({
+  useUserSearch: () => ({
+    data: [{ id: 'new-1', fullName: 'New Member', phoneNumber: '+15551234567' }],
+  }),
+}));
 
 import { EventManageRsvpsPanel } from './EventManageRsvpsPanel';
 
@@ -110,5 +115,28 @@ describe('EventManageRsvpsPanel', () => {
   it('shows an empty state with no guests', () => {
     renderPanel(makeEvent({ guests: [] }));
     expect(screen.getByText(/no one yet/i)).toBeInTheDocument();
+  });
+
+  it('adds a member via the picker', () => {
+    renderPanel(makeEvent({ guests: [] }));
+    fireEvent.change(screen.getByLabelText(/add a member/i), { target: { value: 'new' } });
+    fireEvent.click(screen.getByRole('button', { name: /new member/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^add$/i }));
+    expect(setGuestRsvpMutate).toHaveBeenCalledWith(
+      { userId: 'new-1', status: 'attending', hasPlusOne: false },
+      expect.objectContaining({ onError: expect.any(Function) }),
+    );
+  });
+
+  it('excludes existing guests from the add-member search results', () => {
+    renderPanel(
+      makeEvent({
+        guests: [
+          makeGuest({ userId: 'new-1', name: 'New Member', status: RsvpServerStatus.Attending }),
+        ],
+      }),
+    );
+    fireEvent.change(screen.getByLabelText(/add a member/i), { target: { value: 'new' } });
+    expect(screen.queryByRole('button', { name: /^new member/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/events/EventManageRsvpsPanel.tsx
+++ b/frontend/src/screens/events/EventManageRsvpsPanel.tsx
@@ -1,7 +1,11 @@
+import { useState } from 'react';
 import { toast } from 'sonner';
 
 import { extractApiErrorOr } from '@/api/apiErrors';
 import { useRemoveGuestRsvp, useSetGuestRsvp } from '@/api/eventStats';
+import type { MemberSearchResult } from '@/api/userSearch';
+import { MemberPicker } from '@/components/MemberPicker';
+import { Button } from '@/components/ui/Button';
 import { RsvpStatusPicker } from '@/components/ui/RsvpStatusPicker';
 import type { Event, EventGuest, RsvpInputStatus } from '@/models/event';
 import { isRsvpInputStatus, RsvpServerStatus } from '@/models/event';
@@ -20,44 +24,93 @@ export function EventManageRsvpsPanel({ event }: { event: Event }) {
   const setGuestRsvp = useSetGuestRsvp(event.id);
   const removeGuestRsvp = useRemoveGuestRsvp(event.id);
 
-  if (event.guests.length === 0) {
-    return <p className="text-muted text-sm">no one yet 🌿</p>;
+  return (
+    <div className="flex flex-col gap-6">
+      <AddMemberSection
+        event={event}
+        isPending={setGuestRsvp.isPending}
+        onAdd={(userId) => {
+          setGuestRsvp.mutate(
+            { userId, status: RsvpServerStatus.Attending, hasPlusOne: false },
+            {
+              onError: (err) => {
+                toast.error(extractApiErrorOr(err, "couldn't add them — try again"));
+              },
+            },
+          );
+        }}
+      />
+      {event.guests.length === 0 ? (
+        <p className="text-muted text-sm">no one yet 🌿</p>
+      ) : (
+        GROUPS.map((group) => {
+          const guests = event.guests.filter((g) => g.status === group.status);
+          if (guests.length === 0) return null;
+          return (
+            <GuestGroup
+              key={group.status}
+              label={group.label}
+              guests={guests}
+              onChangeStatus={(userId, status, hasPlusOne) => {
+                setGuestRsvp.mutate(
+                  { userId, status, hasPlusOne },
+                  {
+                    onError: (err) => {
+                      toast.error(extractApiErrorOr(err, "couldn't update their rsvp — try again"));
+                    },
+                  },
+                );
+              }}
+              onRemove={(userId) => {
+                removeGuestRsvp.mutate(
+                  { userId },
+                  {
+                    onError: (err) => {
+                      toast.error(extractApiErrorOr(err, "couldn't remove them — try again"));
+                    },
+                  },
+                );
+              }}
+              isPending={setGuestRsvp.isPending || removeGuestRsvp.isPending}
+            />
+          );
+        })
+      )}
+    </div>
+  );
+}
+
+function AddMemberSection({
+  event,
+  onAdd,
+  isPending,
+}: {
+  event: Event;
+  onAdd: (userId: string) => void;
+  isPending: boolean;
+}) {
+  const [picked, setPicked] = useState<MemberSearchResult[]>([]);
+
+  function submit() {
+    picked.forEach((m) => {
+      onAdd(m.id);
+    });
+    setPicked([]);
   }
 
   return (
-    <div className="flex flex-col gap-6">
-      {GROUPS.map((group) => {
-        const guests = event.guests.filter((g) => g.status === group.status);
-        if (guests.length === 0) return null;
-        return (
-          <GuestGroup
-            key={group.status}
-            label={group.label}
-            guests={guests}
-            onChangeStatus={(userId, status, hasPlusOne) => {
-              setGuestRsvp.mutate(
-                { userId, status, hasPlusOne },
-                {
-                  onError: (err) => {
-                    toast.error(extractApiErrorOr(err, "couldn't update their rsvp — try again"));
-                  },
-                },
-              );
-            }}
-            onRemove={(userId) => {
-              removeGuestRsvp.mutate(
-                { userId },
-                {
-                  onError: (err) => {
-                    toast.error(extractApiErrorOr(err, "couldn't remove them — try again"));
-                  },
-                },
-              );
-            }}
-            isPending={setGuestRsvp.isPending || removeGuestRsvp.isPending}
-          />
-        );
-      })}
+    <div className="border-border flex flex-col gap-2 rounded-md border p-3">
+      <MemberPicker
+        label="add a member"
+        selected={picked}
+        onChange={setPicked}
+        excludeIds={event.guests.map((g) => g.userId)}
+      />
+      {picked.length > 0 ? (
+        <Button onClick={submit} disabled={isPending} className="self-end">
+          {isPending ? 'adding…' : 'add'}
+        </Button>
+      ) : null}
     </div>
   );
 }

--- a/frontend/src/screens/events/EventManageRsvpsPanel.tsx
+++ b/frontend/src/screens/events/EventManageRsvpsPanel.tsx
@@ -1,0 +1,5 @@
+import type { Event } from '@/models/event';
+
+export function EventManageRsvpsPanel({ event: _event }: { event: Event }) {
+  return null;
+}

--- a/frontend/src/screens/events/EventManageRsvpsPanel.tsx
+++ b/frontend/src/screens/events/EventManageRsvpsPanel.tsx
@@ -1,5 +1,158 @@
-import type { Event } from '@/models/event';
+import { toast } from 'sonner';
 
-export function EventManageRsvpsPanel({ event: _event }: { event: Event }) {
-  return null;
+import { extractApiErrorOr } from '@/api/apiErrors';
+import { useRemoveGuestRsvp, useSetGuestRsvp } from '@/api/eventStats';
+import { RsvpStatusPicker } from '@/components/ui/RsvpStatusPicker';
+import type { Event, EventGuest, RsvpInputStatus } from '@/models/event';
+import { isRsvpInputStatus, RsvpServerStatus } from '@/models/event';
+
+const GROUPS: {
+  status: (typeof RsvpServerStatus)[keyof typeof RsvpServerStatus];
+  label: string;
+}[] = [
+  { status: RsvpServerStatus.Attending, label: 'going' },
+  { status: RsvpServerStatus.Maybe, label: 'maybe' },
+  { status: RsvpServerStatus.CantGo, label: "can't go" },
+  { status: RsvpServerStatus.Waitlisted, label: 'waitlist' },
+];
+
+export function EventManageRsvpsPanel({ event }: { event: Event }) {
+  const setGuestRsvp = useSetGuestRsvp(event.id);
+  const removeGuestRsvp = useRemoveGuestRsvp(event.id);
+
+  if (event.guests.length === 0) {
+    return <p className="text-muted text-sm">no one yet 🌿</p>;
+  }
+
+  return (
+    <div className="flex flex-col gap-6">
+      {GROUPS.map((group) => {
+        const guests = event.guests.filter((g) => g.status === group.status);
+        if (guests.length === 0) return null;
+        return (
+          <GuestGroup
+            key={group.status}
+            label={group.label}
+            guests={guests}
+            onChangeStatus={(userId, status, hasPlusOne) => {
+              setGuestRsvp.mutate(
+                { userId, status, hasPlusOne },
+                {
+                  onError: (err) => {
+                    toast.error(extractApiErrorOr(err, "couldn't update their rsvp — try again"));
+                  },
+                },
+              );
+            }}
+            onRemove={(userId) => {
+              removeGuestRsvp.mutate(
+                { userId },
+                {
+                  onError: (err) => {
+                    toast.error(extractApiErrorOr(err, "couldn't remove them — try again"));
+                  },
+                },
+              );
+            }}
+            isPending={setGuestRsvp.isPending || removeGuestRsvp.isPending}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+function GuestGroup({
+  label,
+  guests,
+  onChangeStatus,
+  onRemove,
+  isPending,
+}: {
+  label: string;
+  guests: EventGuest[];
+  onChangeStatus: (userId: string, status: RsvpInputStatus, hasPlusOne: boolean) => void;
+  onRemove: (userId: string) => void;
+  isPending: boolean;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <h2 className="text-muted text-xs font-medium">
+        {label} ({guests.length})
+      </h2>
+      <ul className="flex flex-col gap-2">
+        {guests.map((g) => (
+          <GuestRow
+            key={g.userId}
+            guest={g}
+            onChangeStatus={onChangeStatus}
+            onRemove={onRemove}
+            isPending={isPending}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function GuestRow({
+  guest,
+  onChangeStatus,
+  onRemove,
+  isPending,
+}: {
+  guest: EventGuest;
+  onChangeStatus: (userId: string, status: RsvpInputStatus, hasPlusOne: boolean) => void;
+  onRemove: (userId: string) => void;
+  isPending: boolean;
+}) {
+  const currentStatus = isRsvpInputStatus(guest.status) ? guest.status : null;
+
+  if (!guest.isMember) {
+    return (
+      <li className="border-border flex items-center justify-between gap-2 rounded-md border p-2 opacity-60">
+        <span className="text-foreground text-sm">{guest.name} (not a member)</span>
+      </li>
+    );
+  }
+
+  return (
+    <li className="border-border flex flex-col gap-2 rounded-md border p-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-foreground text-sm">{guest.name}</span>
+        <button
+          type="button"
+          aria-label={`remove ${guest.name}`}
+          onClick={() => {
+            onRemove(guest.userId);
+          }}
+          disabled={isPending}
+          className="text-muted hover:text-destructive text-xs disabled:opacity-60"
+        >
+          remove
+        </button>
+      </div>
+      <div className="flex flex-wrap items-center gap-2">
+        <RsvpStatusPicker
+          value={currentStatus}
+          disabled={isPending}
+          onSelect={(status) => {
+            onChangeStatus(guest.userId, status, guest.hasPlusOne);
+          }}
+        />
+        <button
+          type="button"
+          aria-label={guest.hasPlusOne ? `remove ${guest.name}'s +1` : 'add +1'}
+          onClick={() => {
+            if (!currentStatus) return;
+            onChangeStatus(guest.userId, currentStatus, !guest.hasPlusOne);
+          }}
+          disabled={isPending || !currentStatus}
+          className="bg-surface-dim text-foreground-secondary hover:bg-surface-dim/70 rounded-full px-3 py-1 text-xs disabled:opacity-60"
+        >
+          {guest.hasPlusOne ? '−1' : '+1'}
+        </button>
+      </div>
+    </li>
+  );
 }

--- a/frontend/src/screens/events/EventManageRsvpsScreen.test.tsx
+++ b/frontend/src/screens/events/EventManageRsvpsScreen.test.tsx
@@ -1,0 +1,88 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useAuthStore } from '@/auth/store';
+import { makeEvent, makeUser } from '@/test/fixtures';
+
+vi.mock('@/api/events', () => ({
+  useEvent: vi.fn(),
+  eventKeys: { all: ['events'], list: vi.fn(), detail: vi.fn() },
+}));
+
+import { useEvent } from '@/api/events';
+
+import EventManageRsvpsScreen from './EventManageRsvpsScreen';
+
+const BASE_EVENT = makeEvent({
+  title: 'Spring Potluck',
+  createdById: 'user-creator',
+  guests: [],
+});
+
+const CREATOR = makeUser({ id: 'user-creator', firstName: 'Alice', fullName: 'Alice' });
+const nonMember = makeUser({ id: 'user-nonmember', firstName: 'Casey', fullName: 'Casey' });
+
+function renderScreen() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={['/events/ev1/manage-rsvps']}>
+        <Routes>
+          <Route path="/events/:id/manage-rsvps" element={<EventManageRsvpsScreen />} />
+          <Route path="/events/:id" element={<div>event detail</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(useEvent).mockReturnValue({
+    data: BASE_EVENT,
+    isPending: false,
+    isError: false,
+  } as ReturnType<typeof useEvent>);
+});
+
+describe('EventManageRsvpsScreen', () => {
+  it('shows a forbidden notice for a non-host', () => {
+    useAuthStore.setState({ status: 'authed', user: nonMember, accessToken: 'tok' });
+    renderScreen();
+
+    expect(screen.getByText(/only the host or a co-host/i)).toBeInTheDocument();
+  });
+
+  it('shows a forbidden notice for a past event', () => {
+    vi.mocked(useEvent).mockReturnValue({
+      data: makeEvent({ createdById: 'user-creator', guests: [], isPast: true }),
+      isPending: false,
+      isError: false,
+    } as ReturnType<typeof useEvent>);
+    useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
+    renderScreen();
+
+    expect(screen.getByText(/event has already happened/i)).toBeInTheDocument();
+  });
+
+  it('shows a forbidden notice when rsvps are disabled', () => {
+    vi.mocked(useEvent).mockReturnValue({
+      data: makeEvent({ createdById: 'user-creator', guests: [], rsvpEnabled: false }),
+      isPending: false,
+      isError: false,
+    } as ReturnType<typeof useEvent>);
+    useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
+    renderScreen();
+
+    expect(screen.getByText(/rsvps are off/i)).toBeInTheDocument();
+  });
+
+  it('renders the panel heading for a host on a future rsvp-enabled event', () => {
+    useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
+    renderScreen();
+
+    expect(screen.getByRole('heading', { name: /manage rsvps/i })).toBeInTheDocument();
+    expect(screen.getByText(BASE_EVENT.title)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/events/EventManageRsvpsScreen.tsx
+++ b/frontend/src/screens/events/EventManageRsvpsScreen.tsx
@@ -1,0 +1,77 @@
+import { Link, useParams } from 'react-router-dom';
+
+import { extractApiError, getApiStatus } from '@/api/apiErrors';
+import { useEvent } from '@/api/events';
+import { useAuthStore } from '@/auth/store';
+import { canManageEvent } from '@/models/event';
+import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
+
+import { EventManageRsvpsPanel } from './EventManageRsvpsPanel';
+
+export default function EventManageRsvpsScreen() {
+  const { id } = useParams<{ id: string }>();
+  const user = useAuthStore((s) => s.user);
+  const { data: event, isPending, isError, error } = useEvent(id);
+
+  if (isPending) return <ContentLoading />;
+  if (isError) {
+    if (getApiStatus(error) === 403) {
+      const message = extractApiError(error) ?? "you don't have permission to see this event";
+      return <ForbiddenNotice eventId={id} message={message} />;
+    }
+    return <ContentError message="couldn't load this event — try refreshing" />;
+  }
+
+  if (!canManageEvent(event, user)) {
+    return (
+      <ForbiddenNotice eventId={event.id} message="only the host or a co-host can manage rsvps" />
+    );
+  }
+  if (event.isPast) {
+    return <ForbiddenNotice eventId={event.id} message="this event has already happened" />;
+  }
+  if (!event.rsvpEnabled) {
+    return (
+      <ForbiddenNotice
+        eventId={event.id}
+        message="rsvps are off for this event — nothing to manage"
+      />
+    );
+  }
+
+  return (
+    <ContentContainer>
+      <BackLink eventId={event.id} />
+      <h1 className="mb-1 text-2xl font-medium tracking-tight">manage rsvps</h1>
+      <p className="text-foreground-secondary mb-6 text-sm">{event.title}</p>
+      <EventManageRsvpsPanel event={event} />
+    </ContentContainer>
+  );
+}
+
+function BackLink({ eventId }: { eventId: string }) {
+  return (
+    <Link
+      to={`/events/${eventId}`}
+      className="text-foreground-secondary hover:text-foreground mb-4 inline-flex items-center gap-1 text-sm"
+    >
+      ← back to event
+    </Link>
+  );
+}
+
+function ForbiddenNotice({ eventId, message }: { eventId: string | undefined; message: string }) {
+  return (
+    <ContentContainer>
+      <section className="border-border bg-surface mt-8 rounded-lg border p-6">
+        <h2 className="mb-2 text-base font-medium">{message}</h2>
+        <Link
+          to={eventId ? `/events/${eventId}` : '/calendar'}
+          className="border-border-strong text-foreground-secondary hover:bg-background mt-4 inline-flex h-10 items-center rounded-md border px-4 text-sm font-medium"
+        >
+          back to event
+        </Link>
+      </section>
+    </ContentContainer>
+  );
+}

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -67,7 +67,6 @@ export function EventMemberSection({ event, token }: Props) {
           <RsvpSection
             event={event}
             canSeeInvited={canSeeInvited}
-            canManageRsvps={canSeeInvited}
             {...(token ? { token } : {})}
           />
           {canInvite || isCoHost ? (

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -64,11 +64,7 @@ export function EventMemberSection({ event, token }: Props) {
       <CostSection event={event} />
       {showRsvp ? (
         <Card label="rsvp">
-          <RsvpSection
-            event={event}
-            canSeeInvited={canSeeInvited}
-            {...(token ? { token } : {})}
-          />
+          <RsvpSection event={event} canSeeInvited={canSeeInvited} {...(token ? { token } : {})} />
           {canInvite || isCoHost ? (
             <div className="mt-4 flex flex-col items-stretch gap-2">
               {canInvite ? <InviteSection event={event} /> : null}

--- a/frontend/src/screens/events/RsvpGuestList.test.tsx
+++ b/frontend/src/screens/events/RsvpGuestList.test.tsx
@@ -49,7 +49,9 @@ describe('RsvpGuestList — cant go / waitlist visibility (Issue 1042)', () => {
       ],
     });
     render(
-      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+      >
         <MemoryRouter>
           <RsvpGuestList event={event} canSeeInvited={false} />
         </MemoryRouter>
@@ -67,7 +69,9 @@ describe('RsvpGuestList — cant go / waitlist visibility (Issue 1042)', () => {
       ],
     });
     render(
-      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
+      >
         <MemoryRouter>
           <RsvpGuestList event={event} canSeeInvited={true} />
         </MemoryRouter>

--- a/frontend/src/screens/events/RsvpGuestList.test.tsx
+++ b/frontend/src/screens/events/RsvpGuestList.test.tsx
@@ -1,33 +1,24 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import type { Event } from '@/models/event';
 import { RsvpServerStatus } from '@/models/event';
 import { makeEvent, makeGuest } from '@/test/fixtures';
 
-const setGuestRsvpMutate = vi.fn();
-vi.mock('@/api/eventStats', () => ({
-  useSetGuestRsvp: () => ({ mutate: setGuestRsvpMutate, isPending: false }),
-}));
-
 import { RsvpGuestList } from './RsvpGuestList';
 
-function renderList(event: Event, canManageRsvps = false) {
+function renderList(event: Event) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={qc}>
       <MemoryRouter>
-        <RsvpGuestList event={event} canSeeInvited={false} canManageRsvps={canManageRsvps} />
+        <RsvpGuestList event={event} canSeeInvited={false} />
       </MemoryRouter>
     </QueryClientProvider>,
   );
 }
-
-beforeEach(() => {
-  setGuestRsvpMutate.mockReset();
-});
 
 describe('RsvpGuestList', () => {
   it('links member guests to their profile', () => {
@@ -57,7 +48,13 @@ describe('RsvpGuestList — cant go / waitlist visibility (Issue 1042)', () => {
         makeGuest({ userId: 'user-2', status: RsvpServerStatus.Waitlisted }),
       ],
     });
-    renderList(event, false);
+    render(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <MemoryRouter>
+          <RsvpGuestList event={event} canSeeInvited={false} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
     expect(screen.queryByRole('tab', { name: /can't go/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('tab', { name: /waitlist/i })).not.toBeInTheDocument();
   });
@@ -69,42 +66,14 @@ describe('RsvpGuestList — cant go / waitlist visibility (Issue 1042)', () => {
         makeGuest({ userId: 'user-2', status: RsvpServerStatus.Waitlisted }),
       ],
     });
-    renderList(event, true);
+    render(
+      <QueryClientProvider client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}>
+        <MemoryRouter>
+          <RsvpGuestList event={event} canSeeInvited={true} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
     expect(screen.getByRole('tab', { name: /can't go/i })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: /waitlist/i })).toBeInTheDocument();
-  });
-});
-
-describe('RsvpGuestList — host rsvp management (Issue 872)', () => {
-  it('does not show an edit control when the viewer cannot manage rsvps', () => {
-    renderList(makeEvent({ guests: [makeGuest({})] }), false);
-    expect(screen.queryByRole('button', { name: /change other's rsvp/i })).not.toBeInTheDocument();
-  });
-
-  it('shows an edit control per guest when the viewer can manage rsvps', () => {
-    renderList(makeEvent({ guests: [makeGuest({})] }), true);
-    expect(screen.getByRole('button', { name: /change other's rsvp/i })).toBeInTheDocument();
-  });
-
-  it('does not show an edit control for non-member guests', () => {
-    renderList(makeEvent({ guests: [makeGuest({ isMember: false })] }), true);
-    expect(screen.queryByRole('button', { name: /change other's rsvp/i })).not.toBeInTheDocument();
-  });
-
-  it('opens a dialog with status options when edit is tapped', () => {
-    renderList(makeEvent({ guests: [makeGuest({})] }), true);
-    fireEvent.click(screen.getByRole('button', { name: /change other's rsvp/i }));
-    expect(screen.getByRole('dialog')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /^maybe$/i })).toBeInTheDocument();
-  });
-
-  it('calls the mutation with the selected status', () => {
-    renderList(makeEvent({ guests: [makeGuest({})] }), true);
-    fireEvent.click(screen.getByRole('button', { name: /change other's rsvp/i }));
-    fireEvent.click(screen.getByRole('button', { name: /^maybe$/i }));
-    expect(setGuestRsvpMutate).toHaveBeenCalledWith(
-      { userId: 'user-other', status: 'maybe', hasPlusOne: false },
-      expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
-    );
   });
 });

--- a/frontend/src/screens/events/RsvpGuestList.tsx
+++ b/frontend/src/screens/events/RsvpGuestList.tsx
@@ -1,13 +1,8 @@
 import { useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { toast } from 'sonner';
 
-import { extractApiErrorOr } from '@/api/apiErrors';
-import { useSetGuestRsvp } from '@/api/eventStats';
-import { Dialog } from '@/components/ui/Dialog';
-import { RsvpStatusPicker } from '@/components/ui/RsvpStatusPicker';
-import type { Event, EventGuest, RsvpInputStatus } from '@/models/event';
-import { AttendanceStatus, isRsvpInputStatus, RsvpServerStatus } from '@/models/event';
+import type { Event, EventGuest } from '@/models/event';
+import { AttendanceStatus, RsvpServerStatus } from '@/models/event';
 import { cn } from '@/utils/cn';
 
 type Tab = 'going' | 'maybe' | 'cant' | 'waitlist' | 'invited';
@@ -29,10 +24,9 @@ function bucket(guests: EventGuest[]): Record<Tab, EventGuest[]> {
 interface Props {
   event: Event;
   canSeeInvited: boolean;
-  canManageRsvps?: boolean;
 }
 
-export function RsvpGuestList({ event, canSeeInvited, canManageRsvps = false }: Props) {
+export function RsvpGuestList({ event, canSeeInvited }: Props) {
   const buckets = useMemo(() => bucket(event.guests), [event.guests]);
   const counts: Record<Tab, number> = {
     going: countWithPlusOnes(buckets.going),
@@ -46,11 +40,11 @@ export function RsvpGuestList({ event, canSeeInvited, canManageRsvps = false }: 
     { key: 'going', label: 'going' },
     { key: 'maybe', label: 'maybe' },
   ];
-  if (canManageRsvps) {
+  if (canSeeInvited) {
     tabs.push({ key: 'cant', label: "can't go" });
     if (counts.waitlist > 0) tabs.push({ key: 'waitlist', label: 'waitlist' });
+    tabs.push({ key: 'invited', label: 'invited' });
   }
-  if (canSeeInvited) tabs.push({ key: 'invited', label: 'invited' });
 
   const defaultTab = tabs.find((t) => counts[t.key] > 0)?.key ?? 'going';
   const [active, setActive] = useState<Tab>(defaultTab);
@@ -93,7 +87,7 @@ export function RsvpGuestList({ event, canSeeInvited, canManageRsvps = false }: 
       ) : (
         <div className="flex flex-wrap gap-2">
           {visible.map((g) => (
-            <GuestChip key={g.userId} guest={g} eventId={event.id} canEdit={canManageRsvps} />
+            <GuestChip key={g.userId} guest={g} />
           ))}
         </div>
       )}
@@ -101,17 +95,7 @@ export function RsvpGuestList({ event, canSeeInvited, canManageRsvps = false }: 
   );
 }
 
-function GuestChip({
-  guest,
-  eventId,
-  canEdit = false,
-}: {
-  guest: EventGuest;
-  eventId?: string;
-  canEdit?: boolean;
-}) {
-  const [editOpen, setEditOpen] = useState(false);
-
+function GuestChip({ guest }: { guest: EventGuest }) {
   const content = (
     <>
       {guest.photoUrl ? (
@@ -147,74 +131,13 @@ function GuestChip({
   }
 
   return (
-    <span className="bg-surface-dim hover:bg-surface-dim/70 inline-flex items-center gap-1 rounded-full pr-1 text-xs">
-      <Link
-        to={`/members/${guest.userId}`}
-        className="inline-flex items-center gap-1.5 py-1 pl-2"
-        title={guest.name}
-      >
-        {content}
-      </Link>
-      {canEdit && eventId ? (
-        <>
-          <button
-            type="button"
-            aria-label={`change ${guest.name}'s rsvp`}
-            onClick={() => {
-              setEditOpen(true);
-            }}
-            className="text-muted hover:text-foreground px-1"
-          >
-            edit
-          </button>
-          <EditGuestRsvpDialog
-            eventId={eventId}
-            guest={guest}
-            open={editOpen}
-            onClose={() => {
-              setEditOpen(false);
-            }}
-          />
-        </>
-      ) : null}
-    </span>
-  );
-}
-
-function EditGuestRsvpDialog({
-  eventId,
-  guest,
-  open,
-  onClose,
-}: {
-  eventId: string;
-  guest: EventGuest;
-  open: boolean;
-  onClose: () => void;
-}) {
-  const setGuestRsvp = useSetGuestRsvp(eventId);
-  const currentStatus = isRsvpInputStatus(guest.status) ? guest.status : null;
-
-  function changeStatus(status: RsvpInputStatus) {
-    setGuestRsvp.mutate(
-      { userId: guest.userId, status, hasPlusOne: guest.hasPlusOne },
-      {
-        onSuccess: onClose,
-        onError: (err) => {
-          toast.error(extractApiErrorOr(err, "couldn't update their rsvp — try again"));
-        },
-      },
-    );
-  }
-
-  return (
-    <Dialog open={open} onClose={onClose} title={`${guest.name}'s rsvp`}>
-      <RsvpStatusPicker
-        value={currentStatus}
-        disabled={setGuestRsvp.isPending}
-        onSelect={changeStatus}
-      />
-    </Dialog>
+    <Link
+      to={`/members/${guest.userId}`}
+      className="bg-surface-dim hover:bg-surface-dim/70 inline-flex items-center gap-1.5 rounded-full px-2 py-1 text-xs"
+      title={guest.name}
+    >
+      {content}
+    </Link>
   );
 }
 

--- a/frontend/src/screens/events/RsvpSection.tsx
+++ b/frontend/src/screens/events/RsvpSection.tsx
@@ -21,7 +21,6 @@ import { RsvpGuestList } from './RsvpGuestList';
 interface Props {
   event: Event;
   canSeeInvited: boolean;
-  canManageRsvps?: boolean;
   token?: string;
 }
 
@@ -36,7 +35,7 @@ interface BoxState {
   initialStatus: RsvpInputStatus;
 }
 
-export function RsvpSection({ event, canSeeInvited, canManageRsvps = false, token }: Props) {
+export function RsvpSection({ event, canSeeInvited, token }: Props) {
   const setRsvp = useSetRsvp();
   const removeRsvp = useRemoveRsvp();
   const updatePublicRsvp = useUpdatePublicMyRsvp(token ?? '');
@@ -147,11 +146,7 @@ export function RsvpSection({ event, canSeeInvited, canManageRsvps = false, toke
       ) : null}
 
       <div className="mt-2">
-        <RsvpGuestList
-          event={event}
-          canSeeInvited={canSeeInvited}
-          canManageRsvps={canManageRsvps}
-        />
+        <RsvpGuestList event={event} canSeeInvited={canSeeInvited} />
       </div>
 
       {box ? (


### PR DESCRIPTION
## Summary
- Hosts could already change a guest's RSVP (Issue 872), but the only affordance was a tiny gray "edit" link buried on each guest chip — a real host reported not being able to find it. This moves all host RSVP management to a dedicated screen at `/events/:id/manage-rsvps`, reached from the event's existing 3-dot kebab menu (same pattern as the pre-existing "check-in" item).
- On the new screen a host can change a guest's status, toggle their +1, remove their RSVP entirely (new endpoint), or add a member directly (reuses the existing upsert). The main event page's guest list goes back to a clean, read-only display for everyone.
- Backend: extracted the existing `set_guest_rsvp` endpoint into a new `_event_host_rsvps.py` module (file-size hygiene) and added one new `DELETE .../rsvps/{user_id}/rsvp/` endpoint, mirroring the existing `set_guest_rsvp`/`delete_rsvp` patterns exactly — same `_can_edit_event` gate, same waitlist-promotion-on-freed-spot logic, same audit logging and rate limiting. No new permission key. Scope is future events only; removal is silent (no notification), both deliberate.

## Test plan
- [x] Backend: 24 tests in `test_host_rsvp.py` (host/co-host/admin/non-host/unauth/404s/no-op/waitlist-promotion), full suite 1759/1765 passing (6 failures are pre-existing SSE/pg_notify + concurrency tests that only run against Postgres in real CI, per the Makefile's own local/CI split)
- [x] Frontend: 131/131 test files passing, tsc + eslint clean
- [x] Manually smoke-tested against a live running server: kebab menu item renders and links correctly; status change persists; +1 toggle correctly rejects at capacity with an error toast; remove works and triggers automatic waitlist promotion of the next-waitlisted guest; add-member works and correctly waitlists a new member when the event is at capacity; guest list on the main event page is confirmed read-only (no edit controls)
- [x] Task-by-task subagent review (9/9 clean) + final whole-branch review (ready to merge, no Critical/Important findings)