### PR TITLE
chore(api): use ninja Status instead of deprecated tuple returns

### DIFF
--- a/backend/community/_geocode.py
+++ b/backend/community/_geocode.py
@@ -7,6 +7,7 @@ import httpx
 from config.auth import gated_jwt
 from django.http import HttpRequest
 from ninja import Query, Router
+from ninja.responses import Status
 from pydantic import BaseModel, ConfigDict, Field
 
 from community._shared import ErrorOut
@@ -52,11 +53,11 @@ def geocode(request: HttpRequest, params: Query[GeocodeQuery]):
             timeout=5.0,
         )
         resp.raise_for_status()
-        return 200, resp.json()
+        return Status(200, resp.json())
     except (httpx.HTTPError, ValueError) as e:
         # Expected upstream failures: httpx.HTTPError covers timeout, connection
         # error, and non-2xx (TimeoutException is a subclass); ValueError covers
         # JSON-decode failures when a 2xx response carries a non-JSON body.
         # Log with request context but no PII — the query text is user input.
         logger.warning("geocode proxy error: limit=%s error=%s", params.limit, e)
-        return 502, {"detail": "geocoding service unavailable — try again"}
+        return Status(502, {"detail": "geocoding service unavailable — try again"})

--- a/backend/community/_giphy.py
+++ b/backend/community/_giphy.py
@@ -7,6 +7,7 @@ from config.ratelimit import rate_limit
 from django.conf import settings
 from django.http import HttpRequest
 from ninja import Query, Router
+from ninja.responses import Status
 from pydantic import BaseModel, Field
 
 from community._shared import ErrorOut
@@ -112,7 +113,7 @@ def giphy_search(request: HttpRequest, params: Query[GiphyQuery]):
     giphy_key = getattr(settings, "GIPHY_API_KEY", "")
     pexels_key = getattr(settings, "PEXELS_API_KEY", "")
     if not giphy_key and not pexels_key:
-        return 503, {"detail": "image search is not configured"}
+        return Status(503, {"detail": "image search is not configured"})
 
     query = params.q.strip() or _DEFAULT_QUERY
     gif_limit = params.limit - params.limit // 3
@@ -123,7 +124,7 @@ def giphy_search(request: HttpRequest, params: Query[GiphyQuery]):
         photos = _fetch_photos(pexels_key, query, photo_limit) if pexels_key else []
     except (httpx.HTTPError, ValueError) as e:
         logger.warning("image proxy error: q_len=%s error=%s", len(query), e)
-        return 502, {"detail": "image search unavailable — try again"}
+        return Status(502, {"detail": "image search unavailable — try again"})
 
     results = [
         r
@@ -133,4 +134,4 @@ def giphy_search(request: HttpRequest, params: Query[GiphyQuery]):
         )
         if r is not None
     ]
-    return 200, {"results": results}
+    return Status(200, {"results": results})

--- a/backend/community/_public_rsvp_manage.py
+++ b/backend/community/_public_rsvp_manage.py
@@ -130,13 +130,16 @@ def list_my_rsvps(request, token: str = ""):
                 has_plus_one=rsvp.has_plus_one,
             )
         )
-    return 200, PublicRsvpManageOut(
-        user=PublicRsvpManageUserOut(
-            display_name=user.full_name,
-            email=user.email or "",
-            phone_number=user.phone_number,
+    return Status(
+        200,
+        PublicRsvpManageOut(
+            user=PublicRsvpManageUserOut(
+                display_name=user.full_name,
+                email=user.email or "",
+                phone_number=user.phone_number,
+            ),
+            rsvps=items,
         ),
-        rsvps=items,
     )
 
 
@@ -180,10 +183,13 @@ def update_my_rsvp(request, event_id, payload: PublicRsvpManageIn, token: str = 
         .get(id=event.id)
     )
     final_rsvp = user.event_rsvps.get(event=fresh_event)
-    return 200, PublicRsvpOut(
-        event=_event_out(fresh_event, user),
-        rsvp=PublicRsvpStateOut(status=final_rsvp.status, has_plus_one=final_rsvp.has_plus_one),
-        rsvp_token=rsvp_token.token,
+    return Status(
+        200,
+        PublicRsvpOut(
+            event=_event_out(fresh_event, user),
+            rsvp=PublicRsvpStateOut(status=final_rsvp.status, has_plus_one=final_rsvp.has_plus_one),
+            rsvp_token=rsvp_token.token,
+        ),
     )
 
 


### PR DESCRIPTION
## Summary
- django-ninja deprecated returning `(status_code, body)` tuples from view functions in favor of `Status(status_code, body)`
- Fixed the 7 call sites still using the old tuple form, in `_geocode.py`, `_giphy.py`, and `_public_rsvp_manage.py`
- Eliminates 34 `DeprecationWarning`s that were showing up across the backend test suite

## Test plan
- [x] `pytest backend/tests/` — 1779 passed, 0 warnings (previously 34 deprecation warnings)
- [x] `ty check` — clean
- [x] `ruff check` / `ruff format` — clean