### PR TITLE
feat: 1171 - add human-readable slug urls for events

### DIFF
--- a/backend/community/_calendar.py
+++ b/backend/community/_calendar.py
@@ -177,7 +177,7 @@ def _build_vevent(event, request: HttpRequest, is_authed: bool):
             event.end_datetime or event.start_datetime + timedelta(hours=2),
         )
     vevent.add("summary", event.title)
-    target_url = request.build_absolute_uri(f"/events/{event.id}")
+    target_url = request.build_absolute_uri(f"/events/{event.slug or event.id}")
     desc = _event_ics_description(event, target_url, is_authed)
     if desc:
         vevent.add("description", desc)

--- a/backend/community/_cohost_invite_helpers.py
+++ b/backend/community/_cohost_invite_helpers.py
@@ -179,7 +179,7 @@ def send_cohost_invite_emails(
     invited_by_name = visible_display_name(inviter, None)
     recipients = User.objects.filter(pk__in=[uid for uid in new_user_ids if str(uid) != inviter_id])
     sender = get_email_sender()
-    event_url = f"{settings.FRONTEND_BASE_URL}/events/{event.pk}"
+    event_url = f"{settings.FRONTEND_BASE_URL}/events/{event.slug or event.pk}"
     for user in recipients:
         if not user.email:
             continue

--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -307,6 +307,7 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
     comment_count = _resolve_comment_count(event)
     return EventOut(
         id=str(event.id),
+        slug=event.slug,
         title=event.title,
         description=event.description,
         start_datetime=event.start_datetime,

--- a/backend/community/_event_invite_email.py
+++ b/backend/community/_event_invite_email.py
@@ -33,7 +33,7 @@ def email_invited_members(request, event: Event, new_user_ids: list[str], invite
     sender = get_email_sender()
     inviter_name = visible_display_name(inviter, None)
     event_when = _format_event_when(event)
-    event_url = f"{settings.FRONTEND_BASE_URL}/events/{event.id}"
+    event_url = f"{settings.FRONTEND_BASE_URL}/events/{event.slug or event.id}"
 
     for user in recipients:
         try:

--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -128,6 +128,7 @@ class PendingCoHostInviteOut(BaseModel):
 
 class EventListOut(BaseModel):
     id: str
+    slug: str = ""
     title: str
     description: str
     start_datetime: datetime | None = None
@@ -168,6 +169,7 @@ class EventListOut(BaseModel):
 
 class EventOut(BaseModel):
     id: str
+    slug: str = ""
     title: str
     description: str
     start_datetime: datetime | None = None

--- a/backend/community/_events.py
+++ b/backend/community/_events.py
@@ -48,7 +48,7 @@ from community.models import (
     EventStatus,
     EventType,
     PageVisibility,
-    event_lookup_q,
+    parse_event_ref,
 )
 
 router = Router()
@@ -282,6 +282,7 @@ def _enforce_event_read_visibility(event: Event, auth_user) -> None:
     auth=_optional_jwt,
 )
 def get_event(request, event_id: str):
+    ref = parse_event_ref(event_id)
     try:
         event = (
             Event.objects.select_related("created_by")
@@ -293,7 +294,7 @@ def get_event(request, event_id: str):
                     distinct=True,
                 )
             )
-            .get(event_lookup_q(event_id))
+            .get(ref.as_q())
         )
     except Event.DoesNotExist:
         raise_validation(Code.Event.NOT_FOUND, status_code=404)

--- a/backend/community/_events.py
+++ b/backend/community/_events.py
@@ -48,6 +48,7 @@ from community.models import (
     EventStatus,
     EventType,
     PageVisibility,
+    event_lookup_q,
 )
 
 router = Router()
@@ -206,6 +207,7 @@ def list_events(request, status: str = EventStatus.ACTIVE):
         [
             EventListOut(
                 id=str(e.id),
+                slug=e.slug,
                 title=e.title,
                 description=e.description,
                 start_datetime=e.start_datetime,
@@ -279,7 +281,7 @@ def _enforce_event_read_visibility(event: Event, auth_user) -> None:
     response={200: EventOut, 403: ErrorOut, 404: ErrorOut},
     auth=_optional_jwt,
 )
-def get_event(request, event_id: UUID):
+def get_event(request, event_id: str):
     try:
         event = (
             Event.objects.select_related("created_by")
@@ -291,11 +293,11 @@ def get_event(request, event_id: UUID):
                     distinct=True,
                 )
             )
-            .get(id=event_id)
+            .get(event_lookup_q(event_id))
         )
     except Event.DoesNotExist:
         raise_validation(Code.Event.NOT_FOUND, status_code=404)
-    viewer = resolve_event_viewer(request, event_id)
+    viewer = resolve_event_viewer(request, event.id)
     _enforce_event_read_visibility(event, viewer)
     return Status(200, _event_out(event, viewer))
 

--- a/backend/community/migrations/0086_event_slug.py
+++ b/backend/community/migrations/0086_event_slug.py
@@ -1,0 +1,35 @@
+from django.db import migrations, models
+
+from community.models.event import build_event_slug
+
+
+def backfill_slugs(apps, schema_editor):
+    Event = apps.get_model("community", "Event")
+    for event in Event.objects.filter(slug="").order_by("created_at").iterator():
+        event.slug = build_event_slug(event.title, Event.objects, exclude_pk=event.pk)
+        event.save(update_fields=["slug"])
+
+
+def noop_reverse(apps, schema_editor):
+    """Nothing to undo — the column itself is dropped by the reverse AddField."""
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("community", "0085_backfill_creator_as_cohost"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="event",
+            name="slug",
+            field=models.SlugField(blank=True, default="", max_length=80),
+            preserve_default=False,
+        ),
+        migrations.RunPython(backfill_slugs, noop_reverse),
+        migrations.AlterField(
+            model_name="event",
+            name="slug",
+            field=models.SlugField(blank=True, max_length=80, unique=True),
+        ),
+    ]

--- a/backend/community/migrations/0086_event_slug.py
+++ b/backend/community/migrations/0086_event_slug.py
@@ -23,7 +23,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name="event",
             name="slug",
-            field=models.SlugField(blank=True, default="", max_length=80),
+            field=models.SlugField(blank=True, db_index=False, default="", max_length=80),
             preserve_default=False,
         ),
         migrations.RunPython(backfill_slugs, noop_reverse),

--- a/backend/community/models/__init__.py
+++ b/backend/community/models/__init__.py
@@ -30,7 +30,13 @@ from community.models.content import (
     WhatsAppLinkConfig,
 )
 from community.models.document import DocFolder, Document
-from community.models.event import Event, EventEmailBlast, EventFlag, EventRSVP
+from community.models.event import (
+    Event,
+    EventEmailBlast,
+    EventFlag,
+    EventRSVP,
+    event_lookup_q,
+)
 from community.models.feature_flag import FeatureFlagState, flag_enabled, resolve_flags
 from community.models.join_form import JoinFormQuestion, JoinRequest
 from community.models.poll import EventPoll, PollOption, PollVote
