### PR TITLE
fix(events): prompt login on members-only event 404 (Issue 1150)

### DIFF
--- a/frontend/src/screens/events/EventDetailScreen.test.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.test.tsx
@@ -348,12 +348,24 @@ describe('EventDetailScreen', () => {
       } as unknown as ReturnType<typeof useEvent>);
     }
 
-    it('shows a "nothing here" notice on 404 instead of a refresh prompt', () => {
+    it('prompts an unauthenticated visitor to log in on 404 instead of a dead end (issue 1150)', () => {
+      mockError(404);
+      renderScreen('ev1');
+
+      expect(screen.getByText(/log in to see this event/i)).toBeInTheDocument();
+      expect(screen.queryByText(/try refreshing/i)).not.toBeInTheDocument();
+
+      const loginLink = screen.getByRole('link', { name: /log in/i });
+      expect(loginLink).toHaveAttribute('href', '/login?redirect=%2Fevents%2Fev1');
+    });
+
+    it('shows a "nothing here" notice on 404 for an authed member instead of a login prompt', () => {
+      useAuthStore.setState({ status: 'authed', user: AUTHED_USER, accessToken: 'tok' });
       mockError(404);
       renderScreen('ev1');
 
       expect(screen.getByText(/nothing here/i)).toBeInTheDocument();
-      expect(screen.queryByText(/try refreshing/i)).not.toBeInTheDocument();
+      expect(screen.queryByRole('link', { name: /^log in$/i })).not.toBeInTheDocument();
     });
 
     it('shows a refresh prompt on a generic error', () => {

--- a/frontend/src/screens/events/EventDetailScreen.test.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.test.tsx
@@ -348,7 +348,7 @@ describe('EventDetailScreen', () => {
       } as unknown as ReturnType<typeof useEvent>);
     }
 
-    it('prompts an unauthenticated visitor to log in on 404 instead of a dead end (issue 1150)', () => {
+    it('prompts an unauthenticated visitor to log in on 404 instead of a dead end', () => {
       mockError(404);
       renderScreen('ev1');
 

--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -1,4 +1,4 @@
-import { Link, useParams, useSearchParams } from 'react-router-dom';
+import { Link, useLocation, useParams, useSearchParams } from 'react-router-dom';
 
 import { extractApiError, getApiStatus } from '@/api/apiErrors';
 import { useEvent } from '@/api/events';
@@ -29,6 +29,7 @@ function photoSrc(url: string, updatedAt: string | null): string {
 export default function EventDetailScreen() {
   const { id } = useParams<{ id: string }>();
   const [searchParams] = useSearchParams();
+  const location = useLocation();
   const isAuthed = useAuthStore((s) => s.status === 'authed');
   const user = useAuthStore((s) => s.user);
   // The emailed link carries ?rsvp_token=…; a returning non-member arrives with
@@ -50,8 +51,20 @@ export default function EventDetailScreen() {
       const message = extractApiError(error) ?? "you don't have permission to see this event";
       return <ForbiddenNotice message={message} />;
     }
-    // members-only events 404 for signed-out visitors, so refreshing never helps
+    // members-only events 404 for signed-out visitors (indistinguishable from a
+    // truly missing event, by design — the backend won't confirm existence), so
+    // a login prompt is the most useful next step rather than a dead end.
     if (status === 404) {
+      if (!isAuthed) {
+        const redirect = encodeURIComponent(location.pathname + location.search);
+        return (
+          <ForbiddenNotice
+            message="log in to see this event"
+            subtext="this link may go to a members-only event — sign in to check"
+            loginRedirect={redirect}
+          />
+        );
+      }
       return (
         <ForbiddenNotice
           message="there's nothing here"
@@ -168,21 +181,33 @@ function WhenLine({ event }: { event: Event }) {
 function ForbiddenNotice({
   message,
   subtext = 'if you think this is a mistake, reach out to the host',
+  loginRedirect,
 }: {
   message: string;
   subtext?: string;
+  loginRedirect?: string;
 }) {
   return (
     <ContentContainer>
       <section className="border-border bg-surface mt-8 rounded-lg border p-6">
         <h2 className="mb-2 text-base font-medium">{message}</h2>
         <p className="text-foreground-tertiary mb-4 text-sm">{subtext}</p>
-        <Link
-          to="/calendar"
-          className="border-border-strong text-foreground-secondary hover:bg-background inline-flex h-10 items-center rounded-md border px-4 text-sm font-medium"
-        >
-          back to calendar
-        </Link>
+        <div className="flex flex-wrap gap-3">
+          {loginRedirect ? (
+            <Link
+              to={`/login?redirect=${loginRedirect}`}
+              className="bg-brand-600 text-brand-on hover:bg-brand-700 inline-flex h-10 items-center rounded-md px-4 text-sm font-medium"
+            >
+              log in
+            </Link>
+          ) : null}
+          <Link
+            to="/calendar"
+            className="border-border-strong text-foreground-secondary hover:bg-background inline-flex h-10 items-center rounded-md border px-4 text-sm font-medium"
+          >
+            back to calendar
+          </Link>
+        </div>
       </section>
     </ContentContainer>
   );

--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -51,9 +51,7 @@ export default function EventDetailScreen() {
       const message = extractApiError(error) ?? "you don't have permission to see this event";
       return <ForbiddenNotice message={message} />;
     }
-    // members-only events 404 for signed-out visitors (indistinguishable from a
-    // truly missing event, by design — the backend won't confirm existence), so
-    // a login prompt is the most useful next step rather than a dead end.
+    // members-only events 404 for signed-out visitors, indistinguishable from a missing one
     if (status === 404) {
       if (!isAuthed) {
         const redirect = encodeURIComponent(location.pathname + location.search);


### PR DESCRIPTION
## summary

- fixes #1150: an unauthenticated visitor who follows a link to a members-only event hit a dead-end "there's nothing here" notice with no way forward
- root cause: members-only events 404 for signed-out visitors by design (the backend won't confirm existence to an unauthed caller — see `_enforce_event_read_visibility` in `backend/community/_events.py`), but the frontend's 404 branch in `EventDetailScreen.tsx` rendered a flat not-found message with only a "back to calendar" link
- fix: when the 404 is hit by an unauthenticated viewer, show a friendlier prompt ("log in to see this event") with a login cta that uses the existing `/login?redirect=<path>` pattern (same one `RequireAuth`/`RequirePermission`/`RequireFlag` already use), so login returns them to the event. an authed member hitting a genuine 404 still sees the plain not-found notice — no change there.

## test plan

- [x] updated `EventDetailScreen.test.tsx`: unauthed 404 shows the login prompt + correct `/login?redirect=` href; authed 404 still shows the plain not-found notice
- [x] `npx vitest run src/screens/events/EventDetailScreen.test.tsx` — 21/21 passed
- [x] `npx eslint` + `npx prettier --write` on changed files — clean
- [x] `npx tsc --noEmit` — clean