### PR TITLE
fix: 1165 - attendance report back-link points to attendance

### DIFF
--- a/frontend/src/screens/events/EventCheckInReportScreen.tsx
+++ b/frontend/src/screens/events/EventCheckInReportScreen.tsx
@@ -46,7 +46,12 @@ export default function EventCheckInReportScreen() {
       <div className="mb-6 flex items-start justify-between gap-2">
         <div>
           <h1 className="mb-1 text-2xl font-medium tracking-tight">check-in report</h1>
-          <p className="text-foreground-secondary text-sm">{event.title}</p>
+          <Link
+            to={`/events/${event.id}`}
+            className="text-foreground-secondary hover:text-foreground text-sm"
+          >
+            {event.title}
+          </Link>
         </div>
         <Button
           variant="secondary"
@@ -185,10 +190,10 @@ function CanceledRow({ person }: { person: CanceledPerson }) {
 function BackLink({ eventId }: { eventId: string }) {
   return (
     <Link
-      to={`/events/${eventId}`}
+      to={`/events/${eventId}/attendance`}
       className="text-foreground-secondary hover:text-foreground mb-4 inline-flex items-center gap-1 text-sm"
     >
-      ← back to event
+      ← back to attendance
     </Link>
   );
 }


### PR DESCRIPTION
## Overview

The check-in report screen's back-link read "back to event" but navigated somewhere that isn't called "event" in context, and gave no way to reach the event detail page from that screen. This PR renames the back-link to "back to attendance" (routing to `/events/:id/attendance`) and makes the event title on the report screen a link to the event detail page, so both destinations are reachable and accurately labeled.

`EventAttendanceScreen.tsx` was left unchanged — its own "back to event" label correctly goes straight back to the event detail page, so it doesn't have the same problem.

## Test plan

- [ ] Open an event's check-in report and confirm the back-link reads "back to attendance" and returns to the event's attendance screen
- [ ] Confirm the event title on the report screen links to the event detail page
- [ ] Confirm copy stays lowercase

Closes #1165
