### PR TITLE
fix: 1145 - remove x going tag under rsvp button

### DIFF
--- a/frontend/src/screens/events/RsvpSection.tsx
+++ b/frontend/src/screens/events/RsvpSection.tsx
@@ -142,7 +142,6 @@ export function RsvpSection({ event, token }: Props) {
       )}
 
       <SpotsLeft event={event} />
-      <Summary event={event} />
       {error ? (
         <p role="alert" className="text-destructive text-sm">
           {error}
@@ -231,25 +230,6 @@ function SpotsLeft({ event }: { event: Event }) {
     <p className="text-warning text-center text-xs">
       {left === 1 ? '1 spot left' : `${String(left)} spots left`}
     </p>
-  );
-}
-
-function Summary({ event }: { event: Event }) {
-  const goingLabel =
-    event.maxAttendees !== null
-      ? `${String(event.attendingCount)} / ${String(event.maxAttendees)} going`
-      : `${String(event.attendingCount)} going`;
-  return (
-    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
-      <span className="bg-success-subtle text-success inline-flex items-center rounded-full px-2.5 py-0.5 font-medium">
-        {goingLabel}
-      </span>
-      {event.waitlistedCount > 0 ? (
-        <span className="bg-warning-subtle text-warning inline-flex items-center rounded-full px-2.5 py-0.5 font-medium">
-          {event.waitlistedCount} waitlisted
-        </span>
-      ) : null}
-    </div>
   );
 }
 


### PR DESCRIPTION
## Overview

Removes the "x going" attendee-count pill from `RsvpSection` on the event detail screen. It rendered directly under the rsvp button, which read as confusing/out of place — and the same information is already shown in the "who's going" guest list further down the page, making the pill redundant.

Closes #1145

## Test plan

- [x] `RsvpSection.test.tsx`, `EventDetailScreen.test.tsx`, `EventMemberSection.test.tsx` pass (74 tests)
- [x] `tsc --noEmit` clean
- [x] prettier clean on changed file
- [ ] TODO: manual check on `/events/<id>` that the rsvp button area no longer shows the going-count pill and "who's going" still shows counts
