### PR TITLE
fix(events): keep reactors list in sync during optimistic reaction toggle

### DIFF
--- a/frontend/src/api/eventComments.test.ts
+++ b/frontend/src/api/eventComments.test.ts
@@ -11,7 +11,7 @@ vi.mock('@/api/client', () => ({
 vi.mock('@/auth/store', () => {
   const state = {
     status: 'authed',
-    user: { id: 'u-me', profilePhotoUrl: null },
+    user: { id: 'u-me', fullName: 'Me', profilePhotoUrl: '' },
   };
   const useAuthStore = vi.fn((selector?: (s: typeof state) => unknown) =>
     selector ? selector(state) : state,
@@ -232,6 +232,7 @@ describe('useToggleReaction', () => {
       const reaction = cached?.items[0]?.reactions.find((r) => r.emoji === '👍');
       expect(reaction?.count).toBe(2);
       expect(reaction?.reactedByMe).toBe(true);
+      expect(reaction?.reactors.map((r) => r.userId)).toContain('u-me');
     });
 
     // Resolve with the server response (same as current state)
@@ -252,7 +253,14 @@ describe('useToggleReaction', () => {
           body: 'nice',
           is_deleted: false,
           created_at: '2026-01-01T00:00:00Z',
-          reactions: [{ emoji: '👍', count: 2, reacted_by_me: true, reactors: [] }],
+          reactions: [
+            {
+              emoji: '👍',
+              count: 2,
+              reacted_by_me: true,
+              reactors: [{ user_id: 'u-me', name: 'Me', photo_url: '' }],
+            },
+          ],
           can_delete: false,
           replies: [],
         },
@@ -279,6 +287,7 @@ describe('useToggleReaction', () => {
       const reaction = cached?.items[0]?.reactions.find((r) => r.emoji === '👍');
       expect(reaction?.count).toBe(1);
       expect(reaction?.reactedByMe).toBe(false);
+      expect(reaction?.reactors.map((r) => r.userId)).not.toContain('u-me');
     });
 
     resolvePost?.({ data: wireWithMyReaction.items[0] });

--- a/frontend/src/api/eventComments.ts
+++ b/frontend/src/api/eventComments.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { useAuthStore } from '@/auth/store';
 import type {
+  CommentReactor,
   EventComment,
   EventCommentList,
   EventCommentReply,
@@ -201,27 +202,46 @@ function toggleOnRow<T extends EventCommentReply>(
   row: T,
   commentId: string,
   emoji: ReactionEmojiValue,
+  self: CommentReactor | null,
 ): T {
   if (row.id !== commentId) return row;
   const existing = row.reactions.find((r) => r.emoji === emoji);
   let next = row.reactions.slice();
   if (existing?.reactedByMe) {
     next = next
-      .map((r) => (r.emoji === emoji ? { ...r, count: r.count - 1, reactedByMe: false } : r))
+      .map((r) =>
+        r.emoji === emoji
+          ? {
+              ...r,
+              count: r.count - 1,
+              reactedByMe: false,
+              reactors: self
+                ? r.reactors.filter((reactor) => reactor.userId !== self.userId)
+                : r.reactors,
+            }
+          : r,
+      )
       .filter((r) => r.count > 0);
   } else if (existing) {
     next = next.map((r) =>
-      r.emoji === emoji ? { ...r, count: r.count + 1, reactedByMe: true } : r,
+      r.emoji === emoji
+        ? {
+            ...r,
+            count: r.count + 1,
+            reactedByMe: true,
+            reactors: self ? [...r.reactors, self] : r.reactors,
+          }
+        : r,
     );
   } else {
-    // reactors stays empty here; the settle-time refetch fills in the real name/photo.
-    next = [...next, { emoji, count: 1, reactedByMe: true, reactors: [] }];
+    next = [...next, { emoji, count: 1, reactedByMe: true, reactors: self ? [self] : [] }];
   }
   return { ...row, reactions: next };
 }
 
 export function useToggleReaction(eventId: string, token?: string) {
   const qc = useQueryClient();
+  const user = useAuthStore((s) => s.user);
   return useMutation({
     mutationFn: async ({ commentId, emoji }: ToggleReactionVars): Promise<EventComment> => {
       const { data } = await apiClient.post<WireCommentResponse>(
@@ -234,14 +254,17 @@ export function useToggleReaction(eventId: string, token?: string) {
     onMutate: async ({ commentId, emoji }) => {
       await qc.cancelQueries({ queryKey: eventCommentKeys.list(eventId) });
       const prev = qc.getQueryData<EventCommentList>(eventCommentKeys.list(eventId));
+      const self: CommentReactor | null = user
+        ? { userId: user.id, name: user.fullName, photoUrl: user.profilePhotoUrl }
+        : null;
       if (prev) {
         const nextList: EventCommentList = {
           ...prev,
           items: prev.items.map((c) => {
-            const updated = toggleOnRow(c, commentId, emoji);
+            const updated = toggleOnRow(c, commentId, emoji, self);
             return {
               ...updated,
-              replies: updated.replies.map((r) => toggleOnRow(r, commentId, emoji)),
+              replies: updated.replies.map((r) => toggleOnRow(r, commentId, emoji, self)),
             };
           }),
         };


### PR DESCRIPTION
## Summary
- Found during code review of #1160: `toggleOnRow`'s optimistic update kept `count`/`reactedByMe` in sync on toggle, but not the `reactors` array — so the "who reacted" popover could briefly show a stale list (missing yourself right after reacting, or still showing yourself right after un-reacting) until the settle-time refetch replaced it.
- Now threads the current user (from `useAuthStore`) into `toggleOnRow` and appends/removes them from `reactors` on the increment and un-react branches, matching the count change exactly. Falls back to leaving `reactors` untouched when there's no authed user (e.g. non-member RSVP-token reactions), since we can't fabricate a name-visibility-correct entry client-side.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on changed files — clean
- [x] `npx vitest run src/api/eventComments.test.ts` — 9/9 passing, including two new assertions covering the fix
- [ ] Full CI suite intentionally skipped per request; will run via GitHub CI on push