### PR TITLE
fix: 1139 - move reply/delete buttons next to reactions

### DIFF
--- a/frontend/src/screens/events/AddCoHostDialog.test.tsx
+++ b/frontend/src/screens/events/AddCoHostDialog.test.tsx
@@ -24,6 +24,7 @@ import { AddCoHostDialog } from './AddCoHostDialog';
 
 const BASE_EVENT: Event = {
   id: 'ev1',
+  slug: 'spring-potluck',
   title: 'Spring Potluck',
   description: '',
   startDatetime: new Date('2099-06-01T18:00:00Z'),

--- a/frontend/src/screens/events/comments/CommentItem.tsx
+++ b/frontend/src/screens/events/comments/CommentItem.tsx
@@ -67,30 +67,28 @@ export function CommentItem({ comment, eventId, token }: Props) {
         </p>
       )}
       {!comment.isDeleted ? (
-        <div className="flex items-center justify-between gap-2">
+        <div className="flex flex-wrap items-center gap-3">
           <ReactionBar reactions={comment.reactions} onToggle={handleToggle} />
-          <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => {
+              setReplyOpen((v) => !v);
+            }}
+            className="text-foreground-tertiary text-xs hover:underline"
+          >
+            {replyOpen ? 'cancel' : 'reply'}
+          </button>
+          {comment.canDelete ? (
             <button
               type="button"
               onClick={() => {
-                setReplyOpen((v) => !v);
+                setConfirmOpen(true);
               }}
               className="text-foreground-tertiary text-xs hover:underline"
             >
-              {replyOpen ? 'cancel' : 'reply'}
+              delete
             </button>
-            {comment.canDelete ? (
-              <button
-                type="button"
-                onClick={() => {
-                  setConfirmOpen(true);
-                }}
-                className="text-foreground-tertiary text-xs hover:underline"
-              >
-                delete
-              </button>
-            ) : null}
-          </div>
+          ) : null}
         </div>
       ) : null}
       {replyOpen ? (

--- a/frontend/src/screens/events/comments/ReplyItem.tsx
+++ b/frontend/src/screens/events/comments/ReplyItem.tsx
@@ -54,7 +54,7 @@ export function ReplyItem({ reply, eventId, token }: Props) {
           </p>
         )}
         {!reply.isDeleted ? (
-          <div className="mt-1 flex items-center justify-between gap-2">
+          <div className="mt-1 flex flex-wrap items-center gap-3">
             <ReactionBar reactions={reply.reactions} onToggle={handleToggle} />
             {reply.canDelete ? (
               <button


### PR DESCRIPTION
## Overview

Reported from an event detail page on mobile Safari: the reply and delete buttons in the comments section were pushed to the far end of the row (`justify-between`), away from the emoji reaction bar. This moves them to sit directly next to the reactions instead.

Applied to both `CommentItem` (reply + delete) and `ReplyItem` (delete only), since the layout was duplicated across both.

## Test plan

- [ ] TODO

Closes #1139
