### PR TITLE
fix(events): stop iOS Safari zoom by wrapping long user content (Issue 1131)

### DIFF
--- a/frontend/src/components/ui/DateTimePicker.tsx
+++ b/frontend/src/components/ui/DateTimePicker.tsx
@@ -139,7 +139,7 @@ export function DateTimePicker({
                 const base = selectedDate ?? new Date();
                 onChange(dateToIso(base, h, m));
               }}
-              className="border-border bg-surface focus:border-brand-500 focus:ring-brand-200 h-8 rounded-md border px-2 text-sm outline-none focus:ring-1"
+              className="border-border bg-surface focus:border-brand-500 focus:ring-brand-200 h-8 rounded-md border px-2 text-base outline-none focus:ring-1 md:text-sm"
             />
           </div>
         </div>

--- a/frontend/src/components/ui/LocationField.tsx
+++ b/frontend/src/components/ui/LocationField.tsx
@@ -133,7 +133,7 @@ export function LocationField({
           maxLength={maxLength}
           placeholder={placeholder}
           className={[
-            'bg-surface h-10 w-full rounded-md border px-3 text-sm transition-colors outline-none focus:ring-2',
+            'bg-surface h-10 w-full rounded-md border px-3 text-base transition-colors outline-none focus:ring-2 md:text-sm',
             'border-border-strong focus:border-brand-500 focus:ring-brand-200',
             error && 'border-destructive-border focus:border-red-500 focus:ring-red-100',
             disabled && 'bg-surface-dim text-muted-foreground',

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -31,7 +31,7 @@ export const Select = forwardRef<HTMLSelectElement, Props>(function Select(
           aria-invalid={error ? true : undefined}
           aria-describedby={error ? `${inputId}-error` : undefined}
           className={cn(
-            'border-border-strong bg-surface focus:ring-border h-10 w-full appearance-none rounded-md border pr-9 pl-3 text-sm transition-colors outline-none focus:border-neutral-500 focus:ring-2',
+            'border-border-strong bg-surface focus:ring-border h-10 w-full appearance-none rounded-md border pr-9 pl-3 text-base transition-colors outline-none focus:border-neutral-500 focus:ring-2 md:text-sm',
             error && 'border-destructive-border focus:border-red-500 focus:ring-red-100',
             className,
           )}

--- a/frontend/src/components/ui/TextField.tsx
+++ b/frontend/src/components/ui/TextField.tsx
@@ -31,7 +31,7 @@ export const TextField = forwardRef<HTMLInputElement, Props>(function TextField(
           aria-invalid={error ? true : undefined}
           aria-describedby={describedBy}
           className={cn(
-            'focus:border-brand-500 focus:ring-brand-200 border-border-strong bg-surface h-10 w-full rounded-md border px-3 text-sm transition-colors outline-none focus:ring-2',
+            'focus:border-brand-500 focus:ring-brand-200 border-border-strong bg-surface h-10 w-full rounded-md border px-3 text-base transition-colors outline-none focus:ring-2 md:text-sm',
             error && 'border-destructive-border focus:border-red-500 focus:ring-red-100',
             rightAdornment && 'pr-10',
             className,

--- a/frontend/src/components/ui/Textarea.tsx
+++ b/frontend/src/components/ui/Textarea.tsx
@@ -26,7 +26,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, Props>(function Textarea
         aria-invalid={error ? true : undefined}
         aria-describedby={describedBy}
         className={cn(
-          'focus:border-brand-500 focus:ring-brand-200 border-border-strong bg-surface min-h-[80px] w-full rounded-md border px-3 py-2 text-sm transition-colors outline-none focus:ring-2',
+          'focus:border-brand-500 focus:ring-brand-200 border-border-strong bg-surface min-h-[80px] w-full rounded-md border px-3 py-2 text-base transition-colors outline-none focus:ring-2 md:text-sm',
           error && 'border-destructive-border focus:border-red-500 focus:ring-red-100',
           className,
         )}

--- a/frontend/src/screens/events/EmailBlastDialog.tsx
+++ b/frontend/src/screens/events/EmailBlastDialog.tsx
@@ -170,7 +170,7 @@ export function EmailBlastDialog({ event, open, onClose }: Props) {
             onChange={(e) => {
               setMessage(e.target.value);
             }}
-            className="border-border-strong bg-surface focus:ring-brand-200 focus:border-brand-500 h-32 w-full rounded-md border px-3 py-2 text-sm transition-colors outline-none focus:ring-2"
+            className="border-border-strong bg-surface focus:ring-brand-200 focus:border-brand-500 h-32 w-full rounded-md border px-3 py-2 text-base transition-colors outline-none focus:ring-2 md:text-sm"
           />
         </div>
         <div className="flex flex-col gap-1.5">

--- a/frontend/src/screens/events/EventMemberSection.overflow.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.overflow.test.tsx
@@ -12,10 +12,6 @@ function renderIn(node: React.ReactElement) {
   return render(<MemoryRouter>{node}</MemoryRouter>);
 }
 
-// A long unbroken user-entered string (url/location/zelle) has no break
-// opportunity; without overflow-wrap it pushes the layout wider than the phone
-// viewport and iOS Safari renders the whole page zoomed in (issue 1131, same
-// class as issue 611 which only covered the title + description).
 describe('event detail — long user content wraps (issue 1131)', () => {
   it('wraps a long location so it cannot overflow the viewport', () => {
     const event = { location: `somewhere/${LONG_TOKEN}` } as Event;

--- a/frontend/src/screens/events/EventMemberSection.overflow.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.overflow.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it } from 'vitest';
+
+import type { Event } from '@/models/event';
+
+import { CostSection, LinksSection, LocationSection } from './EventMemberSection';
+
+const LONG_TOKEN = 'x'.repeat(200);
+
+function renderIn(node: React.ReactElement) {
+  return render(<MemoryRouter>{node}</MemoryRouter>);
+}
+
+// A long unbroken user-entered string (url/location/zelle) has no break
+// opportunity; without overflow-wrap it pushes the layout wider than the phone
+// viewport and iOS Safari renders the whole page zoomed in (issue 1131, same
+// class as issue 611 which only covered the title + description).
+describe('event detail — long user content wraps (issue 1131)', () => {
+  it('wraps a long location so it cannot overflow the viewport', () => {
+    const event = { location: `somewhere/${LONG_TOKEN}` } as Event;
+    renderIn(<LocationSection event={event} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveClass('break-words', '[overflow-wrap:anywhere]');
+  });
+
+  it('wraps a long other-link label so it cannot overflow the viewport', () => {
+    const event = {
+      otherLink: `https://example.com/${LONG_TOKEN}`,
+      surveySlugs: [],
+    } as unknown as Event;
+    renderIn(<LinksSection event={event} />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveClass('break-words', '[overflow-wrap:anywhere]');
+  });
+
+  it('wraps long zelle info so it cannot overflow the viewport', () => {
+    const event = { zelleInfo: LONG_TOKEN } as Event;
+    renderIn(<CostSection event={event} />);
+    expect(screen.getByText(new RegExp(LONG_TOKEN.slice(0, 40)))).toHaveClass(
+      'break-words',
+      '[overflow-wrap:anywhere]',
+    );
+  });
+});

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -113,7 +113,7 @@ export function LocationSection({ event }: { event: Event }) {
         target="_blank"
         rel="noopener noreferrer"
         aria-label={`open ${event.location} in maps`}
-        className="text-brand-700 hover:text-brand-900 text-sm"
+        className="text-brand-700 hover:text-brand-900 text-sm [overflow-wrap:anywhere] break-words"
       >
         {primary}
       </a>
@@ -135,7 +135,7 @@ export function LinksSection({ event }: { event: Event }) {
               href={l.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="text-brand-700 hover:text-brand-900"
+              className="text-brand-700 hover:text-brand-900 [overflow-wrap:anywhere] break-words"
             >
               {l.label}
             </a>
@@ -170,12 +170,14 @@ export function CostSection({ event }: { event: Event }) {
                 href={item.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="text-brand-700 hover:text-brand-900"
+                className="text-brand-700 hover:text-brand-900 [overflow-wrap:anywhere] break-words"
               >
                 {item.label}
               </a>
             ) : (
-              <span className="text-foreground">{item.label}</span>
+              <span className="text-foreground [overflow-wrap:anywhere] break-words">
+                {item.label}
+              </span>
             )}
           </li>
         ))}

--- a/frontend/src/screens/events/comments/CommentComposer.tsx
+++ b/frontend/src/screens/events/comments/CommentComposer.tsx
@@ -70,7 +70,7 @@ export function CommentComposer({
             void submit();
           }
         }}
-        className="focus:border-brand-500 focus:ring-brand-200 border-border-strong bg-surface min-h-[80px] w-full rounded-md border px-3 py-2 text-sm transition-colors outline-none focus:ring-2"
+        className="focus:border-brand-500 focus:ring-brand-200 border-border-strong bg-surface min-h-[80px] w-full rounded-md border px-3 py-2 text-base transition-colors outline-none focus:ring-2 md:text-sm"
       />
       <div className="flex items-center justify-between">
         <span

--- a/frontend/src/screens/events/comments/CommentItem.test.tsx
+++ b/frontend/src/screens/events/comments/CommentItem.test.tsx
@@ -49,6 +49,17 @@ describe('CommentItem', () => {
     expect(screen.getByText('Alice')).toBeInTheDocument();
   });
 
+  // A long unbroken token (e.g. a pasted url) in a just-submitted comment must
+  // wrap; without it the body pushes the page wider than the phone viewport and
+  // iOS Safari re-zooms in on submit (issue 1131).
+  it('wraps a long unbroken body so it cannot overflow the viewport', () => {
+    const longToken = `https://example.com/${'x'.repeat(200)}`;
+    wrap(
+      <CommentItem comment={{ ...baseComment, body: longToken }} eventId="evt" canReact canReply />,
+    );
+    expect(screen.getByText(longToken)).toHaveClass('break-words', '[overflow-wrap:anywhere]');
+  });
+
   it('renders [deleted] placeholder when isDeleted', () => {
     wrap(
       <CommentItem

--- a/frontend/src/screens/events/comments/CommentItem.test.tsx
+++ b/frontend/src/screens/events/comments/CommentItem.test.tsx
@@ -49,9 +49,6 @@ describe('CommentItem', () => {
     expect(screen.getByText('Alice')).toBeInTheDocument();
   });
 
-  // A long unbroken token (e.g. a pasted url) in a just-submitted comment must
-  // wrap; without it the body pushes the page wider than the phone viewport and
-  // iOS Safari re-zooms in on submit (issue 1131).
   it('wraps a long unbroken body so it cannot overflow the viewport', () => {
     const longToken = `https://example.com/${'x'.repeat(200)}`;
     wrap(

--- a/frontend/src/screens/events/comments/CommentItem.tsx
+++ b/frontend/src/screens/events/comments/CommentItem.tsx
@@ -72,7 +72,9 @@ export function CommentItem({
       {comment.isDeleted ? (
         <p className="text-foreground-tertiary text-sm italic">[deleted]</p>
       ) : (
-        <p className="text-sm whitespace-pre-wrap">{comment.body}</p>
+        <p className="text-sm [overflow-wrap:anywhere] break-words whitespace-pre-wrap">
+          {comment.body}
+        </p>
       )}
       {!comment.isDeleted ? (
         <div className="flex items-center justify-between gap-2">

--- a/frontend/src/screens/events/comments/ReplyItem.tsx
+++ b/frontend/src/screens/events/comments/ReplyItem.tsx
@@ -51,7 +51,9 @@ export function ReplyItem({ reply, eventId, token, canReact, reactDisabledReason
         {reply.isDeleted ? (
           <p className="text-foreground-tertiary text-sm italic">[deleted]</p>
         ) : (
-          <p className="text-sm whitespace-pre-wrap">{reply.body}</p>
+          <p className="text-sm [overflow-wrap:anywhere] break-words whitespace-pre-wrap">
+            {reply.body}
+          </p>
         )}
         {!reply.isDeleted ? (
           <div className="mt-1 flex items-center justify-between gap-2">


### PR DESCRIPTION
## Summary

Fixes Issue 1131 — on iOS Safari the event detail page **always** loads zoomed in (not on focus), and **re-zooms in whenever you submit a form** (e.g. an RSVP or a comment). You have to pinch back out each time.

### Root cause (corrected)

This is **horizontal overflow**, the same bug class as Issue 611 — *not* the input-focus auto-zoom that the first commit on this branch targeted.

When a user-entered field holds a long unbroken token (a pasted URL, a spaceless location, a zelle handle), it has no break opportunity and pushes the layout wider than the phone viewport. iOS Safari then renders the whole page at a zoomed-in scale, and **resets to that scale on any re-layout** — which is exactly why it "zooms back in" right after you submit a form and the list re-renders.

Issue 611 added `break-words [overflow-wrap:anywhere]` to the **title** and **description** only. The sibling fields that render free-form user text were missed:

- **location** link
- **"other" link** label (a stripped URL, the most likely culprit)
- **cost** lines — `price` and `zelle: …`
- **comment** and **reply** bodies (`whitespace-pre-wrap` alone does *not* break a long token; this is the field most likely to overflow immediately after a submit)

This PR adds the same wrap treatment to all of them, with regression tests mirroring the 611 test.

### Note on the earlier font-size change

The first commit raised text inputs from 14px → 16px (`text-base` + `md:text-sm`) to stop iOS Safari's **focus** auto-zoom. That's a real, separate iOS annoyance and is harmless, so it's kept — but it is **not** what fixes Issue 1131. The overflow fix above is the actual fix.

## Test plan

- [x] `make agent-frontend-typecheck` — passes
- [x] ESLint + Prettier clean on all changed files
- [x] New regression tests: long location / other-link / zelle / comment body all assert `break-words [overflow-wrap:anywhere]` (40+ event tests pass)
- [ ] Manual iOS Safari check on the deployed preview with an event that has a long pasted URL in a link or comment (recommended before merge)
