### PR TITLE
fix(rsvp): label waitlist join button correctly in rsvp modal (Issue 1130)

### DIFF
--- a/frontend/src/screens/events/RsvpBox.test.tsx
+++ b/frontend/src/screens/events/RsvpBox.test.tsx
@@ -147,6 +147,8 @@ describe('RsvpBox', () => {
     const confirmButton = buttons.at(-1);
     if (!confirmButton) throw new Error('expected a join the waitlist confirm button');
     fireEvent.click(confirmButton);
-    expect(onConfirm).toHaveBeenCalledWith(expect.objectContaining({ status: RsvpStatus.Attending }));
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ status: RsvpStatus.Attending }),
+    );
   });
 });

--- a/frontend/src/screens/events/RsvpBox.test.tsx
+++ b/frontend/src/screens/events/RsvpBox.test.tsx
@@ -133,4 +133,20 @@ describe('RsvpBox', () => {
     render(<RsvpBox {...base} mode="create" allowComment={false} onConfirm={() => {}} />);
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
   });
+
+  it('shows "join the waitlist" instead of "i\'m going" when at capacity', () => {
+    render(<RsvpBox {...base} mode="create" atCapacity onConfirm={() => {}} />);
+    expect(screen.getAllByRole('button', { name: /^join the waitlist$/i })).toHaveLength(2);
+    expect(screen.queryByRole('button', { name: /^i'm going$/i })).not.toBeInTheDocument();
+  });
+
+  it('confirms with the attending status when joining the waitlist', () => {
+    const onConfirm = vi.fn();
+    render(<RsvpBox {...base} mode="create" atCapacity onConfirm={onConfirm} />);
+    const buttons = screen.getAllByRole('button', { name: /^join the waitlist$/i });
+    const confirmButton = buttons.at(-1);
+    if (!confirmButton) throw new Error('expected a join the waitlist confirm button');
+    fireEvent.click(confirmButton);
+    expect(onConfirm).toHaveBeenCalledWith(expect.objectContaining({ status: RsvpStatus.Attending }));
+  });
 });

--- a/frontend/src/screens/events/RsvpBox.tsx
+++ b/frontend/src/screens/events/RsvpBox.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import { RsvpStatusPicker } from '@/components/ui/RsvpStatusPicker';
-import { type RsvpInputStatus } from '@/models/event';
+import { type RsvpInputStatus, RsvpStatus } from '@/models/event';
 
 import { RsvpCommentField } from './RsvpCommentField';
 
@@ -20,6 +20,7 @@ interface Props {
   initialHasPlusOne: boolean;
   allowPlusOnes: boolean;
   allowComment?: boolean;
+  atCapacity?: boolean;
   busy?: boolean;
   onConfirm: (args: ConfirmArgs) => void;
   onRemove?: (() => void) | undefined;
@@ -33,6 +34,7 @@ export function RsvpBox({
   initialHasPlusOne,
   allowPlusOnes,
   allowComment,
+  atCapacity = false,
   busy = false,
   onConfirm,
   onRemove,
@@ -44,6 +46,7 @@ export function RsvpBox({
 
   const showComment = allowComment ?? mode === 'create';
   const showPlusOne = allowPlusOnes;
+  const joiningWaitlist = status === RsvpStatus.Attending && atCapacity;
 
   function confirm() {
     const trimmed = comment.trim();
@@ -55,7 +58,14 @@ export function RsvpBox({
   return (
     <Dialog open={open} onClose={onClose} title="rsvp">
       <div className="flex flex-col gap-4">
-        <RsvpStatusPicker value={status} onSelect={setStatus} disabled={busy} />
+        <RsvpStatusPicker
+          value={status}
+          onSelect={setStatus}
+          disabled={busy}
+          labelFor={(s, defaultLabel) =>
+            s === RsvpStatus.Attending && atCapacity ? 'join the waitlist' : defaultLabel
+          }
+        />
 
         {showPlusOne ? (
           <div className="flex justify-center">
@@ -87,11 +97,17 @@ export function RsvpBox({
               cancel
             </Button>
             <Button type="button" onClick={confirm} disabled={busy}>
-              {mode === 'edit' ? 'save' : 'confirm'}
+              {confirmLabel(mode, joiningWaitlist)}
             </Button>
           </div>
         </div>
       </div>
     </Dialog>
   );
+}
+
+function confirmLabel(mode: 'create' | 'edit', joiningWaitlist: boolean): string {
+  if (joiningWaitlist) return 'join the waitlist';
+  if (mode === 'edit') return 'save';
+  return 'confirm';
 }

--- a/frontend/src/screens/events/RsvpSection.tsx
+++ b/frontend/src/screens/events/RsvpSection.tsx
@@ -158,6 +158,7 @@ export function RsvpSection({ event, token }: Props) {
           initialHasPlusOne={hasPlusOne}
           allowPlusOnes={event.allowPlusOnes}
           allowComment={Boolean(token) || box.mode === 'create'}
+          atCapacity={atCapacity}
           busy={busy}
           onConfirm={(args) => void confirmRsvp(args)}
           onRemove={box.mode === 'edit' ? () => void removeMyRsvp() : undefined}


### PR DESCRIPTION
## Summary
- Fixed the rsvp modal (`RsvpBox`) showing "i'm going" instead of "join the waitlist" when a member opens the rsvp dialog for an event at capacity.
- Root cause: `RsvpSection`'s outer status picker already applied a `labelFor` override to show "join the waitlist" when `atCapacity` is true, but that override was never passed into `RsvpBox`, which renders its own internal `RsvpStatusPicker` and confirm button. Those always fell back to the default "attending" label ("i'm going"/"confirm").
- Threaded `atCapacity` through `RsvpSection` -> `RsvpBox`, applied the same `labelFor` override to the picker inside the modal, and updated the confirm button's label via a small helper (`confirmLabel`) so it also reads "join the waitlist" when joining the waitlist, instead of "confirm".

Closes #1130

## Test plan
- [x] `make agent-frontend-typecheck` passes
- [x] `make agent-frontend-lint` passes
- [x] Targeted vitest runs pass: `RsvpBox.test.tsx`, `RsvpSection.test.tsx`, `PublicRsvpForm.test.tsx`, `PublicRsvpSection.test.tsx`, `PublicRsvp.a11y.test.tsx`, `RsvpStatusPicker.test.tsx` (all green)
- [x] Added new `RsvpBox.test.tsx` cases asserting the picker pill and confirm button both read "join the waitlist" (not "i'm going") when `atCapacity` is true, and that confirming still submits `status: attending`