### PR TITLE
fix: hide cancel button on past events (Issue 1081)

### DIFF
--- a/frontend/src/screens/events/EmailBlastDialog.tsx
+++ b/frontend/src/screens/events/EmailBlastDialog.tsx
@@ -17,7 +17,6 @@ interface Props {
 const SUBJECT_MAX = 150;
 const MESSAGE_MAX = 5000;
 
-
 interface AudienceGroup {
   value: string;
   label: string;

--- a/frontend/src/screens/events/EventAdminActions.test.tsx
+++ b/frontend/src/screens/events/EventAdminActions.test.tsx
@@ -111,11 +111,10 @@ describe('EventAdminActions', () => {
     expect(screen.queryByRole('button', { name: /delete$/i })).not.toBeInTheDocument();
   });
 
-  it('creator sees no cancel button for a past event', () => {
+  it('creator sees no cancel button for an already-cancelled event', () => {
     const creator = makeUser(CREATOR_ID);
     useAuthStore.setState({ status: 'authed', user: creator, accessToken: 'tok' });
 
-    // isPast doesn't affect cancel — cancelled status does. Test cancelled event.
     const cancelledEvent: Event = { ...BASE_EVENT, status: EventStatus.Cancelled };
     renderActions(cancelledEvent);
 
@@ -123,6 +122,20 @@ describe('EventAdminActions', () => {
     expect(screen.getByRole('button', { name: /^edit$/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /cancel event/i })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /delete$/i })).toBeInTheDocument();
+  });
+
+  it('creator sees no cancel button for a past (ended) event', () => {
+    const creator = makeUser(CREATOR_ID);
+    useAuthStore.setState({ status: 'authed', user: creator, accessToken: 'tok' });
+
+    const pastEvent: Event = {
+      ...BASE_EVENT,
+      startDatetime: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      isPast: true,
+    };
+    renderActions(pastEvent);
+
+    expect(screen.queryByRole('button', { name: /cancel event/i })).not.toBeInTheDocument();
   });
 
   it('regular member (not creator, not co-host) sees no admin action buttons', () => {

--- a/frontend/src/screens/events/EventAdminActions.tsx
+++ b/frontend/src/screens/events/EventAdminActions.tsx
@@ -51,7 +51,7 @@ function AdminActionRow({
   const isDraft = event.status === EventStatus.Draft;
   const hasNoAttendees = event.attendingCount === 0;
   const canDelete = (isHost || canManage) && (isDraft || isCancelled || hasNoAttendees);
-  const showCancel = !isCancelled && !isDraft && !hasNoAttendees;
+  const showCancel = !isCancelled && !isDraft && !hasNoAttendees && !event.isPast;
   // Drafts are always editable — the edit-window cutoff protects the
   // historical record of published events, which drafts don't have.
   const canEditEvent = isDraft || isEditWindowOpen(event);


### PR DESCRIPTION
## Summary
- `EventAdminActions.tsx`'s `showCancel` didn't check `event.isPast`, so the cancel button rendered on ended events and only failed once clicked (backend already rejects with `PAST_CANNOT_BE_CANCELLED`)
- Added `&& !event.isPast` to the visibility check
- Updated the test that previously pinned the buggy behavior, and added a dedicated past-event test case

Closes #1081

## Test plan
- [x] `EventAdminActions.test.tsx` — 14/14 passing
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files