### PR TITLE
fix: keep calendar month/view in URL so back button restores it (Issue 1144)

### DIFF
--- a/frontend/src/screens/calendar/CalendarScreen.test.tsx
+++ b/frontend/src/screens/calendar/CalendarScreen.test.tsx
@@ -133,9 +133,6 @@ describe('CalendarScreen', () => {
     const tomorrow = addDays(new Date(), 1);
     const expectedLabel = format(tomorrow, 'EEEE, MMM d').toLowerCase();
 
-    // CalendarScreen is lazy-loaded, so a back-button press re-mounts it
-    // fresh at whatever URL is in history — simulate that directly instead
-    // of relying on state carried over from a previous render.
     renderCalendar(`/calendar?view=day&date=${format(tomorrow, 'yyyy-MM-dd')}`);
 
     await waitFor(() => {

--- a/frontend/src/screens/calendar/CalendarScreen.test.tsx
+++ b/frontend/src/screens/calendar/CalendarScreen.test.tsx
@@ -2,7 +2,8 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { addDays, format } from 'date-fns';
-import { MemoryRouter } from 'react-router-dom';
+import { useEffect } from 'react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAuthStore } from '@/auth/store';
@@ -36,11 +37,22 @@ function makeQc() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } });
 }
 
+let currentSearch = '';
+
+function SearchSpy() {
+  const { search } = useLocation();
+  useEffect(() => {
+    currentSearch = search;
+  }, [search]);
+  return null;
+}
+
 function renderCalendar(initialEntry = '/calendar') {
   return render(
     <QueryClientProvider client={makeQc()}>
       <MemoryRouter initialEntries={[initialEntry]}>
         <CalendarScreen />
+        <SearchSpy />
       </MemoryRouter>
     </QueryClientProvider>,
   );
@@ -137,6 +149,31 @@ describe('CalendarScreen', () => {
 
     await waitFor(() => {
       expect(screen.getByText(new RegExp(expectedLabel, 'i'))).toBeInTheDocument();
+    });
+  });
+
+  it('writes stepped-to date into the url, and a fresh mount there restores it', async () => {
+    const user = userEvent.setup();
+    const today = new Date();
+    const { unmount } = renderCalendar(`/calendar?view=day&date=${format(today, 'yyyy-MM-dd')}`);
+
+    await user.click(screen.getByRole('button', { name: /next day/i }));
+
+    const tomorrow = addDays(today, 1);
+    const tomorrowLabel = format(tomorrow, 'EEEE, MMM d').toLowerCase();
+    await waitFor(() => {
+      expect(screen.getByText(new RegExp(tomorrowLabel, 'i'))).toBeInTheDocument();
+    });
+
+    // The step must be persisted to the url, not just to component state — that
+    // url is what a browser-back lands on.
+    expect(currentSearch).toBe(`?view=day&date=${format(tomorrow, 'yyyy-MM-dd')}`);
+
+    unmount();
+    renderCalendar(`/calendar${currentSearch}`);
+
+    await waitFor(() => {
+      expect(screen.getByText(new RegExp(tomorrowLabel, 'i'))).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/screens/calendar/CalendarScreen.test.tsx
+++ b/frontend/src/screens/calendar/CalendarScreen.test.tsx
@@ -1,6 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { addDays, format } from 'date-fns';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -35,10 +36,10 @@ function makeQc() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } });
 }
 
-function renderCalendar() {
+function renderCalendar(initialEntry = '/calendar') {
   return render(
     <QueryClientProvider client={makeQc()}>
-      <MemoryRouter>
+      <MemoryRouter initialEntries={[initialEntry]}>
         <CalendarScreen />
       </MemoryRouter>
     </QueryClientProvider>,
@@ -125,6 +126,20 @@ describe('CalendarScreen', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('button', { name: /go to today/i })).toBeInTheDocument();
+    });
+  });
+
+  it('restores the navigated-to day on a fresh mount at that URL (e.g. browser back)', async () => {
+    const tomorrow = addDays(new Date(), 1);
+    const expectedLabel = format(tomorrow, 'EEEE, MMM d').toLowerCase();
+
+    // CalendarScreen is lazy-loaded, so a back-button press re-mounts it
+    // fresh at whatever URL is in history — simulate that directly instead
+    // of relying on state carried over from a previous render.
+    renderCalendar(`/calendar?view=day&date=${format(tomorrow, 'yyyy-MM-dd')}`);
+
+    await waitFor(() => {
+      expect(screen.getByText(new RegExp(expectedLabel, 'i'))).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/screens/calendar/CalendarScreen.tsx
+++ b/frontend/src/screens/calendar/CalendarScreen.tsx
@@ -1,9 +1,9 @@
 import 'react-big-calendar/lib/css/react-big-calendar.css';
 
-import { addDays, format as dfFormat, startOfWeek } from 'date-fns';
-import { useMemo, useState } from 'react';
+import { addDays, format as dfFormat, isValid, parseISO, startOfWeek } from 'date-fns';
+import { useCallback, useMemo } from 'react';
 import { Calendar, type View } from 'react-big-calendar';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import { useEvents } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
@@ -28,6 +28,16 @@ function toBigCalEvent(e: PdaEvent): BigCalEvent | null {
 }
 
 const lower = (d: Date, f: string) => dfFormat(d, f).toLowerCase();
+
+const VIEWS: View[] = ['month', 'week', 'day', 'agenda'];
+function parseView(raw: string | null): View {
+  return VIEWS.find((v) => v === raw) ?? 'month';
+}
+function parseDate(raw: string | null): Date {
+  if (!raw) return new Date();
+  const parsed = parseISO(raw);
+  return isValid(parsed) ? parsed : new Date();
+}
 
 const FORMATS = {
   weekdayFormat: (d: Date) => lower(d, 'EEE'),
@@ -78,16 +88,51 @@ export default function CalendarScreen() {
   );
   const datedEvents = useMemo(() => events.filter((e) => !e.datetimeTbd), [events]);
 
-  const [view, setView] = useState<View>('month');
-  const [date, setDate] = useState<Date>(new Date());
+  const [searchParams, setSearchParams] = useSearchParams();
+  const view = parseView(searchParams.get('view'));
+  const date = parseDate(searchParams.get('date'));
+
+  const setView = useCallback(
+    (v: View) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.set('view', v);
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
+  const setDate = useCallback(
+    (d: Date) => {
+      setSearchParams(
+        (prev) => {
+          const next = new URLSearchParams(prev);
+          next.set('date', dfFormat(d, 'yyyy-MM-dd'));
+          return next;
+        },
+        { replace: true },
+      );
+    },
+    [setSearchParams],
+  );
   const useNarrowWeek = view === 'week' && !isWide;
   const useWideWeek = view === 'week' && isWide;
   const useDayList = view === 'day';
   const useAgendaList = view === 'agenda';
 
   const goToDay = (d: Date) => {
-    setDate(d);
-    setView('day');
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        next.set('date', dfFormat(d, 'yyyy-MM-dd'));
+        next.set('view', 'day');
+        return next;
+      },
+      { replace: true },
+    );
   };
 
   const goToEvent = (e: PdaEvent) => {

--- a/frontend/src/screens/calendar/CalendarScreen.tsx
+++ b/frontend/src/screens/calendar/CalendarScreen.tsx
@@ -90,7 +90,9 @@ export default function CalendarScreen() {
 
   const [searchParams, setSearchParams] = useSearchParams();
   const view = parseView(searchParams.get('view'));
-  const date = parseDate(searchParams.get('date'));
+  const rawDate = searchParams.get('date');
+  // Keyed on the raw param so an absent date doesn't mint a new Date each render.
+  const date = useMemo(() => parseDate(rawDate), [rawDate]);
 
   const setView = useCallback(
     (v: View) => {

--- a/frontend/src/screens/events/EmailBlastDialog.tsx
+++ b/frontend/src/screens/events/EmailBlastDialog.tsx
@@ -17,7 +17,6 @@ interface Props {
 const SUBJECT_MAX = 150;
 const MESSAGE_MAX = 5000;
 
-
 interface AudienceGroup {
   value: string;
   label: string;


### PR DESCRIPTION
## Summary
- `date`/`view` in `CalendarScreen.tsx` lived in plain `useState(new Date())` — since the route is lazy-loaded, navigating to an event and hitting browser back re-mounted the screen fresh, resetting to today's month
- Moved both into URL search params (`?date=yyyy-MM-dd&view=month`) via `useSearchParams`, matching the pattern already used in `EventDetailScreen.tsx`
- All in-calendar navigation (month/week/day stepping, view switching) uses `replace: true` so it doesn't spam browser history — only leaving to an event page creates a real back-button entry, and back now lands on the same calendar URL
- Added a regression test asserting a fresh mount at a `?view=day&date=...` URL (what a back-button press produces) restores that day

Closes #1144

## Test plan
- [x] `CalendarScreen.test.tsx` — 8/8 passing (new regression test included)
- [x] full calendar suite (`AgendaList`, `CalendarViews.a11y`, `CalendarScreen`) — 17/17 passing
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on changed files