### PR TITLE
feat(feedback): add improvement checkbox to feedback form

### DIFF
--- a/backend/community/_feedback.py
+++ b/backend/community/_feedback.py
@@ -156,6 +156,7 @@ def _build_issue_body(payload: FeedbackIn, auth_user) -> str:
 _FEEDBACK_TYPE_LABELS: dict[FeedbackType, str] = {
     FeedbackType.BUG: "bug",
     FeedbackType.FEATURE_REQUEST: "feature",
+    FeedbackType.IMPROVEMENT: "enhancement",
 }
 
 

--- a/backend/community/models/choices.py
+++ b/backend/community/models/choices.py
@@ -99,6 +99,7 @@ class FeedbackType(models.TextChoices):
 
     BUG = "bug", "Bug"
     FEATURE_REQUEST = "feature request", "Feature request"
+    IMPROVEMENT = "improvement", "Improvement"
 
 
 class FeatureFlag(models.TextChoices):

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -2795,7 +2795,8 @@
         "description": "Categories a user can tag feedback with. Not DB-backed \u2014 these are the\naccepted values on the feedback API payload, mapped to GitHub issue labels\nin ``community._feedback``.",
         "enum": [
           "bug",
-          "feature request"
+          "feature request",
+          "improvement"
         ],
         "title": "FeedbackType",
         "type": "string"

--- a/frontend/src/api/feedback.ts
+++ b/frontend/src/api/feedback.ts
@@ -2,7 +2,7 @@ import { useMutation } from '@tanstack/react-query';
 
 import { apiClient } from './client';
 
-export type FeedbackType = 'bug' | 'feature request';
+export type FeedbackType = 'bug' | 'feature request' | 'improvement';
 
 export interface SubmitFeedbackPayload {
   title: string;

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -3204,7 +3204,7 @@ export interface components {
          *     in ``community._feedback``.
          * @enum {string}
          */
-        FeedbackType: "bug" | "feature request";
+        FeedbackType: "bug" | "feature request" | "improvement";
         /** FinalizePollIn */
         FinalizePollIn: {
             /**

--- a/frontend/src/components/FeedbackButton.tsx
+++ b/frontend/src/components/FeedbackButton.tsx
@@ -25,6 +25,7 @@ export function FeedbackButton() {
   const [description, setDescription] = useState('');
   const [isBug, setIsBug] = useState(false);
   const [isFeature, setIsFeature] = useState(false);
+  const [isImprovement, setIsImprovement] = useState(false);
   const [titleError, setTitleError] = useState<string | undefined>(undefined);
   const [descriptionError, setDescriptionError] = useState<string | undefined>(undefined);
 
@@ -47,6 +48,7 @@ export function FeedbackButton() {
     setDescription('');
     setIsBug(false);
     setIsFeature(false);
+    setIsImprovement(false);
     setTitleError(undefined);
     setDescriptionError(undefined);
   }
@@ -73,6 +75,7 @@ export function FeedbackButton() {
     const feedbackTypes: FeedbackType[] = [];
     if (isBug) feedbackTypes.push('bug');
     if (isFeature) feedbackTypes.push('feature request');
+    if (isImprovement) feedbackTypes.push('improvement');
 
     try {
       const result = await mutateAsync({
@@ -186,6 +189,17 @@ export function FeedbackButton() {
                     className="accent-brand-600 h-4 w-4 cursor-pointer rounded"
                   />
                   feature request
+                </label>
+                <label className="text-foreground flex cursor-pointer items-center gap-2 text-sm">
+                  <input
+                    type="checkbox"
+                    checked={isImprovement}
+                    onChange={(e) => {
+                      setIsImprovement(e.target.checked);
+                    }}
+                    className="accent-brand-600 h-4 w-4 cursor-pointer rounded"
+                  />
+                  improvement
                 </label>
               </div>
               <div className="flex justify-end gap-2 pt-2">


### PR DESCRIPTION
## Summary
- Adds a third feedback category checkbox, "improvement", alongside the existing bug/feature request checkboxes
- Maps to the repo's existing `enhancement` GitHub label (no new label needed)

## Test plan
- [x] `make agent-frontend-typecheck` / `agent-frontend-lint` pass
- [x] `make agent-typecheck` passes
- [x] `FeedbackButton.test.tsx` / `.a11y.test.tsx` pass
- [x] backend feedback tests pass (`pytest -k feedback`)
- [ ] manual check: open the feedback dialog, check "improvement", submit, confirm the created GitHub issue has the `enhancement` label