### PR TITLE
feat: add email blast and group text to event kebab menu

### DIFF
--- a/frontend/src/screens/events/EventDetailKebabMenu.test.tsx
+++ b/frontend/src/screens/events/EventDetailKebabMenu.test.tsx
@@ -6,16 +6,33 @@ import { describe, expect, it, vi } from 'vitest';
 vi.mock('@/api/featureFlags', () => ({
   useFlag: vi.fn(),
 }));
+vi.mock('./EmailBlastDialog', () => ({
+  EmailBlastDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="email-blast-dialog" /> : null,
+}));
+vi.mock('./GroupTextDialog', () => ({
+  GroupTextDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="group-text-dialog" /> : null,
+}));
 
 import { useFlag } from '@/api/featureFlags';
+import type { Event } from '@/models/event';
+import { EventStatus } from '@/models/event';
+import { makeEvent } from '@/test/fixtures';
 
 import { EventDetailKebabMenu } from './EventDetailKebabMenu';
 
-function renderMenu(overrides: { eventHasEnded?: boolean; canManageRsvps?: boolean } = {}) {
+function renderMenu(
+  overrides: {
+    eventHasEnded?: boolean;
+    canManageRsvps?: boolean;
+    event?: Partial<Event>;
+  } = {},
+) {
   return render(
     <MemoryRouter>
       <EventDetailKebabMenu
-        eventId="ev1"
+        event={makeEvent(overrides.event)}
         eventHasEnded={overrides.eventHasEnded ?? false}
         canManageRsvps={overrides.canManageRsvps ?? false}
       />
@@ -85,5 +102,31 @@ describe('EventDetailKebabMenu', () => {
     await openMenu();
 
     expect(screen.queryByRole('menuitem', { name: /manage rsvps/i })).not.toBeInTheDocument();
+  });
+
+  it('shows email blast and group text for a published event with guests', async () => {
+    vi.mocked(useFlag).mockReturnValue(false);
+    renderMenu();
+    await openMenu();
+
+    expect(screen.getByRole('menuitem', { name: 'email blast' })).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'group text' })).toBeInTheDocument();
+  });
+
+  it('hides email blast for a draft event but keeps group text', async () => {
+    vi.mocked(useFlag).mockReturnValue(false);
+    renderMenu({ event: { status: EventStatus.Draft } });
+    await openMenu();
+
+    expect(screen.queryByRole('menuitem', { name: 'email blast' })).not.toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: 'group text' })).toBeInTheDocument();
+  });
+
+  it('hides email blast when there are no guests', async () => {
+    vi.mocked(useFlag).mockReturnValue(false);
+    renderMenu({ event: { guests: [] } });
+    await openMenu();
+
+    expect(screen.queryByRole('menuitem', { name: 'email blast' })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/events/EventDetailKebabMenu.tsx
+++ b/frontend/src/screens/events/EventDetailKebabMenu.tsx
@@ -2,20 +2,29 @@ import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { useFlag } from '@/api/featureFlags';
+import type { Event } from '@/models/event';
+import { EventStatus } from '@/models/event';
 import { Feature } from '@/models/featureFlags';
 
+import { EmailBlastDialog } from './EmailBlastDialog';
+import { GroupTextDialog } from './GroupTextDialog';
+
 interface Props {
-  eventId: string;
+  event: Event;
   eventHasEnded: boolean;
   canManageRsvps: boolean;
 }
 
-export function EventDetailKebabMenu({ eventId, eventHasEnded, canManageRsvps }: Props) {
+export function EventDetailKebabMenu({ event, eventHasEnded, canManageRsvps }: Props) {
+  const eventId = event.id;
   const [open, setOpen] = useState(false);
+  const [emailBlastOpen, setEmailBlastOpen] = useState(false);
+  const [groupTextOpen, setGroupTextOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
   const reportFlagOn = useFlag(Feature.HostAttendanceReport);
   const showCheckInReport = eventHasEnded && reportFlagOn;
   const showManageRsvps = canManageRsvps && !eventHasEnded;
+  const showEmailBlast = event.status !== EventStatus.Draft && event.guests.length > 0;
 
   useEffect(() => {
     if (!open) return;
@@ -82,8 +91,40 @@ export function EventDetailKebabMenu({ eventId, eventHasEnded, canManageRsvps }:
               check-in report
             </MenuLink>
           ) : null}
+          {showEmailBlast ? (
+            <MenuButton
+              onSelect={() => {
+                setOpen(false);
+                setEmailBlastOpen(true);
+              }}
+            >
+              email blast
+            </MenuButton>
+          ) : null}
+          <MenuButton
+            onSelect={() => {
+              setOpen(false);
+              setGroupTextOpen(true);
+            }}
+          >
+            group text
+          </MenuButton>
         </div>
       ) : null}
+      <EmailBlastDialog
+        event={event}
+        open={emailBlastOpen}
+        onClose={() => {
+          setEmailBlastOpen(false);
+        }}
+      />
+      <GroupTextDialog
+        eventId={eventId}
+        open={groupTextOpen}
+        onClose={() => {
+          setGroupTextOpen(false);
+        }}
+      />
     </div>
   );
 }
@@ -106,6 +147,19 @@ function MenuLink({
     >
       {children}
     </Link>
+  );
+}
+
+function MenuButton({ onSelect, children }: { onSelect: () => void; children: string }) {
+  return (
+    <button
+      type="button"
+      role="menuitem"
+      onClick={onSelect}
+      className="text-foreground hover:bg-surface-dim block w-full px-3 py-2 text-left"
+    >
+      {children}
+    </button>
   );
 }
 

--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -77,7 +77,7 @@ export default function EventDetailScreen() {
         {showKebab ? (
           <div className="ml-auto">
             <EventDetailKebabMenu
-              eventId={event.id}
+              event={event}
               eventHasEnded={event.isPast}
               canManageRsvps={showKebab}
             />


### PR DESCRIPTION
## Overview

Adds "email blast" and "group text" entries to the event detail kebab menu, alongside the existing check-in / check-in report items. These reuse the existing `EmailBlastDialog` and `GroupTextDialog` components (previously only reachable via standalone buttons in the RSVP section), gated the same way: email blast requires a non-draft event with at least one guest; group text is available to anyone who can already see the kebab menu (co-hosts and event managers).

## Test plan

- [x] `EventDetailKebabMenu.test.tsx` — new coverage for showing/hiding email blast and group text menu items
- [x] `EventDetailScreen.test.tsx` — passes with updated `event` prop
- [x] `make agent-frontend-lint` — clean
- [x] `make agent-frontend-typecheck` — clean
- [ ] Manual check in browser
