### PR TITLE
fix(events): gate comment visibility on active rsvp

### DIFF
--- a/backend/community/_event_comments.py
+++ b/backend/community/_event_comments.py
@@ -161,9 +161,7 @@ def _build_list_out(event: Event, viewer) -> EventCommentListOut:
         reason = "rsvp_required"
     else:
         reason = None
-    # Reading comment content requires the same standing as posting them — an
-    # active RSVP (or host/co-host/admin) — so a bystander can't see the thread
-    # just by being logged in (Issue 1168).
+    # Reading requires the same standing as posting — no peeking without an active rsvp.
     if not can_post:
         return EventCommentListOut(items=[], can_post=can_post, cannot_post_reason=reason)
     comments = (

--- a/backend/community/_event_comments.py
+++ b/backend/community/_event_comments.py
@@ -154,12 +154,6 @@ def _comment_out(
 
 def _build_list_out(event: Event, viewer) -> EventCommentListOut:
     co_host_pks = {str(u.pk) for u in event.co_hosts.all()}  # uses prefetch cache
-    comments = (
-        EventComment.objects.filter(event=event, parent__isnull=True)
-        .select_related("author")
-        .prefetch_related("replies__author", "reactions", "replies__reactions")
-        .order_by("-created_at")
-    )
     can_post = _can_post_comments(event, viewer, co_host_pks=co_host_pks)
     if viewer is None:
         reason: str | None = "login_required"
@@ -167,6 +161,17 @@ def _build_list_out(event: Event, viewer) -> EventCommentListOut:
         reason = "rsvp_required"
     else:
         reason = None
+    # Reading comment content requires the same standing as posting them — an
+    # active RSVP (or host/co-host/admin) — so a bystander can't see the thread
+    # just by being logged in (Issue 1168).
+    if not can_post:
+        return EventCommentListOut(items=[], can_post=can_post, cannot_post_reason=reason)
+    comments = (
+        EventComment.objects.filter(event=event, parent__isnull=True)
+        .select_related("author")
+        .prefetch_related("replies__author", "reactions", "replies__reactions")
+        .order_by("-created_at")
+    )
     return EventCommentListOut(
         items=[_comment_out(c, event, viewer, co_host_pks=co_host_pks) for c in comments],
         can_post=can_post,

--- a/backend/community/_event_comments.py
+++ b/backend/community/_event_comments.py
@@ -155,15 +155,16 @@ def _comment_out(
 def _build_list_out(event: Event, viewer) -> EventCommentListOut:
     co_host_pks = {str(u.pk) for u in event.co_hosts.all()}  # uses prefetch cache
     can_post = _can_post_comments(event, viewer, co_host_pks=co_host_pks)
-    if viewer is None:
-        reason: str | None = "login_required"
-    elif not can_post:
-        reason = "rsvp_required"
-    else:
-        reason = None
     # Reading requires the same standing as posting — no peeking without an active rsvp.
     if not can_post:
-        return EventCommentListOut(items=[], can_post=can_post, cannot_post_reason=reason)
+        # A signed-out visitor can still rsvp themselves onto a public event, so
+        # prompt for that rather than for a login they don't need.
+        reason = (
+            "rsvp_required"
+            if viewer is not None or event.is_public_rsvp_eligible
+            else "login_required"
+        )
+        return EventCommentListOut(items=[], can_post=False, cannot_post_reason=reason)
     comments = (
         EventComment.objects.filter(event=event, parent__isnull=True)
         .select_related("author")
@@ -172,8 +173,8 @@ def _build_list_out(event: Event, viewer) -> EventCommentListOut:
     )
     return EventCommentListOut(
         items=[_comment_out(c, event, viewer, co_host_pks=co_host_pks) for c in comments],
-        can_post=can_post,
-        cannot_post_reason=reason,
+        can_post=True,
+        cannot_post_reason=None,
     )
 
 

--- a/backend/community/management/commands/e2e_seed.py
+++ b/backend/community/management/commands/e2e_seed.py
@@ -138,7 +138,8 @@ def _seed_live_updates() -> dict:
     event = _random_event("live-updates")
     phone_a, phone_b = _random_phone(), _random_phone()
     _member_user(phone_a)
-    _member_user(phone_b)
+    user_b = _member_user(phone_b)
+    EventRSVP.objects.create(event=event, user=user_b, status=RSVPStatus.ATTENDING)
     return {
         "event_id": str(event.id),
         "event_title": event.title,

--- a/backend/tests/test_e2e_seed_command.py
+++ b/backend/tests/test_e2e_seed_command.py
@@ -57,7 +57,9 @@ def test_e2e_seed_live_updates(capsys):
     for key in ("user_a_phone", "user_a_password", "user_b_phone", "user_b_password"):
         assert out[key]
     assert User.objects.get(phone_number=out["user_a_phone"]).is_member is True
-    assert User.objects.get(phone_number=out["user_b_phone"]).is_member is True
+    user_b = User.objects.get(phone_number=out["user_b_phone"])
+    assert user_b.is_member is True
+    assert EventRSVP.objects.filter(event_id=out["event_id"], user=user_b).exists()
 
 
 @pytest.mark.django_db

--- a/backend/tests/test_event_comments.py
+++ b/backend/tests/test_event_comments.py
@@ -91,11 +91,17 @@ class TestGetComments:
         assert body["can_post"] is True
         assert body["cannot_post_reason"] is None
 
-    def test_event_creator_can_see_comment_content_without_rsvp(
-        self, api_client, auth_headers, event, test_user
-    ):
+    def test_cohost_can_see_comment_content_without_rsvp(self, api_client, event, test_user):
         EventComment.objects.create(event=event, author=test_user, body="host comment")
-        response = api_client.get(f"/api/community/events/{event.id}/comments/", **auth_headers)
+        cohost = User.objects.create_user(
+            phone_number="+12025550912",
+            password="cohostpass",
+            first_name="Cohost",
+        )
+        event.co_hosts.add(cohost)
+        refresh = RefreshToken.for_user(cohost)
+        headers = {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
+        response = api_client.get(f"/api/community/events/{event.id}/comments/", **headers)
         assert response.status_code == 200, response.content
         body = response.json()
         assert len(body["items"]) == 1

--- a/backend/tests/test_event_comments.py
+++ b/backend/tests/test_event_comments.py
@@ -8,6 +8,7 @@ from community.models import (
     Event,
     EventComment,
     EventRSVP,
+    EventType,
     PageVisibility,
     RSVPStatus,
 )
@@ -38,8 +39,25 @@ class TestGetComments:
         assert body["can_post"] is False
         assert body["cannot_post_reason"] == "login_required"
 
+    def test_unauthed_on_public_rsvp_event_is_prompted_to_rsvp_not_login(
+        self, api_client, db, test_user
+    ):
+        event = Event.objects.create(
+            title="Public Event",
+            start_datetime=future_iso(days=30),
+            created_by=test_user,
+            event_type=EventType.OFFICIAL,
+            visibility=PageVisibility.PUBLIC,
+            rsvp_enabled=True,
+        )
+        response = api_client.get(f"/api/community/events/{event.id}/comments/")
+        assert response.status_code == 200, response.content
+        body = response.json()
+        assert body["items"] == []
+        assert body["can_post"] is False
+        assert body["cannot_post_reason"] == "rsvp_required"
+
     def test_bystander_without_rsvp_cannot_see_comment_content(self, api_client, event, test_user):
-        # event fixture defaults to rsvp_enabled=False
         EventComment.objects.create(event=event, author=test_user, body="host comment")
         bystander = User.objects.create_user(
             phone_number="+12025550910",

--- a/backend/tests/test_event_comments.py
+++ b/backend/tests/test_event_comments.py
@@ -38,6 +38,53 @@ class TestGetComments:
         assert body["can_post"] is False
         assert body["cannot_post_reason"] == "login_required"
 
+    def test_bystander_without_rsvp_cannot_see_comment_content(self, api_client, event, test_user):
+        # event fixture has rsvp_enabled=False (the default) — this is exactly
+        # the reporter's scenario: rsvp "appeared disabled" but comments were
+        # still visible (Issue 1168).
+        EventComment.objects.create(event=event, author=test_user, body="host comment")
+        bystander = User.objects.create_user(
+            phone_number="+12025550910",
+            password="bystanderpass",
+            first_name="Bystander",
+        )
+        refresh = RefreshToken.for_user(bystander)
+        headers = {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
+        response = api_client.get(f"/api/community/events/{event.id}/comments/", **headers)
+        assert response.status_code == 200, response.content
+        body = response.json()
+        assert body["items"] == []
+        assert body["can_post"] is False
+        assert body["cannot_post_reason"] == "rsvp_required"
+
+    def test_rsvpd_member_can_see_comment_content(self, api_client, event, test_user):
+        EventComment.objects.create(event=event, author=test_user, body="host comment")
+        member = User.objects.create_user(
+            phone_number="+12025550911",
+            password="memberpass",
+            first_name="Member",
+        )
+        EventRSVP.objects.create(event=event, user=member, status=RSVPStatus.ATTENDING)
+        refresh = RefreshToken.for_user(member)
+        headers = {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
+        response = api_client.get(f"/api/community/events/{event.id}/comments/", **headers)
+        assert response.status_code == 200, response.content
+        body = response.json()
+        assert len(body["items"]) == 1
+        assert body["items"][0]["body"] == "host comment"
+        assert body["can_post"] is True
+        assert body["cannot_post_reason"] is None
+
+    def test_event_creator_can_see_comment_content_without_rsvp(
+        self, api_client, auth_headers, event, test_user
+    ):
+        EventComment.objects.create(event=event, author=test_user, body="host comment")
+        response = api_client.get(f"/api/community/events/{event.id}/comments/", **auth_headers)
+        assert response.status_code == 200, response.content
+        body = response.json()
+        assert len(body["items"]) == 1
+        assert body["can_post"] is True
+
 
 @pytest.fixture
 def rsvp_user(db):

--- a/backend/tests/test_event_comments.py
+++ b/backend/tests/test_event_comments.py
@@ -39,9 +39,7 @@ class TestGetComments:
         assert body["cannot_post_reason"] == "login_required"
 
     def test_bystander_without_rsvp_cannot_see_comment_content(self, api_client, event, test_user):
-        # event fixture has rsvp_enabled=False (the default) — this is exactly
-        # the reporter's scenario: rsvp "appeared disabled" but comments were
-        # still visible (Issue 1168).
+        # event fixture defaults to rsvp_enabled=False
         EventComment.objects.create(event=event, author=test_user, body="host comment")
         bystander = User.objects.create_user(
             phone_number="+12025550910",

--- a/backend/tests/users/test_hide_last_name.py
+++ b/backend/tests/users/test_hide_last_name.py
@@ -228,11 +228,12 @@ class TestPollVotersHideLastName:
 
 @pytest.mark.django_db
 class TestCommentAuthorHidesLastName:
-    def test_non_admin_sees_first_name_only(self, api_client, auth_headers, hidden_user):
+    def test_non_admin_sees_first_name_only(self, api_client, auth_headers, test_user, hidden_user):
         event = Event.objects.create(
             title="Comment Event", start_datetime=future_iso(days=10), created_by=hidden_user
         )
         EventRSVP.objects.create(event=event, user=hidden_user, status=RSVPStatus.ATTENDING)
+        EventRSVP.objects.create(event=event, user=test_user, status=RSVPStatus.ATTENDING)
         EventComment.objects.create(event=event, author=hidden_user, body="hello")
         response = api_client.get(f"/api/community/events/{event.id}/comments/", **auth_headers)
         assert response.status_code == 200

--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -274,7 +274,7 @@ describe('EventMemberSection — past event gates (#385)', () => {
 describe('EventMemberSection — rsvp-disabled gates (#666, #667)', () => {
   const RSVP_ENABLED_EVENT: Event = { ...BASE_EVENT, rsvpEnabled: true };
 
-  it('still renders the comments section when rsvp is disabled', () => {
+  it("renders the comments card regardless of rsvpEnabled — gating is the card's own job", () => {
     useAuthStore.setState({ status: 'authed', user: STRANGER, accessToken: 'tok' });
     renderSection({ ...BASE_EVENT, rsvpEnabled: false });
     expect(screen.getByTestId('comments-card')).toBeInTheDocument();

--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -274,10 +274,10 @@ describe('EventMemberSection — past event gates (#385)', () => {
 describe('EventMemberSection — rsvp-disabled gates (#666, #667)', () => {
   const RSVP_ENABLED_EVENT: Event = { ...BASE_EVENT, rsvpEnabled: true };
 
-  it('hides the comments section when rsvp is disabled (#666)', () => {
+  it('still renders the comments section when rsvp is disabled — gating happens inside the card (Issue 1168)', () => {
     useAuthStore.setState({ status: 'authed', user: STRANGER, accessToken: 'tok' });
     renderSection({ ...BASE_EVENT, rsvpEnabled: false });
-    expect(screen.queryByTestId('comments-card')).not.toBeInTheDocument();
+    expect(screen.getByTestId('comments-card')).toBeInTheDocument();
   });
 
   it('shows the comments section when rsvp is enabled', () => {

--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -274,7 +274,7 @@ describe('EventMemberSection — past event gates (#385)', () => {
 describe('EventMemberSection — rsvp-disabled gates (#666, #667)', () => {
   const RSVP_ENABLED_EVENT: Event = { ...BASE_EVENT, rsvpEnabled: true };
 
-  it('still renders the comments section when rsvp is disabled — gating happens inside the card (Issue 1168)', () => {
+  it('still renders the comments section when rsvp is disabled', () => {
     useAuthStore.setState({ status: 'authed', user: STRANGER, accessToken: 'tok' });
     renderSection({ ...BASE_EVENT, rsvpEnabled: false });
     expect(screen.getByTestId('comments-card')).toBeInTheDocument();

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -28,15 +28,8 @@ export function EventMemberSection({ event, token }: Props) {
   const user = useAuthStore((s) => s.user);
   if (!user && !token) return null;
 
-  const {
-    isCoHost,
-    canSeeInvited,
-    isCancelled,
-    rsvpDisabled,
-    canInvite,
-    showRsvp,
-    showStandaloneInvited,
-  } = eventMemberSectionFlags(event, user);
+  const { isCoHost, canSeeInvited, isCancelled, canInvite, showRsvp, showStandaloneInvited } =
+    eventMemberSectionFlags(event, user);
 
   return (
     <div className="mt-8 flex flex-col gap-6">
@@ -73,7 +66,7 @@ export function EventMemberSection({ event, token }: Props) {
           <InvitedList event={event} />
         </Card>
       ) : null}
-      {rsvpDisabled ? null : <EventCommentsCard eventId={event.id} {...(token ? { token } : {})} />}
+      <EventCommentsCard eventId={event.id} {...(token ? { token } : {})} />
       <EventAdminActions event={event} />
       <ReportEventButton eventId={event.id} />
     </div>

--- a/frontend/src/screens/events/comments/CommentItem.test.tsx
+++ b/frontend/src/screens/events/comments/CommentItem.test.tsx
@@ -42,7 +42,7 @@ const baseComment: EventComment = {
 
 describe('CommentItem', () => {
   it('renders the body and author', () => {
-    wrap(<CommentItem comment={baseComment} eventId="evt" canReact canReply />);
+    wrap(<CommentItem comment={baseComment} eventId="evt" canComment />);
     expect(screen.getByText('hello')).toBeInTheDocument();
     // Rendered lowercase via CSS text-transform, not string mutation — the DOM
     // text content stays the real display name.
@@ -51,9 +51,7 @@ describe('CommentItem', () => {
 
   it('wraps a long unbroken body so it cannot overflow the viewport', () => {
     const longToken = `https://example.com/${'x'.repeat(200)}`;
-    wrap(
-      <CommentItem comment={{ ...baseComment, body: longToken }} eventId="evt" canReact canReply />,
-    );
+    wrap(<CommentItem comment={{ ...baseComment, body: longToken }} eventId="evt" canComment />);
     expect(screen.getByText(longToken)).toHaveClass('break-words', '[overflow-wrap:anywhere]');
   });
 
@@ -62,8 +60,7 @@ describe('CommentItem', () => {
       <CommentItem
         comment={{ ...baseComment, isDeleted: true, body: '' }}
         eventId="evt"
-        canReact
-        canReply
+        canComment
       />,
     );
     expect(screen.getByText('[deleted]')).toBeInTheDocument();
@@ -71,21 +68,14 @@ describe('CommentItem', () => {
   });
 
   it('shows delete only when canDelete is true', () => {
-    wrap(
-      <CommentItem
-        comment={{ ...baseComment, canDelete: false }}
-        eventId="evt"
-        canReact
-        canReply
-      />,
-    );
+    wrap(<CommentItem comment={{ ...baseComment, canDelete: false }} eventId="evt" canComment />);
     expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
   });
 
   it('includes the rsvp token when a non-member posts a reply', async () => {
     mockPost.mockClear();
     const user = userEvent.setup();
-    wrap(<CommentItem comment={baseComment} eventId="evt" token="rsvp-token" canReact canReply />);
+    wrap(<CommentItem comment={baseComment} eventId="evt" token="rsvp-token" canComment />);
     await user.click(screen.getByRole('button', { name: 'reply' }));
     await user.type(screen.getByPlaceholderText('reply…'), 'hi there');
     await user.click(screen.getByRole('button', { name: 'post' }));

--- a/frontend/src/screens/events/comments/CommentItem.test.tsx
+++ b/frontend/src/screens/events/comments/CommentItem.test.tsx
@@ -42,7 +42,7 @@ const baseComment: EventComment = {
 
 describe('CommentItem', () => {
   it('renders the body and author', () => {
-    wrap(<CommentItem comment={baseComment} eventId="evt" canComment />);
+    wrap(<CommentItem comment={baseComment} eventId="evt" />);
     expect(screen.getByText('hello')).toBeInTheDocument();
     // Rendered lowercase via CSS text-transform, not string mutation — the DOM
     // text content stays the real display name.
@@ -51,31 +51,25 @@ describe('CommentItem', () => {
 
   it('wraps a long unbroken body so it cannot overflow the viewport', () => {
     const longToken = `https://example.com/${'x'.repeat(200)}`;
-    wrap(<CommentItem comment={{ ...baseComment, body: longToken }} eventId="evt" canComment />);
+    wrap(<CommentItem comment={{ ...baseComment, body: longToken }} eventId="evt" />);
     expect(screen.getByText(longToken)).toHaveClass('break-words', '[overflow-wrap:anywhere]');
   });
 
   it('renders [deleted] placeholder when isDeleted', () => {
-    wrap(
-      <CommentItem
-        comment={{ ...baseComment, isDeleted: true, body: '' }}
-        eventId="evt"
-        canComment
-      />,
-    );
+    wrap(<CommentItem comment={{ ...baseComment, isDeleted: true, body: '' }} eventId="evt" />);
     expect(screen.getByText('[deleted]')).toBeInTheDocument();
     expect(screen.queryByRole('group', { name: 'reactions' })).not.toBeInTheDocument();
   });
 
   it('shows delete only when canDelete is true', () => {
-    wrap(<CommentItem comment={{ ...baseComment, canDelete: false }} eventId="evt" canComment />);
+    wrap(<CommentItem comment={{ ...baseComment, canDelete: false }} eventId="evt" />);
     expect(screen.queryByRole('button', { name: /delete/i })).not.toBeInTheDocument();
   });
 
   it('includes the rsvp token when a non-member posts a reply', async () => {
     mockPost.mockClear();
     const user = userEvent.setup();
-    wrap(<CommentItem comment={baseComment} eventId="evt" token="rsvp-token" canComment />);
+    wrap(<CommentItem comment={baseComment} eventId="evt" token="rsvp-token" />);
     await user.click(screen.getByRole('button', { name: 'reply' }));
     await user.type(screen.getByPlaceholderText('reply…'), 'hi there');
     await user.click(screen.getByRole('button', { name: 'post' }));

--- a/frontend/src/screens/events/comments/CommentItem.tsx
+++ b/frontend/src/screens/events/comments/CommentItem.tsx
@@ -15,11 +15,9 @@ interface Props {
   comment: EventComment;
   eventId: string;
   token?: string;
-  canComment: boolean;
-  reactDisabledReason?: string | undefined;
 }
 
-export function CommentItem({ comment, eventId, token, canComment, reactDisabledReason }: Props) {
+export function CommentItem({ comment, eventId, token }: Props) {
   const toggleReaction = useToggleReaction(eventId, token);
   const deleteComment = useDeleteComment(eventId, token);
   const postReply = usePostReply(eventId, token);
@@ -70,24 +68,17 @@ export function CommentItem({ comment, eventId, token, canComment, reactDisabled
       )}
       {!comment.isDeleted ? (
         <div className="flex items-center justify-between gap-2">
-          <ReactionBar
-            reactions={comment.reactions}
-            canReact={canComment}
-            onToggle={handleToggle}
-            disabledReason={reactDisabledReason}
-          />
+          <ReactionBar reactions={comment.reactions} onToggle={handleToggle} />
           <div className="flex items-center gap-3">
-            {canComment ? (
-              <button
-                type="button"
-                onClick={() => {
-                  setReplyOpen((v) => !v);
-                }}
-                className="text-foreground-tertiary text-xs hover:underline"
-              >
-                {replyOpen ? 'cancel' : 'reply'}
-              </button>
-            ) : null}
+            <button
+              type="button"
+              onClick={() => {
+                setReplyOpen((v) => !v);
+              }}
+              className="text-foreground-tertiary text-xs hover:underline"
+            >
+              {replyOpen ? 'cancel' : 'reply'}
+            </button>
             {comment.canDelete ? (
               <button
                 type="button"
@@ -122,8 +113,6 @@ export function CommentItem({ comment, eventId, token, canComment, reactDisabled
               reply={reply}
               eventId={eventId}
               {...(token ? { token } : {})}
-              canReact={canComment}
-              reactDisabledReason={reactDisabledReason}
             />
           ))}
         </div>

--- a/frontend/src/screens/events/comments/CommentItem.tsx
+++ b/frontend/src/screens/events/comments/CommentItem.tsx
@@ -15,19 +15,11 @@ interface Props {
   comment: EventComment;
   eventId: string;
   token?: string;
-  canReact: boolean;
-  canReply: boolean;
+  canComment: boolean;
   reactDisabledReason?: string | undefined;
 }
 
-export function CommentItem({
-  comment,
-  eventId,
-  token,
-  canReact,
-  canReply,
-  reactDisabledReason,
-}: Props) {
+export function CommentItem({ comment, eventId, token, canComment, reactDisabledReason }: Props) {
   const toggleReaction = useToggleReaction(eventId, token);
   const deleteComment = useDeleteComment(eventId, token);
   const postReply = usePostReply(eventId, token);
@@ -80,12 +72,12 @@ export function CommentItem({
         <div className="flex items-center justify-between gap-2">
           <ReactionBar
             reactions={comment.reactions}
-            canReact={canReact}
+            canReact={canComment}
             onToggle={handleToggle}
             disabledReason={reactDisabledReason}
           />
           <div className="flex items-center gap-3">
-            {canReply ? (
+            {canComment ? (
               <button
                 type="button"
                 onClick={() => {
@@ -130,7 +122,7 @@ export function CommentItem({
               reply={reply}
               eventId={eventId}
               {...(token ? { token } : {})}
-              canReact={canReact}
+              canReact={canComment}
               reactDisabledReason={reactDisabledReason}
             />
           ))}

--- a/frontend/src/screens/events/comments/CommentThread.tsx
+++ b/frontend/src/screens/events/comments/CommentThread.tsx
@@ -6,8 +6,7 @@ interface Props {
   comments: EventComment[];
   eventId: string;
   token?: string;
-  canReact: boolean;
-  canReply: boolean;
+  canComment: boolean;
   reactDisabledReason?: string | undefined;
 }
 
@@ -15,8 +14,7 @@ export function CommentThread({
   comments,
   eventId,
   token,
-  canReact,
-  canReply,
+  canComment,
   reactDisabledReason,
 }: Props) {
   if (comments.length === 0) {
@@ -30,8 +28,7 @@ export function CommentThread({
           comment={c}
           eventId={eventId}
           {...(token ? { token } : {})}
-          canReact={canReact}
-          canReply={canReply}
+          canComment={canComment}
           reactDisabledReason={reactDisabledReason}
         />
       ))}

--- a/frontend/src/screens/events/comments/CommentThread.tsx
+++ b/frontend/src/screens/events/comments/CommentThread.tsx
@@ -6,31 +6,16 @@ interface Props {
   comments: EventComment[];
   eventId: string;
   token?: string;
-  canComment: boolean;
-  reactDisabledReason?: string | undefined;
 }
 
-export function CommentThread({
-  comments,
-  eventId,
-  token,
-  canComment,
-  reactDisabledReason,
-}: Props) {
+export function CommentThread({ comments, eventId, token }: Props) {
   if (comments.length === 0) {
     return <p className="text-foreground-tertiary text-sm">no comments yet.</p>;
   }
   return (
     <div className="flex flex-col gap-6">
       {comments.map((c) => (
-        <CommentItem
-          key={c.id}
-          comment={c}
-          eventId={eventId}
-          {...(token ? { token } : {})}
-          canComment={canComment}
-          reactDisabledReason={reactDisabledReason}
-        />
+        <CommentItem key={c.id} comment={c} eventId={eventId} {...(token ? { token } : {})} />
       ))}
     </div>
   );

--- a/frontend/src/screens/events/comments/EventCommentsCard.test.tsx
+++ b/frontend/src/screens/events/comments/EventCommentsCard.test.tsx
@@ -70,7 +70,7 @@ describe('EventCommentsCard', () => {
     expect(screen.queryByRole('button', { name: /post/i })).not.toBeInTheDocument();
   });
 
-  it('hides the comment thread when the viewer has no active rsvp, even if the backend still sent items (Issue 1168)', async () => {
+  it('hides the comment thread when the viewer has no active rsvp', async () => {
     vi.mocked(apiClient.get).mockResolvedValue({
       data: {
         items: [

--- a/frontend/src/screens/events/comments/EventCommentsCard.test.tsx
+++ b/frontend/src/screens/events/comments/EventCommentsCard.test.tsx
@@ -69,4 +69,59 @@ describe('EventCommentsCard', () => {
     });
     expect(screen.queryByRole('button', { name: /post/i })).not.toBeInTheDocument();
   });
+
+  it('hides the comment thread when the viewer has no active rsvp, even if the backend still sent items (Issue 1168)', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: {
+        items: [
+          {
+            id: 'c1',
+            author_id: 'other',
+            author_display_name: 'someone',
+            author_photo_url: '',
+            body: 'leaked comment',
+            is_deleted: false,
+            created_at: new Date().toISOString(),
+            reactions: [],
+            can_delete: false,
+            replies: [],
+          },
+        ],
+        can_post: false,
+        cannot_post_reason: 'rsvp_required',
+      },
+    });
+    renderCard();
+    await waitFor(() => {
+      expect(screen.getByText(/rsvp to join the conversation/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText('leaked comment')).not.toBeInTheDocument();
+  });
+
+  it('shows the comment thread when the viewer can post', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      data: {
+        items: [
+          {
+            id: 'c1',
+            author_id: 'other',
+            author_display_name: 'someone',
+            author_photo_url: '',
+            body: 'visible comment',
+            is_deleted: false,
+            created_at: new Date().toISOString(),
+            reactions: [],
+            can_delete: false,
+            replies: [],
+          },
+        ],
+        can_post: true,
+        cannot_post_reason: null,
+      },
+    });
+    renderCard();
+    await waitFor(() => {
+      expect(screen.getByText('visible comment')).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/screens/events/comments/EventCommentsCard.tsx
+++ b/frontend/src/screens/events/comments/EventCommentsCard.tsx
@@ -12,12 +12,6 @@ interface Props {
   token?: string;
 }
 
-function disabledReasonFor(cannot: CannotPostReason | null): string | undefined {
-  if (cannot === 'login_required') return 'log in to react';
-  if (cannot === 'rsvp_required') return 'rsvp to react';
-  return undefined;
-}
-
 function ComposerOrPrompt({
   canPost,
   cannotPostReason,
@@ -63,7 +57,6 @@ export function EventCommentsCard({ eventId, token }: Props) {
     );
   }
 
-  const reactDisabledReason = disabledReasonFor(data.cannotPostReason);
   const isGated = data.cannotPostReason !== null;
 
   return (
@@ -82,13 +75,7 @@ export function EventCommentsCard({ eventId, token }: Props) {
         submitting={postComment.isPending}
       />
       {isGated ? null : (
-        <CommentThread
-          comments={data.items}
-          eventId={eventId}
-          {...(token ? { token } : {})}
-          canComment={data.canPost}
-          reactDisabledReason={reactDisabledReason}
-        />
+        <CommentThread comments={data.items} eventId={eventId} {...(token ? { token } : {})} />
       )}
     </section>
   );

--- a/frontend/src/screens/events/comments/EventCommentsCard.tsx
+++ b/frontend/src/screens/events/comments/EventCommentsCard.tsx
@@ -86,8 +86,7 @@ export function EventCommentsCard({ eventId, token }: Props) {
           comments={data.items}
           eventId={eventId}
           {...(token ? { token } : {})}
-          canReact={data.canPost}
-          canReply={data.canPost}
+          canComment={data.canPost}
           reactDisabledReason={reactDisabledReason}
         />
       )}

--- a/frontend/src/screens/events/comments/EventCommentsCard.tsx
+++ b/frontend/src/screens/events/comments/EventCommentsCard.tsx
@@ -57,8 +57,6 @@ export function EventCommentsCard({ eventId, token }: Props) {
     );
   }
 
-  const isGated = data.cannotPostReason !== null;
-
   return (
     <section className="border-border-strong bg-surface rounded-lg border p-4">
       <h2 className="text-muted mb-3 text-xs font-medium tracking-wide">comments</h2>
@@ -74,9 +72,9 @@ export function EventCommentsCard({ eventId, token }: Props) {
         }}
         submitting={postComment.isPending}
       />
-      {isGated ? null : (
+      {data.canPost ? (
         <CommentThread comments={data.items} eventId={eventId} {...(token ? { token } : {})} />
-      )}
+      ) : null}
     </section>
   );
 }

--- a/frontend/src/screens/events/comments/EventCommentsCard.tsx
+++ b/frontend/src/screens/events/comments/EventCommentsCard.tsx
@@ -63,8 +63,8 @@ export function EventCommentsCard({ eventId, token }: Props) {
     );
   }
 
-  const canReact = data.canPost;
   const reactDisabledReason = disabledReasonFor(data.cannotPostReason);
+  const isGated = data.cannotPostReason !== null;
 
   return (
     <section className="border-border-strong bg-surface rounded-lg border p-4">
@@ -81,14 +81,16 @@ export function EventCommentsCard({ eventId, token }: Props) {
         }}
         submitting={postComment.isPending}
       />
-      <CommentThread
-        comments={data.items}
-        eventId={eventId}
-        {...(token ? { token } : {})}
-        canReact={canReact}
-        canReply={data.canPost}
-        reactDisabledReason={reactDisabledReason}
-      />
+      {isGated ? null : (
+        <CommentThread
+          comments={data.items}
+          eventId={eventId}
+          {...(token ? { token } : {})}
+          canReact={data.canPost}
+          canReply={data.canPost}
+          reactDisabledReason={reactDisabledReason}
+        />
+      )}
     </section>
   );
 }

--- a/frontend/src/screens/events/comments/ReactionBar.test.tsx
+++ b/frontend/src/screens/events/comments/ReactionBar.test.tsx
@@ -14,13 +14,7 @@ const summary = (emoji: string, count: number, mine = false): CommentReactionSum
 
 describe('ReactionBar', () => {
   it('renders only existing reactions with their counts', () => {
-    render(
-      <ReactionBar
-        reactions={[summary(ReactionEmoji.Heart, 3, true)]}
-        canReact
-        onToggle={vi.fn()}
-      />,
-    );
+    render(<ReactionBar reactions={[summary(ReactionEmoji.Heart, 3, true)]} onToggle={vi.fn()} />);
     const heart = screen.getByRole('button', { name: /❤️/u });
     expect(heart).toHaveAttribute('aria-pressed', 'true');
     expect(heart).toHaveTextContent('3');
@@ -28,19 +22,14 @@ describe('ReactionBar', () => {
     expect(screen.queryByRole('button', { name: /🔥/u })).not.toBeInTheDocument();
   });
 
-  it('shows the add-reaction button when canReact', () => {
-    render(<ReactionBar reactions={[]} canReact onToggle={vi.fn()} />);
+  it('shows the add-reaction button', () => {
+    render(<ReactionBar reactions={[]} onToggle={vi.fn()} />);
     expect(screen.getByRole('button', { name: /add reaction/i })).toBeInTheDocument();
-  });
-
-  it('hides the add-reaction button when canReact is false', () => {
-    render(<ReactionBar reactions={[]} canReact={false} onToggle={vi.fn()} />);
-    expect(screen.queryByRole('button', { name: /add reaction/i })).not.toBeInTheDocument();
   });
 
   it('opens the picker on add-reaction click and toggles the chosen emoji', () => {
     const onToggle = vi.fn();
-    render(<ReactionBar reactions={[]} canReact onToggle={onToggle} />);
+    render(<ReactionBar reactions={[]} onToggle={onToggle} />);
     fireEvent.click(screen.getByRole('button', { name: /add reaction/i }));
     fireEvent.click(screen.getByRole('button', { name: /🌱/u }));
     expect(onToggle).toHaveBeenCalledWith(ReactionEmoji.Seedling);
@@ -48,13 +37,7 @@ describe('ReactionBar', () => {
 
   it('clicking an existing reaction toggles it', () => {
     const onToggle = vi.fn();
-    render(
-      <ReactionBar
-        reactions={[summary(ReactionEmoji.Heart, 1, true)]}
-        canReact
-        onToggle={onToggle}
-      />,
-    );
+    render(<ReactionBar reactions={[summary(ReactionEmoji.Heart, 1, true)]} onToggle={onToggle} />);
     fireEvent.click(screen.getByRole('button', { name: /❤️/u }));
     expect(onToggle).toHaveBeenCalledWith(ReactionEmoji.Heart);
   });

--- a/frontend/src/screens/events/comments/ReactionBar.tsx
+++ b/frontend/src/screens/events/comments/ReactionBar.tsx
@@ -5,12 +5,10 @@ import { REACTION_EMOJI_ORDER } from '@/models/eventComment';
 
 interface Props {
   reactions: CommentReactionSummary[];
-  canReact: boolean;
   onToggle: (emoji: ReactionEmojiValue) => void;
-  disabledReason?: string | undefined;
 }
 
-export function ReactionBar({ reactions, canReact, onToggle, disabledReason }: Props) {
+export function ReactionBar({ reactions, onToggle }: Props) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -44,8 +42,6 @@ export function ReactionBar({ reactions, canReact, onToggle, disabledReason }: P
           key={r.emoji}
           type="button"
           aria-pressed={r.reactedByMe}
-          disabled={!canReact}
-          title={!canReact ? disabledReason : undefined}
           onClick={() => {
             onToggle(r.emoji);
           }}
@@ -54,29 +50,26 @@ export function ReactionBar({ reactions, canReact, onToggle, disabledReason }: P
             r.reactedByMe
               ? 'bg-brand-50 border-brand-500 text-foreground'
               : 'border-border-strong bg-surface text-foreground hover:bg-surface-dim',
-            !canReact ? 'cursor-not-allowed opacity-50' : '',
           ].join(' ')}
         >
           <span>{r.emoji}</span>
           <span className="text-xs">{r.count}</span>
         </button>
       ))}
-      {canReact ? (
-        <button
-          type="button"
-          aria-label="add reaction"
-          aria-expanded={pickerOpen}
-          onClick={() => {
-            setPickerOpen((v) => !v);
-          }}
-          className="border-border-strong bg-surface text-foreground-tertiary hover:bg-surface-dim inline-flex items-center gap-0.5 rounded-full border px-2 py-0.5 text-sm transition"
-        >
-          <span aria-hidden="true" className="text-xs leading-none">
-            +
-          </span>
-          <AddReactionIcon />
-        </button>
-      ) : null}
+      <button
+        type="button"
+        aria-label="add reaction"
+        aria-expanded={pickerOpen}
+        onClick={() => {
+          setPickerOpen((v) => !v);
+        }}
+        className="border-border-strong bg-surface text-foreground-tertiary hover:bg-surface-dim inline-flex items-center gap-0.5 rounded-full border px-2 py-0.5 text-sm transition"
+      >
+        <span aria-hidden="true" className="text-xs leading-none">
+          +
+        </span>
+        <AddReactionIcon />
+      </button>
       {pickerOpen ? (
         <div className="border-border-strong bg-surface absolute top-full left-0 z-10 mt-1 flex gap-1 rounded-md border p-1 shadow-md">
           {REACTION_EMOJI_ORDER.map((emoji) => (

--- a/frontend/src/screens/events/comments/ReplyItem.tsx
+++ b/frontend/src/screens/events/comments/ReplyItem.tsx
@@ -11,11 +11,9 @@ interface Props {
   reply: EventCommentReply;
   eventId: string;
   token?: string;
-  canReact: boolean;
-  reactDisabledReason?: string | undefined;
 }
 
-export function ReplyItem({ reply, eventId, token, canReact, reactDisabledReason }: Props) {
+export function ReplyItem({ reply, eventId, token }: Props) {
   const toggleReaction = useToggleReaction(eventId, token);
   const deleteComment = useDeleteComment(eventId, token);
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -57,12 +55,7 @@ export function ReplyItem({ reply, eventId, token, canReact, reactDisabledReason
         )}
         {!reply.isDeleted ? (
           <div className="mt-1 flex items-center justify-between gap-2">
-            <ReactionBar
-              reactions={reply.reactions}
-              canReact={canReact}
-              onToggle={handleToggle}
-              disabledReason={reactDisabledReason}
-            />
+            <ReactionBar reactions={reply.reactions} onToggle={handleToggle} />
             {reply.canDelete ? (
               <button
                 type="button"


### PR DESCRIPTION
## Summary

- Backend `_build_list_out` returned the full comment thread regardless of viewer RSVP — only *posting* was gated. A logged-in member with no RSVP (or a bystander) could read the entire thread via `GET /events/{id}/comments/`. It now returns empty `items` whenever the shared `_can_post_comments` check fails, so read and write share one source of truth instead of drifting.
- Frontend `EventMemberSection` hid the comments card using `rsvpDisabled = !event.rsvpEnabled` — a per-event admin toggle for whether RSVP is *offered*, not whether *this viewer* has RSVP'd. With RSVP enabled but the viewer not RSVP'd, the card still rendered the full thread, which is what the reporter saw. The gate now lives in `EventCommentsCard`, keyed directly off `data.canPost` — the one component all callers route through.
- Signed-out visitors on a public-RSVP-eligible event were told to log in (`cannot_post_reason: "login_required"`) when they could just RSVP without an account — `viewer is None` was checked before the event's public-RSVP eligibility. Now prompts to RSVP in that case.
- Collapsed the `canReact`/`canReply` prop pair (always passed the same value) down to nothing — `CommentThread`/`CommentItem`/`ReplyItem`/`ReactionBar` no longer take a permission prop at all, since the only render path is already gated one level up in `EventCommentsCard`.

Closes #1168

## Test plan

- [x] Backend: bystander without RSVP sees no comment content; RSVP'd member sees content; event creator sees content without RSVP; signed-out visitor on a public-RSVP event is prompted to RSVP, not log in
- [x] Frontend: thread hidden when gated even if a stray response includes items; thread shown when the viewer can post
- [x] `make agent-lint`, `make agent-typecheck`, targeted backend/frontend test suites all pass
