### PR TITLE
fix(calendar): give event tag pills contrast on colored cards (Issue 1172)

### DIFF
--- a/frontend/src/screens/calendar/AgendaList.tsx
+++ b/frontend/src/screens/calendar/AgendaList.tsx
@@ -125,7 +125,7 @@ function AgendaCard({ event, onSelect }: CardProps) {
       <div className="text-[15px] font-semibold">{event.title}</div>
       {event.eventType === EventType.Official || event.eventType === EventType.Club ? (
         <div className="mt-1 flex flex-wrap gap-1.5">
-          <EventBadge event={event} />
+          <EventBadge event={event} onCard />
         </div>
       ) : null}
       {when ? <div className="mt-1 text-[13px] opacity-90">{when}</div> : null}

--- a/frontend/src/screens/calendar/DayEventList.tsx
+++ b/frontend/src/screens/calendar/DayEventList.tsx
@@ -85,7 +85,7 @@ function DayEventCard({ event, onSelect }: CardProps) {
       <div className="text-[15px] font-semibold">{event.title}</div>
       {event.eventType === EventType.Official || event.eventType === EventType.Club ? (
         <div className="mt-1 flex flex-wrap gap-1.5">
-          <EventBadge event={event} />
+          <EventBadge event={event} onCard />
         </div>
       ) : null}
       {timeRange ? <div className="mt-1 text-[13px] opacity-90">{timeRange}</div> : null}

--- a/frontend/src/screens/events/EventBadge.test.tsx
+++ b/frontend/src/screens/events/EventBadge.test.tsx
@@ -16,4 +16,14 @@ describe('EventBadge', () => {
     render(<EventBadge event={makeEvent({ eventType: EventType.Club })} />);
     expect(screen.getByText('pda club')).toBeInTheDocument();
   });
+
+  it.each([
+    ['official', EventType.Official],
+    ['pda club', EventType.Club],
+  ])('uses a contrasting overlay for %s on a card', (label, eventType) => {
+    render(<EventBadge event={makeEvent({ eventType })} onCard />);
+    const badge = screen.getByText(label);
+    expect(badge).toHaveClass('bg-black/10', 'dark:bg-white/15');
+    expect(badge).not.toHaveAttribute('style');
+  });
 });

--- a/frontend/src/screens/events/EventBadge.tsx
+++ b/frontend/src/screens/events/EventBadge.tsx
@@ -1,52 +1,53 @@
-import type { ReactNode } from 'react';
-
 import { type Event, EventStatus, EventType, EventVisibility } from '@/models/event';
 
 interface Props {
   event: Event;
+  onCard?: boolean;
 }
 
-export function EventBadge({ event }: Props) {
-  if (event.status === EventStatus.Cancelled) {
-    return <Badge tone="neutral">cancelled</Badge>;
-  }
-  if (event.eventType === EventType.Official) {
-    return <Badge tone="blue">official</Badge>;
-  }
-  if (event.eventType === EventType.Club) {
-    return <Badge tone="rose">pda club</Badge>;
-  }
-  if (event.visibility === EventVisibility.InviteOnly) {
-    return <Badge tone="lavender">invite only</Badge>;
-  }
-  if (event.visibility === EventVisibility.MembersOnly) {
-    return <Badge tone="amber">members only</Badge>;
-  }
+type Tone = 'neutral' | 'blue' | 'amber' | 'lavender' | 'rose';
+
+const TONE_CLASS: Record<Tone, string> = {
+  neutral: 'bg-surface-dim text-foreground-secondary',
+  blue: 'bg-info-subtle text-info',
+  amber: 'bg-warning-subtle text-warning',
+  lavender: 'bg-highlight-subtle text-highlight',
+  rose: '',
+};
+
+function badgeFor(event: Event): { tone: Tone; label: string } | null {
+  if (event.status === EventStatus.Cancelled) return { tone: 'neutral', label: 'cancelled' };
+  if (event.eventType === EventType.Official) return { tone: 'blue', label: 'official' };
+  if (event.eventType === EventType.Club) return { tone: 'rose', label: 'pda club' };
+  if (event.visibility === EventVisibility.InviteOnly)
+    return { tone: 'lavender', label: 'invite only' };
+  if (event.visibility === EventVisibility.MembersOnly)
+    return { tone: 'amber', label: 'members only' };
   return null;
 }
 
-function Badge({
-  tone,
-  children,
-}: {
-  tone: 'neutral' | 'blue' | 'amber' | 'lavender' | 'rose';
-  children: ReactNode;
-}) {
-  const tones = {
-    neutral: 'bg-surface-dim text-foreground-secondary',
-    blue: 'bg-info-subtle text-info',
-    amber: 'bg-warning-subtle text-warning',
-    lavender: 'bg-highlight-subtle text-highlight',
-    rose: '',
-  };
+export function EventBadge({ event, onCard = false }: Props) {
+  const badge = badgeFor(event);
+  if (!badge) return null;
+
+  // On a pda-evt card the pill would sit on the same --color-evt-*-bg it uses,
+  // making it invisible. A translucent overlay reads against any card tone.
+  if (onCard) {
+    return (
+      <span className="rounded-full bg-black/10 px-2 py-0.5 text-xs dark:bg-white/15">
+        {badge.label}
+      </span>
+    );
+  }
+
   const style =
-    tone === 'rose'
+    badge.tone === 'rose'
       ? { background: 'var(--color-evt-club-bg)', color: 'var(--color-evt-club-fg)' }
       : undefined;
 
   return (
-    <span className={`rounded-full px-2 py-0.5 text-xs ${tones[tone]}`} style={style}>
-      {children}
+    <span className={`rounded-full px-2 py-0.5 text-xs ${TONE_CLASS[badge.tone]}`} style={style}>
+      {badge.label}
     </span>
   );
 }


### PR DESCRIPTION
## Summary

- The pill and the card beneath it resolved the **same CSS variable**, so this was a same-surface collision rather than a missing dark-mode token. The club badge's background was literally `var(--color-evt-club-bg)` — byte-identical to its card — and the official badge's `bg-info-subtle` is a navy at 30% opacity over a navy card in dark mode.
- Worth noting the report said "dark mode", but the club pill was equally invisible in **light** mode. Fixing only the reported symptom would have left that behind.
- Reuses the translucent `bg-black/10 dark:bg-white/15` overlay that `EventCardBadges` already uses for RSVP/headcount pills, which reads against any card tone — no new tokens.
- `EventDetailScreen` renders on the page background rather than a colored card, so it keeps its existing tones.

Closes #1172

## Test plan

- [ ] Dark mode: official and club pills are legible on event cards in the calendar list
- [ ] Light mode: same, and previously-fine pills are unchanged
- [ ] Event detail screen badges are visually unchanged
- [ ] Visual confirmation on a real device is still outstanding — the contrast reasoning came from reading token values, not from rendering