### PR TITLE
fix(seed): reset join-request-range users so welcome modal reappears

### DIFF
--- a/backend/community/management/commands/seed_staging.py
+++ b/backend/community/management/commands/seed_staging.py
@@ -89,6 +89,9 @@ class Command(BaseCommand):
         User.objects.filter(phone_number__startswith="+170255501").delete()
         User.objects.filter(phone_number__startswith="+170255502").delete()
         User.objects.filter(phone_number__startswith="+170255503").delete()
+        # +170255504 is the join-request range: approving a request creates a user
+        # at that phone, so reset must clear those too or reseeds re-orphan them.
+        User.objects.filter(phone_number__startswith="+170255504").delete()
         User.objects.filter(phone_number__startswith="+170255505").delete()
         User.objects.filter(phone_number__startswith="+170255506").delete()
         Role.objects.filter(name__startswith="perm: ").delete()

--- a/backend/tests/test_seed_staging.py
+++ b/backend/tests/test_seed_staging.py
@@ -256,6 +256,18 @@ def test_seed_staging_reset_removes_non_member_band():
 
 
 @pytest.mark.django_db
+def test_seed_staging_reset_removes_approval_created_join_request_users():
+    call_command("seed_staging")
+    # approving a join request creates a member user at the request's phone, which
+    # then collides with the reseeded pending request and suppresses the welcome
+    # modal (no token minted). --reset must clear the join-request band's users too.
+    orphan = User.objects.create(phone_number=joinreq_phone(0), is_member=True)
+    call_command("seed_staging", "--reset")
+    assert not User.objects.filter(phone_number=joinreq_phone(0)).exists()
+    assert orphan.pk not in User.objects.values_list("pk", flat=True)
+
+
+@pytest.mark.django_db
 def test_seed_staging_non_members_idempotent():
     call_command("seed_staging")
     call_command("seed_staging")


### PR DESCRIPTION
## what

`seed_staging --reset` deleted staging demo users in the `+170255501/502/503/505/506` phone bands but **skipped `+170255504`** — the join-request range.

Approving a join request creates a member `User` at the request's phone number. Because `--reset` never cleared that band, every reseed left the approval-created users behind and re-created a fresh *pending* join request at the same phone. On the next approve, the backend correctly saw "this phone already belongs to an active member," minted **no** magic-link token, and the welcome popup (`ApprovalCredentialsDialog`) was silently skipped. The join card showed nothing unusual because those users weren't archived — they were active members.

## fix

- add `User.objects.filter(phone_number__startswith="+170255504").delete()` to `_reset()`
- regression test: an approval-created user in the `+170255504` band is cleared by `--reset` (fails without the fix)

## not an app bug

The frontend/backend approval flow is correct — the modal shows whenever the backend returns a token, which it does for genuinely-new applicants. This was purely inconsistent staging seed data.

## staging already cleaned

Staging was manually de-orphaned and reseeded during diagnosis; all 6 pending requests now resolve to no existing user, so approving them shows the welcome modal. This PR prevents the orphaning from recurring on future reseeds.

## test plan

- [x] `pytest tests/test_seed_staging.py` — 34 passed
- [x] new test fails with the fix reverted, passes with it
- [x] ruff lint + ty typecheck clean
