### PR TITLE
fix: 1141 - keep search bar sticky on members page

### DIFF
--- a/frontend/src/screens/members/MembersDirectoryScreen.tsx
+++ b/frontend/src/screens/members/MembersDirectoryScreen.tsx
@@ -26,7 +26,7 @@ export default function MembersDirectoryScreen() {
 
   return (
     <ContentContainer className="pt-4 md:pt-6">
-      <div className="mb-4">
+      <div className="bg-background sticky top-10 z-10 -mx-4 mb-4 px-4 pt-2 pb-3">
         <TextField
           label="search"
           hideLabel


### PR DESCRIPTION
## Overview

the search bar on `/members` scrolled away with the directory list, so filtering a long list of members meant scrolling back to the top first. reported on mobile safari/iphone.

the search wrapper is now `position: sticky` at `top-10`, pinning it directly beneath the app header (`AppShell`'s header is `sticky top-0` at `h-10`). the wrapper carries `bg-background` plus `-mx-4 px-4` so member rows scroll cleanly underneath it — without the opaque background, rows would show through the header's fading gradient. the previous `mb-4` spacing is kept and paired with `pt-2 pb-3` so there is no transparent gap between the header and the bar.

css-only, no scroll listeners. `AppShell` already avoids `overflow-x-hidden` on the content wrapper precisely so `position: sticky` descendants anchor to the window (see the comment there re #286), so this works without layout changes. desktop is unaffected — the same offset applies since the header height is not breakpoint-dependent.

## Test plan

- [ ] on mobile (ios safari), open `/members` and scroll the list — the search bar stays pinned below the `pda` header
- [ ] member rows scroll *underneath* the search bar with no text bleeding through
- [ ] on desktop, confirm the search bar sticks and layout/spacing is unchanged
- [ ] typing a query still filters by name, email, and phone
- [ ] check both light and dark themes for the sticky background

## Screenshots

TODO

Closes #1141
