### PR TITLE
feat(events): partiful-style guest list summary + detail overlay (Issue 1129)

### DIFF
--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -32,6 +32,9 @@ vi.mock('@/api/publicRsvp', () => ({
 // Stub heavy sub-sections so we focus on the host row.
 vi.mock('./RsvpGuestList', () => ({
   RsvpGuestList: () => <div data-testid="guest-list" />,
+}));
+vi.mock('./GuestChip', () => ({
+  GuestChip: () => null,
   InvitedList: () => null,
 }));
 vi.mock('./EventAdminActions', () => ({ EventAdminActions: () => null }));

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -20,8 +20,9 @@ import { EventFlagDialog } from './EventFlagDialog';
 import { EventHostSection } from './EventHostSection';
 import { eventMemberSectionFlags } from './eventMemberFlags';
 import { GroupTextButton } from './GroupTextButton';
+import { InvitedList } from './GuestChip';
 import { InviteDialog } from './InviteDialog';
-import { InvitedList, RsvpGuestList } from './RsvpGuestList';
+import { RsvpGuestList } from './RsvpGuestList';
 
 interface Props {
   event: Event;

--- a/frontend/src/screens/events/GuestChip.tsx
+++ b/frontend/src/screens/events/GuestChip.tsx
@@ -2,34 +2,43 @@ import { Link } from 'react-router-dom';
 
 import type { Event, EventGuest } from '@/models/event';
 import { AttendanceStatus } from '@/models/event';
+import { cn } from '@/utils/cn';
 
-export function GuestChip({ guest }: { guest: EventGuest }) {
+export function GuestChip({ guest, row = false }: { guest: EventGuest; row?: boolean }) {
+  const avatarSize = row ? 'h-8 w-8 text-xs' : 'h-5 w-5 text-[10px]';
   const content = (
     <>
       {guest.photoUrl ? (
         <img
           src={guest.photoUrl}
           alt=""
-          className="h-5 w-5 rounded-full object-cover"
+          className={cn('shrink-0 rounded-full object-cover', avatarSize)}
           loading="lazy"
         />
       ) : (
         <span
           aria-hidden="true"
-          className="bg-toggle-off text-foreground-secondary flex h-5 w-5 items-center justify-center rounded-full text-[10px]"
+          className={cn(
+            'bg-toggle-off text-foreground-secondary flex shrink-0 items-center justify-center rounded-full',
+            avatarSize,
+          )}
         >
           {guest.name.slice(0, 1).toLowerCase()}
         </span>
       )}
-      {guest.name}
+      <span className={row ? 'truncate' : undefined}>{guest.name}</span>
       {guest.hasPlusOne ? <span className="text-muted">+1</span> : null}
     </>
   );
 
+  const shape = row
+    ? 'flex w-full items-center gap-3 rounded-lg px-2 py-2 text-sm'
+    : 'inline-flex items-center gap-1.5 rounded-full px-2 py-1 text-xs';
+
   if (!guest.isMember) {
     return (
       <span
-        className="bg-surface-dim/60 text-foreground-secondary inline-flex items-center gap-1.5 rounded-full px-2 py-1 text-xs opacity-60 grayscale"
+        className={cn('bg-surface-dim/60 text-foreground-secondary opacity-60 grayscale', shape)}
         title={`${guest.name} (not a member)`}
         aria-label={`${guest.name} (not a member)`}
       >
@@ -41,7 +50,7 @@ export function GuestChip({ guest }: { guest: EventGuest }) {
   return (
     <Link
       to={`/members/${guest.userId}`}
-      className="bg-surface-dim hover:bg-surface-dim/70 inline-flex items-center gap-1.5 rounded-full px-2 py-1 text-xs"
+      className={cn('bg-surface-dim hover:bg-surface-dim/70', shape)}
       title={guest.name}
     >
       {content}
@@ -49,18 +58,19 @@ export function GuestChip({ guest }: { guest: EventGuest }) {
   );
 }
 
-export function InvitedList({ event }: { event: Event }) {
+export function InvitedList({ event, row = false }: { event: Event; row?: boolean }) {
   if (event.invitedUserIds.length === 0) {
     return <p className="text-muted text-xs">no one invited yet</p>;
   }
   return (
-    <div className="flex flex-wrap gap-2">
+    <div className={row ? 'flex flex-col gap-1' : 'flex flex-wrap gap-2'}>
       {event.invitedUserIds.map((id, i) => {
         const name = event.invitedUserNames[i] ?? 'member';
         const photoUrl = event.invitedUserPhotoUrls[i] ?? '';
         return (
           <GuestChip
             key={id}
+            row={row}
             guest={{
               userId: id,
               name,

--- a/frontend/src/screens/events/GuestChip.tsx
+++ b/frontend/src/screens/events/GuestChip.tsx
@@ -1,0 +1,80 @@
+import { Link } from 'react-router-dom';
+
+import type { Event, EventGuest } from '@/models/event';
+import { AttendanceStatus } from '@/models/event';
+
+export function GuestChip({ guest }: { guest: EventGuest }) {
+  const content = (
+    <>
+      {guest.photoUrl ? (
+        <img
+          src={guest.photoUrl}
+          alt=""
+          className="h-5 w-5 rounded-full object-cover"
+          loading="lazy"
+        />
+      ) : (
+        <span
+          aria-hidden="true"
+          className="bg-toggle-off text-foreground-secondary flex h-5 w-5 items-center justify-center rounded-full text-[10px]"
+        >
+          {guest.name.slice(0, 1).toLowerCase()}
+        </span>
+      )}
+      {guest.name}
+      {guest.hasPlusOne ? <span className="text-muted">+1</span> : null}
+    </>
+  );
+
+  if (!guest.isMember) {
+    return (
+      <span
+        className="bg-surface-dim/60 text-foreground-secondary inline-flex items-center gap-1.5 rounded-full px-2 py-1 text-xs opacity-60 grayscale"
+        title={`${guest.name} (not a member)`}
+        aria-label={`${guest.name} (not a member)`}
+      >
+        {content}
+      </span>
+    );
+  }
+
+  return (
+    <Link
+      to={`/members/${guest.userId}`}
+      className="bg-surface-dim hover:bg-surface-dim/70 inline-flex items-center gap-1.5 rounded-full px-2 py-1 text-xs"
+      title={guest.name}
+    >
+      {content}
+    </Link>
+  );
+}
+
+export function InvitedList({ event }: { event: Event }) {
+  if (event.invitedUserIds.length === 0) {
+    return <p className="text-muted text-xs">no one invited yet</p>;
+  }
+  return (
+    <div className="flex flex-wrap gap-2">
+      {event.invitedUserIds.map((id, i) => {
+        const name = event.invitedUserNames[i] ?? 'member';
+        const photoUrl = event.invitedUserPhotoUrls[i] ?? '';
+        return (
+          <GuestChip
+            key={id}
+            guest={{
+              userId: id,
+              name,
+              status: 'invited',
+              phone: null,
+              photoUrl,
+              hasPlusOne: false,
+              attendance: AttendanceStatus.Unknown,
+              isMember: true,
+              paidConfirmed: false,
+            }}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/screens/events/GuestListDialog.tsx
+++ b/frontend/src/screens/events/GuestListDialog.tsx
@@ -1,0 +1,144 @@
+import { useMemo, useState } from 'react';
+
+import { TextField } from '@/components/ui/TextField';
+import type { Event, RsvpServerStatusValue } from '@/models/event';
+import { RsvpServerStatus } from '@/models/event';
+import { cn } from '@/utils/cn';
+
+import { GuestChip, InvitedList } from './GuestChip';
+import { countWithPlusOnes } from './guestSort';
+
+export type GuestTab = 'going' | 'maybe' | 'cant' | 'waitlist' | 'invited';
+
+const TAB_STATUS: Record<Exclude<GuestTab, 'invited'>, RsvpServerStatusValue> = {
+  going: RsvpServerStatus.Attending,
+  maybe: RsvpServerStatus.Maybe,
+  cant: RsvpServerStatus.CantGo,
+  waitlist: RsvpServerStatus.Waitlisted,
+};
+
+const TAB_LABELS: Record<GuestTab, string> = {
+  going: 'going',
+  maybe: 'maybe',
+  cant: "can't go",
+  waitlist: 'waitlist',
+  invited: 'invited',
+};
+
+function guestTabs(event: Event, canSeeInvited: boolean): GuestTab[] {
+  const tabs: GuestTab[] = ['going', 'maybe'];
+  if (!canSeeInvited) return tabs;
+  tabs.push('cant');
+  if (event.guests.some((g) => g.status === RsvpServerStatus.Waitlisted)) tabs.push('waitlist');
+  tabs.push('invited');
+  return tabs;
+}
+
+interface Props {
+  event: Event;
+  canSeeInvited: boolean;
+  initialTab: GuestTab;
+  onClose: () => void;
+}
+
+export function GuestListDialog({ event, canSeeInvited, initialTab, onClose }: Props) {
+  const tabs = guestTabs(event, canSeeInvited);
+  const [active, setActive] = useState<GuestTab>(initialTab);
+  const [query, setQuery] = useState('');
+
+  const inTab = useMemo(
+    () => (active === 'invited' ? [] : event.guests.filter((g) => g.status === TAB_STATUS[active])),
+    [event.guests, active],
+  );
+
+  const needle = query.trim().toLowerCase();
+  const visible = needle ? inTab.filter((g) => g.name.toLowerCase().includes(needle)) : inTab;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="guest list"
+      className="fixed inset-0 z-50 flex items-stretch justify-center sm:items-center sm:p-4"
+    >
+      <button
+        type="button"
+        aria-label="close"
+        onClick={onClose}
+        className="absolute inset-0 cursor-default bg-black/60"
+      />
+      <div className="bg-surface relative flex h-full w-full flex-col sm:h-auto sm:max-h-[80vh] sm:max-w-md sm:rounded-lg sm:shadow-(--shadow-xl)">
+        <div className="flex items-center justify-between gap-2 p-4 pb-2">
+          <h2 className="text-base font-medium">guest list</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="text-foreground-secondary hover:bg-surface-dim rounded-full px-3 py-1 text-sm"
+          >
+            done
+          </button>
+        </div>
+
+        <div
+          role="tablist"
+          aria-label="guest status"
+          className="flex gap-1 overflow-x-auto px-4 pb-2"
+        >
+          {tabs.map((t) => (
+            <button
+              key={t}
+              type="button"
+              role="tab"
+              aria-selected={active === t}
+              onClick={() => {
+                setActive(t);
+              }}
+              className={cn(
+                'shrink-0 rounded-full px-3 py-1.5 text-sm whitespace-nowrap transition-colors',
+                active === t
+                  ? 'bg-brand-600 text-brand-on'
+                  : 'text-foreground-secondary hover:bg-surface-dim',
+              )}
+            >
+              {TAB_LABELS[t]} {tabCount(event, t)}
+            </button>
+          ))}
+        </div>
+
+        {active === 'invited' ? null : (
+          <div className="px-4 pb-2">
+            <TextField
+              label="search guests"
+              hideLabel
+              type="search"
+              placeholder="search guests"
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value);
+              }}
+            />
+          </div>
+        )}
+
+        <div className="flex-1 overflow-y-auto px-4 pb-4">
+          {active === 'invited' ? (
+            <InvitedList event={event} />
+          ) : visible.length === 0 ? (
+            <p className="text-muted text-xs">{needle ? 'no one matches' : 'no one yet'}</p>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {visible.map((g) => (
+                <GuestChip key={g.userId} guest={g} />
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function tabCount(event: Event, tab: GuestTab): number {
+  if (tab === 'invited') return event.invitedCount;
+  return countWithPlusOnes(event.guests.filter((g) => g.status === TAB_STATUS[tab]));
+}

--- a/frontend/src/screens/events/GuestListDialog.tsx
+++ b/frontend/src/screens/events/GuestListDialog.tsx
@@ -122,13 +122,13 @@ export function GuestListDialog({ event, canSeeInvited, initialTab, onClose }: P
 
         <div className="flex-1 overflow-y-auto px-4 pb-4">
           {active === 'invited' ? (
-            <InvitedList event={event} />
+            <InvitedList event={event} row />
           ) : visible.length === 0 ? (
             <p className="text-muted text-xs">{needle ? 'no one matches' : 'no one yet'}</p>
           ) : (
-            <div className="flex flex-wrap gap-2">
+            <div className="flex flex-col gap-1">
               {visible.map((g) => (
-                <GuestChip key={g.userId} guest={g} />
+                <GuestChip key={g.userId} guest={g} row />
               ))}
             </div>
           )}

--- a/frontend/src/screens/events/RsvpGuestList.test.tsx
+++ b/frontend/src/screens/events/RsvpGuestList.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
 
@@ -9,87 +10,174 @@ import { makeEvent, makeGuest } from '@/test/fixtures';
 
 import { RsvpGuestList } from './RsvpGuestList';
 
-function renderList(event: Event) {
+function renderList(event: Event, canSeeInvited = false) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={qc}>
       <MemoryRouter>
-        <RsvpGuestList event={event} canSeeInvited={false} />
+        <RsvpGuestList event={event} canSeeInvited={canSeeInvited} />
       </MemoryRouter>
     </QueryClientProvider>,
   );
 }
 
-describe('RsvpGuestList', () => {
-  it('links member guests to their profile', () => {
+describe('RsvpGuestList summary', () => {
+  it('shows going and maybe counts', () => {
     const event = makeEvent({
-      guests: [makeGuest({ userId: 'user-1', name: 'Alex', isMember: true })],
+      guests: [
+        makeGuest({ userId: 'u1', status: RsvpServerStatus.Attending }),
+        makeGuest({ userId: 'u2', status: RsvpServerStatus.Attending }),
+        makeGuest({ userId: 'u3', status: RsvpServerStatus.Maybe }),
+      ],
     });
     renderList(event);
-    const link = screen.getByRole('link', { name: /alex/i });
-    expect(link).toHaveAttribute('href', '/members/user-1');
+    expect(screen.getByText(/2 going/)).toBeInTheDocument();
+    expect(screen.getByText(/1 maybe/)).toBeInTheDocument();
   });
 
-  it('renders non-member guests without a profile link', () => {
+  it('counts plus-ones toward the going total', () => {
     const event = makeEvent({
-      guests: [makeGuest({ userId: 'guest-1', name: 'Sam', isMember: false, hasPlusOne: true })],
+      guests: [makeGuest({ userId: 'u1', status: RsvpServerStatus.Attending, hasPlusOne: true })],
     });
     renderList(event);
-    expect(screen.queryByRole('link', { name: /sam/i })).not.toBeInTheDocument();
-    expect(screen.getByText('Sam')).toBeInTheDocument();
+    expect(screen.getByText(/2 going/)).toBeInTheDocument();
+  });
+
+  it('previews at most five avatars and shows the overflow count', () => {
+    const guests = Array.from({ length: 8 }, (_, i) =>
+      makeGuest({ userId: `u${String(i)}`, name: `Guest ${String(i)}` }),
+    );
+    renderList(makeEvent({ guests }));
+    expect(screen.getByRole('button', { name: /view all 8 guests/i })).toHaveTextContent('+3');
+  });
+
+  it('omits the overflow bubble when everyone fits in the preview', () => {
+    const guests = Array.from({ length: 3 }, (_, i) => makeGuest({ userId: `u${String(i)}` }));
+    renderList(makeEvent({ guests }));
+    expect(screen.queryByRole('button', { name: /view all \d+ guests/i })).not.toBeInTheDocument();
+  });
+
+  it('previews members before non-members', () => {
+    const event = makeEvent({
+      guests: [
+        makeGuest({ userId: 'n1', name: 'Nonmember', isMember: false }),
+        makeGuest({ userId: 'm1', name: 'Member', isMember: true }),
+      ],
+    });
+    renderList(event);
+    const avatars = screen.getAllByTitle(/member/i);
+    expect(avatars[0]).toHaveAttribute('title', 'Member');
   });
 
   it('shows a genuinely-empty message when there are no attendees', () => {
-    const event = makeEvent({ guests: [], attendingCount: 0 });
-    renderList(event);
+    renderList(makeEvent({ guests: [], attendingCount: 0 }));
     expect(screen.getByText('no one yet')).toBeInTheDocument();
   });
 
   it('shows a gated message when guests are hidden but attendees exist', () => {
-    const event = makeEvent({ guests: [], attendingCount: 3 });
-    renderList(event);
+    renderList(makeEvent({ guests: [], attendingCount: 3 }));
     expect(screen.getByText("rsvp to see who's going")).toBeInTheDocument();
   });
 });
 
-describe('RsvpGuestList — cant go / waitlist visibility (Issue 1042)', () => {
-  it('hides the cant go and waitlist tabs from a guest', () => {
+describe('RsvpGuestList dialog', () => {
+  it('opens the guest list and filters by search', async () => {
+    const user = userEvent.setup();
     const event = makeEvent({
       guests: [
-        makeGuest({ userId: 'user-1', status: RsvpServerStatus.CantGo }),
-        makeGuest({ userId: 'user-2', status: RsvpServerStatus.Waitlisted }),
+        makeGuest({ userId: 'u1', name: 'Alex', status: RsvpServerStatus.Attending }),
+        makeGuest({ userId: 'u2', name: 'Sam', status: RsvpServerStatus.Attending }),
       ],
     });
-    render(
-      <QueryClientProvider
-        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
-      >
-        <MemoryRouter>
-          <RsvpGuestList event={event} canSeeInvited={false} />
-        </MemoryRouter>
-      </QueryClientProvider>,
-    );
-    expect(screen.queryByRole('tab', { name: /can't go/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('tab', { name: /waitlist/i })).not.toBeInTheDocument();
+    renderList(event);
+    await user.click(screen.getByRole('button', { name: 'view all' }));
+
+    const dialog = screen.getByRole('dialog', { name: /guest list/i });
+    expect(within(dialog).getByText('Alex')).toBeInTheDocument();
+
+    await user.type(within(dialog).getByPlaceholderText('search guests'), 'ale');
+    expect(within(dialog).getByText('Alex')).toBeInTheDocument();
+    expect(within(dialog).queryByText('Sam')).not.toBeInTheDocument();
   });
 
-  it('shows the cant go and waitlist tabs to a host', () => {
+  it('separates going and maybe into tabs', async () => {
+    const user = userEvent.setup();
     const event = makeEvent({
       guests: [
-        makeGuest({ userId: 'user-1', status: RsvpServerStatus.CantGo }),
-        makeGuest({ userId: 'user-2', status: RsvpServerStatus.Waitlisted }),
+        makeGuest({ userId: 'u1', name: 'Alex', status: RsvpServerStatus.Attending }),
+        makeGuest({ userId: 'u2', name: 'Sam', status: RsvpServerStatus.Maybe }),
       ],
     });
-    render(
-      <QueryClientProvider
-        client={new QueryClient({ defaultOptions: { queries: { retry: false } } })}
-      >
-        <MemoryRouter>
-          <RsvpGuestList event={event} canSeeInvited={true} />
-        </MemoryRouter>
-      </QueryClientProvider>,
+    renderList(event);
+    await user.click(screen.getByRole('button', { name: 'view all' }));
+
+    const dialog = screen.getByRole('dialog', { name: /guest list/i });
+    expect(within(dialog).queryByText('Sam')).not.toBeInTheDocument();
+
+    await user.click(within(dialog).getByRole('tab', { name: /maybe/i }));
+    expect(within(dialog).getByText('Sam')).toBeInTheDocument();
+    expect(within(dialog).queryByText('Alex')).not.toBeInTheDocument();
+  });
+
+  it('hides the cant go and waitlist tabs from a guest (Issue 1042)', async () => {
+    const user = userEvent.setup();
+    const event = makeEvent({
+      guests: [
+        makeGuest({ userId: 'u1', status: RsvpServerStatus.Attending }),
+        makeGuest({ userId: 'u2', status: RsvpServerStatus.CantGo }),
+        makeGuest({ userId: 'u3', status: RsvpServerStatus.Waitlisted }),
+      ],
+    });
+    renderList(event, false);
+    await user.click(screen.getByRole('button', { name: 'view all' }));
+
+    const dialog = screen.getByRole('dialog', { name: /guest list/i });
+    expect(within(dialog).queryByRole('tab', { name: /can't go/i })).not.toBeInTheDocument();
+    expect(within(dialog).queryByRole('tab', { name: /waitlist/i })).not.toBeInTheDocument();
+  });
+
+  it('shows the cant go and waitlist tabs to a host (Issue 1042)', async () => {
+    const user = userEvent.setup();
+    const event = makeEvent({
+      guests: [
+        makeGuest({ userId: 'u1', status: RsvpServerStatus.Attending }),
+        makeGuest({ userId: 'u2', status: RsvpServerStatus.CantGo }),
+        makeGuest({ userId: 'u3', status: RsvpServerStatus.Waitlisted }),
+      ],
+    });
+    renderList(event, true);
+    await user.click(screen.getByRole('button', { name: 'view all' }));
+
+    const dialog = screen.getByRole('dialog', { name: /guest list/i });
+    expect(within(dialog).getByRole('tab', { name: /can't go/i })).toBeInTheDocument();
+    expect(within(dialog).getByRole('tab', { name: /waitlist/i })).toBeInTheDocument();
+  });
+
+  it('links member guests to their profile in the dialog', async () => {
+    const user = userEvent.setup();
+    const event = makeEvent({
+      guests: [makeGuest({ userId: 'user-1', name: 'Alex', isMember: true })],
+    });
+    renderList(event);
+    await user.click(screen.getByRole('button', { name: 'view all' }));
+
+    const dialog = screen.getByRole('dialog', { name: /guest list/i });
+    expect(within(dialog).getByRole('link', { name: /alex/i })).toHaveAttribute(
+      'href',
+      '/members/user-1',
     );
-    expect(screen.getByRole('tab', { name: /can't go/i })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: /waitlist/i })).toBeInTheDocument();
+  });
+
+  it('renders non-member guests without a profile link', async () => {
+    const user = userEvent.setup();
+    const event = makeEvent({
+      guests: [makeGuest({ userId: 'guest-1', name: 'Sam', isMember: false })],
+    });
+    renderList(event);
+    await user.click(screen.getByRole('button', { name: 'view all' }));
+
+    const dialog = screen.getByRole('dialog', { name: /guest list/i });
+    expect(within(dialog).queryByRole('link', { name: /sam/i })).not.toBeInTheDocument();
+    expect(within(dialog).getByText('Sam')).toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/events/RsvpGuestList.tsx
+++ b/frontend/src/screens/events/RsvpGuestList.tsx
@@ -51,7 +51,7 @@ export function RsvpGuestList({ event, canSeeInvited }: Props) {
         </button>
       </div>
 
-      <div className="flex items-center -space-x-2">
+      <div className="flex items-center gap-1.5">
         {preview.map((g) => (
           <PreviewAvatar key={g.userId} guest={g} />
         ))}
@@ -62,7 +62,7 @@ export function RsvpGuestList({ event, canSeeInvited }: Props) {
               setOpenTab('going');
             }}
             aria-label={`view all ${String(going.length + maybe.length)} guests`}
-            className="border-surface bg-surface-dim text-foreground-secondary hover:bg-surface-dim/70 flex h-8 w-8 items-center justify-center rounded-full border-2 text-[11px]"
+            className="bg-surface-dim text-foreground-secondary hover:bg-surface-dim/70 flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-[11px]"
           >
             +{overflow}
           </button>
@@ -91,7 +91,7 @@ function PreviewAvatar({ guest }: { guest: EventGuest }) {
         alt={guest.name}
         title={guest.name}
         loading="lazy"
-        className="border-surface h-8 w-8 rounded-full border-2 object-cover"
+        className="h-8 w-8 shrink-0 rounded-full object-cover"
       />
     );
   }
@@ -99,7 +99,7 @@ function PreviewAvatar({ guest }: { guest: EventGuest }) {
     <span
       title={guest.name}
       aria-label={guest.name}
-      className="border-surface bg-toggle-off text-foreground-secondary flex h-8 w-8 items-center justify-center rounded-full border-2 text-xs"
+      className="bg-toggle-off text-foreground-secondary flex h-8 w-8 shrink-0 items-center justify-center rounded-full text-xs"
     >
       {guest.name.slice(0, 1).toLowerCase()}
     </span>

--- a/frontend/src/screens/events/RsvpGuestList.tsx
+++ b/frontend/src/screens/events/RsvpGuestList.tsx
@@ -64,7 +64,7 @@ export function RsvpGuestList({ event, canSeeInvited }: Props) {
       <div
         role="tablist"
         aria-label="guest status"
-        className="border-border-strong bg-surface mb-2 flex w-full rounded-full border p-1"
+        className="border-border-strong bg-surface mb-2 flex w-full gap-1 overflow-x-auto rounded-full border p-1"
       >
         {tabs.map((t) => (
           <button
@@ -76,7 +76,7 @@ export function RsvpGuestList({ event, canSeeInvited }: Props) {
               setActive(t.key);
             }}
             className={cn(
-              'inline-flex flex-1 flex-col items-center justify-center rounded-full px-2 py-1 text-sm leading-tight whitespace-nowrap transition-colors',
+              'inline-flex grow shrink-0 basis-auto flex-col items-center justify-center rounded-full px-2 py-1 text-sm leading-tight whitespace-nowrap transition-colors',
               active === t.key
                 ? 'bg-brand-600 text-brand-on'
                 : 'text-foreground-secondary hover:bg-surface-dim',

--- a/frontend/src/screens/events/RsvpGuestList.tsx
+++ b/frontend/src/screens/events/RsvpGuestList.tsx
@@ -1,25 +1,12 @@
-import { useMemo, useState } from 'react';
-import { Link } from 'react-router-dom';
+import { useState } from 'react';
 
 import type { Event, EventGuest } from '@/models/event';
-import { AttendanceStatus, RsvpServerStatus } from '@/models/event';
-import { cn } from '@/utils/cn';
+import { RsvpServerStatus } from '@/models/event';
 
-type Tab = 'going' | 'maybe' | 'cant' | 'waitlist' | 'invited';
+import { GuestListDialog, type GuestTab } from './GuestListDialog';
+import { countWithPlusOnes, previewGuests } from './guestSort';
 
-function countWithPlusOnes(guests: EventGuest[]): number {
-  return guests.reduce((acc, g) => acc + 1 + (g.hasPlusOne ? 1 : 0), 0);
-}
-
-function bucket(guests: EventGuest[]): Record<Tab, EventGuest[]> {
-  return {
-    going: guests.filter((g) => g.status === RsvpServerStatus.Attending),
-    maybe: guests.filter((g) => g.status === RsvpServerStatus.Maybe),
-    cant: guests.filter((g) => g.status === RsvpServerStatus.CantGo),
-    waitlist: guests.filter((g) => g.status === RsvpServerStatus.Waitlisted),
-    invited: [],
-  };
-}
+const PREVIEW_LIMIT = 5;
 
 interface Props {
   event: Event;
@@ -27,30 +14,14 @@ interface Props {
 }
 
 export function RsvpGuestList({ event, canSeeInvited }: Props) {
-  const buckets = useMemo(() => bucket(event.guests), [event.guests]);
-  const counts: Record<Tab, number> = {
-    going: countWithPlusOnes(buckets.going),
-    maybe: countWithPlusOnes(buckets.maybe),
-    cant: countWithPlusOnes(buckets.cant),
-    waitlist: countWithPlusOnes(buckets.waitlist),
-    invited: canSeeInvited ? event.invitedCount : 0,
-  };
+  const [openTab, setOpenTab] = useState<GuestTab | null>(null);
 
-  const tabs: { key: Tab; label: string }[] = [
-    { key: 'going', label: 'going' },
-    { key: 'maybe', label: 'maybe' },
-  ];
-  if (canSeeInvited) {
-    tabs.push({ key: 'cant', label: "can't go" });
-    if (counts.waitlist > 0) tabs.push({ key: 'waitlist', label: 'waitlist' });
-    tabs.push({ key: 'invited', label: 'invited' });
-  }
+  const going = event.guests.filter((g) => g.status === RsvpServerStatus.Attending);
+  const maybe = event.guests.filter((g) => g.status === RsvpServerStatus.Maybe);
+  const goingCount = countWithPlusOnes(going);
+  const maybeCount = countWithPlusOnes(maybe);
 
-  const defaultTab = tabs.find((t) => counts[t.key] > 0)?.key ?? 'going';
-  const [active, setActive] = useState<Tab>(defaultTab);
-  const visible = active === 'invited' ? [] : buckets[active];
-
-  if (tabs.every((t) => counts[t.key] === 0)) {
+  if (goingCount === 0 && maybeCount === 0) {
     const guestListHidden = event.guests.length === 0 && event.attendingCount > 0;
     return (
       <p className="text-muted text-xs">
@@ -59,119 +30,78 @@ export function RsvpGuestList({ event, canSeeInvited }: Props) {
     );
   }
 
+  const preview = previewGuests([...going, ...maybe], PREVIEW_LIMIT);
+  const overflow = going.length + maybe.length - preview.length;
+
   return (
     <div>
-      <div
-        role="tablist"
-        aria-label="guest status"
-        className="border-border-strong bg-surface mb-2 flex w-full gap-1 overflow-x-auto rounded-full border p-1"
-      >
-        {tabs.map((t) => (
-          <button
-            key={t.key}
-            type="button"
-            role="tab"
-            aria-selected={active === t.key}
-            onClick={() => {
-              setActive(t.key);
-            }}
-            className={cn(
-              'inline-flex grow shrink-0 basis-auto flex-col items-center justify-center rounded-full px-2 py-1 text-sm leading-tight whitespace-nowrap transition-colors',
-              active === t.key
-                ? 'bg-brand-600 text-brand-on'
-                : 'text-foreground-secondary hover:bg-surface-dim',
-            )}
-          >
-            <span>{t.label}</span>
-            <span className="text-xs opacity-80">{counts[t.key]}</span>
-          </button>
-        ))}
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <p className="text-foreground-secondary text-sm">
+          {goingCount} going
+          {maybeCount > 0 ? <span className="text-muted"> · {maybeCount} maybe</span> : null}
+        </p>
+        <button
+          type="button"
+          onClick={() => {
+            setOpenTab('going');
+          }}
+          className="text-brand-600 hover:bg-surface-dim rounded-full px-2 py-1 text-sm"
+        >
+          view all
+        </button>
       </div>
-      {active === 'invited' ? (
-        <InvitedList event={event} />
-      ) : (
-        <div className="flex flex-wrap gap-2">
-          {visible.map((g) => (
-            <GuestChip key={g.userId} guest={g} />
-          ))}
-        </div>
-      )}
+
+      <div className="flex items-center -space-x-2">
+        {preview.map((g) => (
+          <PreviewAvatar key={g.userId} guest={g} />
+        ))}
+        {overflow > 0 ? (
+          <button
+            type="button"
+            onClick={() => {
+              setOpenTab('going');
+            }}
+            aria-label={`view all ${String(going.length + maybe.length)} guests`}
+            className="border-surface bg-surface-dim text-foreground-secondary hover:bg-surface-dim/70 flex h-8 w-8 items-center justify-center rounded-full border-2 text-[11px]"
+          >
+            +{overflow}
+          </button>
+        ) : null}
+      </div>
+
+      {openTab ? (
+        <GuestListDialog
+          event={event}
+          canSeeInvited={canSeeInvited}
+          initialTab={openTab}
+          onClose={() => {
+            setOpenTab(null);
+          }}
+        />
+      ) : null}
     </div>
   );
 }
 
-function GuestChip({ guest }: { guest: EventGuest }) {
-  const content = (
-    <>
-      {guest.photoUrl ? (
-        <img
-          src={guest.photoUrl}
-          alt=""
-          className="h-5 w-5 rounded-full object-cover"
-          loading="lazy"
-        />
-      ) : (
-        <span
-          aria-hidden="true"
-          className="bg-toggle-off text-foreground-secondary flex h-5 w-5 items-center justify-center rounded-full text-[10px]"
-        >
-          {guest.name.slice(0, 1).toLowerCase()}
-        </span>
-      )}
-      {guest.name}
-      {guest.hasPlusOne ? <span className="text-muted">+1</span> : null}
-    </>
-  );
-
-  if (!guest.isMember) {
+function PreviewAvatar({ guest }: { guest: EventGuest }) {
+  if (guest.photoUrl) {
     return (
-      <span
-        className="bg-surface-dim/60 text-foreground-secondary inline-flex items-center gap-1.5 rounded-full px-2 py-1 text-xs opacity-60 grayscale"
-        title={`${guest.name} (not a member)`}
-        aria-label={`${guest.name} (not a member)`}
-      >
-        {content}
-      </span>
+      <img
+        src={guest.photoUrl}
+        alt={guest.name}
+        title={guest.name}
+        loading="lazy"
+        className="border-surface h-8 w-8 rounded-full border-2 object-cover"
+      />
     );
   }
-
   return (
-    <Link
-      to={`/members/${guest.userId}`}
-      className="bg-surface-dim hover:bg-surface-dim/70 inline-flex items-center gap-1.5 rounded-full px-2 py-1 text-xs"
+    <span
       title={guest.name}
+      aria-label={guest.name}
+      className="border-surface bg-toggle-off text-foreground-secondary flex h-8 w-8 items-center justify-center rounded-full border-2 text-xs"
     >
-      {content}
-    </Link>
-  );
-}
-
-export function InvitedList({ event }: { event: Event }) {
-  if (event.invitedUserIds.length === 0) {
-    return <p className="text-muted text-xs">no one invited yet</p>;
-  }
-  return (
-    <div className="flex flex-wrap gap-2">
-      {event.invitedUserIds.map((id, i) => {
-        const name = event.invitedUserNames[i] ?? 'member';
-        const photoUrl = event.invitedUserPhotoUrls[i] ?? '';
-        return (
-          <GuestChip
-            key={id}
-            guest={{
-              userId: id,
-              name,
-              status: 'invited',
-              phone: null,
-              photoUrl,
-              hasPlusOne: false,
-              attendance: AttendanceStatus.Unknown,
-              isMember: true,
-              paidConfirmed: false,
-            }}
-          />
-        );
-      })}
-    </div>
+      {guest.name.slice(0, 1).toLowerCase()}
+    </span>
   );
 }

--- a/frontend/src/screens/events/guestSort.ts
+++ b/frontend/src/screens/events/guestSort.ts
@@ -1,0 +1,19 @@
+import type { EventGuest, RsvpServerStatusValue } from '@/models/event';
+import { RsvpServerStatus } from '@/models/event';
+
+export function countWithPlusOnes(guests: EventGuest[]): number {
+  return guests.reduce((acc, g) => acc + 1 + (g.hasPlusOne ? 1 : 0), 0);
+}
+
+const AVATAR_TIERS: { status: RsvpServerStatusValue; isMember: boolean }[] = [
+  { status: RsvpServerStatus.Attending, isMember: true },
+  { status: RsvpServerStatus.Maybe, isMember: true },
+  { status: RsvpServerStatus.Attending, isMember: false },
+  { status: RsvpServerStatus.Maybe, isMember: false },
+];
+
+export function previewGuests(guests: EventGuest[], limit: number): EventGuest[] {
+  return AVATAR_TIERS.flatMap((tier) =>
+    guests.filter((g) => g.status === tier.status && g.isMember === tier.isMember),
+  ).slice(0, limit);
+}


### PR DESCRIPTION
## Summary

Fixes Issue 1129. The "who's going" tab strip squished its labels on narrow viewports. Rather than just making the tabs fit, this replaces the strip with a Partiful-style guest list.

**Summary view** (in the event detail card):

```
who's going
5 going · 1 maybe                    view all
(s) (j) (r) (r) (t) (+46)
```

- a `N going · N maybe` count line
- a `view all` action on the right
- up to 5 guest avatars (no overlap), with a `+N` bubble when there are more — the bubble is clickable and opens the same detail view as `view all`

**Detail view** — opened by `view all` or the `+N` bubble:

- full-screen sheet on mobile, centered modal on desktop
- going / maybe / can't go / waitlist / invited tabs (the last three only for hosts, unchanged from Issue 1042)
- name search that filters the active tab
- guests render one per line (row layout), not wrapped pills — easier to scan a long list

Avatar preview order prefers members over non-members (non-members have no photos, so they'd render as bare initials), and going over maybe within each group.

## Changes

- `RsvpGuestList.tsx` — rewritten as the summary (count line, avatar row, view-all)
- `GuestListDialog.tsx` (new) — the tabbed + searchable overlay, one guest per row
- `GuestChip.tsx` (new) — `GuestChip` / `InvitedList` moved out, with a `row` variant for the dialog's per-line layout
- `guestSort.ts` (new) — `countWithPlusOnes` + avatar preview ordering
- `EventMemberSection.tsx` — imports `InvitedList` from its new home

Split into separate files to keep each under the project size limit.

Follow-up filed to apply the same avatar-summary + view-all pattern to the host section: #1306.

## Test plan

- [x] `make agent-frontend-typecheck` — clean
- [x] `make agent-frontend-lint` + `agent-frontend-format-check` — clean
- [x] `make agent-frontend-test` — 423 events tests passed
- [x] `RsvpGuestList.test.tsx` covers counts, plus-ones in totals, 5-avatar cap + overflow count, members-before-non-members ordering, search filtering, going/maybe tab separation, and the Issue 1042 host-only tab gating
