### PR TITLE
fix: 1182 - remove co-host picker from event edit form

### DIFF
--- a/backend/tests/test_event_edit_preserves_cohosts.py
+++ b/backend/tests/test_event_edit_preserves_cohosts.py
@@ -35,9 +35,7 @@ def cohost(db) -> User:
 
 @pytest.mark.django_db
 class TestEventEditPreservesCohosts:
-    def test_patch_without_cohost_ids_preserves_accepted_cohosts(
-        self, api_client, creator, cohost
-    ):
+    def test_patch_without_cohost_ids_preserves_accepted_cohosts(self, api_client, creator, cohost):
         event_id = Event.objects.create(
             title="Potluck",
             start_datetime=future_iso(days=30),
@@ -68,9 +66,7 @@ class TestEventEditPreservesCohosts:
         invite.refresh_from_db()
         assert invite.status == CoHostInviteStatus.ACCEPTED
 
-    def test_patch_without_cohost_ids_preserves_pending_invites(
-        self, api_client, creator, cohost
-    ):
+    def test_patch_without_cohost_ids_preserves_pending_invites(self, api_client, creator, cohost):
         event_id = Event.objects.create(
             title="Potluck",
             start_datetime=future_iso(days=30),

--- a/backend/tests/test_event_edit_preserves_cohosts.py
+++ b/backend/tests/test_event_edit_preserves_cohosts.py
@@ -1,0 +1,132 @@
+import json
+
+import pytest
+from community.models import Event, EventCoHostInvite, EventStatus
+from community.models.choices import CoHostInviteStatus
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
+
+from tests.conftest import future_iso
+
+
+def _make_user(phone: str, name: str = "Member", email: str | None = "") -> User:
+    return User.objects.create_user(
+        phone_number=phone,
+        password="testpass123",
+        first_name=name,
+        email=email,
+    )
+
+
+def _auth_headers(user: User) -> dict:
+    refresh = RefreshToken.for_user(user)
+    return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
+
+
+@pytest.fixture
+def creator(db) -> User:
+    return _make_user("+12025550201", "Creator", email="creator@example.com")
+
+
+@pytest.fixture
+def cohost(db) -> User:
+    return _make_user("+12025550202", "CoHost", email="cohost@example.com")
+
+
+@pytest.mark.django_db
+class TestEventEditPreservesCohosts:
+    def test_patch_without_cohost_ids_preserves_accepted_cohosts(
+        self, api_client, creator, cohost
+    ):
+        event_id = Event.objects.create(
+            title="Potluck",
+            start_datetime=future_iso(days=30),
+            end_datetime=future_iso(days=30, hours=2),
+            status=EventStatus.ACTIVE,
+            created_by=creator,
+        ).id
+
+        event = Event.objects.get(id=event_id)
+        invite = EventCoHostInvite.objects.create(
+            event=event,
+            user=cohost,
+            invited_by=creator,
+            status=CoHostInviteStatus.ACCEPTED,
+        )
+        event.co_hosts.add(cohost)
+
+        response = api_client.patch(
+            f"/api/community/events/{event_id}/",
+            data=json.dumps({"title": "Updated Potluck"}),
+            content_type="application/json",
+            **_auth_headers(creator),
+        )
+
+        assert response.status_code == 200, response.content
+        event.refresh_from_db()
+        assert event.co_hosts.filter(pk=cohost.pk).exists()
+        invite.refresh_from_db()
+        assert invite.status == CoHostInviteStatus.ACCEPTED
+
+    def test_patch_without_cohost_ids_preserves_pending_invites(
+        self, api_client, creator, cohost
+    ):
+        event_id = Event.objects.create(
+            title="Potluck",
+            start_datetime=future_iso(days=30),
+            end_datetime=future_iso(days=30, hours=2),
+            status=EventStatus.ACTIVE,
+            created_by=creator,
+        ).id
+
+        event = Event.objects.get(id=event_id)
+        invite = EventCoHostInvite.objects.create(
+            event=event,
+            user=cohost,
+            invited_by=creator,
+            status=CoHostInviteStatus.PENDING,
+        )
+
+        response = api_client.patch(
+            f"/api/community/events/{event_id}/",
+            data=json.dumps({"title": "Updated Potluck"}),
+            content_type="application/json",
+            **_auth_headers(creator),
+        )
+
+        assert response.status_code == 200, response.content
+        invite.refresh_from_db()
+        assert invite.status == CoHostInviteStatus.PENDING
+
+    def test_patch_with_empty_cohost_ids_removes_accepted_cohosts(
+        self, api_client, creator, cohost
+    ):
+        event_id = Event.objects.create(
+            title="Potluck",
+            start_datetime=future_iso(days=30),
+            end_datetime=future_iso(days=30, hours=2),
+            status=EventStatus.ACTIVE,
+            created_by=creator,
+        ).id
+
+        event = Event.objects.get(id=event_id)
+        invite = EventCoHostInvite.objects.create(
+            event=event,
+            user=cohost,
+            invited_by=creator,
+            status=CoHostInviteStatus.ACCEPTED,
+        )
+        event.co_hosts.add(cohost)
+
+        response = api_client.patch(
+            f"/api/community/events/{event_id}/",
+            data=json.dumps({"title": "Updated Potluck", "co_host_ids": []}),
+            content_type="application/json",
+            **_auth_headers(creator),
+        )
+
+        assert response.status_code == 200, response.content
+        event.refresh_from_db()
+        assert not event.co_hosts.filter(pk=cohost.pk).exists()
+        invite.refresh_from_db()
+        assert invite.status == CoHostInviteStatus.RESCINDED

--- a/frontend/src/screens/events/form/EventForm.tsx
+++ b/frontend/src/screens/events/form/EventForm.tsx
@@ -79,17 +79,7 @@ export function EventForm({ existing }: Props) {
   const [values, setValues] = useState<EventFormValues>(() =>
     existing ? eventToFormValues(existing) : emptyEventFormValues(),
   );
-  // coHosts is picker-driven local state. We can't fully reconstruct
-  // MemberSearchResult from `existing` (no phone numbers in the event-out wire
-  // shape, by design), so it starts empty even on edit. To avoid clobbering
-  // server-side relations on edit-PATCH, we track whether the picker has been
-  // touched and only include co_host_ids in the payload when dirty. Untouched
-  // → key is omitted, BE preserves the existing list.
-  //
-  // Member invites are handled out-of-band by InviteDialog on the event page;
-  // the form doesn't manage invited_user_ids anymore.
   const [coHosts, setCoHosts] = useState<MemberSearchResult[]>([]);
-  const [coHostsDirty, setCoHostsDirty] = useState(false);
   // On edit, pre-run validation so issues in the loaded values (e.g. a stale
   // draft whose start is now in the past) are visible immediately instead of
   // waiting for the first save attempt.
@@ -128,9 +118,10 @@ export function EventForm({ existing }: Props) {
   async function submit(nextStatus: 'active' | 'draft') {
     setServerError(null);
     const timeLocked = !!existing?.hasPoll && !existing.startDatetime;
+    const coHostIds = coHosts.map((m) => m.id);
     const merged: EventFormValues = {
       ...values,
-      coHostIds: coHosts.map((m) => m.id),
+      coHostIds,
       status: nextStatus,
     };
     const errs = validateEventForm(merged);
@@ -151,17 +142,18 @@ export function EventForm({ existing }: Props) {
         // While a poll is active, the poll owns the time. Send a Partial
         // that omits start/end/tbd so useUpdateEvent's undefined-filter drops
         // them from the PATCH body (backend rejects those edits).
-        // Also drop coHostIds when the picker hasn't been touched: it's a
-        // many-to-many relation the form can't fully reconstruct from
-        // EventOut (no phone numbers on the wire), so an empty list would
-        // clobber whatever's already on the BE.
+        // On edit, never send coHostIds — co-host management happens on the
+        // event detail page only, not in this form. Omitting the key ensures
+        // the backend preserves existing invites and accepted co-hosts.
         const patchBody: Partial<EventFormValues> = timeLocked
           ? (() => {
-              const { startDatetime: _s, endDatetime: _e, datetimeTbd: _t, ...rest } = merged;
+              const { startDatetime: _s, endDatetime: _e, datetimeTbd: _t, coHostIds: _c, ...rest } = merged;
               return rest;
             })()
-          : { ...merged };
-        if (!coHostsDirty) delete patchBody.coHostIds;
+          : (() => {
+              const { coHostIds: _c, ...rest } = merged;
+              return rest;
+            })();
         try {
           await update.mutateAsync(patchBody);
         } catch (err) {
@@ -267,31 +259,31 @@ export function EventForm({ existing }: Props) {
           onBufferPoll={setBufferedPollOptions}
         />
 
-        <CollapsibleCard
-          title="hosts"
-          summary={
-            hostsCount > 0
-              ? `${String(hostsCount)} ${hostsCount === 1 ? 'person' : 'people'}`
-              : undefined
-          }
-        >
-          {existing?.isPast ? (
-            <p className="text-foreground-tertiary text-sm">
-              this event is in the past — co-host invites are closed
-            </p>
-          ) : (
+        {!existing && (
+          <CollapsibleCard
+            title="hosts"
+            summary={
+              hostsCount > 0
+                ? `${String(hostsCount)} ${hostsCount === 1 ? 'person' : 'people'}`
+                : undefined
+            }
+          >
             <MemberPicker
               label="co-hosts"
               selected={coHosts}
-              onChange={(next) => {
-                setCoHosts(next);
-                setCoHostsDirty(true);
-              }}
+              onChange={setCoHosts}
               excludeIds={user ? [user.id] : []}
               hint="co-hosts get an invite — once they accept, they can edit the event and manage rsvps"
             />
-          )}
-        </CollapsibleCard>
+          </CollapsibleCard>
+        )}
+        {existing && (
+          <CollapsibleCard title="hosts">
+            <p className="text-foreground-tertiary text-sm">
+              manage co-hosts on the event page
+            </p>
+          </CollapsibleCard>
+        )}
 
         <CollapsibleCard
           title="details"

--- a/frontend/src/screens/events/form/EventForm.tsx
+++ b/frontend/src/screens/events/form/EventForm.tsx
@@ -147,7 +147,13 @@ export function EventForm({ existing }: Props) {
         // the backend preserves existing invites and accepted co-hosts.
         const patchBody: Partial<EventFormValues> = timeLocked
           ? (() => {
-              const { startDatetime: _s, endDatetime: _e, datetimeTbd: _t, coHostIds: _c, ...rest } = merged;
+              const {
+                startDatetime: _s,
+                endDatetime: _e,
+                datetimeTbd: _t,
+                coHostIds: _c,
+                ...rest
+              } = merged;
               return rest;
             })()
           : (() => {
@@ -279,9 +285,7 @@ export function EventForm({ existing }: Props) {
         )}
         {existing && (
           <CollapsibleCard title="hosts">
-            <p className="text-foreground-tertiary text-sm">
-              manage co-hosts on the event page
-            </p>
+            <p className="text-foreground-tertiary text-sm">manage co-hosts on the event page</p>
           </CollapsibleCard>
         )}
 

--- a/frontend/src/screens/events/form/EventForm.tsx
+++ b/frontend/src/screens/events/form/EventForm.tsx
@@ -142,9 +142,7 @@ export function EventForm({ existing }: Props) {
         // While a poll is active, the poll owns the time. Send a Partial
         // that omits start/end/tbd so useUpdateEvent's undefined-filter drops
         // them from the PATCH body (backend rejects those edits).
-        // On edit, never send coHostIds — co-host management happens on the
-        // event detail page only, not in this form. Omitting the key ensures
-        // the backend preserves existing invites and accepted co-hosts.
+        // On edit, omit coHostIds so the backend preserves existing invites/co-hosts.
         const patchBody: Partial<EventFormValues> = timeLocked
           ? (() => {
               const {


### PR DESCRIPTION
## Overview

On the event edit form, the co-host picker always started empty — even when the event already had accepted co-hosts and pending invites — because the form can't reconstruct member details from the event's wire shape (no phone numbers, by design). A `coHostsDirty` flag was meant to compensate by omitting `coHostIds` from the PATCH while the picker was untouched, but as soon as a host touched the picker to add one person, the backend's `sync_cohost_invites` treated the submitted list as a **replacement** — silently rescinding every other pending invite and removing every other accepted co-host, including the creator.

This implements direction B from the issue (the smaller, recommended fix): the co-host picker is removed from the event **edit** form entirely. Co-host management (invite, rescind, kick, step down) already lives on the event detail page — that stays the single source of truth. The picker still works as before on **event creation**, where there's no existing roster to lose.

Concretely:
- `EventForm.tsx`: removed the `coHostsDirty` tracking flag; on edit, `coHostIds` is now unconditionally omitted from the PATCH body regardless of picker state. The "hosts" card renders the picker only when creating a new event; on edit it shows read-only text pointing to the event page.
- Backend required no changes — `_apply_field_updates` already treats a missing `co_host_ids` key as "leave existing invites/co-hosts alone," it only acts when the key is present.
- Added `backend/tests/test_event_edit_preserves_cohosts.py`: regression coverage proving a PATCH without `co_host_ids` preserves both accepted co-hosts and pending invites (and that an explicit empty list still works for intentional removal).

## Test plan

- [x] `make agent-frontend-typecheck` — clean
- [x] `make agent-frontend-lint` — clean
- [x] New regression tests (`test_event_edit_preserves_cohosts.py`) — 3/3 pass
- [x] Existing cohost-related backend tests (invites, remove, past-guard, invite email) — 58/58 pass
- [x] Existing EventForm-adjacent frontend tests — 35/35 pass
- [ ] Manual: edit an event with existing co-hosts/pending invites and confirm saving without touching hosts leaves the roster untouched
- [ ] Manual: confirm the edit form's hosts card now reads "manage co-hosts on the event page" instead of showing an empty picker

Closes #1182
