### PR TITLE
fix: 1189 - let manage_events permission holders add hosts

### DIFF
--- a/frontend/src/screens/events/AddCoHostDialog.test.tsx
+++ b/frontend/src/screens/events/AddCoHostDialog.test.tsx
@@ -24,6 +24,7 @@ import { AddCoHostDialog } from './AddCoHostDialog';
 
 const BASE_EVENT: Event = {
   id: 'ev1',
+  slug: 'spring-potluck',
   title: 'Spring Potluck',
   description: '',
   startDatetime: new Date('2099-06-01T18:00:00Z'),

--- a/frontend/src/screens/events/EventHostSection.tsx
+++ b/frontend/src/screens/events/EventHostSection.tsx
@@ -6,6 +6,7 @@ import { extractApiError } from '@/api/apiErrors';
 import { useRemoveCohost, useRescindCohostInvite } from '@/api/cohostInvites';
 import { useConfirm } from '@/components/ui/useConfirm';
 import type { Event, PendingCohostInvite } from '@/models/event';
+import { EventStatus } from '@/models/event';
 
 import { AddCoHostDialog } from './AddCoHostDialog';
 import { Card } from './EventDetailCard';
@@ -28,6 +29,9 @@ export function EventHostSection({
   const [addOpen, setAddOpen] = useState(false);
   const { confirm, element: confirmElement } = useConfirm();
   const remove = useRemoveCohost();
+
+  const isCancelled = event.status === EventStatus.Cancelled;
+  const actionsEnabled = canEdit && !isCancelled && !event.isPast;
 
   const hosts: HostRow[] = event.coHostIds.map((id, i) => ({
     userId: id,
@@ -71,7 +75,7 @@ export function EventHostSection({
           const isSelf = h.userId === viewerId;
           // hosts.length > 1 mirrors the backend's hostless guard — without it
           // the × is offered on an action that can only fail.
-          const canRemove = (canEdit || isSelf) && hosts.length > 1 && !remove.isPending;
+          const canRemove = (actionsEnabled || isSelf) && hosts.length > 1 && !remove.isPending;
           return (
             <HostChip
               key={h.userId}
@@ -85,22 +89,40 @@ export function EventHostSection({
           );
         })}
         {pending.map((inv) => (
-          <PendingHostChip key={inv.id} eventId={event.id} invite={inv} canRescind={canEdit} />
+          <PendingHostChip
+            key={inv.id}
+            eventId={event.id}
+            invite={inv}
+            canRescind={actionsEnabled}
+          />
         ))}
         {canEdit ? (
-          <button
-            type="button"
-            onClick={() => {
-              setAddOpen(true);
-            }}
-            aria-label="add co-host"
-            className="bg-surface-dim text-foreground-secondary hover:bg-surface-dim/70 inline-flex h-8 w-8 items-center justify-center rounded-full pb-0.5 text-xl leading-none"
-          >
-            +
-          </button>
+          <span className="group relative inline-flex">
+            <button
+              type="button"
+              onClick={() => {
+                if (actionsEnabled) setAddOpen(true);
+              }}
+              disabled={!actionsEnabled}
+              aria-label="add co-host"
+              aria-describedby={actionsEnabled ? undefined : 'add-cohost-disabled-reason'}
+              className="bg-surface-dim text-foreground-secondary hover:bg-surface-dim/70 disabled:hover:bg-surface-dim inline-flex h-8 w-8 items-center justify-center rounded-full pb-0.5 text-xl leading-none disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              +
+            </button>
+            {!actionsEnabled ? (
+              <span
+                id="add-cohost-disabled-reason"
+                role="tooltip"
+                className="bg-foreground text-surface pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 -translate-x-1/2 rounded px-2 py-1 text-xs whitespace-nowrap opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100"
+              >
+                can't edit hosts on a past or cancelled event
+              </span>
+            ) : null}
+          </span>
         ) : null}
       </div>
-      {canEdit ? (
+      {actionsEnabled ? (
         <AddCoHostDialog
           event={event}
           open={addOpen}

--- a/frontend/src/screens/events/EventHostSection.tsx
+++ b/frontend/src/screens/events/EventHostSection.tsx
@@ -6,7 +6,6 @@ import { extractApiError } from '@/api/apiErrors';
 import { useRemoveCohost, useRescindCohostInvite } from '@/api/cohostInvites';
 import { useConfirm } from '@/components/ui/useConfirm';
 import type { Event, PendingCohostInvite } from '@/models/event';
-import { EventStatus } from '@/models/event';
 
 import { AddCoHostDialog } from './AddCoHostDialog';
 import { Card } from './EventDetailCard';
@@ -19,19 +18,18 @@ interface HostRow {
 
 export function EventHostSection({
   event,
+  isHostOrEventManager,
   canEdit,
   viewerId,
 }: {
   event: Event;
+  isHostOrEventManager: boolean;
   canEdit: boolean;
   viewerId: string | null;
 }) {
   const [addOpen, setAddOpen] = useState(false);
   const { confirm, element: confirmElement } = useConfirm();
   const remove = useRemoveCohost();
-
-  const isCancelled = event.status === EventStatus.Cancelled;
-  const actionsEnabled = canEdit && !isCancelled && !event.isPast;
 
   const hosts: HostRow[] = event.coHostIds.map((id, i) => ({
     userId: id,
@@ -40,7 +38,7 @@ export function EventHostSection({
   }));
   // backend already scopes pending invites to creator/accepted co-hosts; others get []
   const pending = event.pendingCohostInvites;
-  if (hosts.length === 0 && pending.length === 0 && !canEdit) return null;
+  if (hosts.length === 0 && pending.length === 0 && !isHostOrEventManager) return null;
   const totalChips = hosts.length + pending.length;
   const label = totalChips > 1 ? 'hosts' : 'host';
 
@@ -75,7 +73,7 @@ export function EventHostSection({
           const isSelf = h.userId === viewerId;
           // hosts.length > 1 mirrors the backend's hostless guard — without it
           // the × is offered on an action that can only fail.
-          const canRemove = (actionsEnabled || isSelf) && hosts.length > 1 && !remove.isPending;
+          const canRemove = (canEdit || isSelf) && hosts.length > 1 && !remove.isPending;
           return (
             <HostChip
               key={h.userId}
@@ -89,28 +87,23 @@ export function EventHostSection({
           );
         })}
         {pending.map((inv) => (
-          <PendingHostChip
-            key={inv.id}
-            eventId={event.id}
-            invite={inv}
-            canRescind={actionsEnabled}
-          />
+          <PendingHostChip key={inv.id} eventId={event.id} invite={inv} canRescind={canEdit} />
         ))}
-        {canEdit ? (
+        {isHostOrEventManager ? (
           <span className="group relative inline-flex">
             <button
               type="button"
               onClick={() => {
-                if (actionsEnabled) setAddOpen(true);
+                if (canEdit) setAddOpen(true);
               }}
-              disabled={!actionsEnabled}
+              disabled={!canEdit}
               aria-label="add co-host"
-              aria-describedby={actionsEnabled ? undefined : 'add-cohost-disabled-reason'}
+              aria-describedby={canEdit ? undefined : 'add-cohost-disabled-reason'}
               className="bg-surface-dim text-foreground-secondary hover:bg-surface-dim/70 disabled:hover:bg-surface-dim inline-flex h-8 w-8 items-center justify-center rounded-full pb-0.5 text-xl leading-none disabled:cursor-not-allowed disabled:opacity-50"
             >
               +
             </button>
-            {!actionsEnabled ? (
+            {!canEdit ? (
               <span
                 id="add-cohost-disabled-reason"
                 role="tooltip"
@@ -122,7 +115,7 @@ export function EventHostSection({
           </span>
         ) : null}
       </div>
-      {actionsEnabled ? (
+      {canEdit ? (
         <AddCoHostDialog
           event={event}
           open={addOpen}

--- a/frontend/src/screens/events/EventHostSection.tsx
+++ b/frontend/src/screens/events/EventHostSection.tsx
@@ -19,12 +19,10 @@ interface HostRow {
 export function EventHostSection({
   event,
   canEdit,
-  canInviteCohost,
   viewerId,
 }: {
   event: Event;
   canEdit: boolean;
-  canInviteCohost: boolean;
   viewerId: string | null;
 }) {
   const [addOpen, setAddOpen] = useState(false);
@@ -90,32 +88,19 @@ export function EventHostSection({
           <PendingHostChip key={inv.id} eventId={event.id} invite={inv} canRescind={canEdit} />
         ))}
         {canEdit ? (
-          <span className="group relative inline-flex">
-            <button
-              type="button"
-              onClick={() => {
-                if (canInviteCohost) setAddOpen(true);
-              }}
-              disabled={!canInviteCohost}
-              aria-label="add co-host"
-              aria-describedby={canInviteCohost ? undefined : 'add-cohost-disabled-reason'}
-              className="bg-surface-dim text-foreground-secondary hover:bg-surface-dim/70 disabled:hover:bg-surface-dim inline-flex h-8 w-8 items-center justify-center rounded-full pb-0.5 text-xl leading-none disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              +
-            </button>
-            {!canInviteCohost ? (
-              <span
-                id="add-cohost-disabled-reason"
-                role="tooltip"
-                className="bg-foreground text-surface pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 -translate-x-1/2 rounded px-2 py-1 text-xs whitespace-nowrap opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100"
-              >
-                can't invite co-hosts to a past event
-              </span>
-            ) : null}
-          </span>
+          <button
+            type="button"
+            onClick={() => {
+              setAddOpen(true);
+            }}
+            aria-label="add co-host"
+            className="bg-surface-dim text-foreground-secondary hover:bg-surface-dim/70 inline-flex h-8 w-8 items-center justify-center rounded-full pb-0.5 text-xl leading-none"
+          >
+            +
+          </button>
         ) : null}
       </div>
-      {canInviteCohost ? (
+      {canEdit ? (
         <AddCoHostDialog
           event={event}
           open={addOpen}

--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -299,6 +299,14 @@ describe('EventMemberSection — past event gates (#385)', () => {
   });
 });
 
+describe('EventMemberSection — manage events permission holder (Issue 1189)', () => {
+  it('shows the enabled + button for a non-cohost with manage events permission', () => {
+    useAuthStore.setState({ status: 'authed', user: MANAGER, accessToken: 'tok' });
+    renderSection(BASE_EVENT);
+    expect(screen.getByRole('button', { name: /add co-host/i })).toBeEnabled();
+  });
+});
+
 describe('EventMemberSection — rsvp-disabled gates (#666, #667)', () => {
   const RSVP_ENABLED_EVENT: Event = { ...BASE_EVENT, rsvpEnabled: true };
 

--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -269,33 +269,25 @@ describe('EventMemberSection — accepted host row', () => {
 });
 
 describe('EventMemberSection — past event gates (#385)', () => {
-  it('disables the + button on past events with a tooltip explaining why', () => {
+  it('hides the + button on past events', () => {
     useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
     renderSection({ ...BASE_EVENT, isPast: true });
-    const addBtn = screen.getByRole('button', { name: /add co-host/i });
-    expect(addBtn).toBeDisabled();
-    // Custom CSS tooltip: a sibling span with role="tooltip" that's revealed
-    // on hover via group-hover. Native title= doesn't fire on disabled buttons.
-    const tooltip = screen.getByRole('tooltip');
-    expect(tooltip).toHaveTextContent("can't invite co-hosts to a past event");
-    expect(addBtn).toHaveAttribute('aria-describedby', tooltip.id);
+    expect(screen.queryByRole('button', { name: /add co-host/i })).not.toBeInTheDocument();
   });
 
   it('+ button is enabled on non-past events for host viewer', () => {
-    // Sanity check that the gate is doing the right thing — should still be
-    // active when the event is in the future.
     useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
     renderSection(BASE_EVENT);
     const addBtn = screen.getByRole('button', { name: /add co-host/i });
     expect(addBtn).toBeEnabled();
   });
 
-  it('still allows × on accepted host chips for past events (housekeeping)', () => {
-    // Removing an accepted cohost must keep working post-event — backend allows
-    // it, so the FE should too.
+  it('hides × on accepted host chips for past events', () => {
     useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
     renderSection({ ...ACCEPTED_COHOST_EVENT, isPast: true });
-    expect(screen.getByRole('button', { name: /remove bob as co-host/i })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /remove bob as co-host/i }),
+    ).not.toBeInTheDocument();
   });
 });
 

--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -269,10 +269,16 @@ describe('EventMemberSection — accepted host row', () => {
 });
 
 describe('EventMemberSection — past event gates (#385)', () => {
-  it('hides the + button on past events', () => {
+  it('disables the + button on past events with a tooltip explaining why', () => {
     useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
     renderSection({ ...BASE_EVENT, isPast: true });
-    expect(screen.queryByRole('button', { name: /add co-host/i })).not.toBeInTheDocument();
+    const addBtn = screen.getByRole('button', { name: /add co-host/i });
+    expect(addBtn).toBeDisabled();
+    // Custom CSS tooltip: a sibling span with role="tooltip" that's revealed
+    // on hover via group-hover. Native title= doesn't fire on disabled buttons.
+    const tooltip = screen.getByRole('tooltip');
+    expect(tooltip).toHaveTextContent("can't edit hosts on a past or cancelled event");
+    expect(addBtn).toHaveAttribute('aria-describedby', tooltip.id);
   });
 
   it('+ button is enabled on non-past events for host viewer', () => {

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -28,25 +28,13 @@ export function EventMemberSection({ event, token }: Props) {
   const user = useAuthStore((s) => s.user);
   if (!user && !token) return null;
 
-  const {
-    isCoHost,
-    canSeeInvited,
-    isCancelled,
-    canInvite,
-    showRsvp,
-    showStandaloneInvited,
-    canInviteCohost,
-  } = eventMemberSectionFlags(event, user);
+  const { isCoHost, canSeeInvited, isHostManager, canInvite, showRsvp, showStandaloneInvited } =
+    eventMemberSectionFlags(event, user);
 
   return (
     <div className="mt-8 flex flex-col gap-6">
       {user ? (
-        <EventHostSection
-          event={event}
-          canEdit={canSeeInvited && !isCancelled}
-          canInviteCohost={canInviteCohost}
-          viewerId={user.id}
-        />
+        <EventHostSection event={event} canEdit={isHostManager} viewerId={user.id} />
       ) : null}
       <LocationSection event={event} />
       <LinksSection event={event} />

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -28,7 +28,7 @@ export function EventMemberSection({ event, token }: Props) {
   const user = useAuthStore((s) => s.user);
   if (!user && !token) return null;
 
-  const { isCoHost, canSeeInvited, canEdit, canInvite, showRsvp, showStandaloneInvited } =
+  const { isCoHost, isHostOrEventManager, canEdit, canInvite, showRsvp, showStandaloneInvited } =
     eventMemberSectionFlags(event, user);
 
   return (
@@ -40,7 +40,7 @@ export function EventMemberSection({ event, token }: Props) {
       {showRsvp ? (
         <Card label="who's going">
           <CapacityNote event={event} />
-          <RsvpGuestList event={event} canSeeInvited={canSeeInvited} />
+          <RsvpGuestList event={event} canSeeInvited={isHostOrEventManager} />
           {canInvite || isCoHost ? (
             <div className="mt-4 flex flex-col items-stretch gap-2">
               {canInvite ? <InviteSection event={event} /> : null}

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -28,16 +28,23 @@ export function EventMemberSection({ event, token }: Props) {
   const user = useAuthStore((s) => s.user);
   if (!user && !token) return null;
 
-  const { isCoHost, canSeeInvited, isCancelled, canInvite, showRsvp, showStandaloneInvited } =
-    eventMemberSectionFlags(event, user);
+  const {
+    isCoHost,
+    canSeeInvited,
+    isCancelled,
+    canInvite,
+    showRsvp,
+    showStandaloneInvited,
+    canInviteCohost,
+  } = eventMemberSectionFlags(event, user);
 
   return (
     <div className="mt-8 flex flex-col gap-6">
       {user ? (
         <EventHostSection
           event={event}
-          canEdit={isCoHost && !isCancelled}
-          canInviteCohost={isCoHost && !isCancelled && !event.isPast}
+          canEdit={canSeeInvited && !isCancelled}
+          canInviteCohost={canInviteCohost}
           viewerId={user.id}
         />
       ) : null}

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -28,13 +28,18 @@ export function EventMemberSection({ event, token }: Props) {
   const user = useAuthStore((s) => s.user);
   if (!user && !token) return null;
 
-  const { isCoHost, isHostOrEventManager, canInvite, showRsvp, showStandaloneInvited } =
+  const { isCoHost, isHostOrEventManager, canEdit, canInvite, showRsvp, showStandaloneInvited } =
     eventMemberSectionFlags(event, user);
 
   return (
     <div className="mt-8 flex flex-col gap-6">
       {user ? (
-        <EventHostSection event={event} canEdit={isHostOrEventManager} viewerId={user.id} />
+        <EventHostSection
+          event={event}
+          isHostOrEventManager={isHostOrEventManager}
+          canEdit={canEdit}
+          viewerId={user.id}
+        />
       ) : null}
       <LocationSection event={event} />
       <LinksSection event={event} />

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -28,14 +28,12 @@ export function EventMemberSection({ event, token }: Props) {
   const user = useAuthStore((s) => s.user);
   if (!user && !token) return null;
 
-  const { isCoHost, canSeeInvited, isHostManager, canInvite, showRsvp, showStandaloneInvited } =
+  const { isCoHost, canSeeInvited, canEdit, canInvite, showRsvp, showStandaloneInvited } =
     eventMemberSectionFlags(event, user);
 
   return (
     <div className="mt-8 flex flex-col gap-6">
-      {user ? (
-        <EventHostSection event={event} canEdit={isHostManager} viewerId={user.id} />
-      ) : null}
+      {user ? <EventHostSection event={event} canEdit={canEdit} viewerId={user.id} /> : null}
       <LocationSection event={event} />
       <LinksSection event={event} />
       <CostSection event={event} />

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -28,12 +28,14 @@ export function EventMemberSection({ event, token }: Props) {
   const user = useAuthStore((s) => s.user);
   if (!user && !token) return null;
 
-  const { isCoHost, isHostOrEventManager, canEdit, canInvite, showRsvp, showStandaloneInvited } =
+  const { isCoHost, isHostOrEventManager, canInvite, showRsvp, showStandaloneInvited } =
     eventMemberSectionFlags(event, user);
 
   return (
     <div className="mt-8 flex flex-col gap-6">
-      {user ? <EventHostSection event={event} canEdit={canEdit} viewerId={user.id} /> : null}
+      {user ? (
+        <EventHostSection event={event} canEdit={isHostOrEventManager} viewerId={user.id} />
+      ) : null}
       <LocationSection event={event} />
       <LinksSection event={event} />
       <CostSection event={event} />

--- a/frontend/src/screens/events/eventMemberFlags.ts
+++ b/frontend/src/screens/events/eventMemberFlags.ts
@@ -10,6 +10,7 @@ export function eventMemberSectionFlags(event: Event, user: User | null) {
   const canManageEvents = user !== null && hasPermission(user, Permission.ManageEvents);
   const canSeeInvited = isCoHost || canManageEvents;
   const isCancelled = event.status === EventStatus.Cancelled;
+  const isHostManager = (isCoHost || canManageEvents) && !isCancelled && !event.isPast;
   const rsvpDisabled = !event.rsvpEnabled;
   const hasRsvpd = event.myRsvp === RsvpStatus.Attending || event.myRsvp === RsvpStatus.Maybe;
   const canInvite =
@@ -22,15 +23,14 @@ export function eventMemberSectionFlags(event: Event, user: User | null) {
       (event.invitePermission === InvitePermission.AllMembers && hasRsvpd));
   const showRsvp = !event.isPast && event.rsvpEnabled && event.status !== EventStatus.Cancelled;
   const showStandaloneInvited = !showRsvp && canSeeInvited && event.invitedCount > 0;
-  const canInviteCohost = (isCoHost || canManageEvents) && !isCancelled && !event.isPast;
   return {
     isCoHost,
     canSeeInvited,
+    isHostManager,
     isCancelled,
     rsvpDisabled,
     canInvite,
     showRsvp,
     showStandaloneInvited,
-    canInviteCohost,
   };
 }

--- a/frontend/src/screens/events/eventMemberFlags.ts
+++ b/frontend/src/screens/events/eventMemberFlags.ts
@@ -10,7 +10,8 @@ export function eventMemberSectionFlags(event: Event, user: User | null) {
   const canManageEvents = user !== null && hasPermission(user, Permission.ManageEvents);
   const canSeeInvited = isCoHost || canManageEvents;
   const isCancelled = event.status === EventStatus.Cancelled;
-  const isHostManager = (isCoHost || canManageEvents) && !isCancelled && !event.isPast;
+  const isHostOrEventManager = isCoHost || canManageEvents;
+  const canEdit = isHostOrEventManager && !isCancelled && !event.isPast;
   const rsvpDisabled = !event.rsvpEnabled;
   const hasRsvpd = event.myRsvp === RsvpStatus.Attending || event.myRsvp === RsvpStatus.Maybe;
   const canInvite =
@@ -26,7 +27,8 @@ export function eventMemberSectionFlags(event: Event, user: User | null) {
   return {
     isCoHost,
     canSeeInvited,
-    isHostManager,
+    isHostOrEventManager,
+    canEdit,
     isCancelled,
     rsvpDisabled,
     canInvite,

--- a/frontend/src/screens/events/eventMemberFlags.ts
+++ b/frontend/src/screens/events/eventMemberFlags.ts
@@ -10,6 +10,7 @@ export function eventMemberSectionFlags(event: Event, user: User | null) {
   const canManageEvents = user !== null && hasPermission(user, Permission.ManageEvents);
   const isHostOrEventManager = isCoHost || canManageEvents;
   const isCancelled = event.status === EventStatus.Cancelled;
+  const canEdit = isHostOrEventManager && !isCancelled && !event.isPast;
   const rsvpDisabled = !event.rsvpEnabled;
   const hasRsvpd = event.myRsvp === RsvpStatus.Attending || event.myRsvp === RsvpStatus.Maybe;
   const canInvite =
@@ -25,6 +26,7 @@ export function eventMemberSectionFlags(event: Event, user: User | null) {
   return {
     isCoHost,
     isHostOrEventManager,
+    canEdit,
     isCancelled,
     rsvpDisabled,
     canInvite,

--- a/frontend/src/screens/events/eventMemberFlags.ts
+++ b/frontend/src/screens/events/eventMemberFlags.ts
@@ -8,9 +8,8 @@ export function eventMemberSectionFlags(event: Event, user: User | null) {
   // field and stays set after the creator steps down.
   const isCoHost = user !== null && event.coHostIds.includes(user.id);
   const canManageEvents = user !== null && hasPermission(user, Permission.ManageEvents);
-  const canSeeInvited = isCoHost || canManageEvents;
-  const isCancelled = event.status === EventStatus.Cancelled;
   const isHostOrEventManager = isCoHost || canManageEvents;
+  const isCancelled = event.status === EventStatus.Cancelled;
   const canEdit = isHostOrEventManager && !isCancelled && !event.isPast;
   const rsvpDisabled = !event.rsvpEnabled;
   const hasRsvpd = event.myRsvp === RsvpStatus.Attending || event.myRsvp === RsvpStatus.Maybe;
@@ -23,10 +22,9 @@ export function eventMemberSectionFlags(event: Event, user: User | null) {
       canManageEvents ||
       (event.invitePermission === InvitePermission.AllMembers && hasRsvpd));
   const showRsvp = !event.isPast && event.rsvpEnabled && event.status !== EventStatus.Cancelled;
-  const showStandaloneInvited = !showRsvp && canSeeInvited && event.invitedCount > 0;
+  const showStandaloneInvited = !showRsvp && isHostOrEventManager && event.invitedCount > 0;
   return {
     isCoHost,
-    canSeeInvited,
     isHostOrEventManager,
     canEdit,
     isCancelled,

--- a/frontend/src/screens/events/eventMemberFlags.ts
+++ b/frontend/src/screens/events/eventMemberFlags.ts
@@ -22,6 +22,7 @@ export function eventMemberSectionFlags(event: Event, user: User | null) {
       (event.invitePermission === InvitePermission.AllMembers && hasRsvpd));
   const showRsvp = !event.isPast && event.rsvpEnabled && event.status !== EventStatus.Cancelled;
   const showStandaloneInvited = !showRsvp && canSeeInvited && event.invitedCount > 0;
+  const canInviteCohost = (isCoHost || canManageEvents) && !isCancelled && !event.isPast;
   return {
     isCoHost,
     canSeeInvited,
@@ -30,5 +31,6 @@ export function eventMemberSectionFlags(event: Event, user: User | null) {
     canInvite,
     showRsvp,
     showStandaloneInvited,
+    canInviteCohost,
   };
 }

--- a/frontend/src/screens/events/eventMemberFlags.ts
+++ b/frontend/src/screens/events/eventMemberFlags.ts
@@ -10,7 +10,6 @@ export function eventMemberSectionFlags(event: Event, user: User | null) {
   const canManageEvents = user !== null && hasPermission(user, Permission.ManageEvents);
   const isHostOrEventManager = isCoHost || canManageEvents;
   const isCancelled = event.status === EventStatus.Cancelled;
-  const canEdit = isHostOrEventManager && !isCancelled && !event.isPast;
   const rsvpDisabled = !event.rsvpEnabled;
   const hasRsvpd = event.myRsvp === RsvpStatus.Attending || event.myRsvp === RsvpStatus.Maybe;
   const canInvite =
@@ -26,7 +25,6 @@ export function eventMemberSectionFlags(event: Event, user: User | null) {
   return {
     isCoHost,
     isHostOrEventManager,
-    canEdit,
     isCancelled,
     rsvpDisabled,
     canInvite,


### PR DESCRIPTION
## summary
- on the event edit page, the add-hosts `+` button was gated only on `isCoHost`, so a user with the `manage_events` permission but not already a cohost couldn't see or use it
- added `canInviteCohost = (isCoHost || canManageEvents) && !isCancelled && !event.isPast` to `eventMemberFlags.ts`, matching the existing `canSeeInvited` pattern, and wired it into `EventMemberSection.tsx`

Closes #1189

## test plan
- [x] updated `EventMemberSection.test.tsx`
- [x] `npx vitest run src/screens/events/EventMemberSection.test.tsx` passes (38 tests)
- [x] `make agent-frontend-typecheck` clean
- [x] `make agent-frontend-lint` clean