### PR TITLE
fix: 1140 - kebab menu placement

### DIFF
--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -94,19 +94,19 @@ export default function EventDetailScreen() {
 
   const body = (
     <>
-      <div className="mb-2 flex flex-wrap items-center gap-2">
-        <h1 className="text-2xl font-medium tracking-tight [overflow-wrap:anywhere] break-words">
-          {event.title}
-        </h1>
-        <EventBadge event={event} />
+      <div className="mb-2 flex items-center gap-2">
+        <div className="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+          <h1 className="text-2xl font-medium tracking-tight [overflow-wrap:anywhere] break-words">
+            {event.title}
+          </h1>
+          <EventBadge event={event} />
+        </div>
         {showKebab ? (
-          <div className="ml-auto">
-            <EventDetailKebabMenu
-              event={event}
-              eventHasEnded={event.isPast}
-              canManageRsvps={showKebab}
-            />
-          </div>
+          <EventDetailKebabMenu
+            event={event}
+            eventHasEnded={event.isPast}
+            canManageRsvps={showKebab}
+          />
         ) : null}
       </div>
 


### PR DESCRIPTION
## Overview

On mobile, the event detail kebab menu was pushed to the far right of the header row via `ml-auto`. When the title + badge wrapped onto their own line (common on narrow viewports), the kebab ended up alone on a second row, disconnected from the title — matching the report that it "should be in line with the title".

Fix: title + badge now wrap within their own inner flex row, while the kebab sits as a sibling on the outer non-wrapping row — so it always stays inline with the first line of the title instead of floating onto its own row.

## Test plan

- [ ] TODO: manually verify on a narrow viewport (e.g. iPhone Safari width) that the kebab stays inline with the title, with and without a long wrapping title
- [ ] TODO: verify kebab dropdown still opens/positions correctly (`absolute right-0`) after the layout change

Closes #1140
