### PR TITLE
fix: 1192 - gate poll endpoints behind event visibility

### DIFF
--- a/backend/community/_polls.py
+++ b/backend/community/_polls.py
@@ -25,6 +25,8 @@ from community._event_poll_schemas import (
     EventPollVoteIn,
     VoterOut,
 )
+from community._event_viewer import resolve_event_viewer
+from community._events import _enforce_event_read_visibility
 from community._shared import ErrorOut, _authenticated_user, _optional_jwt
 from community._validation import Code, raise_validation
 from community.models import (
@@ -70,6 +72,17 @@ def _validate_poll_options(dts: list[datetime], *, require_at_least_one: bool) -
         raise_validation(Code.Poll.OPTIONS_REQUIRED, status_code=400)
     if _any_in_past(dts):
         raise_validation(Code.Poll.OPTIONS_MUST_BE_FUTURE, status_code=400)
+
+
+def _get_visible_event(event_id: UUID) -> Event:
+    try:
+        return (
+            Event.objects.select_related("created_by")
+            .prefetch_related("co_hosts", "invited_users")
+            .get(id=event_id)
+        )
+    except Event.DoesNotExist:
+        raise_validation(Code.Event.NOT_FOUND, status_code=404)
 
 
 def _can_manage_poll(user, event: Event) -> bool:
@@ -189,10 +202,12 @@ def create_event_poll(request, event_id: UUID, payload: EventPollIn):
 
 @router.get(
     "/events/{event_id}/poll/",
-    response={200: EventPollOut, 404: ErrorOut},
+    response={200: EventPollOut, 403: ErrorOut, 404: ErrorOut},
     auth=_optional_jwt,
 )
 def get_event_poll(request, event_id: UUID):
+    viewer = resolve_event_viewer(request, event_id)
+    _enforce_event_read_visibility(_get_visible_event(event_id), viewer)
     try:
         poll = (
             EventPoll.objects.select_related("winning_option")
@@ -201,8 +216,7 @@ def get_event_poll(request, event_id: UUID):
         )
     except EventPoll.DoesNotExist:
         raise_validation(Code.Poll.NOT_FOUND, status_code=404)
-    auth_user = _authenticated_user(request.auth)
-    return Status(200, _poll_out(poll, auth_user))
+    return Status(200, _poll_out(poll, viewer))
 
 
 @router.post(
@@ -212,6 +226,7 @@ def get_event_poll(request, event_id: UUID):
 )
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="30/m")
 def vote_on_event_poll(request, event_id: UUID, payload: EventPollVoteIn):
