### PR TITLE
fix: 1190 - exclude pending cohost invitees from add-cohost picker

### DIFF
--- a/frontend/src/screens/events/AddCoHostDialog.test.tsx
+++ b/frontend/src/screens/events/AddCoHostDialog.test.tsx
@@ -1,0 +1,98 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Event } from '@/models/event';
+import {
+  EventStatus,
+  EventType,
+  EventVisibility,
+  InvitePermission,
+} from '@/models/event';
+
+const updateMutateAsync = vi.fn();
+
+vi.mock('@/api/eventWrites', () => ({
+  useUpdateEvent: () => ({ mutateAsync: updateMutateAsync, isPending: false }),
+}));
+
+vi.mock('@/api/userSearch', () => ({
+  useUserSearch: () => ({
+    data: [
+      { id: 'user-accepted', fullName: 'Accepted Host', phoneNumber: '5551110000' },
+      { id: 'user-pending', fullName: 'Pending Invitee', phoneNumber: '5552220000' },
+      { id: 'user-available', fullName: 'Available Member', phoneNumber: '5553330000' },
+    ],
+  }),
+}));
+
+import { AddCoHostDialog } from './AddCoHostDialog';
+
+const BASE_EVENT: Event = {
+  id: 'ev1',
+  title: 'Spring Potluck',
+  description: '',
+  startDatetime: new Date('2099-06-01T18:00:00Z'),
+  endDatetime: null,
+  location: '',
+  latitude: null,
+  longitude: null,
+  whatsappLink: '',
+  partifulLink: '',
+  otherLink: '',
+  venmoLink: '',
+  cashappLink: '',
+  zelleInfo: '',
+  price: '',
+  rsvpEnabled: false,
+  allowPlusOnes: false,
+  maxAttendees: null,
+  attendingCount: 0,
+  waitlistedCount: 0,
+  invitedCount: 0,
+  datetimeTbd: false,
+  hasPoll: false,
+  datetimePollSlug: null,
+  createdById: 'user-creator',
+  createdByName: 'Alice',
+  createdByPhotoUrl: '',
+  coHostIds: ['user-creator', 'user-accepted'],
+  coHostNames: [],
+  coHostPhotoUrls: [],
+  guests: [],
+  myRsvp: null,
+  viewerUserId: null,
+  surveySlugs: [],
+  invitedUserIds: [],
+  invitedUserNames: [],
+  invitedUserPhotoUrls: [],
+  invitePermission: InvitePermission.AllMembers,
+  pendingCohostInvites: [
+    {
+      id: 'inv1',
+      userId: 'user-pending',
+      userName: 'Pending Invitee',
+      userPhotoUrl: '',
+      invitedAt: new Date(),
+    },
+  ],
+  myPendingCohostInviteId: null,
+  eventType: EventType.Community,
+  visibility: EventVisibility.Public,
+  photoUrl: '',
+  photoUpdatedAt: null,
+  tags: [],
+  isPast: false,
+  status: EventStatus.Active,
+};
+
+describe('AddCoHostDialog', () => {
+  it('excludes members with a pending cohost invite from search results', () => {
+    render(<AddCoHostDialog event={BASE_EVENT} open onClose={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText('search members'), { target: { value: 'me' } });
+
+    expect(screen.getByText('Available Member')).toBeInTheDocument();
+    expect(screen.queryByText('Pending Invitee')).not.toBeInTheDocument();
+    expect(screen.queryByText('Accepted Host')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/events/AddCoHostDialog.test.tsx
+++ b/frontend/src/screens/events/AddCoHostDialog.test.tsx
@@ -2,12 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { Event } from '@/models/event';
-import {
-  EventStatus,
-  EventType,
-  EventVisibility,
-  InvitePermission,
-} from '@/models/event';
+import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
 
 const updateMutateAsync = vi.fn();
 

--- a/frontend/src/screens/events/AddCoHostDialog.tsx
+++ b/frontend/src/screens/events/AddCoHostDialog.tsx
@@ -18,6 +18,10 @@ export function AddCoHostDialog({ event, open, onClose }: Props) {
   const update = useUpdateEvent(event.id);
   const [added, setAdded] = useState<MemberSearchResult[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const excludeIds = [
+    ...event.coHostIds,
+    ...event.pendingCohostInvites.map((invite) => invite.userId),
+  ];
 
   async function submit() {
     setError(null);
@@ -37,7 +41,7 @@ export function AddCoHostDialog({ event, open, onClose }: Props) {
         label="search members"
         selected={added}
         onChange={setAdded}
-        excludeIds={event.coHostIds}
+        excludeIds={excludeIds}
       />
       {error ? (
         <p role="alert" className="text-destructive mt-2 text-sm">


### PR DESCRIPTION
## summary
- selecting a member who already has a pending cohost invite silently no-opped on submit, with no feedback that nothing changed
- `AddCoHostDialog` now excludes both accepted cohosts (`event.coHostIds`) and members with a pending invite (`event.pendingCohostInvites`) from the member picker's search results, so they can't be re-selected

Closes #1190

## test plan
- [x] added `AddCoHostDialog.test.tsx` covering pending/accepted exclusion
- [x] `npx vitest run src/screens/events/AddCoHostDialog.test.tsx` passes
- [x] `make agent-frontend-typecheck` clean
- [x] `make agent-frontend-lint` clean