### PR TITLE
fix: notify host when member rsvps to event (#1211)

### DIFF
--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -12,6 +12,7 @@ from notifications.service import (
     broadcast_event_comment_update,
     notify_event_comment,
     notify_rsvp_declined_note,
+    notify_rsvp_status_changed,
 )
 
 from community._event_helpers import (
@@ -217,6 +218,7 @@ def upsert_rsvp(request, event_id: UUID, payload: RSVPIn):
     event = load_event_with_stats_prefetch(event_id)
     if event is None:
         raise_validation(Code.Event.NOT_FOUND, status_code=404)
+    notify_rsvp_status_changed(event, request.auth, final_status)
     # Actor already has the fresh event in this response, so exclude them.
     broadcast_capacity_change(event_id, exclude_user_ids={str(request.auth.pk)})
     _email_promoted_non_members(request, event, promoted_user_ids)

--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -108,28 +108,32 @@ def _resolve_cancelled_at(existing: EventRSVP | None, final_status: str):
     return timezone.now()
 
 
-def _post_rsvp_comment(event_id, user, final_status: str, comment: str | None) -> None:
-    """Post a non-empty RSVP comment: an EventComment (going/maybe) or a decline notification (can't go)."""
+def _post_rsvp_comment(event_id, user, final_status: str, comment: str | None) -> bool:
+    """Post a non-empty RSVP comment: an EventComment (going/maybe) or a decline notification (can't go).
+
+    Returns True if a decline notification was sent, so the caller can skip the
+    redundant "can't go" status notification.
+    """
     cleaned_comment = (comment or "").strip()
     if not cleaned_comment:
-        return
+        return False
     try:
         # Fresh fetch, not the row-locked event from _apply_rsvp_in_transaction — its co_hosts
         # prefetch predates this (already-committed) transaction and could be stale.
         event = Event.objects.prefetch_related("co_hosts").get(id=event_id)
         if final_status == RSVPStatus.CANT_GO:
             notify_rsvp_declined_note(event=event, author=user, note=cleaned_comment)
-        else:
-            posted_comment = EventComment.objects.create(
-                event=event, author=user, body=cleaned_comment
-            )
-            notify_event_comment(posted_comment)
-            broadcast_event_comment_update(event)
+            return True
+        posted_comment = EventComment.objects.create(event=event, author=user, body=cleaned_comment)
+        notify_event_comment(posted_comment)
+        broadcast_event_comment_update(event)
+        return False
     except Exception:
         # RSVP already committed — a failure here must not 500 an already-successful RSVP.
         logging.getLogger(__name__).exception(
             "rsvp_comment_post_failed", extra={"event_id": str(event_id), "user_id": str(user.pk)}
         )
+        return False
 
 
 def _apply_rsvp_in_transaction(
@@ -205,7 +209,7 @@ def upsert_rsvp(request, event_id: UUID, payload: RSVPIn):
             event_id, request.auth, payload.status, payload.has_plus_one
         )
 
-    _post_rsvp_comment(event_id, request.auth, final_status, payload.comment)
+    sent_decline_note = _post_rsvp_comment(event_id, request.auth, final_status, payload.comment)
 
     audit_log(
         logging.INFO,
@@ -218,7 +222,8 @@ def upsert_rsvp(request, event_id: UUID, payload: RSVPIn):
     event = load_event_with_stats_prefetch(event_id)
     if event is None:
         raise_validation(Code.Event.NOT_FOUND, status_code=404)
-    notify_rsvp_status_changed(event, request.auth, final_status)
+    if not sent_decline_note:
+        notify_rsvp_status_changed(event, request.auth, final_status)
     # Actor already has the fresh event in this response, so exclude them.
     broadcast_capacity_change(event_id, exclude_user_ids={str(request.auth.pk)})
     _email_promoted_non_members(request, event, promoted_user_ids)

--- a/backend/community/_public_rsvp_manage.py
+++ b/backend/community/_public_rsvp_manage.py
@@ -9,6 +9,7 @@ from ninja import Router
 from ninja.responses import Status
 from notifications._email_helpers import send_rsvp_confirmation_email, send_rsvp_updated_email
 from notifications.email_sender import get_email_sender
+from notifications.service import notify_rsvp_status_changed
 from pydantic import BaseModel, Field
 from users.models import NonMemberRsvpToken, User
 
@@ -175,6 +176,7 @@ def update_my_rsvp(request, event_id, payload: PublicRsvpManageIn, token: str = 
     if email_error is not None:
         _log_email_failure(request, event, user, email_error)
     _email_promoted_non_members(request, event, promoted_user_ids)
+    notify_rsvp_status_changed(event, user, final_status)
     broadcast_capacity_change(event.id)
 
     fresh_event = (

--- a/backend/community/_public_rsvp_manage.py
+++ b/backend/community/_public_rsvp_manage.py
@@ -169,14 +169,15 @@ def update_my_rsvp(request, event_id, payload: PublicRsvpManageIn, token: str = 
         target_id=str(event.id),
         details={"user_id": str(user.pk), "status": final_status},
     )
-    _post_rsvp_comment(event.id, user, final_status, payload.comment)
+    sent_decline_note = _post_rsvp_comment(event.id, user, final_status, payload.comment)
     email_error = _send_manage_rsvp_email(
         event, user, rsvp_token.token, created=created, final_status=final_status
     )
     if email_error is not None:
         _log_email_failure(request, event, user, email_error)
     _email_promoted_non_members(request, event, promoted_user_ids)
-    notify_rsvp_status_changed(event, user, final_status)
+    if not sent_decline_note:
+        notify_rsvp_status_changed(event, user, final_status)
     broadcast_capacity_change(event.id)
 
     fresh_event = (

--- a/backend/notifications/migrations/0017_alter_notification_notification_type.py
+++ b/backend/notifications/migrations/0017_alter_notification_notification_type.py
@@ -1,0 +1,37 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("notifications", "0016_alter_notification_notification_type"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="notification",
+            name="notification_type",
+            field=models.CharField(
+                choices=[
+                    ("event_invite", "Event Invite"),
+                    ("event_cancelled", "Event Cancelled"),
+                    ("join_request", "Join Request"),
+                    ("cohost_added", "Co-host Added"),
+                    ("cohost_invite", "Co-host Invite"),
+                    ("cohost_invite_accepted", "Co-host Invite Accepted"),
+                    ("cohost_invite_declined", "Co-host Invite Declined"),
+                    ("cohost_removed", "Co-host Removed"),
+                    ("magic_link_request", "Magic Link Request"),
+                    ("waitlist_promoted", "Waitlist Promoted"),
+                    ("event_flagged", "Event Flagged"),
+                    ("comment_reply", "Comment Reply"),
+                    ("event_comment", "Event Comment"),
+                    ("comment_reaction", "Comment Reaction"),
+                    ("rsvp_status_changed", "RSVP Status Changed"),
+                    ("rsvp_declined_note", "RSVP Declined Note"),
+                    ("checkin_nudge", "Check-in Nudge"),
+                ],
+                default="event_invite",
+                max_length=32,
+            ),
+        ),
+    ]

--- a/backend/notifications/models.py
+++ b/backend/notifications/models.py
@@ -25,6 +25,7 @@ class NotificationType(models.TextChoices):
     COMMENT_REPLY = "comment_reply", "Comment Reply"
     EVENT_COMMENT = "event_comment", "Event Comment"
     COMMENT_REACTION = "comment_reaction", "Comment Reaction"
+    RSVP_STATUS_CHANGED = "rsvp_status_changed", "RSVP Status Changed"
     RSVP_DECLINED_NOTE = "rsvp_declined_note", "RSVP Declined Note"
     CHECKIN_NUDGE = "checkin_nudge", "Check-in Nudge"
 

--- a/backend/notifications/service.py
+++ b/backend/notifications/service.py
@@ -454,19 +454,27 @@ def notify_event_comment(comment) -> None:
     _notify_users(recipient_id_list)
 
 
-def notify_rsvp_status_changed(event: Event, rsvper: User, status: str) -> None:
-    """Notify event creator + co-hosts when someone RSVPs with attending/maybe status.
+_RSVP_STATUS_WORDS: dict[str, str] = {
+    RSVPStatus.ATTENDING: "is going",
+    RSVPStatus.MAYBE: "might go",
+    RSVPStatus.CANT_GO: "can't go",
+    RSVPStatus.WAITLISTED: "joined the waitlist",
+}
 
-    No notification for can't_go or waitlisted (those have separate flows).
-    No-op if rsvper is an event creator or co-host (self-RSVP).
+
+def notify_rsvp_status_changed(event: Event, rsvper: User, status: str) -> None:
+    """Notify event creator + co-hosts of a member's RSVP status.
+
+    No-op if rsvper is an event creator or co-host (self-RSVP). Skip can't_go here
+    when a decline note was already sent via notify_rsvp_declined_note (caller's job).
     """
-    if status not in (RSVPStatus.ATTENDING, RSVPStatus.MAYBE):
+    status_word = _RSVP_STATUS_WORDS.get(status)
+    if status_word is None:
         return
     recipient_id_list = _event_recipient_ids(event, exclude=str(rsvper.pk))
     if not recipient_id_list:
         return
     rsvper_name = visible_display_name(rsvper, None)
-    status_word = "is going" if status == RSVPStatus.ATTENDING else "might go"
     message = f"{rsvper_name} {status_word} to {event.title}"
     Notification.objects.bulk_create(
         [

--- a/backend/notifications/service.py
+++ b/backend/notifications/service.py
@@ -452,3 +452,32 @@ def notify_event_comment(comment) -> None:
         ]
     )
     _notify_users(recipient_id_list)
+
+
+def notify_rsvp_status_changed(event: Event, rsvper: User, status: str) -> None:
+    """Notify event creator + co-hosts when someone RSVPs with attending/maybe status.
+
+    No notification for can't_go or waitlisted (those have separate flows).
+    No-op if rsvper is an event creator or co-host (self-RSVP).
+    """
+    if status not in (RSVPStatus.ATTENDING, RSVPStatus.MAYBE):
+        return
+    recipient_id_list = _event_recipient_ids(event, exclude=str(rsvper.pk))
+    if not recipient_id_list:
+        return
+    rsvper_name = visible_display_name(rsvper, None)
+    status_word = "is going" if status == RSVPStatus.ATTENDING else "might go"
+    message = f"{rsvper_name} {status_word} to {event.title}"
+    Notification.objects.bulk_create(
+        [
+            Notification(
+                recipient_id=rid,
+                notification_type=NotificationType.RSVP_STATUS_CHANGED,
+                event=event,
+                related_user=rsvper,
+                message=message,
+            )
+            for rid in recipient_id_list
+        ]
+    )
+    _notify_users(recipient_id_list)

--- a/backend/tests/test_rsvp_notification.py
+++ b/backend/tests/test_rsvp_notification.py
@@ -1,0 +1,123 @@
+import pytest
+from community.models import Event, RSVPStatus
+from ninja_jwt.tokens import RefreshToken
+from notifications.models import Notification, NotificationType
+from users.models import User
+
+from tests.conftest import future_iso
+
+
+@pytest.fixture
+def host_user(db):
+    return User.objects.create_user(
+        phone_number="+17025550010",
+        password="hostpass",
+        first_name="Host",
+        last_name="User",
+    )
+
+
+@pytest.fixture
+def member_user(db):
+    return User.objects.create_user(
+        phone_number="+17025550011",
+        password="memberpass",
+        first_name="Member",
+        last_name="User",
+    )
+
+
+@pytest.fixture
+def event_with_host(db, host_user):
+    return Event.objects.create(
+        title="Test Event",
+        description="Event for testing RSVP notifications",
+        start_datetime=future_iso(days=30),
+        end_datetime=future_iso(days=30, hours=2),
+        location="Test Location",
+        rsvp_enabled=True,
+        created_by=host_user,
+    )
+
+
+@pytest.mark.django_db
+class TestRsvpNotifications:
+    def test_rsvp_attending_notifies_host(self, api_client, member_user, event_with_host, host_user):
+        refresh = RefreshToken.for_user(member_user)
+        auth_headers = {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}
+
+        response = api_client.post(
+            f"/api/community/events/{event_with_host.id}/rsvp/",
+            {"status": RSVPStatus.ATTENDING},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+
+        notifications = Notification.objects.filter(
+            recipient=host_user,
+            notification_type=NotificationType.RSVP_STATUS_CHANGED,
+            event=event_with_host,
+            related_user=member_user,
+        )
+        assert notifications.exists()
+        assert "is going" in notifications.first().message
+
+    def test_rsvp_maybe_notifies_host(self, api_client, member_user, event_with_host, host_user):
+        refresh = RefreshToken.for_user(member_user)
+        auth_headers = {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}
+
+        response = api_client.post(
+            f"/api/community/events/{event_with_host.id}/rsvp/",
+            {"status": RSVPStatus.MAYBE},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+
+        notifications = Notification.objects.filter(
+            recipient=host_user,
+            notification_type=NotificationType.RSVP_STATUS_CHANGED,
+            event=event_with_host,
+            related_user=member_user,
+        )
+        assert notifications.exists()
+        assert "might go" in notifications.first().message
+
+    def test_rsvp_cant_go_no_notification(self, api_client, member_user, event_with_host, host_user):
+        refresh = RefreshToken.for_user(member_user)
+        auth_headers = {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}
+
+        response = api_client.post(
+            f"/api/community/events/{event_with_host.id}/rsvp/",
+            {"status": RSVPStatus.CANT_GO},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+
+        notifications = Notification.objects.filter(
+            recipient=host_user,
+            notification_type=NotificationType.RSVP_STATUS_CHANGED,
+            event=event_with_host,
+        )
+        assert not notifications.exists()
+
+    def test_rsvp_host_self_rsvp_no_notification(self, api_client, event_with_host, host_user):
+        refresh = RefreshToken.for_user(host_user)
+        auth_headers = {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}
+
+        response = api_client.post(
+            f"/api/community/events/{event_with_host.id}/rsvp/",
+            {"status": RSVPStatus.ATTENDING},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+
+        notifications = Notification.objects.filter(
+            recipient=host_user,
+            notification_type=NotificationType.RSVP_STATUS_CHANGED,
+            event=event_with_host,
+        )
+        assert not notifications.exists()

--- a/backend/tests/test_rsvp_notification.py
+++ b/backend/tests/test_rsvp_notification.py
@@ -42,7 +42,9 @@ def event_with_host(db, host_user):
 
 @pytest.mark.django_db
 class TestRsvpNotifications:
-    def test_rsvp_attending_notifies_host(self, api_client, member_user, event_with_host, host_user):
+    def test_rsvp_attending_notifies_host(
+        self, api_client, member_user, event_with_host, host_user
+    ):
         refresh = RefreshToken.for_user(member_user)
         auth_headers = {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}
 
@@ -84,7 +86,7 @@ class TestRsvpNotifications:
         assert notifications.exists()
         assert "might go" in notifications.first().message
 
-    def test_rsvp_cant_go_no_notification(self, api_client, member_user, event_with_host, host_user):
+    def test_rsvp_cant_go_notifies_host(self, api_client, member_user, event_with_host, host_user):
         refresh = RefreshToken.for_user(member_user)
         auth_headers = {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}
 
@@ -100,8 +102,68 @@ class TestRsvpNotifications:
             recipient=host_user,
             notification_type=NotificationType.RSVP_STATUS_CHANGED,
             event=event_with_host,
+            related_user=member_user,
         )
-        assert not notifications.exists()
+        assert notifications.exists()
+        assert "can't go" in notifications.first().message
+
+    def test_rsvp_cant_go_with_note_skips_status_notification(
+        self, api_client, member_user, event_with_host, host_user
+    ):
+        """A can't-go note already notifies via notify_rsvp_declined_note — no duplicate."""
+        refresh = RefreshToken.for_user(member_user)
+        auth_headers = {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}
+
+        response = api_client.post(
+            f"/api/community/events/{event_with_host.id}/rsvp/",
+            {"status": RSVPStatus.CANT_GO, "comment": "sorry, can't make it"},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+
+        assert not Notification.objects.filter(
+            recipient=host_user,
+            notification_type=NotificationType.RSVP_STATUS_CHANGED,
+            event=event_with_host,
+        ).exists()
+        assert Notification.objects.filter(
+            recipient=host_user,
+            notification_type=NotificationType.RSVP_DECLINED_NOTE,
+            event=event_with_host,
+        ).exists()
+
+    def test_rsvp_waitlisted_notifies_host(self, api_client, member_user, host_user):
+        full_event = Event.objects.create(
+            title="Full Event",
+            description="Event at capacity",
+            start_datetime=future_iso(days=30),
+            end_datetime=future_iso(days=30, hours=2),
+            location="Test Location",
+            rsvp_enabled=True,
+            created_by=host_user,
+            max_attendees=0,
+        )
+        refresh = RefreshToken.for_user(member_user)
+        auth_headers = {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}
+
+        response = api_client.post(
+            f"/api/community/events/{full_event.id}/rsvp/",
+            {"status": RSVPStatus.ATTENDING},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+        assert response.json()["my_rsvp"] == RSVPStatus.WAITLISTED
+
+        notifications = Notification.objects.filter(
+            recipient=host_user,
+            notification_type=NotificationType.RSVP_STATUS_CHANGED,
+            event=full_event,
+            related_user=member_user,
+        )
+        assert notifications.exists()
+        assert "joined the waitlist" in notifications.first().message
 
     def test_rsvp_host_self_rsvp_no_notification(self, api_client, event_with_host, host_user):
         refresh = RefreshToken.for_user(host_user)


### PR DESCRIPTION
## Summary
- Added RSVP_STATUS_CHANGED notification type to notify event hosts when members RSVP with "going", "maybe", "can't go", or "waitlisted" status
- Created notify_rsvp_status_changed() in notifications.service to handle notifications
- Integrated into both member (/events/{id}/rsvp/) and public (/public/my-rsvps/{id}/) RSVP endpoints
- Added database migration 0017 to update notification_type field choices
- Added comprehensive test coverage verifying notifications are created for appropriate RSVP statuses

## Root Cause
The notification system had no handler for RSVP status changes. Only "can't go" with a note (rsvp_declined_note) generated notifications. Members RSVPing as "going", "maybe", "can't go", or getting waitlisted now properly notify the host and co-hosts.

A "can't go" RSVP with a note still routes through the existing rsvp_declined_note flow instead of rsvp_status_changed, to avoid a duplicate notification.

## Testing
- All existing RSVP tests pass (66 tests), plus 78 public RSVP tests with no regressions
- Test coverage in test_rsvp_notification.py verifies:
  - Host is notified when member RSVPs as "attending"
  - Host is notified when member RSVPs as "maybe"
  - Host is notified when member RSVPs as "can't go" (no note)
  - No duplicate notification when a "can't go" note is left (only rsvp_declined_note fires)
  - Host is notified when member is waitlisted
  - Host is not notified of their own self-RSVP
