### PR TITLE
feat: 1121 - add EVENT_PAYMENT_CONFIRMATION feature flag + flag-off baseline

### DIFF
--- a/backend/community/models/choices.py
+++ b/backend/community/models/choices.py
@@ -107,9 +107,11 @@ class FeatureFlag(models.TextChoices):
 
     HOST_ATTENDANCE_REPORT = "host_attendance_report", "Host attendance report"
     ADMIN_ATTENDANCE_ANALYTICS = "admin_attendance_analytics", "Admin attendance analytics"
+    EVENT_PAYMENT_CONFIRMATION = "event_payment_confirmation", "Event payment confirmation"
 
 
 FLAG_DEFAULTS: dict[str, bool] = {
     FeatureFlag.HOST_ATTENDANCE_REPORT: False,
     FeatureFlag.ADMIN_ATTENDANCE_ANALYTICS: False,
+    FeatureFlag.EVENT_PAYMENT_CONFIRMATION: False,
 }

--- a/backend/tests/test_payment_confirmation_flag_off.py
+++ b/backend/tests/test_payment_confirmation_flag_off.py
@@ -1,9 +1,3 @@
-"""Baseline: with EVENT_PAYMENT_CONFIRMATION off, RSVP on a paid event behaves
-exactly as it does today — no confirmation required, no gate. Guards against
-regressions while the gate (Issue 1045) is built behind the flag. Must pass on
-main before any gate code exists, and keep passing after.
-"""
-
 import pytest
 from community.models import (
     Event,
@@ -45,8 +39,6 @@ class TestFlagRegistered:
 
 @pytest.mark.django_db
 class TestMemberPathFlagOff:
-    """Signed-in member RSVPing 'attending' to a paid event: no gate either way."""
-
     def test_default_off_attending_paid_succeeds_without_confirmation(
         self, api_client, auth_headers, paid_event, test_user
     ):
@@ -78,8 +70,6 @@ class TestMemberPathFlagOff:
 
 @pytest.mark.django_db
 class TestPublicPathFlagOff:
-    """Brand-new person RSVPing 'attending' to a paid event: no gate either way."""
-
     def _paid_official_event(self):
         return make_official_event(price="$10", venmo_link="https://venmo.com/host")
 

--- a/backend/tests/test_payment_confirmation_flag_off.py
+++ b/backend/tests/test_payment_confirmation_flag_off.py
@@ -1,0 +1,106 @@
+"""Baseline: with EVENT_PAYMENT_CONFIRMATION off, RSVP on a paid event behaves
+exactly as it does today — no confirmation required, no gate. Guards against
+regressions while the gate (Issue 1045) is built behind the flag. Must pass on
+main before any gate code exists, and keep passing after.
+"""
+
+import pytest
+from community.models import (
+    Event,
+    EventRSVP,
+    FeatureFlag,
+    FeatureFlagState,
+    RSVPStatus,
+    resolve_flags,
+)
+
+from tests._public_rsvp_helpers import make_official_event, post, url
+from tests.conftest import future_iso
+
+FLAG = FeatureFlag.EVENT_PAYMENT_CONFIRMATION
+
+
+def disable_flag():
+    FeatureFlagState.objects.update_or_create(key=FLAG, defaults={"enabled": False})
+
+
+@pytest.fixture
+def paid_event(db, test_user):
+    return Event.objects.create(
+        title="Paid Event",
+        start_datetime=future_iso(days=30),
+        end_datetime=future_iso(days=30, hours=2),
+        rsvp_enabled=True,
+        created_by=test_user,
+        price="$10",
+        venmo_link="https://venmo.com/host",
+    )
+
+
+@pytest.mark.django_db
+class TestFlagRegistered:
+    def test_flag_defaults_off(self):
+        assert resolve_flags()[FLAG] is False
+
+
+@pytest.mark.django_db
+class TestMemberPathFlagOff:
+    """Signed-in member RSVPing 'attending' to a paid event: no gate either way."""
+
+    def test_default_off_attending_paid_succeeds_without_confirmation(
+        self, api_client, auth_headers, paid_event, test_user
+    ):
+        response = api_client.post(
+            f"/api/community/events/{paid_event.id}/rsvp/",
+            {"status": RSVPStatus.ATTENDING},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+        assert response.json()["my_rsvp"] == RSVPStatus.ATTENDING
+        assert EventRSVP.objects.filter(
+            event=paid_event, user=test_user, status=RSVPStatus.ATTENDING
+        ).exists()
+
+    def test_explicitly_off_attending_paid_succeeds_without_confirmation(
+        self, api_client, auth_headers, paid_event, test_user
+    ):
+        disable_flag()
+        response = api_client.post(
+            f"/api/community/events/{paid_event.id}/rsvp/",
+            {"status": RSVPStatus.ATTENDING},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+        assert response.json()["my_rsvp"] == RSVPStatus.ATTENDING
+
+
+@pytest.mark.django_db
+class TestPublicPathFlagOff:
+    """Brand-new person RSVPing 'attending' to a paid event: no gate either way."""
+
+    def _paid_official_event(self):
+        return make_official_event(price="$10", venmo_link="https://venmo.com/host")
+
+    def test_default_off_new_person_attending_paid_succeeds(self, api_client, fake_email_sender):
+        event = self._paid_official_event()
+        response = post(api_client, event, status=RSVPStatus.ATTENDING)
+        assert response.status_code == 200
+
+    def test_explicitly_off_new_person_attending_paid_succeeds(self, api_client, fake_email_sender):
+        disable_flag()
+        event = self._paid_official_event()
+        response = api_client.post(
+            url(event),
+            {
+                "first_name": "Sam",
+                "last_name": "Green",
+                "email": "sam@example.com",
+                "phone_number": "+14155550123",
+                "status": RSVPStatus.ATTENDING,
+                "has_plus_one": False,
+            },
+            content_type="application/json",
+        )
+        assert response.status_code == 200

--- a/frontend/src/models/featureFlags.ts
+++ b/frontend/src/models/featureFlags.ts
@@ -1,6 +1,7 @@
 export const Feature = {
   HostAttendanceReport: 'host_attendance_report',
   AdminAttendanceAnalytics: 'admin_attendance_analytics',
+  EventPaymentConfirmation: 'event_payment_confirmation',
 } as const;
 
 export type FeatureFlagKey = (typeof Feature)[keyof typeof Feature];

--- a/frontend/src/screens/admin/FeatureFlagsScreen.tsx
+++ b/frontend/src/screens/admin/FeatureFlagsScreen.tsx
@@ -7,6 +7,7 @@ import { ContentContainer, ContentError, ContentLoading } from '@/screens/public
 const FLAG_LABELS: Record<FeatureFlagKey, string> = {
   [Feature.HostAttendanceReport]: 'host attendance report',
   [Feature.AdminAttendanceAnalytics]: 'admin attendance analytics',
+  [Feature.EventPaymentConfirmation]: 'event payment confirmation',
 };
 
 export default function FeatureFlagsScreen() {


### PR DESCRIPTION
## Overview

Registers the `EVENT_PAYMENT_CONFIRMATION` feature flag (default **off**) that
will gate the RSVP payment-confirmation feature (Issue 1045), synced across the
backend `FeatureFlag` enum + `FLAG_DEFAULTS`, the frontend `Feature` mirror, and
the admin `FeatureFlagsScreen` labels. The existing parity test enforces the
backend↔frontend sync.

Adds a flag-off baseline suite proving that with the flag both defaulted-off and
explicitly-toggled-off, RSVPing `attending` to a paid event (member and
new-person paths) succeeds with no confirmation required — a regression net the
gate work builds against.

First two children of the epic (#1120). Flag off ⇒ behavior identical to today.

Closes #1121
Closes #1122

## Test plan

- [x] backend: 5 baseline tests + existing flag suite pass (isolated sqlite)
- [x] frontend: flag parity + hook + admin screen tests pass; tsc clean
- [x] flag verified end-to-end via Django shell (default off → toggles on → clears)
- [ ] reviewer: confirm flag appears + toggles in admin feature-flags screen