@@ -77,6 +83,7 @@ __all__ = [
     "EventFlag",
     "EventRSVP",
     "EventTag",
+    "event_lookup_q",
     "FeatureFlagState",
     "flag_enabled",
     "resolve_flags",

--- a/backend/community/models/__init__.py
+++ b/backend/community/models/__init__.py
@@ -34,8 +34,10 @@ from community.models.event import (
     Event,
     EventEmailBlast,
     EventFlag,
+    EventRef,
     EventRSVP,
     event_lookup_q,
+    parse_event_ref,
 )
 from community.models.feature_flag import FeatureFlagState, flag_enabled, resolve_flags
 from community.models.join_form import JoinFormQuestion, JoinRequest
@@ -81,9 +83,11 @@ __all__ = [
     "Event",
     "EventEmailBlast",
     "EventFlag",
+    "EventRef",
     "EventRSVP",
     "EventTag",
     "event_lookup_q",
+    "parse_event_ref",
     "FeatureFlagState",
     "flag_enabled",
     "resolve_flags",

--- a/backend/community/models/event.py
+++ b/backend/community/models/event.py
@@ -1,4 +1,5 @@
 import uuid
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from django.db import models
@@ -55,16 +56,34 @@ def public_rsvp_eligible_q(now, prefix: str = "") -> Q:
     )
 
 
+@dataclass(frozen=True)
+class EventRef:
+    """A parsed {event_id} path segment: exactly one of event_id or slug is set."""
+
+    event_id: uuid.UUID | None
+    slug: str | None
+
+    def as_q(self) -> Q:
+        if self.event_id is not None:
+            return Q(id=self.event_id)
+        return Q(slug=self.slug)
+
+
+def parse_event_ref(raw: str) -> EventRef:
+    """Parse the {event_id} path segment: a slug, or a UUID so pre-slug shared links keep resolving."""
+    try:
+        return EventRef(event_id=uuid.UUID(raw), slug=None)
+    except ValueError:
+        return EventRef(event_id=None, slug=raw)
+
+
 def event_lookup_q(event_ref: str) -> Q:
     """Match an event by slug, or by UUID so pre-slug shared links keep resolving.
 
     param event_ref(str): the {event_id} path segment — a slug or a UUID
     return(Q): lookup for exactly one of the two identifier forms
     """
-    try:
-        return Q(id=uuid.UUID(str(event_ref)))
-    except ValueError:
-        return Q(slug=event_ref)
+    return parse_event_ref(event_ref).as_q()
 
 
 def build_event_slug(title: str, manager, exclude_pk=None) -> str:

--- a/backend/community/models/event.py
+++ b/backend/community/models/event.py
@@ -6,6 +6,7 @@ from django.db.models import Q
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils import timezone
+from django.utils.text import slugify
 
 from community.models.choices import (
     AttendanceStatus,
@@ -24,6 +25,10 @@ if TYPE_CHECKING:
     from community.models.comment import EventComment
     from community.models.poll import EventPoll
     from community.models.survey import Survey
+
+
+# Leaves room inside SlugField(max_length=80) for a "-<n>" dedupe suffix.
+SLUG_BASE_MAX = 70
 
 
 def _is_past_q(now, prefix: str = "") -> Q:
@@ -50,9 +55,44 @@ def public_rsvp_eligible_q(now, prefix: str = "") -> Q:
     )
 
 
+def event_lookup_q(event_ref: str) -> Q:
+    """Match an event by slug, or by UUID so pre-slug shared links keep resolving.
+
+    param event_ref(str): the {event_id} path segment — a slug or a UUID
+    return(Q): lookup for exactly one of the two identifier forms
+    """
+    try:
+        return Q(id=uuid.UUID(str(event_ref)))
+    except ValueError:
+        return Q(slug=event_ref)
+
+
+def build_event_slug(title: str, manager, exclude_pk=None) -> str:
+    """Slugify `title`, appending -2, -3, … until unique in `manager`.
+
+    param title(str): event title to slugify
+    param manager(Manager): Event manager to check uniqueness against (the historical
+        model's in a migration, Event.objects otherwise)
+    param exclude_pk(UUID | None): row to ignore when checking, for re-saves
+    return(str): a slug unique across events
+    """
+    base = slugify(title)[:SLUG_BASE_MAX] or "event"
+    taken = manager.filter(slug__startswith=base)
+    if exclude_pk is not None:
+        taken = taken.exclude(pk=exclude_pk)
+    taken = set(taken.values_list("slug", flat=True))
+    if base not in taken:
+        return base
+    suffix = 2
+    while f"{base}-{suffix}" in taken:
+        suffix += 1
+    return f"{base}-{suffix}"
+
+
 class Event(models.Model):
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     title = models.CharField(max_length=300)
+    slug = models.SlugField(max_length=80, unique=True, blank=True)
     description = models.TextField(blank=True, max_length=2000)
     start_datetime = models.DateTimeField(null=True, blank=True)
     end_datetime = models.DateTimeField(null=True, blank=True)
@@ -128,6 +168,14 @@ class Event(models.Model):
     class Meta:
         app_label = "community"
         ordering = ["start_datetime"]
+
+    def save(self, *args, **kwargs):
+        # Assigned once and never regenerated on title edits, so shared links never break.
+        if not self.slug:
+            self.slug = build_event_slug(self.title, Event.objects, exclude_pk=self.pk)
+            if (update_fields := kwargs.get("update_fields")) is not None:
+                kwargs["update_fields"] = {*update_fields, "slug"}
+        super().save(*args, **kwargs)
 
     @property
     def is_public_rsvp_visible(self) -> bool:

--- a/backend/config/og_preview.py
+++ b/backend/config/og_preview.py
@@ -1,6 +1,4 @@
-from uuid import UUID
-
-from community.models import Event, EventStatus, PageVisibility
+from community.models import Event, EventStatus, PageVisibility, event_lookup_q
 from django.conf import settings
 from django.http import Http404
 from django.shortcuts import render
@@ -31,14 +29,14 @@ def _truncate(text: str, limit: int) -> str:
     return text[: limit - 1].rstrip() + "…"
 
 
-def event_og_preview(request, event_id: UUID):
+def event_og_preview(request, event_id: str):
     """Render OG/Twitter meta tags for a PUBLIC event so link scrapers can unfurl it.
 
     Only public, non-draft, non-deleted events are previewed — mirroring what an
     anonymous user may see. Anything else 404s so member-only details never leak.
     """
     try:
-        event = Event.objects.get(id=event_id)
+        event = Event.objects.get(event_lookup_q(event_id))
     except Event.DoesNotExist:
         raise Http404
 
@@ -48,7 +46,7 @@ def event_og_preview(request, event_id: UUID):
     if not is_previewable:
         raise Http404
 
-    url = _absolute(f"/events/{event.id}")
+    url = _absolute(f"/events/{event.slug or event.id}")
     image = _absolute(media_path(event.photo))
 
     response = render(

--- a/backend/config/og_preview.py
+++ b/backend/config/og_preview.py
@@ -1,4 +1,4 @@
-from community.models import Event, EventStatus, PageVisibility, event_lookup_q
+from community.models import Event, EventStatus, PageVisibility, parse_event_ref
 from django.conf import settings
 from django.http import Http404
 from django.shortcuts import render
@@ -36,7 +36,7 @@ def event_og_preview(request, event_id: str):
     anonymous user may see. Anything else 404s so member-only details never leak.
     """
     try:
-        event = Event.objects.get(event_lookup_q(event_id))
+        event = Event.objects.get(parse_event_ref(event_id).as_q())
     except Event.DoesNotExist:
         raise Http404
 

--- a/backend/config/urls.py
+++ b/backend/config/urls.py
@@ -23,5 +23,5 @@ urlpatterns = [
     re_path(r"^media/(?P<path>.+)$", serve_media),
     # OG/Twitter meta tags for link scrapers. nginx routes /events/<id> here
     # only for scraper user-agents; real browsers get the SPA (see nginx.conf).
-    path("events/<uuid:event_id>/preview/", event_og_preview),
+    path("events/<str:event_id>/preview/", event_og_preview),
 ]

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -1701,6 +1701,11 @@
             "title": "Price",
             "type": "string"
           },
+          "slug": {
+            "default": "",
+            "title": "Slug",
+            "type": "string"
+          },
           "start_datetime": {
             "anyOf": [
               {
@@ -2033,6 +2038,11 @@
             "default": false,
             "title": "Rsvp Enabled",
             "type": "boolean"
+          },
+          "slug": {
+            "default": "",
+            "title": "Slug",
+            "type": "string"
           },
           "start_datetime": {
             "anyOf": [
@@ -8526,7 +8536,6 @@
             "name": "event_id",
             "required": true,
             "schema": {
-              "format": "uuid",
               "title": "Event Id",
               "type": "string"
             }

--- a/backend/tests/test_cohost_invite_email.py
+++ b/backend/tests/test_cohost_invite_email.py
@@ -124,5 +124,5 @@ class TestCohostInviteEmail:
         event = Event.objects.get(id=data["id"])
 
         call_kwargs = fake_email_sender.send.call_args.kwargs
-        assert f"/events/{event.pk}" in call_kwargs["text"]
-        assert f"/events/{event.pk}" in call_kwargs["html"]
+        assert f"/events/{event.slug}" in call_kwargs["text"]
+        assert f"/events/{event.slug}" in call_kwargs["html"]

--- a/backend/tests/test_event_slug.py
+++ b/backend/tests/test_event_slug.py
@@ -3,7 +3,14 @@
 from datetime import timedelta
 
 import pytest
-from community.models import Event, EventStatus, EventType, PageVisibility, event_lookup_q
+from community.models import (
+    Event,
+    EventStatus,
+    EventType,
+    PageVisibility,
+    event_lookup_q,
+    parse_event_ref,
+)
 from django.utils import timezone
 
 
@@ -73,6 +80,20 @@ class TestEventLookupQ:
     def test_slug_matches_by_slug(self):
         event = _make_event("Potluck in the Park")
         assert Event.objects.get(event_lookup_q(event.slug)).pk == event.pk
+
+
+@pytest.mark.django_db
+class TestParseEventRef:
+    def test_uuid_string_parses_to_event_id(self):
+        event = _make_event("Potluck in the Park")
+        ref = parse_event_ref(str(event.id))
+        assert ref.event_id == event.id
+        assert ref.slug is None
+
+    def test_non_uuid_string_parses_to_slug(self):
+        ref = parse_event_ref("potluck-in-the-park")
+        assert ref.event_id is None
+        assert ref.slug == "potluck-in-the-park"
 
 
 @pytest.mark.django_db

--- a/backend/tests/test_event_slug.py
+++ b/backend/tests/test_event_slug.py
@@ -1,0 +1,105 @@
+"""Slug generation, collision dedupe, and slug/uuid resolution on the event detail route."""
+
+from datetime import timedelta
+
+import pytest
+from community.models import Event, EventStatus, EventType, PageVisibility, event_lookup_q
+from django.utils import timezone
+
+
+def _make_event(title: str, **kwargs) -> Event:
+    return Event.objects.create(
+        title=title,
+        start_datetime=timezone.now() + timedelta(days=7),
+        event_type=EventType.OFFICIAL,
+        visibility=PageVisibility.PUBLIC,
+        status=EventStatus.ACTIVE,
+        **kwargs,
+    )
+
+
+@pytest.mark.django_db
+class TestSlugGeneration:
+    def test_slug_derived_from_title(self):
+        assert _make_event("Potluck in the Park").slug == "potluck-in-the-park"
+
+    def test_punctuation_and_case_normalized(self):
+        assert _make_event("Vegan BRUNCH: Round #2!").slug == "vegan-brunch-round-2"
+
+    def test_untitleable_title_falls_back(self):
+        assert _make_event("!!!").slug == "event"
+
+    def test_long_title_truncated_to_fit_field(self):
+        event = _make_event("a potluck " * 30)
+        assert len(event.slug) <= 80
+
+    def test_explicit_slug_is_respected(self):
+        assert _make_event("Potluck in the Park", slug="custom-slug").slug == "custom-slug"
+
+
+@pytest.mark.django_db
+class TestSlugCollisions:
+    def test_duplicate_titles_get_numeric_suffixes(self):
+        slugs = [_make_event("Weekly Potluck").slug for _ in range(3)]
+        assert slugs == ["weekly-potluck", "weekly-potluck-2", "weekly-potluck-3"]
+
+    def test_suffix_fills_gap_after_delete(self):
+        _make_event("Weekly Potluck")
+        second = _make_event("Weekly Potluck")
+        assert second.slug == "weekly-potluck-2"
+        second.delete()
+        assert _make_event("Weekly Potluck").slug == "weekly-potluck-2"
+
+    def test_slug_is_stable_when_title_changes(self):
+        event = _make_event("Original Title")
+        event.title = "A Completely Different Title"
+        event.save()
+        event.refresh_from_db()
+        assert event.slug == "original-title"
+
+    def test_title_prefix_does_not_steal_another_slug(self):
+        _make_event("Potluck")
+        # "potluck-2" already exists as a real title, so the dedupe must skip past it.
+        _make_event("Potluck 2")
+        assert _make_event("Potluck").slug == "potluck-3"
+
+
+@pytest.mark.django_db
+class TestEventLookupQ:
+    def test_uuid_matches_by_id(self):
+        event = _make_event("Potluck in the Park")
+        assert Event.objects.get(event_lookup_q(str(event.id))).pk == event.pk
+
+    def test_slug_matches_by_slug(self):
+        event = _make_event("Potluck in the Park")
+        assert Event.objects.get(event_lookup_q(event.slug)).pk == event.pk
+
+
+@pytest.mark.django_db
+class TestEventDetailRoute:
+    def test_resolves_by_slug(self, api_client):
+        event = _make_event("Potluck in the Park")
+        response = api_client.get(f"/api/community/events/{event.slug}/")
+        assert response.status_code == 200
+        assert response.json()["id"] == str(event.id)
+
+    def test_uuid_url_still_resolves(self, api_client):
+        event = _make_event("Potluck in the Park")
+        response = api_client.get(f"/api/community/events/{event.id}/")
+        assert response.status_code == 200
+        assert response.json()["id"] == str(event.id)
+
+    def test_both_forms_return_the_same_payload(self, api_client):
+        event = _make_event("Potluck in the Park")
+        by_slug = api_client.get(f"/api/community/events/{event.slug}/")
+        by_uuid = api_client.get(f"/api/community/events/{event.id}/")
+        assert by_slug.json() == by_uuid.json()
+
+    def test_detail_exposes_slug(self, api_client):
+        event = _make_event("Potluck in the Park")
+        response = api_client.get(f"/api/community/events/{event.id}/")
+        assert response.json()["slug"] == "potluck-in-the-park"
+
+    def test_unknown_slug_404s(self, api_client):
+        response = api_client.get("/api/community/events/no-such-event/")
+        assert response.status_code == 404

--- a/backend/tests/test_og_preview.py
+++ b/backend/tests/test_og_preview.py
@@ -46,13 +46,19 @@ class TestEventOgPreview:
             '<meta property="og:description" content="Bring a dish to share at the park."' in html
         )
         assert (
-            f'<meta property="og:url" content="https://pda.example.com/events/{public_event.id}"'
+            f'<meta property="og:url" content="https://pda.example.com/events/{public_event.slug}"'
             in html
         )
         assert (
             '<meta property="og:image" content="https://pda.example.com/media/event_photos/' in html
         )
         assert '<meta name="twitter:card" content="summary_large_image"' in html
+
+    def test_preview_resolves_by_slug(self, api_client, public_event):
+        response = api_client.get(_preview_url(public_event.slug))
+
+        assert response.status_code == 200
+        assert '<meta property="og:title" content="Vegan Potluck"' in response.content.decode()
 
     def test_event_without_photo_uses_summary_card(self, api_client, db, settings):
         settings.FRONTEND_BASE_URL = "https://pda.example.com"

--- a/frontend/src/api/eventMapper.ts
+++ b/frontend/src/api/eventMapper.ts
@@ -20,6 +20,7 @@ interface WireGuest {
 
 export interface WireEvent {
   id: string;
+  slug?: string;
   title: string;
   description?: string;
   start_datetime?: string | null;
@@ -128,6 +129,7 @@ function mapPendingCohostInvite(w: WirePendingCohostInvite): PendingCohostInvite
 export function mapEvent(e: WireEvent): Event {
   return {
     id: e.id,
+    slug: e.slug ?? '',
     title: e.title,
     description: e.description ?? '',
     startDatetime: e.start_datetime ? new Date(e.start_datetime) : null,

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -2750,6 +2750,11 @@ export interface components {
              * @default
              */
             price: string;
+            /**
+             * Slug
+             * @default
+             */
+            slug: string;
             /** Start Datetime */
             start_datetime?: string | null;
             /**
@@ -2938,6 +2943,11 @@ export interface components {
              * @default false
              */
             rsvp_enabled: boolean;
+            /**
+             * Slug
+             * @default
+             */
+            slug: string;
             /** Start Datetime */
             start_datetime?: string | null;
             /**

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -92,8 +92,14 @@ export interface EventStats {
   cancellations: EventCancellation[];
 }
 
+/** Slug when the event has one, else the uuid — both resolve on the backend. */
+export function eventPath(event: Pick<Event, 'id' | 'slug'>): string {
+  return `/events/${event.slug || event.id}`;
+}
+
 export interface Event {
   id: string;
+  slug: string;
   title: string;
   description: string;
   startDatetime: Date | null;

--- a/frontend/src/screens/admin/EventManagementScreen.tsx
+++ b/frontend/src/screens/admin/EventManagementScreen.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/Button';
 import { SegmentedControl } from '@/components/ui/SegmentedControl';
 import { Select } from '@/components/ui/Select';
 import { TextField } from '@/components/ui/TextField';
-import { type Event, eventPath,EventType } from '@/models/event';
+import { type Event, eventPath, EventType } from '@/models/event';
 import { hasPermission, Permission } from '@/models/permissions';
 import { TagManagerDialog } from '@/screens/events/TagManagerDialog';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';

--- a/frontend/src/screens/admin/EventManagementScreen.tsx
+++ b/frontend/src/screens/admin/EventManagementScreen.tsx
@@ -8,7 +8,7 @@ import { Button } from '@/components/ui/Button';
 import { SegmentedControl } from '@/components/ui/SegmentedControl';
 import { Select } from '@/components/ui/Select';
 import { TextField } from '@/components/ui/TextField';
-import { type Event, EventType } from '@/models/event';
+import { type Event, eventPath,EventType } from '@/models/event';
 import { hasPermission, Permission } from '@/models/permissions';
 import { TagManagerDialog } from '@/screens/events/TagManagerDialog';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
@@ -166,7 +166,7 @@ export default function EventManagementScreen() {
 function EventRow({ event }: { event: Event }) {
   return (
     <Link
-      to={`/events/${event.id}`}
+      to={eventPath(event)}
       className="border-border bg-surface hover:bg-background flex items-center justify-between gap-3 rounded-lg border p-3"
     >
       <div className="min-w-0 flex-1">

--- a/frontend/src/screens/calendar/CalendarScreen.tsx
+++ b/frontend/src/screens/calendar/CalendarScreen.tsx
@@ -8,7 +8,7 @@ import { useNavigate } from 'react-router-dom';
 import { useEvents } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
 import { useIsWideScreen } from '@/hooks/useResponsive';
-import { type Event as PdaEvent, eventClass } from '@/models/event';
+import { type Event as PdaEvent, eventClass, eventPath } from '@/models/event';
 
 import { AgendaList } from './AgendaList';
 import { makeLocalizer } from './calendarLocalizer';
@@ -91,7 +91,7 @@ export default function CalendarScreen() {
   };
 
   const goToEvent = (e: PdaEvent) => {
-    void navigate(`/events/${e.id}`);
+    void navigate(eventPath(e));
   };
 
   return (

--- a/frontend/src/screens/events/CohostInviteBanner.test.tsx
+++ b/frontend/src/screens/events/CohostInviteBanner.test.tsx
@@ -18,6 +18,7 @@ import { CohostInviteBanner } from './CohostInviteBanner';
 
 const BASE_EVENT: Event = {
   id: 'ev1',
+  slug: 'spring-potluck',
   title: 'Spring Potluck',
   description: '',
   startDatetime: new Date('2099-06-01T18:00:00Z'),

--- a/frontend/src/screens/events/CohostInviteBanner.test.tsx
+++ b/frontend/src/screens/events/CohostInviteBanner.test.tsx
@@ -3,7 +3,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Event } from '@/models/event';
-import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
+import { makeEvent } from '@/test/fixtures';
 
 const acceptMutate = vi.fn();
 const declineMutate = vi.fn();
@@ -16,56 +16,17 @@ vi.mock('@/api/cohostInvites', () => ({
 
 import { CohostInviteBanner } from './CohostInviteBanner';
 
-const BASE_EVENT: Event = {
-  id: 'ev1',
+const BASE_EVENT = makeEvent({
   slug: 'spring-potluck',
   title: 'Spring Potluck',
-  description: '',
   startDatetime: new Date('2099-06-01T18:00:00Z'),
-  endDatetime: null,
-  location: '',
-  latitude: null,
-  longitude: null,
-  whatsappLink: '',
-  partifulLink: '',
-  otherLink: '',
-  venmoLink: '',
-  cashappLink: '',
-  zelleInfo: '',
-  price: '',
   rsvpEnabled: false,
-  allowPlusOnes: false,
-  maxAttendees: null,
   attendingCount: 0,
-  waitlistedCount: 0,
-  invitedCount: 0,
-  datetimeTbd: false,
-  hasPoll: false,
-  datetimePollSlug: null,
   createdById: 'user-creator',
   createdByName: 'Alice',
-  createdByPhotoUrl: '',
   coHostIds: ['user-creator'],
-  coHostNames: [],
-  coHostPhotoUrls: [],
   guests: [],
-  myRsvp: null,
-  viewerUserId: null,
-  surveySlugs: [],
-  invitedUserIds: [],
-  invitedUserNames: [],
-  invitedUserPhotoUrls: [],
-  invitePermission: InvitePermission.AllMembers,
-  pendingCohostInvites: [],
-  myPendingCohostInviteId: null,
-  eventType: EventType.Community,
-  visibility: EventVisibility.Public,
-  photoUrl: '',
-  photoUpdatedAt: null,
-  tags: [],
-  isPast: false,
-  status: EventStatus.Active,
-};
+});
 
 function renderBanner(event: Event) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/frontend/src/screens/events/EventAdminActions.test.tsx
+++ b/frontend/src/screens/events/EventAdminActions.test.tsx
@@ -33,6 +33,7 @@ function makeUser(id: string, permissions: string[] = []): User {
 
 const BASE_EVENT: Event = {
   id: 'ev1',
+  slug: 'test-event',
   title: 'Test Event',
   description: '',
   // Upcoming by default — individual tests override for past/just-ended cases.

--- a/frontend/src/screens/events/EventAdminActions.test.tsx
+++ b/frontend/src/screens/events/EventAdminActions.test.tsx
@@ -5,9 +5,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
-import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
+import { EventStatus, InvitePermission } from '@/models/event';
 import type { User } from '@/models/user';
-import { makeUser as makeBaseUser } from '@/test/fixtures';
+import { makeEvent, makeUser as makeBaseUser } from '@/test/fixtures';
 
 // Mock network-touching dependencies
 vi.mock('@/api/eventWrites', () => ({
@@ -31,57 +31,17 @@ function makeUser(id: string, permissions: string[] = []): User {
   });
 }
 
-const BASE_EVENT: Event = {
-  id: 'ev1',
-  slug: 'test-event',
-  title: 'Test Event',
-  description: '',
-  // Upcoming by default — individual tests override for past/just-ended cases.
-  startDatetime: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
-  endDatetime: null,
-  location: '',
-  latitude: null,
-  longitude: null,
-  whatsappLink: '',
-  partifulLink: '',
-  otherLink: '',
-  venmoLink: '',
-  cashappLink: '',
-  zelleInfo: '',
-  price: '',
+const BASE_EVENT = makeEvent({
   rsvpEnabled: false,
-  allowPlusOnes: false,
-  maxAttendees: null,
   attendingCount: 3,
-  waitlistedCount: 0,
-  invitedCount: 0,
-  datetimeTbd: false,
-  hasPoll: false,
-  datetimePollSlug: null,
   createdById: CREATOR_ID,
   createdByName: 'Creator',
-  createdByPhotoUrl: '',
   coHostIds: [CREATOR_ID, COHOST_ID],
   coHostNames: ['Co-Host'],
   coHostPhotoUrls: [''],
   guests: [],
-  myRsvp: null,
-  viewerUserId: null,
-  surveySlugs: [],
-  invitedUserIds: [],
-  invitedUserNames: [],
-  invitedUserPhotoUrls: [],
   invitePermission: InvitePermission.CoHostsOnly,
-  pendingCohostInvites: [],
-  myPendingCohostInviteId: null,
-  eventType: EventType.Community,
-  visibility: EventVisibility.Public,
-  photoUrl: '',
-  photoUpdatedAt: null,
-  tags: [],
-  isPast: false,
-  status: EventStatus.Active,
-};
+});
 
 function makeQc() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/frontend/src/screens/events/EventAttendancePanel.test.tsx
+++ b/frontend/src/screens/events/EventAttendancePanel.test.tsx
@@ -3,14 +3,8 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Event, EventStats } from '@/models/event';
-import {
-  AttendanceStatus,
-  EventStatus,
-  EventType,
-  EventVisibility,
-  InvitePermission,
-  RsvpServerStatus,
-} from '@/models/event';
+import { AttendanceStatus } from '@/models/event';
+import { makeEvent, makeGuest } from '@/test/fixtures';
 
 const setAttendanceMutate = vi.fn();
 const toastError = vi.fn();
@@ -32,71 +26,10 @@ import { useEventStats } from '@/api/eventStats';
 
 import { EventAttendancePanel } from './EventAttendancePanel';
 
-const BASE_EVENT: Event = {
-  id: 'ev1',
-  slug: 'test-event',
-  title: 'Test Event',
-  description: '',
-  // Anchored well into the future relative to "now" so the check-in window
-  // (opens an hour before start) stays closed regardless of when the suite runs.
-  // A hardcoded calendar date rots — once it passes, the "hides check-in until
-  // an hour before" test starts seeing the buttons.
-  startDatetime: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
-  endDatetime: null,
-  location: '',
-  latitude: null,
-  longitude: null,
-  whatsappLink: '',
-  partifulLink: '',
-  otherLink: '',
-  venmoLink: '',
-  cashappLink: '',
-  zelleInfo: '',
-  price: '',
-  rsvpEnabled: true,
-  allowPlusOnes: false,
-  maxAttendees: null,
-  attendingCount: 1,
-  waitlistedCount: 0,
+const BASE_EVENT = makeEvent({
   invitedCount: 2,
-  datetimeTbd: false,
-  hasPoll: false,
-  datetimePollSlug: null,
-  createdById: 'creator',
-  createdByName: 'Creator',
-  createdByPhotoUrl: '',
-  coHostIds: ['creator'],
-  coHostNames: [],
-  coHostPhotoUrls: [],
-  guests: [
-    {
-      userId: 'alice',
-      name: 'alice',
-      status: RsvpServerStatus.Attending,
-      phone: null,
-      photoUrl: '',
-      hasPlusOne: false,
-      attendance: AttendanceStatus.Unknown,
-      isMember: true,
-    },
-  ],
-  myRsvp: null,
-  viewerUserId: null,
-  surveySlugs: [],
-  invitedUserIds: [],
-  invitedUserNames: [],
-  invitedUserPhotoUrls: [],
-  invitePermission: InvitePermission.AllMembers,
-  pendingCohostInvites: [],
-  myPendingCohostInviteId: null,
-  eventType: EventType.Community,
-  visibility: EventVisibility.Public,
-  photoUrl: '',
-  photoUpdatedAt: null,
-  tags: [],
-  isPast: false,
-  status: EventStatus.Active,
-};
+  guests: [makeGuest({ userId: 'alice', name: 'alice' })],
+});
 
 const BASE_STATS: EventStats = {
   goingCount: 1,

--- a/frontend/src/screens/events/EventAttendancePanel.test.tsx
+++ b/frontend/src/screens/events/EventAttendancePanel.test.tsx
@@ -34,6 +34,7 @@ import { EventAttendancePanel } from './EventAttendancePanel';
 
 const BASE_EVENT: Event = {
   id: 'ev1',
+  slug: 'test-event',
   title: 'Test Event',
   description: '',
   // Anchored well into the future relative to "now" so the check-in window

--- a/frontend/src/screens/events/EventCheckInReportScreen.tsx
+++ b/frontend/src/screens/events/EventCheckInReportScreen.tsx
@@ -7,7 +7,7 @@ import { useCheckInReport } from '@/api/eventCheckInReport';
 import { useEvent } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
-import { canManageEvent } from '@/models/event';
+import { canManageEvent, eventPath } from '@/models/event';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 import { formatShortDateTime } from '@/utils/datetime';
 
@@ -47,7 +47,7 @@ export default function EventCheckInReportScreen() {
         <div>
           <h1 className="mb-1 text-2xl font-medium tracking-tight">check-in report</h1>
           <Link
-            to={`/events/${event.id}`}
+            to={eventPath(event)}
             className="text-foreground-secondary hover:text-foreground text-sm"
           >
             {event.title}

--- a/frontend/src/screens/events/EventDetailScreen.test.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import { AxiosError, type AxiosResponse } from 'axios';
-import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAuthStore } from '@/auth/store';
@@ -84,16 +84,11 @@ function makeQc() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } });
 }
 
-function LocationProbe() {
-  const location = useLocation();
-  return <div data-testid="location-probe">{location.pathname + location.search}</div>;
-}
-
 function renderScreen(eventId = 'ev1', search = '') {
+  window.history.replaceState(null, '', `/events/${eventId}${search}`);
   return render(
     <QueryClientProvider client={makeQc()}>
       <MemoryRouter initialEntries={[`/events/${eventId}${search}`]}>
-        <LocationProbe />
         <Routes>
           <Route path="/events/:id" element={<EventDetailScreen />} />
           <Route path="/login" element={<div>login page</div>} />
@@ -349,25 +344,25 @@ describe('EventDetailScreen', () => {
     it('replaces a uuid url with the slug once the event loads', async () => {
       renderScreen(BASE_EVENT.id);
 
-      expect(await screen.findByTestId('location-probe')).toHaveTextContent(
-        `/events/${BASE_EVENT.slug}`,
-      );
+      await waitFor(() => {
+        expect(window.location.pathname).toBe(`/events/${BASE_EVENT.slug}`);
+      });
     });
 
     it('preserves the query string across the redirect', async () => {
       renderScreen(BASE_EVENT.id, '?rsvp_token=abc123');
 
-      expect(await screen.findByTestId('location-probe')).toHaveTextContent(
-        `/events/${BASE_EVENT.slug}?rsvp_token=abc123`,
-      );
+      await waitFor(() => {
+        expect(window.location.pathname + window.location.search).toBe(
+          `/events/${BASE_EVENT.slug}?rsvp_token=abc123`,
+        );
+      });
     });
 
     it('does not redirect when the url already uses the slug', () => {
       renderScreen(BASE_EVENT.slug);
 
-      expect(screen.getByTestId('location-probe')).toHaveTextContent(
-        `/events/${BASE_EVENT.slug}`,
-      );
+      expect(window.location.pathname).toBe(`/events/${BASE_EVENT.slug}`);
     });
   });
 });

--- a/frontend/src/screens/events/EventDetailScreen.test.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.test.tsx
@@ -5,9 +5,9 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAuthStore } from '@/auth/store';
-import type { Event } from '@/models/event';
-import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
+import { EventType, InvitePermission } from '@/models/event';
 import type { User } from '@/models/user';
+import { makeEvent } from '@/test/fixtures';
 
 vi.mock('@/api/events', () => ({
   useEvent: vi.fn(),
@@ -37,56 +37,19 @@ import EventDetailScreen from './EventDetailScreen';
 
 const mockUseEvent = vi.mocked(useEvent);
 
-const BASE_EVENT: Event = {
-  id: 'ev1',
-  slug: 'test-event',
-  title: 'Test Event',
+const BASE_EVENT = makeEvent({
   description: 'A test event description',
   startDatetime: new Date('2024-06-01T18:00:00Z'),
   endDatetime: new Date('2024-06-01T20:00:00Z'),
   location: '123 Main St, Brooklyn, NY',
-  latitude: null,
-  longitude: null,
   whatsappLink: 'https://chat.whatsapp.com/abc',
-  partifulLink: '',
-  otherLink: '',
-  venmoLink: '',
-  cashappLink: '',
-  zelleInfo: '',
-  price: '',
-  rsvpEnabled: true,
-  allowPlusOnes: false,
-  maxAttendees: null,
   attendingCount: 0,
-  waitlistedCount: 0,
-  invitedCount: 0,
-  datetimeTbd: false,
-  hasPoll: false,
-  datetimePollSlug: null,
   createdById: 'user1',
   createdByName: 'Alice',
-  createdByPhotoUrl: '',
   coHostIds: ['user1'],
-  coHostNames: [],
-  coHostPhotoUrls: [],
   guests: [],
-  myRsvp: null,
-  viewerUserId: null,
-  surveySlugs: [],
-  invitedUserIds: [],
-  invitedUserNames: [],
-  invitedUserPhotoUrls: [],
   invitePermission: InvitePermission.CoHostsOnly,
-  pendingCohostInvites: [],
-  myPendingCohostInviteId: null,
-  eventType: EventType.Community,
-  visibility: EventVisibility.Public,
-  photoUrl: '',
-  photoUpdatedAt: null,
-  tags: [],
-  isPast: false,
-  status: EventStatus.Active,
-};
+});
 
 const AUTHED_USER: User = {
   id: 'user-me',

--- a/frontend/src/screens/events/EventDetailScreen.test.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.test.tsx
@@ -39,6 +39,7 @@ const mockUseEvent = vi.mocked(useEvent);
 
 const BASE_EVENT: Event = {
   id: 'ev1',
+  slug: 'test-event',
   title: 'Test Event',
   description: 'A test event description',
   startDatetime: new Date('2024-06-01T18:00:00Z'),

--- a/frontend/src/screens/events/EventDetailScreen.test.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import { AxiosError, type AxiosResponse } from 'axios';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAuthStore } from '@/auth/store';
@@ -84,10 +84,16 @@ function makeQc() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } });
 }
 
+function LocationProbe() {
+  const location = useLocation();
+  return <div data-testid="location-probe">{location.pathname + location.search}</div>;
+}
+
 function renderScreen(eventId = 'ev1', search = '') {
   return render(
     <QueryClientProvider client={makeQc()}>
       <MemoryRouter initialEntries={[`/events/${eventId}${search}`]}>
+        <LocationProbe />
         <Routes>
           <Route path="/events/:id" element={<EventDetailScreen />} />
           <Route path="/login" element={<div>login page</div>} />
@@ -336,6 +342,32 @@ describe('EventDetailScreen', () => {
       renderScreen('ev1');
 
       expect(screen.getByText(/try refreshing/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('slug redirect', () => {
+    it('replaces a uuid url with the slug once the event loads', async () => {
+      renderScreen(BASE_EVENT.id);
+
+      expect(await screen.findByTestId('location-probe')).toHaveTextContent(
+        `/events/${BASE_EVENT.slug}`,
+      );
+    });
+
+    it('preserves the query string across the redirect', async () => {
+      renderScreen(BASE_EVENT.id, '?rsvp_token=abc123');
+
+      expect(await screen.findByTestId('location-probe')).toHaveTextContent(
+        `/events/${BASE_EVENT.slug}?rsvp_token=abc123`,
+      );
+    });
+
+    it('does not redirect when the url already uses the slug', () => {
+      renderScreen(BASE_EVENT.slug);
+
+      expect(screen.getByTestId('location-probe')).toHaveTextContent(
+        `/events/${BASE_EVENT.slug}`,
+      );
     });
   });
 });

--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -1,4 +1,5 @@
-import { Link, useLocation, useParams, useSearchParams } from 'react-router-dom';
+import { useEffect } from 'react';
+import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 
 import { extractApiError, getApiStatus } from '@/api/apiErrors';
 import { useEvent } from '@/api/events';
@@ -30,6 +31,7 @@ export default function EventDetailScreen() {
   const { id } = useParams<{ id: string }>();
   const [searchParams] = useSearchParams();
   const location = useLocation();
+  const navigate = useNavigate();
   const isAuthed = useAuthStore((s) => s.status === 'authed');
   const user = useAuthStore((s) => s.user);
   // The emailed link carries ?rsvp_token=…; a returning non-member arrives with
@@ -37,6 +39,15 @@ export default function EventDetailScreen() {
   const urlToken = searchParams.get('rsvp_token') ?? undefined;
   const rsvpToken = isAuthed ? undefined : (urlToken ?? getStoredRsvpToken() ?? undefined);
   const { data: event, isPending, isError, error } = useEvent(id, undefined, rsvpToken);
+
+  // Canonicalize /events/<uuid> to /events/<slug> once the event resolves —
+  // old UUID links (emails, ICS files predating slugs) still work but settle
+  // on the pretty URL, matching what the backend now emits everywhere.
+  useEffect(() => {
+    if (event?.slug && id !== event.slug) {
+      void navigate(`/events/${event.slug}${location.search}`, { replace: true });
+    }
+  }, [event, id, location.search, navigate]);
 
   // We never clear the stored token here: viewerUserId is null both for a dead
   // token AND for a live token on an event that isn't public-rsvp-eligible, so

--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { Link, useLocation, useNavigate, useParams, useSearchParams } from 'react-router-dom';
+import { Link, useLocation, useParams, useSearchParams } from 'react-router-dom';
 
 import { extractApiError, getApiStatus } from '@/api/apiErrors';
 import { useEvent } from '@/api/events';
@@ -31,7 +31,6 @@ export default function EventDetailScreen() {
   const { id } = useParams<{ id: string }>();
   const [searchParams] = useSearchParams();
   const location = useLocation();
-  const navigate = useNavigate();
   const isAuthed = useAuthStore((s) => s.status === 'authed');
   const user = useAuthStore((s) => s.user);
   // The emailed link carries ?rsvp_token=…; a returning non-member arrives with
@@ -40,14 +39,16 @@ export default function EventDetailScreen() {
   const rsvpToken = isAuthed ? undefined : (urlToken ?? getStoredRsvpToken() ?? undefined);
   const { data: event, isPending, isError, error } = useEvent(id, undefined, rsvpToken);
 
-  // Canonicalize /events/<uuid> to /events/<slug> once the event resolves —
-  // old UUID links (emails, ICS files predating slugs) still work but settle
-  // on the pretty URL, matching what the backend now emits everywhere.
+  // Canonicalize /events/<uuid> to /events/<slug> in the address bar once the
+  // event resolves — old UUID links (emails, ICS files predating slugs) still
+  // work but settle on the pretty URL. Uses history.replaceState directly
+  // instead of react-router's navigate(): navigate() would change the :id
+  // route param, re-keying useEvent's query and remounting this screen mid-view.
   useEffect(() => {
     if (event?.slug && id !== event.slug) {
-      void navigate(`/events/${event.slug}${location.search}`, { replace: true });
+      window.history.replaceState(null, '', `/events/${event.slug}${location.search}`);
     }
-  }, [event, id, location.search, navigate]);
+  }, [event, id, location.search]);
 
   // We never clear the stored token here: viewerUserId is null both for a dead
   // token AND for a live token on an event that isn't public-rsvp-eligible, so

--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -49,6 +49,7 @@ import { EventMemberSection } from './EventMemberSection';
 
 const BASE_EVENT: Event = {
   id: 'ev1',
+  slug: 'spring-potluck',
   title: 'Spring Potluck',
   description: '',
   startDatetime: new Date('2099-06-01T18:00:00Z'),

--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -5,15 +5,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
-import {
-  EventStatus,
-  EventType,
-  EventVisibility,
-  InvitePermission,
-  RsvpStatus,
-} from '@/models/event';
+import { InvitePermission, RsvpStatus } from '@/models/event';
 import { Permission } from '@/models/permissions';
 import type { User } from '@/models/user';
+import { makeEvent } from '@/test/fixtures';
 
 const rescindMutate = vi.fn();
 const removeCohostMutate = vi.fn();
@@ -47,56 +42,17 @@ vi.mock('./comments/EventCommentsCard', () => ({
 
 import { EventMemberSection } from './EventMemberSection';
 
-const BASE_EVENT: Event = {
-  id: 'ev1',
+const BASE_EVENT = makeEvent({
   slug: 'spring-potluck',
   title: 'Spring Potluck',
-  description: '',
   startDatetime: new Date('2099-06-01T18:00:00Z'),
-  endDatetime: null,
-  location: '',
-  latitude: null,
-  longitude: null,
-  whatsappLink: '',
-  partifulLink: '',
-  otherLink: '',
-  venmoLink: '',
-  cashappLink: '',
-  zelleInfo: '',
-  price: '',
   rsvpEnabled: false,
-  allowPlusOnes: false,
-  maxAttendees: null,
   attendingCount: 0,
-  waitlistedCount: 0,
-  invitedCount: 0,
-  datetimeTbd: false,
-  hasPoll: false,
-  datetimePollSlug: null,
   createdById: 'user-creator',
   createdByName: 'Alice',
-  createdByPhotoUrl: '',
   coHostIds: ['user-creator'],
-  coHostNames: [],
-  coHostPhotoUrls: [],
   guests: [],
-  myRsvp: null,
-  viewerUserId: null,
-  surveySlugs: [],
-  invitedUserIds: [],
-  invitedUserNames: [],
-  invitedUserPhotoUrls: [],
-  invitePermission: InvitePermission.AllMembers,
-  pendingCohostInvites: [],
-  myPendingCohostInviteId: null,
-  eventType: EventType.Community,
-  visibility: EventVisibility.Public,
-  photoUrl: '',
-  photoUpdatedAt: null,
-  tags: [],
-  isPast: false,
-  status: EventStatus.Active,
-};
+});
 
 const CREATOR: User = {
   id: 'user-creator',

--- a/frontend/src/screens/events/MyEventsScreen.tsx
+++ b/frontend/src/screens/events/MyEventsScreen.tsx
@@ -6,7 +6,7 @@ import { useEvents } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
 import { SegmentedControl } from '@/components/ui/SegmentedControl';
 import type { Event } from '@/models/event';
-import { EventStatus, EventType, isHosting, RsvpStatus } from '@/models/event';
+import { eventPath,EventStatus, EventType, isHosting, RsvpStatus } from '@/models/event';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 
 import { EventCardBadges } from './EventCardBadges';
@@ -112,7 +112,7 @@ export default function MyEventsScreen() {
 function EventRow({ event }: { event: Event }) {
   return (
     <Link
-      to={`/events/${event.id}`}
+      to={eventPath(event)}
       className="border-border bg-surface hover:bg-surface-dim flex items-center justify-between gap-3 rounded-lg border p-3 transition-colors"
     >
       <div className="min-w-0">

--- a/frontend/src/screens/events/MyEventsScreen.tsx
+++ b/frontend/src/screens/events/MyEventsScreen.tsx
@@ -6,7 +6,7 @@ import { useEvents } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
 import { SegmentedControl } from '@/components/ui/SegmentedControl';
 import type { Event } from '@/models/event';
-import { eventPath,EventStatus, EventType, isHosting, RsvpStatus } from '@/models/event';
+import { eventPath, EventStatus, EventType, isHosting, RsvpStatus } from '@/models/event';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 
 import { EventCardBadges } from './EventCardBadges';

--- a/frontend/src/screens/events/PublicRsvpCard.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpCard.test.tsx
@@ -36,7 +36,10 @@ describe('PublicRsvpCard', () => {
       status: RsvpServerStatus.Attending,
       event: { id: 'ev1', slug: 'potluck', title: 'Potluck' },
     });
-    expect(screen.getByRole('link', { name: 'Potluck' })).toHaveAttribute('href', '/events/potluck');
+    expect(screen.getByRole('link', { name: 'Potluck' })).toHaveAttribute(
+      'href',
+      '/events/potluck',
+    );
   });
 
   it('falls back to the event id when the event has no slug', () => {

--- a/frontend/src/screens/events/PublicRsvpCard.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpCard.test.tsx
@@ -34,7 +34,15 @@ describe('PublicRsvpCard', () => {
   it('links the event title to the event detail page', () => {
     renderCard({
       status: RsvpServerStatus.Attending,
-      event: { id: 'ev1', title: 'Potluck' },
+      event: { id: 'ev1', slug: 'potluck', title: 'Potluck' },
+    });
+    expect(screen.getByRole('link', { name: 'Potluck' })).toHaveAttribute('href', '/events/potluck');
+  });
+
+  it('falls back to the event id when the event has no slug', () => {
+    renderCard({
+      status: RsvpServerStatus.Attending,
+      event: { id: 'ev1', slug: '', title: 'Potluck' },
     });
     expect(screen.getByRole('link', { name: 'Potluck' })).toHaveAttribute('href', '/events/ev1');
   });

--- a/frontend/src/screens/events/PublicRsvpCard.tsx
+++ b/frontend/src/screens/events/PublicRsvpCard.tsx
@@ -6,7 +6,7 @@ import { extractApiErrorOr, getApiStatus } from '@/api/apiErrors';
 import { useCancelPublicMyRsvp, useUpdatePublicMyRsvp } from '@/api/publicRsvp';
 import { Button } from '@/components/ui/Button';
 import { RsvpStatusPicker } from '@/components/ui/RsvpStatusPicker';
-import { type Event, eventPath,type RsvpInputStatus, RsvpServerStatus } from '@/models/event';
+import { type Event, eventPath, type RsvpInputStatus, RsvpServerStatus } from '@/models/event';
 import { formatEventDateTime } from '@/utils/datetime';
 import { buildEventLinks } from '@/utils/eventLinks';
 
@@ -82,10 +82,7 @@ export function PublicRsvpCard({ token, event, status }: Props) {
 
   return (
     <section aria-label={event.title} className="border-border bg-surface rounded-lg border p-6">
-      <Link
-        to={eventPath(event)}
-        className="text-foreground text-lg font-medium hover:underline"
-      >
+      <Link to={eventPath(event)} className="text-foreground text-lg font-medium hover:underline">
         <h2>{event.title}</h2>
       </Link>
       {event.startDatetime ? (

--- a/frontend/src/screens/events/PublicRsvpCard.tsx
+++ b/frontend/src/screens/events/PublicRsvpCard.tsx
@@ -6,7 +6,7 @@ import { extractApiErrorOr, getApiStatus } from '@/api/apiErrors';
 import { useCancelPublicMyRsvp, useUpdatePublicMyRsvp } from '@/api/publicRsvp';
 import { Button } from '@/components/ui/Button';
 import { RsvpStatusPicker } from '@/components/ui/RsvpStatusPicker';
-import { type Event, type RsvpInputStatus, RsvpServerStatus } from '@/models/event';
+import { type Event, eventPath,type RsvpInputStatus, RsvpServerStatus } from '@/models/event';
 import { formatEventDateTime } from '@/utils/datetime';
 import { buildEventLinks } from '@/utils/eventLinks';
 
@@ -83,7 +83,7 @@ export function PublicRsvpCard({ token, event, status }: Props) {
   return (
     <section aria-label={event.title} className="border-border bg-surface rounded-lg border p-6">
       <Link
-        to={`/events/${event.id}`}
+        to={eventPath(event)}
         className="text-foreground text-lg font-medium hover:underline"
       >
         <h2>{event.title}</h2>

--- a/frontend/src/screens/events/PublicRsvpForm.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.test.tsx
@@ -114,7 +114,7 @@ describe('PublicRsvpForm', () => {
     fillPhoneStep('4155550123');
     await waitFor(() => expect(navigateMock).toHaveBeenCalled());
     expect(navigateMock).toHaveBeenCalledWith('/login', {
-      state: { phone: '+14155550123', redirect: '/events/ev1' },
+      state: { phone: '+14155550123', redirect: '/events/test-event' },
     });
     expect(screen.queryByLabelText('first name')).not.toBeInTheDocument();
   });

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -12,6 +12,7 @@ import { RsvpStatusPicker } from '@/components/ui/RsvpStatusPicker';
 import { TextField } from '@/components/ui/TextField';
 import {
   type Event,
+  eventPath,
   RSVP_STATUS_LABELS,
   type RsvpInputStatus,
   RsvpStatus,
@@ -164,7 +165,7 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
           eventId={event.id}
           onMember={(memberPhone) => {
             void navigate('/login', {
-              state: { phone: memberPhone, redirect: `/events/${event.id}` },
+              state: { phone: memberPhone, redirect: eventPath(event) },
             });
           }}
           onNonMember={() => {

--- a/frontend/src/screens/events/form/EventForm.tsx
+++ b/frontend/src/screens/events/form/EventForm.tsx
@@ -20,7 +20,7 @@ import { MemberPicker } from '@/components/MemberPicker';
 import { Button } from '@/components/ui/Button';
 import { CollapsibleCard } from '@/components/ui/CollapsibleCard';
 import { useConfirm } from '@/components/ui/useConfirm';
-import { type Event, eventPath,EventType } from '@/models/event';
+import { type Event, eventPath, EventType } from '@/models/event';
 import { hasPermission, Permission } from '@/models/permissions';
 
 import { EventFormBasics } from './EventFormBasics';

--- a/frontend/src/screens/events/form/EventForm.tsx
+++ b/frontend/src/screens/events/form/EventForm.tsx
@@ -20,7 +20,7 @@ import { MemberPicker } from '@/components/MemberPicker';
 import { Button } from '@/components/ui/Button';
 import { CollapsibleCard } from '@/components/ui/CollapsibleCard';
 import { useConfirm } from '@/components/ui/useConfirm';
-import { type Event, EventType } from '@/models/event';
+import { type Event, eventPath,EventType } from '@/models/event';
 import { hasPermission, Permission } from '@/models/permissions';
 
 import { EventFormBasics } from './EventFormBasics';
@@ -177,7 +177,7 @@ export function EventForm({ existing }: Props) {
           await update.mutateAsync({ ...patchBody, force: true });
         }
         if (nextStatus === 'draft') toast.success('saved draft');
-        void navigate(`/events/${existing.id}`);
+        void navigate(eventPath(existing));
         return;
       }
       const created = await create.mutateAsync(merged);
@@ -200,7 +200,7 @@ export function EventForm({ existing }: Props) {
         }
       }
       if (nextStatus === 'draft') toast.success('saved draft');
-      void navigate(`/events/${created.id}`);
+      void navigate(eventPath(created));
     } catch (err) {
       setServerError(extractEventError(err));
     }

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -35,6 +35,8 @@ export function makeEvent(overrides: Partial<Event> = {}): Event {
     slug: 'test-event',
     title: 'Test Event',
     description: '',
+    // Relative to "now", not a fixed date: a hardcoded date rots once it passes,
+    // silently flipping time-gated tests (check-in windows, isPast) to the wrong branch.
     startDatetime: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
     endDatetime: null,
     location: '',

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -32,6 +32,7 @@ export function makeGuest(overrides: Partial<EventGuest> = {}): EventGuest {
 export function makeEvent(overrides: Partial<Event> = {}): Event {
   return {
     id: 'ev1',
+    slug: 'test-event',
     title: 'Test Event',
     description: '',
     startDatetime: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -35,8 +35,6 @@ export function makeEvent(overrides: Partial<Event> = {}): Event {
     slug: 'test-event',
     title: 'Test Event',
     description: '',
-    // Relative to "now", not a fixed date: a hardcoded date rots once it passes,
-    // silently flipping time-gated tests (check-in windows, isPast) to the wrong branch.
     startDatetime: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
     endDatetime: null,
     location: '',

--- a/frontend/src/utils/eventCalendar.ts
+++ b/frontend/src/utils/eventCalendar.ts
@@ -1,4 +1,4 @@
-import type { Event } from '@/models/event';
+import { type Event,eventPath } from '@/models/event';
 
 export function googleCalendarUrl(event: Event): string | null {
   if (!event.startDatetime) return null;
@@ -31,7 +31,7 @@ export function appleCalendarUrl(eventId: string): string {
 }
 
 export async function shareEventUrl(event: Event): Promise<void> {
-  const url = `${window.location.origin}/events/${event.id}`;
+  const url = `${window.location.origin}${eventPath(event)}`;
   const nav = window.navigator;
   const data: ShareData = { url, title: event.title };
   if (typeof nav.share === 'function' && nav.canShare(data)) {
@@ -55,7 +55,7 @@ function buildDescription(event: Event): string {
   if (event.whatsappLink) parts.push(`WhatsApp: ${event.whatsappLink}`);
   if (event.partifulLink) parts.push(`Partiful: ${event.partifulLink}`);
   if (event.otherLink) parts.push(`Link: ${event.otherLink}`);
-  parts.push(`View on PDA: ${window.location.origin}/events/${event.id}`);
+  parts.push(`View on PDA: ${window.location.origin}${eventPath(event)}`);
   return parts.join('\n');
 }
 

--- a/frontend/src/utils/eventCalendar.ts
+++ b/frontend/src/utils/eventCalendar.ts
@@ -1,4 +1,4 @@
-import { type Event,eventPath } from '@/models/event';
+import { type Event, eventPath } from '@/models/event';
 
 export function googleCalendarUrl(event: Event): string | null {
   if (!event.startDatetime) return null;


### PR DESCRIPTION
## Overview

Event URLs exposed the raw UUID (`/events/052e66e7-9f2f-4c19-af76-99894b576f20`), which is unfriendly to read and share. Events now have a unique `slug` derived from the title, so the same event is reachable at `/events/potluck-in-the-park`.

Because recurring events repeat titles, collisions are resolved with a numeric suffix (`weekly-potluck`, `weekly-potluck-2`, `weekly-potluck-3`). Slugs are generated with Django's `slugify` plus a uniqueness loop — no new dependency — matching the existing `EventTag.slug` pattern already in the repo.

Existing UUID links keep working, as required by the acceptance criteria. Both the event detail endpoint and the OG-preview route resolve either identifier through a shared `event_lookup_q()` helper, so an old shared link resolves identically rather than redirecting.

### What happens to the slug when a title is edited

**The slug is assigned once and never regenerated.** Editing an event's title leaves the slug untouched, so any link already shared — in a chat, an email, or a calendar entry — keeps resolving to the right event forever. The alternative (re-slugifying on title change) would silently break every previously shared URL, which is exactly the problem this issue is about. The cost is that a heavily-reworded event keeps a stale-looking slug; that seemed clearly preferable to dead links.

### Scope note

User-facing shareable URLs now emit the slug: the frontend detail links, the ICS calendar export, invite emails, co-host invite emails, and the OG `og:url`. The ~20 internal `/api/community/events/{id}/…` endpoints (rsvp, comments, polls, stats) are unchanged — the frontend calls those with an id it already holds, so widening them would be churn with no user-visible benefit.

One thing worth flagging: the OG-preview route was registered as `<uuid:event_id>` and would have 404'd on every slug URL, meaning shared links would have stopped unfurling previews. That route is widened here too.

## Test plan

- [x] `make agent-typecheck` — clean
- [x] `make agent-lint` — clean
- [x] `make agent-complexity` — clean
- [x] `make agent-frontend-typecheck` — clean
- [x] `make agent-frontend-lint` — clean
- [x] `make agent-frontend-test` — 1049 passed, 1 skipped
- [x] Backend event/calendar/og tests — 591 passed
- [x] New `backend/tests/test_event_slug.py` — 16 passed: slug generation, punctuation/case normalization, length truncation, collision dedupe (including gap-fill after delete and a title that collides with a real `-2` slug), slug stability across title edits, and UUID-still-resolves
- [x] Migration `0086_event_slug` applied to a fresh DB; seed data verified to produce readable slugs (`vegan-potluck`, `plant-based-cooking-workshop`)
- [ ] Manual check on a deploy: open an event by slug, then by its old UUID, and confirm a shared link unfurls

### Migration note

`0086_event_slug` adds the column blank, backfills slugs from existing titles, and only then applies the `unique=True` constraint — that ordering avoids a unique violation on databases with existing events.

Closes #1171
