### PR TITLE
fix: 1146 - match header gradient to footer's 3-stop treatment

### DIFF
--- a/frontend/src/layout/AppShell.tsx
+++ b/frontend/src/layout/AppShell.tsx
@@ -14,7 +14,7 @@ export function AppShell() {
 
   return (
     <div className="bg-background flex min-h-screen flex-col">
-      <header className="from-surface to-surface/60 sticky top-0 z-10 bg-gradient-to-b">
+      <header className="from-surface via-surface/85 to-surface/20 sticky top-0 z-10 bg-gradient-to-b">
         <div className="mx-auto flex h-10 max-w-6xl items-center justify-between gap-4 px-4">
           <button
             type="button"


### PR DESCRIPTION
## Overview

The header lacked the 3-stop opacity gradient the footer (`BottomNav`) already has, so scrolled content faded out smoothly under the bottom nav but not under the top header.

`BottomNav` uses `from-surface/20 via-surface/85 to-surface` (bottom-fixed, fading from mostly-transparent to opaque). This PR mirrors that treatment for the header — `from-surface via-surface/85 to-surface/20` (top-fixed, fading from opaque to mostly-transparent) — so both fixed bars fade scrolled content consistently.

Closes #1146

## Test plan

- [x] `AppShell.test.tsx` and `BottomNav.test.tsx` pass (10/10)
- [x] `npx tsc --noEmit` clean
- [x] `prettier --check` clean on changed file
- [ ] TODO: visual check on `/events/<id>` to confirm the fade looks right against real content
