### PR TITLE
feat(devtools): add "make me a guest" toggle to dev test events

### DIFF
--- a/backend/community/_dev_tools.py
+++ b/backend/community/_dev_tools.py
@@ -24,7 +24,7 @@ from community._field_limits import FieldLimit
 from community._shared import ErrorOut
 from community._validation import Code, raise_validation
 from community.management.commands._seed_staging_data import is_seed_allowed
-from community.models import Event, EventStatus, EventType, PageVisibility
+from community.models import Event, EventRSVP, EventStatus, EventType, PageVisibility, RSVPStatus
 
 router = Router()
 
@@ -37,6 +37,7 @@ class DevTestEventIn(BaseModel):
     is_official: bool = False
     is_club: bool = False
     make_me_host: bool = False
+    make_me_guest: bool = False
     price: str = Field(default="", max_length=FieldLimit.SHORT_TEXT)
     venmo_link: str = Field(default="", max_length=FieldLimit.PAYMENT_HANDLE)
     cashapp_link: str = Field(default="", max_length=FieldLimit.PAYMENT_HANDLE)
@@ -146,6 +147,11 @@ def create_dev_test_event(request, payload: DevTestEventIn):
         ),
     )
     populate_invited_users(event, count=payload.invited_count)
+
+    if payload.make_me_guest:
+        EventRSVP.objects.update_or_create(
+            event=event, user=request.auth, defaults={"status": RSVPStatus.ATTENDING}
+        )
 
     audit_log(
         logging.INFO,

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -682,6 +682,11 @@
             "title": "Is Past",
             "type": "boolean"
           },
+          "make_me_guest": {
+            "default": false,
+            "title": "Make Me Guest",
+            "type": "boolean"
+          },
           "make_me_host": {
             "default": false,
             "title": "Make Me Host",

--- a/backend/tests/test_dev_tools.py
+++ b/backend/tests/test_dev_tools.py
@@ -230,6 +230,20 @@ class TestCreateDevTestEvent:
         event = Event.objects.get(id=response.json()["id"])
         assert list(event.co_hosts.values_list("id", flat=True)) == [dev_tools_user.id]
 
+    def test_make_me_guest_adds_creator_rsvp(
+        self, api_client, dev_tools_headers, dev_tools_user, monkeypatch
+    ):
+        monkeypatch.delenv("RAILWAY_ENVIRONMENT_NAME", raising=False)
+        response = api_client.post(
+            "/api/community/dev/test-events/",
+            data={"make_me_guest": True, "going_count": 0},
+            content_type="application/json",
+            **dev_tools_headers,
+        )
+        event = Event.objects.get(id=response.json()["id"])
+        rsvp = event.rsvps.get(user=dev_tools_user)
+        assert rsvp.status == RSVPStatus.ATTENDING
+
     def test_creator_not_a_cohost_by_default(
         self, api_client, dev_tools_headers, dev_tools_user, monkeypatch
     ):

--- a/frontend/src/api/devTools.ts
+++ b/frontend/src/api/devTools.ts
@@ -11,6 +11,7 @@ export interface DevTestEventOptions {
   isOfficial: boolean;
   isClub: boolean;
   makeMeHost: boolean;
+  makeMeGuest: boolean;
   price: string;
   venmoLink: string;
   cashappLink: string;
@@ -45,6 +46,7 @@ export function useCreateDevTestEvents() {
           is_official: options.isOfficial,
           is_club: options.isClub,
           make_me_host: options.makeMeHost,
+          make_me_guest: options.makeMeGuest,
           price: options.price,
           venmo_link: options.venmoLink,
           cashapp_link: options.cashappLink,

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -2324,6 +2324,11 @@ export interface components {
              */
             is_past: boolean;
             /**
+             * Make Me Guest
+             * @default false
+             */
+            make_me_guest: boolean;
+            /**
              * Make Me Host
              * @default false
              */

--- a/frontend/src/components/DevTestEventOverrides.tsx
+++ b/frontend/src/components/DevTestEventOverrides.tsx
@@ -82,7 +82,14 @@ export function DevTestEventOverrides({ options, onChange }: Props) {
           label="make me a host"
           checked={options.makeMeHost}
           onChange={(v) => {
-            set('makeMeHost', v);
+            onChange({ ...options, makeMeHost: v, makeMeGuest: v ? false : options.makeMeGuest });
+          }}
+        />
+        <Toggle
+          label="make me a guest"
+          checked={options.makeMeGuest}
+          onChange={(v) => {
+            onChange({ ...options, makeMeGuest: v, makeMeHost: v ? false : options.makeMeHost });
           }}
         />
         <Toggle

--- a/frontend/src/components/DevTestEventsButton.tsx
+++ b/frontend/src/components/DevTestEventsButton.tsx
@@ -15,6 +15,7 @@ const DEFAULT_OPTIONS: DevTestEventOptions = {
   isOfficial: false,
   isClub: false,
   makeMeHost: false,
+  makeMeGuest: false,
   price: '',
   venmoLink: '',
   cashappLink: '',


### PR DESCRIPTION
## Overview

Adds a "make me a guest" toggle to the dev test-events tool, alongside the existing "make me a host" toggle. Checking it creates an `EventRSVP` (status `attending`) for the creator on the generated event, so you can preview an event as an attendee instead of only as host/cohost. Mutually exclusive with "make me a host" in the UI.

## Test plan

- [x] Backend: added `test_make_me_guest_adds_creator_rsvp`, ran `backend/tests/test_dev_tools.py` (21/21 passed)
- [x] Backend: `ruff check`, `ruff format --check`, `ty check` on touched files
- [x] Frontend: `tsc --noEmit`, `eslint` on touched files
- [ ] Manual: toggle "make me a guest" in the dev tool UI and confirm the created event shows you as an attendee
