### PR TITLE
fix: 1187 - stop showing today's ended events in calendar list view

### DIFF
--- a/frontend/src/screens/calendar/AgendaList.test.tsx
+++ b/frontend/src/screens/calendar/AgendaList.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { EventType } from '@/models/event';
 import { makeEvent } from '@/test/fixtures';
@@ -41,5 +41,36 @@ describe('AgendaList type filter', () => {
     render(<AgendaList events={communityOnly} onSelectEvent={vi.fn()} />);
     await user.click(screen.getByRole('radio', { name: 'pda official' }));
     expect(screen.getByText('no pda official events coming up')).toBeInTheDocument();
+  });
+});
+
+describe('AgendaList upcoming filter', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-01T14:00:00'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('excludes events that already ended earlier today', () => {
+    const events = [
+      makeEvent({
+        id: 'ended',
+        title: 'morning standup',
+        startDatetime: new Date('2026-08-01T10:00:00'),
+        endDatetime: new Date('2026-08-01T11:00:00'),
+      }),
+      makeEvent({
+        id: 'later',
+        title: 'evening social',
+        startDatetime: new Date('2026-08-01T18:00:00'),
+        endDatetime: new Date('2026-08-01T20:00:00'),
+      }),
+    ];
+    render(<AgendaList events={events} onSelectEvent={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: 'morning standup' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'evening social' })).toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/calendar/AgendaList.tsx
+++ b/frontend/src/screens/calendar/AgendaList.tsx
@@ -41,7 +41,6 @@ function buildWhenLabel(event: PdaEvent): string {
 
 function upcomingEvents(events: PdaEvent[]): PdaEvent[] {
   const now = new Date();
-  now.setHours(0, 0, 0, 0);
   return events
     .filter((e) => {
       if (!e.startDatetime) return false;


### PR DESCRIPTION
## summary
- `upcomingEvents` in `AgendaList.tsx` zeroed `now` to midnight before filtering, so an event ending earlier today (e.g. 10am–2pm) still passed `end >= now`
- compare against the real current time instead, so already-ended events are correctly excluded from the list view

Closes #1187

## test plan
- [x] updated `AgendaList.test.tsx`
- [x] `npx vitest run src/screens/calendar/AgendaList.test.tsx` passes (5 tests)
- [x] `make agent-frontend-typecheck` clean
- [x] `make agent-frontend-lint` clean