### PR TITLE
fix(mobile): raise remaining text-sm inputs to 16px to stop ios safari zoom

### DIFF
--- a/frontend/src/components/PhotoLibraryDialog.tsx
+++ b/frontend/src/components/PhotoLibraryDialog.tsx
@@ -175,7 +175,7 @@ export function PhotoLibraryDialog({ onCancel, onSelect }: Props) {
               }}
               placeholder="search gifs and photos"
               disabled={picking}
-              className="border-border bg-background text-foreground rounded-[var(--radius-md)] border px-3 py-2 text-sm"
+              className="border-border bg-background text-foreground rounded-[var(--radius-md)] border px-3 py-2 text-base md:text-sm"
             />
 
             <div className="grid max-h-80 grid-cols-3 gap-2 overflow-y-auto">

--- a/frontend/src/components/ui/PhoneField.tsx
+++ b/frontend/src/components/ui/PhoneField.tsx
@@ -61,7 +61,7 @@ export function PhoneField({
           'aria-label': label,
           ...numberInputProps,
           className: cn(
-            'h-10 w-full rounded-md border border-border-strong bg-surface px-3 text-sm transition-colors outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-200',
+            'h-10 w-full rounded-md border border-border-strong bg-surface px-3 text-base transition-colors outline-none focus:border-brand-500 focus:ring-2 focus:ring-brand-200 md:text-sm',
             error && 'border-destructive-border focus:border-red-500 focus:ring-red-100',
             numberInputProps?.className,
           ),

--- a/frontend/src/screens/admin/MemberPromotionMessageEditorDialog.tsx
+++ b/frontend/src/screens/admin/MemberPromotionMessageEditorDialog.tsx
@@ -69,7 +69,7 @@ function EditorForm({ initialBody, onClose }: { initialBody: string; onClose: ()
           setBody(e.target.value);
         }}
         rows={10}
-        className="border-border bg-background text-foreground focus-visible:ring-brand-200 w-full rounded-md border p-3 font-mono text-sm focus-visible:ring-2 focus-visible:outline-none"
+        className="border-border bg-background text-foreground focus-visible:ring-brand-200 w-full rounded-md border p-3 font-mono text-base focus-visible:ring-2 focus-visible:outline-none md:text-sm"
         aria-label="member promotion message body"
       />
       <div

--- a/frontend/src/screens/admin/TentativeApprovalMessageEditorDialog.tsx
+++ b/frontend/src/screens/admin/TentativeApprovalMessageEditorDialog.tsx
@@ -68,7 +68,7 @@ function EditorForm({ initialBody, onClose }: { initialBody: string; onClose: ()
           setBody(e.target.value);
         }}
         rows={10}
-        className="border-border bg-background text-foreground focus-visible:ring-brand-200 w-full rounded-md border p-3 font-mono text-sm focus-visible:ring-2 focus-visible:outline-none"
+        className="border-border bg-background text-foreground focus-visible:ring-brand-200 w-full rounded-md border p-3 font-mono text-base focus-visible:ring-2 focus-visible:outline-none md:text-sm"
         aria-label="tentative approval message body"
       />
       <div

--- a/frontend/src/screens/admin/WelcomeTemplateEditorDialog.tsx
+++ b/frontend/src/screens/admin/WelcomeTemplateEditorDialog.tsx
@@ -68,7 +68,7 @@ function EditorForm({ initialBody, onClose }: { initialBody: string; onClose: ()
           setBody(e.target.value);
         }}
         rows={14}
-        className="border-border bg-background text-foreground focus-visible:ring-brand-200 w-full rounded-md border p-3 font-mono text-sm focus-visible:ring-2 focus-visible:outline-none"
+        className="border-border bg-background text-foreground focus-visible:ring-brand-200 w-full rounded-md border p-3 font-mono text-base focus-visible:ring-2 focus-visible:outline-none md:text-sm"
         aria-label="welcome message body"
       />
       <div

--- a/frontend/src/screens/admin/WhatsAppLinkEditorDialog.tsx
+++ b/frontend/src/screens/admin/WhatsAppLinkEditorDialog.tsx
@@ -59,7 +59,7 @@ function EditorForm({ initialLink, onClose }: { initialLink: string; onClose: ()
           setLink(e.target.value);
         }}
         placeholder="https://chat.whatsapp.com/…"
-        className="border-border bg-background text-foreground focus-visible:ring-brand-200 w-full rounded-md border p-3 font-mono text-sm focus-visible:ring-2 focus-visible:outline-none"
+        className="border-border bg-background text-foreground focus-visible:ring-brand-200 w-full rounded-md border p-3 font-mono text-base focus-visible:ring-2 focus-visible:outline-none md:text-sm"
         aria-label="whatsapp link"
       />
       {formError ? (

--- a/frontend/src/screens/docs/DocsScreen.tsx
+++ b/frontend/src/screens/docs/DocsScreen.tsx
@@ -94,7 +94,7 @@ export default function DocsScreen() {
             <label className="text-muted flex min-w-[10rem] flex-col gap-1 text-xs">
               folder
               <select
-                className="border-border bg-background text-foreground rounded-md border px-2 py-2 text-sm"
+                className="border-border bg-background text-foreground rounded-md border px-2 py-2 text-base md:text-sm"
                 value={effectiveDocFolderId}
                 onChange={(e) => {
                   setNewDocFolderId(e.target.value);


### PR DESCRIPTION
## Summary
- Follow-up to Issue 1131 / PR #1136, which fixed the iOS Safari auto-zoom-on-focus bug for most form inputs but missed several.
- Applies the same `text-base md:text-sm` pattern (16px on mobile to avoid the zoom, reverting to 14px at `md:` and up) to the remaining real text-entry inputs:
  - `PhoneField` internal number input
  - `PhotoLibraryDialog` gif/photo search input
  - `WhatsAppLinkEditorDialog` link input
  - `MemberPromotionMessageEditorDialog`, `TentativeApprovalMessageEditorDialog`, `WelcomeTemplateEditorDialog` message textareas
  - `DocsScreen` folder `<select>`

## Test plan
- [x] `make agent-frontend-typecheck` passes
- [ ] Manually focus each affected input on an iOS Safari device/simulator and confirm no auto-zoom