+    _enforce_event_read_visibility(_get_visible_event(event_id), request.auth)
     try:
         poll = (
             EventPoll.objects.select_related("winning_option", "event")

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -9865,6 +9865,16 @@
             },
             "description": "OK"
           },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
           "404": {
             "content": {
               "application/json": {

--- a/backend/tests/test_poll_visibility.py
+++ b/backend/tests/test_poll_visibility.py
@@ -1,5 +1,3 @@
-"""Visibility gating for the poll endpoints (Issue 1192)."""
-
 import json
 
 import pytest

--- a/backend/tests/test_poll_visibility.py
+++ b/backend/tests/test_poll_visibility.py
@@ -1,0 +1,122 @@
+"""Visibility gating for the poll endpoints (Issue 1192)."""
+
+import json
+
+import pytest
+from community.models import Event, EventPoll, PageVisibility, PollOption
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
+
+from tests.conftest import future_iso
+
+
+@pytest.fixture
+def stranger_headers(db):
+    stranger = User.objects.create_user(
+        phone_number="+12025550707",
+        password="strangerpass",
+        first_name="Stranger",
+    )
+    refresh = RefreshToken.for_user(stranger)
+    return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
+
+
+@pytest.fixture
+def invitee_headers(db, invite_only_event):
+    invitee = User.objects.create_user(
+        phone_number="+12025550808",
+        password="inviteepass",
+        first_name="Invitee",
+    )
+    invite_only_event.invited_users.add(invitee)
+    refresh = RefreshToken.for_user(invitee)
+    return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
+
+
+@pytest.fixture
+def invite_only_event(db, test_user):
+    return Event.objects.create(
+        title="Invite-only poll event",
+        start_datetime=future_iso(days=30),
+        created_by=test_user,
+        visibility=PageVisibility.INVITE_ONLY,
+    )
+
+
+@pytest.fixture
+def invite_only_poll(db, invite_only_event, test_user):
+    poll = EventPoll.objects.create(event=invite_only_event, created_by=test_user)
+    PollOption.objects.create(poll=poll, datetime=future_iso(days=120), display_order=0)
+    return poll
+
+
+@pytest.mark.django_db
+class TestGetPollVisibility:
+    def test_anonymous_cannot_read_invite_only_poll(
+        self, api_client, invite_only_event, invite_only_poll
+    ):
+        response = api_client.get(f"/api/community/events/{invite_only_event.id}/poll/")
+        assert response.status_code == 403
+
+    def test_non_invitee_cannot_read_invite_only_poll(
+        self, api_client, stranger_headers, invite_only_event, invite_only_poll
+    ):
+        response = api_client.get(
+            f"/api/community/events/{invite_only_event.id}/poll/",
+            **stranger_headers,
+        )
+        assert response.status_code == 403
+
+    def test_invitee_can_read_invite_only_poll(
+        self, api_client, invitee_headers, invite_only_event, invite_only_poll
+    ):
+        response = api_client.get(
+            f"/api/community/events/{invite_only_event.id}/poll/",
+            **invitee_headers,
+        )
+        assert response.status_code == 200
+        assert len(response.json()["options"]) == 1
+
+    def test_creator_can_read_invite_only_poll(
+        self, api_client, auth_headers, invite_only_event, invite_only_poll
+    ):
+        response = api_client.get(
+            f"/api/community/events/{invite_only_event.id}/poll/",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+
+    def test_anonymous_can_still_read_public_event_poll(self, api_client, db, test_user):
+        event = Event.objects.create(
+            title="Public poll event",
+            start_datetime=future_iso(days=30),
+            created_by=test_user,
+        )
+        poll = EventPoll.objects.create(event=event, created_by=test_user)
+        PollOption.objects.create(poll=poll, datetime=future_iso(days=120), display_order=0)
+        response = api_client.get(f"/api/community/events/{event.id}/poll/")
+        assert response.status_code == 200
+
+
+@pytest.mark.django_db
+class TestVotePollVisibility:
+    def _vote(self, api_client, event, poll, headers):
+        option = poll.options.first()
+        return api_client.post(
+            f"/api/community/events/{event.id}/poll/vote/",
+            data=json.dumps({"votes": {str(option.id): "yes"}}),
+            content_type="application/json",
+            **headers,
+        )
+
+    def test_non_invitee_cannot_vote_on_invite_only_poll(
+        self, api_client, stranger_headers, invite_only_event, invite_only_poll
+    ):
+        response = self._vote(api_client, invite_only_event, invite_only_poll, stranger_headers)
+        assert response.status_code == 403
+
+    def test_invitee_can_vote_on_invite_only_poll(
+        self, api_client, invitee_headers, invite_only_event, invite_only_poll
+    ):
+        response = self._vote(api_client, invite_only_event, invite_only_poll, invitee_headers)
+        assert response.status_code == 200

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -7343,6 +7343,15 @@ export interface operations {
                     "application/json": components["schemas"]["EventPollOut"];
                 };
             };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
             /** @description Not Found */
             404: {
                 headers: {


### PR DESCRIPTION
## Overview

`GET /api/community/events/{event_id}/poll/` had no visibility gate, so an unauthenticated caller holding an invite-only event's UUID received a `200` with every candidate datetime — invite-only events are meant to be invisible outside `invited_users` / co-hosts / creator.

Auditing the rest of `_polls.py` turned up a second, unreported instance of the same gap: `POST .../poll/vote/` only required `gated_jwt`, so **any logged-in member could read and cast votes on an invite-only event's poll**. Both endpoints now route through `_enforce_event_read_visibility`, matching the reference pattern in `_event_comments.py` and `_event_rsvps.py`.

### Endpoints audited

| Endpoint | Before | After |
|---|---|---|
| `GET /events/{id}/poll/` | ❌ no gate (`_optional_jwt`, anonymous read) | ✅ `_enforce_event_read_visibility` |
| `POST /events/{id}/poll/vote/` | ❌ `gated_jwt` only — any member could vote | ✅ `_enforce_event_read_visibility` |
| `POST /events/{id}/poll/` (create) | ✅ `gated_jwt` + `_can_manage_poll` (403) | unchanged |
| `POST /events/{id}/poll/finalize/` | ✅ `gated_jwt` + `_can_manage_poll` (403) | unchanged |
| `DELETE /events/{id}/poll/` | ✅ `gated_jwt` + `_can_manage_poll` (403) | unchanged |

The three management endpoints were checked and found already correct — `_can_manage_poll` requires `MANAGE_EVENTS`, `MANAGE_SURVEYS`, or co-host standing, all of which are strictly narrower than event read visibility.

### Notes

- Added `_get_visible_event()`, a small local loader that fetches the `Event` with `co_hosts` / `invited_users` prefetched (both relations are needed by the invite-only branch of the shared helper). No new gating logic — the decision still lives entirely in `_enforce_event_read_visibility`.
- The GET now resolves its viewer via `resolve_event_viewer`, so non-member RSVP-token holders keep the access they already had on public-RSVP-eligible events, consistent with the comments endpoints.
- Declared `403: ErrorOut` on the GET's response map, which previously only listed `200`/`404`.

## Test plan

New file `backend/tests/test_poll_visibility.py` (7 tests). Each fixed endpoint gets a blocked/allowed pair:

- [x] anonymous caller against an invite-only event's poll → `403` (was `200` with full option list)
- [x] logged-in non-invitee against an invite-only poll → `403`
- [x] invited member can still read the poll → `200`, options intact
- [x] creator can still read the poll → `200`
- [x] anonymous caller against a **public** event's poll still → `200` (no over-correction)
- [x] logged-in non-invitee voting on an invite-only poll → `403` (was `200`, vote recorded)
- [x] invited member can still vote → `200`

Verified the tests actually catch the bug by reverting the gate: 3 of the 7 fail without it (including the vote leak, where a stranger's `poll_vote` was accepted), all 7 pass with it.

Also ran `test_polls.py`, `test_poll_option_errors.py`, and `test_event_comments.py` — 66 passed, no regressions. `make agent-lint`, `make agent-typecheck`, and `make agent-complexity` all clean.

Closes #1192
