### PR TITLE
fix: 1138 - broadcast event_updated so new events refresh the calendar live

### DIFF
--- a/backend/community/_event_transitions.py
+++ b/backend/community/_event_transitions.py
@@ -3,9 +3,11 @@
 import logging
 
 from config.audit import audit_log
+from django.db import transaction
 from django.utils import timezone
 from ninja.responses import Status
 from notifications.service import (
+    broadcast_event_created,
     create_cohost_invite_notifications,
     create_event_cancellation_notifications,
     create_event_invite_notifications,
@@ -59,6 +61,7 @@ def _uncancel_event(request, event: Event) -> None:
     """CANCELLED → ACTIVE. Permission check is the caller's responsibility."""
     event.status = EventStatus.ACTIVE
     event.save(update_fields=["status"])
+    transaction.on_commit(lambda: broadcast_event_created(event))
     audit_log(
         logging.INFO,
         "event_uncancelled",
@@ -101,6 +104,7 @@ def _publish_draft(request, event: Event) -> None:
         )
     event.status = EventStatus.ACTIVE
     event.save(update_fields=["status"])
+    transaction.on_commit(lambda: broadcast_event_created(event))
     invited_ids = [str(u.id) for u in event.invited_users.all()]
     if invited_ids:
         create_event_invite_notifications(event, invited_ids, request.auth)

--- a/backend/community/_events.py
+++ b/backend/community/_events.py
@@ -12,6 +12,7 @@ from django.db.models import Count, Q
 from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
+from notifications.service import broadcast_event_created
 from users._helpers import visible_display_name
 from users.permissions import PermissionKey
 
@@ -359,6 +360,8 @@ def create_event(request, payload: EventIn):
     )
     _set_event_participants(request, event, payload.co_host_ids)
     _set_event_tags(event, payload.tag_ids)
+    if event.status == EventStatus.ACTIVE:
+        transaction.on_commit(lambda: broadcast_event_created(event))
     audit_log(
         logging.INFO,
         "event_created_draft" if event.is_draft else "event_created",

--- a/backend/notifications/service.py
+++ b/backend/notifications/service.py
@@ -65,6 +65,20 @@ def broadcast_event_comment_update(event: Event) -> None:
     _ping_event_update(["*"], str(event.pk))
 
 
+def broadcast_event_created(event: Event) -> None:
+    """Live-update ping so a newly-created event shows up on connected calendars.
+
+    Same visibility split as `broadcast_event_comment_update`: a fresh event has
+    no co-hosts/invites/RSVPs yet, so the stakeholder-scoped `broadcast_event_update`
+    would only ping the creator — public/members-only events need the "*" ping to
+    reach everyone already viewing the calendar.
+    """
+    if event.visibility == PageVisibility.INVITE_ONLY:
+        broadcast_event_update(event)
+        return
+    _ping_event_update(["*"], str(event.pk))
+
+
 def broadcast_cohost_change(
     event: Event,
     *,

--- a/frontend/src/screens/events/AddCoHostDialog.test.tsx
+++ b/frontend/src/screens/events/AddCoHostDialog.test.tsx
@@ -24,6 +24,7 @@ import { AddCoHostDialog } from './AddCoHostDialog';
 
 const BASE_EVENT: Event = {
   id: 'ev1',
+  slug: 'spring-potluck',
   title: 'Spring Potluck',
   description: '',
   startDatetime: new Date('2099-06-01T18:00:00Z'),


### PR DESCRIPTION
## Overview

Fixes the multi-minute delay between an event being created and it showing up on the calendar (Issue 1138).

### Root cause

The repo has a live-update SSE channel for events (`event_updates`, backed by Postgres `pg_notify`) and the frontend is correctly wired to it: `NotificationBell.tsx` subscribes to `event_updated` SSE frames and invalidates the `['events']` query key, which prefix-matches the calendar list's query key (`['events', 'list', {...}]`). Nothing was wrong on the frontend.

The problem was entirely server-side: **nothing ever fired an `event_updated` ping when an event became newly visible on the calendar.**

- `create_event` (`backend/community/_events.py`) created the `Event` row but never called any broadcast helper.
- `_publish_draft` (DRAFT → ACTIVE) and `_uncancel_event` (CANCELLED → ACTIVE) in `backend/community/_event_transitions.py` had the same gap — both make an event calendar-visible without notifying anyone.

Other mutations (RSVPs, co-host changes, capacity changes) already call `broadcast_event_update()`/`broadcast_cohost_change()`, so those paths refresh live. Event creation and the two "becomes active" transitions were simply missed. Without a ping, the calendar list only refreshed once the query's 30s `staleTime` expired *and* something triggered a refetch (refocus, remount) — in practice this could stretch to minutes, matching the report. Visiting `/events/<uuid>` directly worked because that page does its own fetch on mount, independent of the stale calendar cache.

### Fix

Added `broadcast_event_created()` in `backend/notifications/service.py`, mirroring the visibility split already used by `broadcast_event_comment_update()`:

- **invite-only** events use the existing stakeholder-scoped `broadcast_event_update()` (pings creator/co-hosts/invitees/RSVPs)
- **public/members-only** events ping every connected viewer (`"*"`) — necessary because a brand-new event has no co-hosts/invites/RSVPs yet, so the stakeholder-scoped broadcast alone would only reach the creator, not everyone watching the calendar

Wired this into the three transitions that make an event calendar-visible: `create_event` (only when created directly as `ACTIVE`, not `DRAFT`), `_publish_draft`, and `_uncancel_event`. All three use `transaction.on_commit(...)`, matching the existing `broadcast_capacity_change` pattern, so the ping only fires after the write actually commits.

## Test plan

- [ ] TODO: manually verify locally with `make dev-pg` (SSE requires Postgres — returns 503 on SQLite), creating an event in one browser tab and confirming the calendar list in another tab updates without a manual refresh
- [ ] TODO: verify draft → publish and cancelled → uncancel also trigger a live calendar refresh

Closes #1138
