### PR TITLE
refactor(events): make co_hosts the sole source of truth for hosts (Issue 425)

### DIFF
--- a/backend/community/_checkin_nudge.py
+++ b/backend/community/_checkin_nudge.py
@@ -60,9 +60,8 @@ def send_checkin_nudge(event: Event) -> bool:
 
     sender = get_email_sender()
     event_url = f"{settings.FRONTEND_BASE_URL}/events/{event.pk}/attendance"
-    recipients = [event.created_by, *event.co_hosts.all()]
-    for user in recipients:
-        if user is None or not user.email:
+    for user in event.co_hosts.all():
+        if not user.email:
             continue
         try:
             result = send_checkin_reminder_email(

--- a/backend/community/_event_actions.py
+++ b/backend/community/_event_actions.py
@@ -50,9 +50,8 @@ def upload_event_photo(request, event_id: UUID, photo: UploadedFile = File(...))
     except Event.DoesNotExist:
         raise_validation(Code.Event.NOT_FOUND, status_code=404)
     is_manager = request.auth.has_permission(PermissionKey.MANAGE_EVENTS)
-    is_creator = event.created_by_id == request.auth.pk
-    is_cohost = event.co_hosts.filter(pk=request.auth.pk).exists()
-    if not is_manager and not is_creator and not is_cohost:
+    is_host = event.co_hosts.filter(pk=request.auth.pk).exists()
+    if not is_manager and not is_host:
         audit_log(
             logging.WARNING,
             "permission_denied",

--- a/backend/community/_event_cohost_invites.py
+++ b/backend/community/_event_cohost_invites.py
@@ -108,11 +108,7 @@ def decline_cohost_invite(request, event_id: UUID, invite_id: UUID):
 
 
 def _would_leave_event_hostless(event: Event, removing_user_id: str) -> bool:
-    """True if removing this user would leave the event with zero hosts.
-
-    co_hosts is the sole source of truth for "who is a host" (the creator is
-    seeded into it at creation) — refuse if they're the only one left.
-    """
+    """True if removing this user would leave the event with zero hosts."""
     co_host_ids = {str(uid) for uid in event.co_hosts.values_list("pk", flat=True)}
     return co_host_ids <= {str(removing_user_id)}
 

--- a/backend/community/_event_cohost_invites.py
+++ b/backend/community/_event_cohost_invites.py
@@ -110,14 +110,11 @@ def decline_cohost_invite(request, event_id: UUID, invite_id: UUID):
 def _would_leave_event_hostless(event: Event, removing_user_id: str) -> bool:
     """True if removing this user would leave the event with zero hosts.
 
-    The creator is a host. If they're set, removing any co-host is fine. If
-    they're None (e.g. SET_NULL after deletion) and we'd be removing the only
-    accepted co-host, refuse — the event needs at least one host.
+    co_hosts is the sole source of truth for "who is a host" (the creator is
+    seeded into it at creation) — refuse if they're the only one left.
     """
-    if event.created_by_id is not None:
-        return False
     co_host_ids = {str(uid) for uid in event.co_hosts.values_list("pk", flat=True)}
-    return co_host_ids == {str(removing_user_id)}
+    return co_host_ids <= {str(removing_user_id)}
 
 
 def _rescind_pending(invite: EventCoHostInvite, is_host: bool) -> None:
@@ -160,7 +157,7 @@ def rescind_cohost_invite(request, event_id: UUID, invite_id: UUID):
     invite = _get_invite_or_404(event_id, invite_id)
     event = invite.event
     co_host_ids = {str(uid) for uid in event.co_hosts.values_list("pk", flat=True)}
-    is_host = _can_manage_cohost_invites(request.auth, event.created_by, co_host_ids)
+    is_host = _can_manage_cohost_invites(request.auth, co_host_ids)
     is_self = invite.user_id == request.auth.pk
 
     if invite.status == CoHostInviteStatus.PENDING:

--- a/backend/community/_event_comments.py
+++ b/backend/community/_event_comments.py
@@ -59,8 +59,6 @@ def _can_post_comments(
         return False
     if user.has_permission(PermissionKey.MANAGE_EVENTS):
         return True
-    if event.created_by_id == user.pk:
-        return True
     if co_host_pks is not None:
         if str(user.pk) in co_host_pks:
             return True
@@ -75,14 +73,12 @@ def _can_delete_comment(
     user,
     co_host_pks: set[str] | None = None,
 ) -> bool:
-    """Authors can always delete their own; creator / co-host / MANAGE_EVENTS can delete others'."""
+    """Authors can always delete their own; host / MANAGE_EVENTS can delete others'."""
     if user is None:
         return False
     if comment.author_id == user.pk:
         return True
     if user.has_permission(PermissionKey.MANAGE_EVENTS):
-        return True
-    if event.created_by_id == user.pk:
         return True
     if co_host_pks is not None:
         return str(user.pk) in co_host_pks

--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -205,18 +205,16 @@ def _can_see_invited(
 
 def _can_manage_cohost_invites(
     requesting_user,
-    creator,
     co_host_ids: set[str],
 ) -> bool:
-    """Creator + accepted co-hosts can see pending invites and rescind them.
+    """Accepted co-hosts (which includes the creator) can see pending invites
+    and rescind them.
 
     Admins are intentionally excluded — co-host management is a host-only
     workflow, not an admin moderation surface.
     """
     if requesting_user is None:
         return False
-    if creator is not None and requesting_user.pk == creator.pk:
-        return True
     return str(requesting_user.pk) in co_host_ids
 
 
@@ -270,9 +268,9 @@ def _get_datetime_poll_slug(event: Event) -> str | None:
 
 
 def _pending_cohost_invites_out(
-    event: Event, auth_user, creator, co_host_ids: set[str]
+    event: Event, auth_user, co_host_ids: set[str]
 ) -> list[PendingCoHostInviteOut]:
-    if not _can_manage_cohost_invites(auth_user, creator, co_host_ids):
+    if not _can_manage_cohost_invites(auth_user, co_host_ids):
         return []
     return [
         PendingCoHostInviteOut(
@@ -324,7 +322,7 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
     all_invited = list(event.invited_users.all())
     invited = all_invited if _can_see_invited(auth_user, creator, co_host_ids) else []
 
-    pending_invites_out = _pending_cohost_invites_out(event, auth_user, creator, co_host_ids)
+    pending_invites_out = _pending_cohost_invites_out(event, auth_user, co_host_ids)
     my_pending_invite = get_my_pending_invite(event, auth_user)
     my_pending_invite_id = str(my_pending_invite.id) if my_pending_invite else None
     co_host_invite_ids = _accepted_invite_ids_for_co_hosts(event, co_hosts)

--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -207,12 +207,8 @@ def _can_manage_cohost_invites(
     requesting_user,
     co_host_ids: set[str],
 ) -> bool:
-    """Accepted co-hosts (which includes the creator) can see pending invites
-    and rescind them.
-
-    Admins are intentionally excluded — co-host management is a host-only
-    workflow, not an admin moderation surface.
-    """
+    """Accepted co-hosts can see and rescind pending invites. Admins are
+    intentionally excluded — this is a host-only workflow, not admin moderation."""
     if requesting_user is None:
         return False
     return str(requesting_user.pk) in co_host_ids

--- a/backend/community/_event_invitations.py
+++ b/backend/community/_event_invitations.py
@@ -41,8 +41,6 @@ def _can_invite_to_event(user, event: Event) -> bool:
     intentionally not enforced here (Issue 688)."""
     if user.has_permission(PermissionKey.MANAGE_EVENTS):
         return True
-    if event.created_by_id == user.pk:
-        return True
     if event.co_hosts.filter(pk=user.pk).exists():
         return True
     return event.invite_permission == InvitePermission.ALL_MEMBERS

--- a/backend/community/_event_transitions.py
+++ b/backend/community/_event_transitions.py
@@ -150,11 +150,10 @@ def _handle_status_update(request, event: Event, new_status: str, notify: bool):
     with the event representation), or None to continue processing field edits.
     Raises ValidationException on validation failures.
     """
-    # Uncancel requires creator/manager — co-hosts cannot uncancel
     if new_status == EventStatus.ACTIVE and event.is_cancelled:
         is_manager = request.auth.has_permission(PermissionKey.MANAGE_EVENTS)
-        is_creator = event.created_by_id == request.auth.pk
-        if not is_creator and not is_manager:
+        is_host = event.co_hosts.filter(pk=request.auth.pk).exists()
+        if not is_host and not is_manager:
             raise_validation(Code.Perm.DENIED, status_code=403, action="uncancel_event")
 
     _apply_status_transition(request, event, new_status, notify)

--- a/backend/community/_events.py
+++ b/backend/community/_events.py
@@ -54,10 +54,8 @@ router = Router()
 
 
 def _can_edit_event(user, event: Event) -> bool:
-    """Check if user can edit/delete this event (creator, co-host, or manager)."""
+    """Check if user can edit/delete this event (host or manager)."""
     if user.has_permission(PermissionKey.MANAGE_EVENTS):
-        return True
-    if event.created_by_id == user.pk:
         return True
     return event.co_hosts.filter(pk=user.pk).exists()
 

--- a/backend/community/_polls.py
+++ b/backend/community/_polls.py
@@ -77,11 +77,7 @@ def _can_manage_poll(user, event: Event) -> bool:
         return True
     if user.has_permission(PermissionKey.MANAGE_SURVEYS):
         return True
-    if event.created_by_id == user.pk:
-        return True
-    if event.co_hosts.filter(pk=user.pk).exists():
-        return True
-    return False
+    return event.co_hosts.filter(pk=user.pk).exists()
 
 
 def _voter_out(user, viewer=None) -> VoterOut:

--- a/backend/community/_survey_helpers.py
+++ b/backend/community/_survey_helpers.py
@@ -176,8 +176,6 @@ def _has_finalize_permission(request, survey: Survey, event: Event | None) -> bo
         return True
     if survey.created_by_id == request.auth.pk:
         return True
-    if event and event.created_by_id == request.auth.pk:
-        return True
     if event and event.co_hosts.filter(pk=request.auth.pk).exists():
         return True
     return False

--- a/backend/community/migrations/0085_backfill_creator_as_cohost.py
+++ b/backend/community/migrations/0085_backfill_creator_as_cohost.py
@@ -2,6 +2,7 @@ from django.db import migrations
 
 
 def add_creators_to_cohosts(apps, schema_editor):
+    # Bulk insert via the through table instead of per-event .add() to avoid N+1 queries.
     Event = apps.get_model("community", "Event")
     through = Event.co_hosts.through
     existing = set(through.objects.values_list("event_id", "user_id"))
@@ -16,11 +17,8 @@ def add_creators_to_cohosts(apps, schema_editor):
 
 
 def noop_reverse(apps, schema_editor):
-    """Irreversible in practice: once creators are co-hosts they're
-    indistinguishable from co-hosts added by hand, so removing them on reverse
-    would strip legitimately-invited creators. Leaving the rows is harmless —
-    pre-migration code treats the creator as a host anyway.
-    """
+    """Irreversible in practice: seeded creators are indistinguishable from
+    hand-added co-hosts, so reverse can't safely strip them. Harmless to leave."""
 
 
 class Migration(migrations.Migration):

--- a/backend/community/migrations/0085_backfill_creator_as_cohost.py
+++ b/backend/community/migrations/0085_backfill_creator_as_cohost.py
@@ -1,0 +1,33 @@
+from django.db import migrations
+
+
+def add_creators_to_cohosts(apps, schema_editor):
+    Event = apps.get_model("community", "Event")
+    through = Event.co_hosts.through
+    existing = set(through.objects.values_list("event_id", "user_id"))
+    rows = [
+        through(event_id=event_id, user_id=created_by_id)
+        for event_id, created_by_id in Event.objects.filter(
+            created_by__isnull=False,
+        ).values_list("id", "created_by_id")
+        if (event_id, created_by_id) not in existing
+    ]
+    through.objects.bulk_create(rows, batch_size=1000)
+
+
+def noop_reverse(apps, schema_editor):
+    """Irreversible in practice: once creators are co-hosts they're
+    indistinguishable from co-hosts added by hand, so removing them on reverse
+    would strip legitimately-invited creators. Leaving the rows is harmless —
+    pre-migration code treats the creator as a host anyway.
+    """
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("community", "0084_event_checkin_nudge_sent_at"),
+    ]
+
+    operations = [
+        migrations.RunPython(add_creators_to_cohosts, noop_reverse),
+    ]

--- a/backend/community/models/event.py
+++ b/backend/community/models/event.py
@@ -185,10 +185,8 @@ class Event(models.Model):
 
 @receiver(post_save, sender=Event)
 def seed_creator_as_host(sender, instance, created, **kwargs):
-    """co_hosts is the sole source of truth for "who is a host" — seed the
-    creator into it so they can later step down without losing authorship
-    (created_by stays a permanent audit field, untouched by step-down).
-    """
+    """co_hosts is the sole source of truth for hosts; seed the creator so
+    they can step down later. created_by is a separate, permanent audit field."""
     if created and instance.created_by_id is not None:
         instance.co_hosts.add(instance.created_by_id)
 

--- a/backend/community/models/event.py
+++ b/backend/community/models/event.py
@@ -3,6 +3,8 @@ from typing import TYPE_CHECKING
 
 from django.db import models
 from django.db.models import Q
+from django.db.models.signals import post_save
+from django.dispatch import receiver
 from django.utils import timezone
 
 from community.models.choices import (
@@ -179,6 +181,16 @@ class Event(models.Model):
     def __str__(self):
         dt = self.start_datetime
         return f"{self.title} — {dt:%Y-%m-%d %H:%M}" if dt else f"{self.title} — TBD"
+
+
+@receiver(post_save, sender=Event)
+def seed_creator_as_host(sender, instance, created, **kwargs):
+    """co_hosts is the sole source of truth for "who is a host" — seed the
+    creator into it so they can later step down without losing authorship
+    (created_by stays a permanent audit field, untouched by step-down).
+    """
+    if created and instance.created_by_id is not None:
+        instance.co_hosts.add(instance.created_by_id)
 
 
 class EventRSVP(models.Model):

--- a/backend/tests/test_event_cancel.py
+++ b/backend/tests/test_event_cancel.py
@@ -277,11 +277,21 @@ class TestUncancel:
         assert response.status_code == 200
         assert response.json()["status"] == "active"
 
-    def test_cohost_cannot_uncancel(
+    def test_cohost_can_uncancel(
         self, api_client, auth_headers, test_user, manage_events_user, upcoming_event_with_rsvp
     ):
         upcoming_event_with_rsvp.created_by = manage_events_user
         upcoming_event_with_rsvp.co_hosts.add(test_user)
+        upcoming_event_with_rsvp.status = EventStatus.CANCELLED
+        upcoming_event_with_rsvp.save(update_fields=["created_by", "status"])
+        response = _patch_status(api_client, auth_headers, upcoming_event_with_rsvp.id, "active")
+        assert response.status_code == 200
+        assert response.json()["status"] == "active"
+
+    def test_stranger_cannot_uncancel(
+        self, api_client, auth_headers, manage_events_user, upcoming_event_with_rsvp
+    ):
+        upcoming_event_with_rsvp.created_by = manage_events_user
         upcoming_event_with_rsvp.status = EventStatus.CANCELLED
         upcoming_event_with_rsvp.save(update_fields=["created_by", "status"])
         response = _patch_status(api_client, auth_headers, upcoming_event_with_rsvp.id, "active")

--- a/backend/tests/test_event_cohost_remove.py
+++ b/backend/tests/test_event_cohost_remove.py
@@ -159,9 +159,7 @@ class TestRemoveAcceptedCoHost:
     def test_last_host_cannot_step_down(
         self, api_client, event_with_accepted_cohost, creator, cohost
     ):
-        # Set the scene: cohost is accepted, then the creator's account is
-        # deleted — created_by gets nulled (SET_NULL) and they drop out of
-        # co_hosts (M2M cascade). cohost is now the only host.
+        # Simulate creator account deletion (SET_NULL + M2M cascade) — cohost is now the only host.
         event, invite = event_with_accepted_cohost
         event.co_hosts.remove(creator)
         Event.objects.filter(pk=event.pk).update(created_by=None)

--- a/backend/tests/test_event_cohost_remove.py
+++ b/backend/tests/test_event_cohost_remove.py
@@ -156,10 +156,14 @@ class TestRemoveAcceptedCoHost:
         )
         assert response.status_code == 403
 
-    def test_last_host_cannot_step_down(self, api_client, event_with_accepted_cohost, cohost):
-        # Set the scene: cohost is accepted, then creator deletes their account
-        # so created_by gets nulled (SET_NULL). cohost is now the only host.
+    def test_last_host_cannot_step_down(
+        self, api_client, event_with_accepted_cohost, creator, cohost
+    ):
+        # Set the scene: cohost is accepted, then the creator's account is
+        # deleted — created_by gets nulled (SET_NULL) and they drop out of
+        # co_hosts (M2M cascade). cohost is now the only host.
         event, invite = event_with_accepted_cohost
+        event.co_hosts.remove(creator)
         Event.objects.filter(pk=event.pk).update(created_by=None)
         response = api_client.delete(
             f"/api/community/events/{event.id}/cohost-invites/{invite.id}/",

--- a/backend/tests/test_event_cohosts.py
+++ b/backend/tests/test_event_cohosts.py
@@ -38,10 +38,11 @@ def other_headers(other_user):
 @pytest.mark.django_db
 class TestCreateEventWithCohosts:
     def test_create_event_with_cohosts_creates_pending_invite(
-        self, api_client, auth_headers, other_user
+        self, api_client, auth_headers, test_user, other_user
     ):
         # With the invite-approval flow (#363), passing ``co_host_ids`` queues
-        # a PENDING invite — the user is NOT in event.co_hosts until they accept.
+        # a PENDING invite for the invitee — they're NOT in event.co_hosts until
+        # they accept. The creator IS already in co_hosts (seeded on creation).
         response = api_client.post(
             "/api/community/events/",
             {
@@ -55,7 +56,7 @@ class TestCreateEventWithCohosts:
         )
         assert response.status_code == 201
         data = response.json()
-        assert data["co_host_ids"] == []
+        assert data["co_host_ids"] == [str(test_user.pk)]
         assert any(inv["user_id"] == str(other_user.pk) for inv in data["pending_cohost_invites"])
 
     def test_create_event_with_rsvp_enabled(self, api_client, auth_headers):

--- a/backend/tests/test_event_cohosts.py
+++ b/backend/tests/test_event_cohosts.py
@@ -40,9 +40,7 @@ class TestCreateEventWithCohosts:
     def test_create_event_with_cohosts_creates_pending_invite(
         self, api_client, auth_headers, test_user, other_user
     ):
-        # With the invite-approval flow (#363), passing ``co_host_ids`` queues
-        # a PENDING invite for the invitee — they're NOT in event.co_hosts until
-        # they accept. The creator IS already in co_hosts (seeded on creation).
+        # co_host_ids queues a PENDING invite (#363) — invitee isn't in co_hosts until accepted.
         response = api_client.post(
             "/api/community/events/",
             {


### PR DESCRIPTION
## Overview

Prep refactor for [Issue 425](https://github.com/ProteinDeficientsAnonymous/pda/issues/425) (unhosted events). Splits `created_by` (a permanent audit field) from "who is a host" (now answered purely by `co_hosts` membership), so a creator can later step down as host without losing their authorship record.

- Seeds the creator into `co_hosts` on event creation via a `post_save` signal, so every creation path (API, tests, seed scripts) gets it for free.
- Backfills existing events with a data migration (`0085_backfill_creator_as_cohost`).
- Collapses ~8 now-redundant `created_by == user` permission checks (events, comments, polls, surveys, cohost-invites) to their existing `co_hosts` fallback.
- Generalizes the cohost-removal hostless guard to count all hosts instead of special-casing the creator.
- **Behavior change:** any host (not just the creator) can now uncancel a cancelled event — the prior creator-only restriction would leave a cancelled event permanently stuck once the creator steps down (decided with the issue reporter).

This PR is a pure structural change — it does not itself add the step-down flow. That's a separate follow-up PR (`feat-425-unhosted-events`) stacked on this one.

## Test plan

- [x] `make agent-lint` clean
- [x] `make agent-typecheck` clean
- [x] `make agent-complexity` clean
- [x] Full backend test suite: 1770 passed. Remaining failures are pre-existing/unrelated to this change (SSE ticket auth needs `pg_notify`, not available on sqlite; an RSVP capacity-race test with sqlite locking; a calendar feed test with a stale hardcoded date) — confirmed none touch files in this diff.
- [x] Verified the backfill migration against seeded data: all 5 existing events had their creator correctly added to `co_hosts`.

Part of #425 — prep only, doesn't close the issue on its own.
