### PR TITLE
feat(events): add RSVP questions for member responses

### DIFF
--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -25,6 +25,7 @@ from community._cohost_invite_helpers import (
 from community._event_schemas import (
     CancellationOut,
     EventOut,
+    EventRsvpQuestionOut,
     PendingCoHostInviteOut,
     RSVPGuestOut,
     TagOut,
@@ -38,6 +39,7 @@ from community._shared import _authenticated_user, _members_only
 from community.models import (
     Event,
     EventRSVP,
+    EventRsvpQuestion,
     EventTag,
     RSVPStatus,
     SurveyQuestionType,
@@ -50,7 +52,7 @@ if TYPE_CHECKING:
 def load_event_with_stats_prefetch(event_id: UUID) -> Event | None:
     return (
         Event.objects.select_related("created_by")
-        .prefetch_related("co_hosts", "invited_users", "rsvps__user")
+        .prefetch_related("co_hosts", "invited_users", "rsvps__user", "rsvp_questions")
         .filter(id=event_id)
         .first()
     )
@@ -63,7 +65,7 @@ def broadcast_capacity_change(event_id: UUID, *, exclude_user_ids: set[str] | No
     def _run() -> None:
         event = (
             Event.objects.select_related("created_by")
-            .prefetch_related("co_hosts", "invited_users", "rsvps__user")
+            .prefetch_related("co_hosts", "invited_users", "rsvps__user", "rsvp_questions")
             .filter(id=event_id)
             .first()
         )
@@ -108,6 +110,26 @@ def _find_my_rsvp(rsvps, user) -> str | None:
         if r.user_id == user.pk:
             return r.status
     return None
+
+
+def _find_my_rsvp_answers(rsvps, user) -> dict:
+    if user is None:
+        return {}
+    for r in rsvps:
+        if r.user_id == user.pk:
+            return dict(r.answers or {})
+    return {}
+
+
+def event_rsvp_question_out(question: EventRsvpQuestion) -> EventRsvpQuestionOut:
+    return EventRsvpQuestionOut(
+        id=str(question.id),
+        label=question.label,
+        field_type=question.field_type,
+        options=list(question.options or []),
+        required=question.required,
+        display_order=question.display_order,
+    )
 
 
 def _cancellations(event: Event, viewer=None) -> list[CancellationOut]:
@@ -338,6 +360,7 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
         co_host_photo_urls=[media_path(u.profile_photo) for u in co_hosts],
         guests=_members_only(_build_guest_list(rsvps, phones_visible, auth_user), [], is_authed),
         my_rsvp=_find_my_rsvp(rsvps, auth_user),
+        my_rsvp_answers=_find_my_rsvp_answers(rsvps, auth_user),
         viewer_user_id=str(auth_user.pk) if auth_user else None,
         event_type=event.event_type,
         visibility=event.visibility,
@@ -355,6 +378,9 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
         pending_cohost_invites=pending_invites_out,
         my_pending_cohost_invite_id=my_pending_invite_id,
         tags=_tags_out(event),
+        rsvp_questions=[
+            event_rsvp_question_out(question) for question in event.rsvp_questions.all()
+        ],
     )
 
 

--- a/backend/community/_event_rsvp_answers.py
+++ b/backend/community/_event_rsvp_answers.py
@@ -1,0 +1,83 @@
+"""Validate and snapshot RSVP question answers."""
+
+from community._field_limits import FieldLimit
+from community._validation import Code, raise_validation
+from community.models import EventRsvpQuestion, RSVPStatus, SurveyQuestionType
+
+AnswersIn = dict[str, str]
+
+
+def answers_required_for_status(status: str) -> bool:
+    return status in {
+        RSVPStatus.ATTENDING,
+        RSVPStatus.MAYBE,
+        RSVPStatus.WAITLISTED,
+    }
+
+
+def _is_empty(answer: str | None) -> bool:
+    return answer is None or not str(answer).strip()
+
+
+def _require_if_needed(q: EventRsvpQuestion, *, require_answers: bool) -> None:
+    if require_answers and q.required:
+        raise_validation(
+            Code.Event.RSVP_ANSWER_REQUIRED,
+            field=f"answers.{q.id}",
+            label=q.label,
+        )
+
+
+def _normalize_answer(q: EventRsvpQuestion, answer: str) -> str:
+    if q.field_type == SurveyQuestionType.MULTISELECT:
+        cleaned = [v.strip() for v in str(answer).split(",") if v.strip()]
+        options = set(q.options or [])
+        for val in cleaned:
+            if val not in options:
+                raise_validation(
+                    Code.Event.RSVP_ANSWER_INVALID_OPTION,
+                    field=f"answers.{q.id}",
+                    label=q.label,
+                )
+        return ",".join(cleaned)
+
+    text = str(answer).strip()
+    if q.field_type == SurveyQuestionType.DROPDOWN and text not in (q.options or []):
+        raise_validation(
+            Code.Event.RSVP_ANSWER_INVALID_OPTION,
+            field=f"answers.{q.id}",
+            label=q.label,
+        )
+    return text
+
+
+def build_rsvp_answers(
+    questions: list[EventRsvpQuestion],
+    raw: AnswersIn | None,
+    *,
+    require_answers: bool,
+) -> dict:
+    """Return snapshot dict {qid: {label, answer}} or raise ValidationException."""
+    incoming = raw or {}
+    snapshot: dict = {}
+    for q in questions:
+        key = str(q.id)
+        answer = incoming.get(key)
+        if _is_empty(answer):
+            _require_if_needed(q, require_answers=require_answers)
+            continue
+        assert answer is not None
+        if len(answer) > FieldLimit.DESCRIPTION:
+            raise_validation(
+                Code.Event.RSVP_ANSWER_TOO_LONG,
+                field=f"answers.{key}",
+                label=q.label,
+                max=FieldLimit.DESCRIPTION,
+            )
+        normalized = _normalize_answer(q, answer)
+        # Multiselect ",,," normalizes to "" — treat as unanswered.
+        if _is_empty(normalized):
+            _require_if_needed(q, require_answers=require_answers)
+            continue
+        snapshot[key] = {"label": q.label, "answer": normalized}
+    return snapshot

--- a/backend/community/_event_rsvp_answers.py
+++ b/backend/community/_event_rsvp_answers.py
@@ -4,10 +4,10 @@ from community._field_limits import FieldLimit
 from community._question_answers import (
     assert_single_choice_member,
     is_answer_empty,
-    normalize_multiselect_csv,
+    normalize_checkbox_csv,
 )
 from community._validation import Code, raise_validation
-from community.models import EventRsvpQuestion, RSVPStatus, RsvpQuestionType
+from community.models import EventRsvpQuestion, RsvpQuestionType, RSVPStatus
 
 AnswersIn = dict[str, str]
 
@@ -31,8 +31,8 @@ def _require_if_needed(q: EventRsvpQuestion, *, require_answers: bool) -> None:
 
 def _normalize_answer(q: EventRsvpQuestion, answer: str) -> str:
     field = f"answers.{q.id}"
-    if q.field_type == RsvpQuestionType.MULTISELECT:
-        return normalize_multiselect_csv(
+    if q.field_type == RsvpQuestionType.CHECKBOX:
+        return normalize_checkbox_csv(
             answer,
             q.options,
             code=Code.Event.RSVP_ANSWER_INVALID_OPTION,
@@ -41,7 +41,7 @@ def _normalize_answer(q: EventRsvpQuestion, answer: str) -> str:
         )
 
     text = str(answer).strip()
-    if q.field_type == RsvpQuestionType.DROPDOWN:
+    if q.field_type == RsvpQuestionType.SELECT:
         assert_single_choice_member(
             text,
             q.options,
@@ -76,7 +76,7 @@ def build_rsvp_answers(
                 max=FieldLimit.DESCRIPTION,
             )
         normalized = _normalize_answer(q, answer)
-        # Multiselect ",,," normalizes to "" — treat as unanswered.
+        # Checkbox ",,," normalizes to "" — treat as unanswered.
         if is_answer_empty(normalized):
             _require_if_needed(q, require_answers=require_answers)
             continue

--- a/backend/community/_event_rsvp_answers.py
+++ b/backend/community/_event_rsvp_answers.py
@@ -1,8 +1,13 @@
 """Validate and snapshot RSVP question answers."""
 
 from community._field_limits import FieldLimit
+from community._question_answers import (
+    assert_single_choice_member,
+    is_answer_empty,
+    normalize_multiselect_csv,
+)
 from community._validation import Code, raise_validation
-from community.models import EventRsvpQuestion, RSVPStatus, SurveyQuestionType
+from community.models import EventRsvpQuestion, RSVPStatus, RsvpQuestionType
 
 AnswersIn = dict[str, str]
 
@@ -15,10 +20,6 @@ def answers_required_for_status(status: str) -> bool:
     }
 
 
-def _is_empty(answer: str | None) -> bool:
-    return answer is None or not str(answer).strip()
-
-
 def _require_if_needed(q: EventRsvpQuestion, *, require_answers: bool) -> None:
     if require_answers and q.required:
         raise_validation(
@@ -29,23 +30,23 @@ def _require_if_needed(q: EventRsvpQuestion, *, require_answers: bool) -> None:
 
 
 def _normalize_answer(q: EventRsvpQuestion, answer: str) -> str:
-    if q.field_type == SurveyQuestionType.MULTISELECT:
-        cleaned = [v.strip() for v in str(answer).split(",") if v.strip()]
-        options = set(q.options or [])
-        for val in cleaned:
-            if val not in options:
-                raise_validation(
-                    Code.Event.RSVP_ANSWER_INVALID_OPTION,
-                    field=f"answers.{q.id}",
-                    label=q.label,
-                )
-        return ",".join(cleaned)
+    field = f"answers.{q.id}"
+    if q.field_type == RsvpQuestionType.MULTISELECT:
+        return normalize_multiselect_csv(
+            answer,
+            q.options,
+            code=Code.Event.RSVP_ANSWER_INVALID_OPTION,
+            field=field,
+            label=q.label,
+        )
 
     text = str(answer).strip()
-    if q.field_type == SurveyQuestionType.DROPDOWN and text not in (q.options or []):
-        raise_validation(
-            Code.Event.RSVP_ANSWER_INVALID_OPTION,
-            field=f"answers.{q.id}",
+    if q.field_type == RsvpQuestionType.DROPDOWN:
+        assert_single_choice_member(
+            text,
+            q.options,
+            code=Code.Event.RSVP_ANSWER_INVALID_OPTION,
+            field=field,
             label=q.label,
         )
     return text
@@ -63,7 +64,7 @@ def build_rsvp_answers(
     for q in questions:
         key = str(q.id)
         answer = incoming.get(key)
-        if _is_empty(answer):
+        if is_answer_empty(answer):
             _require_if_needed(q, require_answers=require_answers)
             continue
         assert answer is not None
@@ -76,7 +77,7 @@ def build_rsvp_answers(
             )
         normalized = _normalize_answer(q, answer)
         # Multiselect ",,," normalizes to "" — treat as unanswered.
-        if _is_empty(normalized):
+        if is_answer_empty(normalized):
             _require_if_needed(q, require_answers=require_answers)
             continue
         snapshot[key] = {"label": q.label, "answer": normalized}

--- a/backend/community/_event_rsvp_questions.py
+++ b/backend/community/_event_rsvp_questions.py
@@ -1,0 +1,111 @@
+"""CRUD endpoints for per-event RSVP questions."""
+
+import logging
+from uuid import UUID
+
+from config.audit import audit_log
+from config.auth import gated_jwt
+from django.db import transaction
+from ninja import Router
+from ninja.responses import Status
+
+from community._event_helpers import event_rsvp_question_out
+from community._event_schemas import (
+    EventRsvpQuestionOut,
+    EventRsvpQuestionSyncPayload,
+    validate_event_rsvp_question,
+)
+from community._events import _can_edit_event
+from community._shared import ErrorOut
+from community._validation import Code, raise_validation
+from community.models import Event, EventRsvpQuestion
+
+router = Router()
+
+
+def _load_editable_event(request, event_id: UUID) -> Event:
+    try:
+        event = Event.objects.get(id=event_id)
+    except Event.DoesNotExist:
+        raise_validation(Code.Event.NOT_FOUND, status_code=404)
+    if not _can_edit_event(request.auth, event):
+        audit_log(
+            logging.WARNING,
+            "permission_denied",
+            request,
+            target_type="event",
+            target_id=str(event_id),
+            details={"endpoint": "event_rsvp_questions", "required": "edit_event"},
+        )
+        raise_validation(Code.Event.PERM_DENIED, status_code=403, action="manage_rsvp_questions")
+    return event
+
+
+@router.put(
+    "/events/{event_id}/rsvp-questions/",
+    response={
+        200: list[EventRsvpQuestionOut],
+        400: ErrorOut,
+        403: ErrorOut,
+        404: ErrorOut,
+        422: ErrorOut,
+    },
+    auth=gated_jwt,
+)
+@transaction.atomic
+def replace_event_rsvp_questions(request, event_id: UUID, payload: EventRsvpQuestionSyncPayload):
+    event = _load_editable_event(request, event_id)
+    Event.objects.select_for_update().get(id=event.id)
+    for item in payload.questions:
+        validate_event_rsvp_question(item)
+
+    existing = {
+        question.id: question
+        for question in EventRsvpQuestion.objects.select_for_update().filter(event=event)
+    }
+    current = sorted(existing.values(), key=lambda question: question.display_order)
+    current_state = [
+        (question.id, question.label, question.field_type, question.options, question.required)
+        for question in current
+    ]
+    expected_state = [
+        (item.id, item.label, item.field_type, item.options, item.required)
+        for item in payload.expected
+    ]
+    if current_state != expected_state:
+        raise_validation(Code.Event.RSVP_QUESTION_CONFLICT, status_code=409)
+
+    requested_ids = [item.id for item in payload.questions if item.id is not None]
+    if len(requested_ids) != len(set(requested_ids)):
+        raise_validation(
+            Code.Event.RSVP_QUESTION_DUPLICATE,
+            field="questions.id",
+            status_code=400,
+        )
+    if any(question_id not in existing for question_id in requested_ids):
+        raise_validation(Code.Event.RSVP_QUESTION_NOT_FOUND, status_code=404)
+
+    synced = []
+    for display_order, item in enumerate(payload.questions):
+        question = existing.get(item.id) if item.id is not None else None
+        if question is None:
+            question = EventRsvpQuestion(event=event)
+        question.label = item.label
+        question.field_type = item.field_type
+        question.options = item.options
+        question.required = item.required
+        question.display_order = display_order
+        question.save()
+        synced.append(question)
+
+    keep_ids = {question.id for question in synced}
+    EventRsvpQuestion.objects.filter(event=event).exclude(id__in=keep_ids).delete()
+    audit_log(
+        logging.INFO,
+        "event_rsvp_questions_replaced",
+        request,
+        target_type="event",
+        target_id=str(event_id),
+        details={"question_count": len(synced)},
+    )
+    return Status(200, [event_rsvp_question_out(question) for question in synced])

--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -20,6 +20,7 @@ from community._event_helpers import (
     load_event_with_stats_prefetch,
     promote_from_waitlist,
 )
+from community._event_rsvp_answers import answers_required_for_status, build_rsvp_answers
 from community._event_schemas import EventOut, RSVPIn
 from community._events import _can_edit_event, _enforce_event_read_visibility
 from community._public_rsvp_shared import _email_promoted_non_members
@@ -131,8 +132,46 @@ def _post_rsvp_comment(event_id, user, final_status: str, comment: str | None) -
         )
 
 
+def _snapshot_rsvp_answers(
+    event: Event,
+    existing: EventRSVP | None,
+    final_status: str,
+    answers: dict[str, str] | None,
+) -> dict:
+    existing_answers = dict(existing.answers or {}) if existing is not None else {}
+    if not answers_required_for_status(final_status):
+        return existing_answers
+
+    questions = list(event.rsvp_questions.all())
+    current_ids = {str(question.id) for question in questions}
+    if answers is None:
+        answers = {
+            question_id: snapshot["answer"]
+            for question_id, snapshot in existing_answers.items()
+            if question_id in current_ids
+        }
+        build_rsvp_answers(questions, answers, require_answers=True)
+        return existing_answers
+
+    current_answers = build_rsvp_answers(questions, answers, require_answers=True)
+    for question_id, snapshot in current_answers.items():
+        previous = existing_answers.get(question_id)
+        if previous is not None and previous["answer"] == snapshot["answer"]:
+            current_answers[question_id] = previous
+    historical_answers = {
+        question_id: snapshot
+        for question_id, snapshot in existing_answers.items()
+        if question_id not in current_ids
+    }
+    return historical_answers | current_answers
+
+
 def _apply_rsvp_in_transaction(
-    event_id, user, status: str, has_plus_one: bool
+    event_id,
+    user,
+    status: str,
+    has_plus_one: bool,
+    answers: dict[str, str] | None = None,
 ) -> tuple[str, list[str], bool]:
     """Execute RSVP upsert inside a locked transaction.
 
@@ -147,7 +186,7 @@ def _apply_rsvp_in_transaction(
     # is locked under select_for_update.
     event = (
         Event.objects.select_for_update()
-        .prefetch_related("co_hosts", "invited_users")
+        .prefetch_related("co_hosts", "invited_users", "rsvp_questions")
         .get(id=event_id)
     )
 
@@ -159,11 +198,13 @@ def _apply_rsvp_in_transaction(
     created = existing is None
     was_attending = existing is not None and existing.status == RSVPStatus.ATTENDING
     had_plus_one = existing is not None and existing.has_plus_one
+    answers_snapshot = _snapshot_rsvp_answers(event, existing, final_status, answers)
 
     if (
         existing is not None
         and existing.status == final_status
         and existing.has_plus_one == final_plus_one
+        and dict(existing.answers or {}) == answers_snapshot
     ):
         return final_status, [], False
 
@@ -174,6 +215,7 @@ def _apply_rsvp_in_transaction(
             "status": final_status,
             "has_plus_one": final_plus_one,
             "cancelled_at": _resolve_cancelled_at(existing, final_status),
+            "answers": answers_snapshot,
         },
     )
 
@@ -187,7 +229,14 @@ def _apply_rsvp_in_transaction(
 
 @router.post(
     "/events/{event_id}/rsvp/",
-    response={200: EventOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut, 429: ErrorOut},
+    response={
+        200: EventOut,
+        400: ErrorOut,
+        403: ErrorOut,
+        404: ErrorOut,
+        422: ErrorOut,
+        429: ErrorOut,
+    },
     auth=gated_jwt,
 )
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="10/m")
@@ -201,7 +250,11 @@ def upsert_rsvp(request, event_id: UUID, payload: RSVPIn):
 
     with transaction.atomic():
         final_status, promoted_user_ids, _created = _apply_rsvp_in_transaction(
-            event_id, request.auth, payload.status, payload.has_plus_one
+            event_id,
+            request.auth,
+            payload.status,
+            payload.has_plus_one,
+            answers=payload.answers,
         )
 
     _post_rsvp_comment(event_id, request.auth, final_status, payload.comment)

--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -1,14 +1,18 @@
 import re
 from datetime import datetime
+from typing import Annotated, Literal
 from urllib.parse import urlparse
+from uuid import UUID
 
 import phonenumbers
 from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic.json_schema import WithJsonSchema
 
 from community._field_limits import FieldLimit
 from community._shared import require_url_path, validate_whatsapp_url
 from community._validation import Code, raise_validation
 from community.models import (
+    RSVP_CHOICE_TYPES,
     AttendanceStatus,
     EventStatus,
     EventType,
@@ -17,9 +21,71 @@ from community.models import (
     RSVPStatus,
 )
 
-# Loose RFC-5322-ish email check — Pydantic's full EmailStr validator is
-# overkill for a free-text payment field, and we don't need DNS lookups.
 _EMAIL_RE = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
+
+RsvpQuestionFieldType = Literal["textarea", "dropdown", "multiselect"]
+RsvpQuestionOption = Annotated[str, Field(max_length=FieldLimit.OPTION_TEXT)]
+RsvpAnswer = Annotated[str, WithJsonSchema({"type": "string", "maxLength": FieldLimit.DESCRIPTION})]
+
+
+class EventRsvpQuestionOut(BaseModel):
+    id: str
+    label: str
+    field_type: RsvpQuestionFieldType
+    options: list[str] = []
+    required: bool
+    display_order: int
+
+
+class EventRsvpQuestionIn(BaseModel):
+    label: str = Field(max_length=FieldLimit.SHORT_TEXT)
+    field_type: RsvpQuestionFieldType
+    options: list[RsvpQuestionOption] = []
+    required: bool = False
+
+    @field_validator("label")
+    @classmethod
+    def label_not_blank(cls, value: str) -> str:
+        trimmed = value.strip()
+        if not trimmed:
+            raise ValueError("label required")
+        return trimmed
+
+    @field_validator("options")
+    @classmethod
+    def trim_options(cls, value: list[str]) -> list[str]:
+        trimmed = [o.strip() for o in value if o.strip()]
+        if any(len(option) > FieldLimit.OPTION_TEXT for option in trimmed):
+            raise ValueError(f"options must be {FieldLimit.OPTION_TEXT} characters or fewer")
+        return trimmed
+
+
+class EventRsvpQuestionSyncIn(EventRsvpQuestionIn):
+    id: UUID | None = None
+
+
+class EventRsvpQuestionExpectedIn(EventRsvpQuestionIn):
+    id: UUID
+
+
+class EventRsvpQuestionSyncPayload(BaseModel):
+    expected: list[EventRsvpQuestionExpectedIn]
+    questions: list[EventRsvpQuestionSyncIn]
+
+
+def validate_event_rsvp_question(payload: EventRsvpQuestionIn) -> None:
+    if payload.field_type in RSVP_CHOICE_TYPES and not payload.options:
+        raise_validation(
+            Code.Event.RSVP_QUESTION_OPTIONS_REQUIRED,
+            field="options",
+            status_code=400,
+        )
+    if payload.field_type == "multiselect" and any("," in option for option in payload.options):
+        raise_validation(
+            Code.Event.RSVP_QUESTION_OPTION_NO_COMMA,
+            field="options",
+            status_code=400,
+        )
 
 
 def _looks_like_email(s: str) -> bool:
@@ -193,6 +259,7 @@ class EventOut(BaseModel):
     co_host_photo_urls: list[str] = []
     guests: list[RSVPGuestOut] = []
     my_rsvp: str | None = None
+    my_rsvp_answers: dict = {}
     # Same gating as my_rsvp (both derive from the resolved viewer in
     # _event_out) — lets a token-holding, not-logged-in viewer identify their
     # own entry in `guests` without a real auth session to key off of.
@@ -220,6 +287,7 @@ class EventOut(BaseModel):
     pending_cohost_invites: list[PendingCoHostInviteOut] = []
     my_pending_cohost_invite_id: str | None = None
     tags: list[TagOut] = []
+    rsvp_questions: list[EventRsvpQuestionOut] = []
 
 
 class RSVPIn(BaseModel):
@@ -228,6 +296,10 @@ class RSVPIn(BaseModel):
     # Not persisted on the RSVP — a non-empty value is a one-time post: a
     # public EventComment (going/maybe) or a host-only notification (can't go).
     comment: str | None = Field(default=None, max_length=FieldLimit.SHORT_TEXT)
+    answers: dict[str, RsvpAnswer] = Field(
+        default_factory=dict,
+        description="Question UUID to answer; multiselect values are comma-separated.",
+    )
 
 
 class HostRSVPIn(BaseModel):
@@ -307,6 +379,7 @@ class EventIn(BaseModel):
     )
     co_host_ids: list[str] = []
     tag_ids: list[str] = []
+    rsvp_questions: list[EventRsvpQuestionIn] = []
     status: str = Field(default=EventStatus.ACTIVE, max_length=FieldLimit.CHOICE)
 
     @model_validator(mode="after")

--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -23,7 +23,7 @@ from community.models import (
 
 _EMAIL_RE = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
 
-RsvpQuestionFieldType = Literal["textarea", "dropdown", "multiselect"]
+RsvpQuestionFieldType = Literal["textarea", "select", "checkbox"]
 RsvpQuestionOption = Annotated[str, Field(max_length=FieldLimit.OPTION_TEXT)]
 RsvpAnswer = Annotated[str, WithJsonSchema({"type": "string", "maxLength": FieldLimit.DESCRIPTION})]
 
@@ -80,7 +80,7 @@ def validate_event_rsvp_question(payload: EventRsvpQuestionIn) -> None:
             field="options",
             status_code=400,
         )
-    if payload.field_type == "multiselect" and any("," in option for option in payload.options):
+    if payload.field_type == "checkbox" and any("," in option for option in payload.options):
         raise_validation(
             Code.Event.RSVP_QUESTION_OPTION_NO_COMMA,
             field="options",
@@ -298,7 +298,7 @@ class RSVPIn(BaseModel):
     comment: str | None = Field(default=None, max_length=FieldLimit.SHORT_TEXT)
     answers: dict[str, RsvpAnswer] = Field(
         default_factory=dict,
-        description="Question UUID to answer; multiselect values are comma-separated.",
+        description="Question UUID to answer; checkbox values are comma-separated.",
     )
 
 

--- a/backend/community/_events.py
+++ b/backend/community/_events.py
@@ -35,6 +35,7 @@ from community._event_schemas import (
     EventListOut,
     EventOut,
     EventPatchIn,
+    validate_event_rsvp_question,
 )
 from community._event_transitions import (
     _handle_status_update,
@@ -46,6 +47,7 @@ from community._shared import ErrorOut, _authenticated_user, _members_only, _opt
 from community._validation import Code, raise_validation
 from community.models import (
     Event,
+    EventRsvpQuestion,
     EventStatus,
     EventType,
     PageVisibility,
@@ -287,7 +289,7 @@ def get_event(request, event_id: str):
     try:
         event = (
             Event.objects.select_related("created_by")
-            .prefetch_related("co_hosts", "invited_users", "rsvps__user", "tags")
+            .prefetch_related("co_hosts", "invited_users", "rsvps__user", "tags", "rsvp_questions")
             .annotate(
                 comment_count=Count(
                     "comments",
@@ -306,10 +308,11 @@ def get_event(request, event_id: str):
 
 @router.post(
     "/events/",
-    response={201: EventOut, 400: ErrorOut, 403: ErrorOut, 429: ErrorOut},
+    response={201: EventOut, 400: ErrorOut, 403: ErrorOut, 422: ErrorOut, 429: ErrorOut},
     auth=gated_jwt,
 )
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="10/d")
+@transaction.atomic
 def create_event(request, payload: EventIn):
     # Any authenticated member can create community or draft events.
     # Official/club events require their respective tag permission.
@@ -332,6 +335,8 @@ def create_event(request, payload: EventIn):
             payload.datetime_tbd,
             check_past=True,
         )
+    for question in payload.rsvp_questions:
+        validate_event_rsvp_question(question)
 
     event = Event.objects.create(
         title=payload.title,
@@ -360,6 +365,19 @@ def create_event(request, payload: EventIn):
     )
     _set_event_participants(request, event, payload.co_host_ids)
     _set_event_tags(event, payload.tag_ids)
+    EventRsvpQuestion.objects.bulk_create(
+        [
+            EventRsvpQuestion(
+                event=event,
+                label=question.label,
+                field_type=question.field_type,
+                options=question.options,
+                required=question.required,
+                display_order=display_order,
+            )
+            for display_order, question in enumerate(payload.rsvp_questions)
+        ]
+    )
     if event.status == EventStatus.ACTIVE:
         transaction.on_commit(lambda: broadcast_event_created(event))
     audit_log(
@@ -416,7 +434,7 @@ def update_event(request, event_id: UUID, payload: EventPatchIn):
     try:
         event = (
             Event.objects.select_related("created_by")
-            .prefetch_related("co_hosts", "invited_users", "rsvps__user", "tags")
+            .prefetch_related("co_hosts", "invited_users", "rsvps__user", "tags", "rsvp_questions")
             .get(id=event_id)
         )
     except Event.DoesNotExist:

--- a/backend/community/_validation.py
+++ b/backend/community/_validation.py
@@ -29,6 +29,14 @@ class Code:
         RSVP_NOT_FOUND = "event.rsvp_not_found"
         MEMBER_CONTACT_MUST_SIGN_IN = "event.member_contact_must_sign_in"
         RSVP_COULD_NOT_BE_CREATED = "event.rsvp_could_not_be_created"  # generic, no-oracle
+        RSVP_QUESTION_NOT_FOUND = "event.rsvp_question_not_found"
+        RSVP_QUESTION_DUPLICATE = "event.rsvp_question_duplicate"
+        RSVP_QUESTION_CONFLICT = "event.rsvp_question_conflict"
+        RSVP_QUESTION_OPTIONS_REQUIRED = "event.rsvp_question_options_required"
+        RSVP_QUESTION_OPTION_NO_COMMA = "event.rsvp_question_option_no_comma"
+        RSVP_ANSWER_REQUIRED = "event.rsvp_answer_required"  # params: { label: str }
+        RSVP_ANSWER_INVALID_OPTION = "event.rsvp_answer_invalid_option"  # params: { label: str }
+        RSVP_ANSWER_TOO_LONG = "event.rsvp_answer_too_long"  # params: { label: str, max: int }
         ATTENDANCE_OPENS_LATER = "event.attendance_opens_later"
         ATTENDANCE_ONLY_FOR_GOING_RSVPS = "event.attendance_only_for_going_rsvps"
         PERM_DENIED = "event.perm_denied"  # params: { action?: str }

--- a/backend/community/api.py
+++ b/backend/community/api.py
@@ -21,6 +21,7 @@ from community._event_host_actions import router as event_host_actions_router
 from community._event_host_rsvps import router as event_host_rsvps_router
 from community._event_invitations import router as event_invitations_router
 from community._event_report import router as event_report_router
+from community._event_rsvp_questions import router as event_rsvp_questions_router
 from community._event_rsvps import router as event_rsvps_router
 from community._event_schemas import EventPatchIn  # noqa: F401
 from community._event_tags import router as event_tags_router
@@ -71,6 +72,7 @@ router.add_router("", attendance_report_router)
 router.add_router("", events_router)
 router.add_router("", event_tags_router)
 router.add_router("", event_rsvps_router)
+router.add_router("", event_rsvp_questions_router)
 router.add_router("", event_host_actions_router)
 router.add_router("", event_host_rsvps_router)
 router.add_router("", event_report_router)

--- a/backend/community/migrations/0089_event_rsvp_questions.py
+++ b/backend/community/migrations/0089_event_rsvp_questions.py
@@ -30,8 +30,8 @@ class Migration(migrations.Migration):
                     models.CharField(
                         choices=[
                             ("textarea", "Text area"),
-                            ("dropdown", "Dropdown"),
-                            ("multiselect", "Multi select"),
+                            ("select", "Select"),
+                            ("checkbox", "Checkbox"),
                         ],
                         max_length=20,
                     ),

--- a/backend/community/migrations/0089_event_rsvp_questions.py
+++ b/backend/community/migrations/0089_event_rsvp_questions.py
@@ -1,0 +1,53 @@
+import uuid
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("community", "0088_join_form_question_types"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="eventrsvp",
+            name="answers",
+            field=models.JSONField(blank=True, default=dict),
+        ),
+        migrations.CreateModel(
+            name="EventRsvpQuestion",
+            fields=[
+                (
+                    "id",
+                    models.UUIDField(
+                        default=uuid.uuid4, editable=False, primary_key=True, serialize=False
+                    ),
+                ),
+                ("label", models.CharField(max_length=300)),
+                (
+                    "field_type",
+                    models.CharField(
+                        choices=[
+                            ("textarea", "Text area"),
+                            ("dropdown", "Dropdown"),
+                            ("multiselect", "Multi select"),
+                        ],
+                        max_length=20,
+                    ),
+                ),
+                ("options", models.JSONField(blank=True, default=list)),
+                ("required", models.BooleanField(default=False)),
+                ("display_order", models.PositiveIntegerField(default=0)),
+                (
+                    "event",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="rsvp_questions",
+                        to="community.event",
+                    ),
+                ),
+            ],
+            options={"ordering": ["display_order"]},
+        ),
+    ]

--- a/backend/community/models/__init__.py
+++ b/backend/community/models/__init__.py
@@ -1,5 +1,7 @@
 from community.models.attendance_reminder import AttendanceMilestone, AttendanceReminder
 from community.models.choices import (
+    RSVP_CHOICE_TYPES,
+    RSVP_QUESTION_TYPE_CHOICES,
     AttendanceStatus,
     CoHostInviteStatus,
     EventFlagStatus,
@@ -14,6 +16,7 @@ from community.models.choices import (
     PollAvailability,
     QuestionType,
     RSVPStatus,
+    RsvpQuestionType,
     SurveyQuestionType,
     SurveyVisibility,
 )
@@ -37,6 +40,7 @@ from community.models.event import (
     EventFlag,
     EventRef,
     EventRSVP,
+    EventRsvpQuestion,
     event_lookup_q,
     parse_event_ref,
 )
@@ -67,7 +71,10 @@ __all__ = [
     "PageVisibility",
     "PollAvailability",
     "QuestionType",
+    "RSVP_CHOICE_TYPES",
+    "RSVP_QUESTION_TYPE_CHOICES",
     "RSVPStatus",
+    "RsvpQuestionType",
     "SurveyQuestionType",
     "SurveyVisibility",
     "EventCoHostInvite",
@@ -86,6 +93,7 @@ __all__ = [
     "EventEmailBlast",
     "EventFlag",
     "EventRef",
+    "EventRsvpQuestion",
     "EventRSVP",
     "EventTag",
     "event_lookup_q",

--- a/backend/community/models/choices.py
+++ b/backend/community/models/choices.py
@@ -75,6 +75,20 @@ class JoinFormQuestionType(models.TextChoices):
     SELECT = QuestionType.SELECT.value, QuestionType.SELECT.label
 
 
+class RsvpQuestionType(models.TextChoices):
+    """Question types supported by event RSVP questions."""
+
+    TEXTAREA = QuestionType.TEXTAREA.value, QuestionType.TEXTAREA.label
+    DROPDOWN = QuestionType.DROPDOWN.value, QuestionType.DROPDOWN.label
+    MULTISELECT = QuestionType.MULTISELECT.value, QuestionType.MULTISELECT.label
+
+
+RSVP_QUESTION_TYPE_CHOICES = RsvpQuestionType.choices
+RSVP_CHOICE_TYPES = frozenset(
+    {RsvpQuestionType.DROPDOWN, RsvpQuestionType.MULTISELECT},
+)
+
+
 class InvitePermission(models.TextChoices):
     ALL_MEMBERS = "all_members", "All members"
     CO_HOSTS_ONLY = "co_hosts_only", "Co-hosts only"

--- a/backend/community/models/choices.py
+++ b/backend/community/models/choices.py
@@ -79,13 +79,13 @@ class RsvpQuestionType(models.TextChoices):
     """Question types supported by event RSVP questions."""
 
     TEXTAREA = QuestionType.TEXTAREA.value, QuestionType.TEXTAREA.label
-    DROPDOWN = QuestionType.DROPDOWN.value, QuestionType.DROPDOWN.label
-    MULTISELECT = QuestionType.MULTISELECT.value, QuestionType.MULTISELECT.label
+    SELECT = QuestionType.SELECT.value, QuestionType.SELECT.label
+    CHECKBOX = QuestionType.CHECKBOX.value, QuestionType.CHECKBOX.label
 
 
 RSVP_QUESTION_TYPE_CHOICES = RsvpQuestionType.choices
 RSVP_CHOICE_TYPES = frozenset(
-    {RsvpQuestionType.DROPDOWN, RsvpQuestionType.MULTISELECT},
+    {RsvpQuestionType.SELECT, RsvpQuestionType.CHECKBOX},
 )
 
 

--- a/backend/community/models/event.py
+++ b/backend/community/models/event.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from django.utils.text import slugify
 
 from community.models.choices import (
+    RSVP_QUESTION_TYPE_CHOICES,
     AttendanceStatus,
     EventFlagStatus,
     EventStatus,
@@ -157,6 +158,7 @@ class Event(models.Model):
     if TYPE_CHECKING:
         created_by_id: uuid.UUID | None
         rsvps: "Manager[EventRSVP]"
+        rsvp_questions: "Manager[EventRsvpQuestion]"
         surveys: "Manager[Survey]"
         poll: "EventPoll"
         comments: "Manager[EventComment]"
@@ -275,6 +277,8 @@ class EventRSVP(models.Model):
     # member re-RSVPs going/maybe. Accurate cancellation lead-time (unlike the
     # lossy updated_at proxy, which any later save would overwrite).
     cancelled_at = models.DateTimeField(null=True, blank=True)
+    # Snapshot of RSVP question answers: {question_id: {label, answer}}.
+    answers = models.JSONField(default=dict, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 
@@ -289,6 +293,23 @@ class EventRSVP(models.Model):
         return (
             f"{self.user.full_name or self.user.phone_number} → {self.event.title}: {self.status}"
         )
+
+
+class EventRsvpQuestion(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    event = models.ForeignKey(Event, on_delete=models.CASCADE, related_name="rsvp_questions")
+    label = models.CharField(max_length=300)
+    field_type = models.CharField(max_length=20, choices=RSVP_QUESTION_TYPE_CHOICES)
+    options = models.JSONField(default=list, blank=True)
+    required = models.BooleanField(default=False)
+    display_order = models.PositiveIntegerField(default=0)
+
+    class Meta:
+        app_label = "community"
+        ordering = ["display_order"]
+
+    def __str__(self):
+        return f"{self.label} ({self.event.title})"
 
 
 class EventFlag(models.Model):

--- a/backend/community/validation_codes.json
+++ b/backend/community/validation_codes.json
@@ -122,6 +122,53 @@
         "params": []
       },
       {
+        "name": "RSVP_QUESTION_NOT_FOUND",
+        "value": "event.rsvp_question_not_found",
+        "params": []
+      },
+      {
+        "name": "RSVP_QUESTION_DUPLICATE",
+        "value": "event.rsvp_question_duplicate",
+        "params": []
+      },
+      {
+        "name": "RSVP_QUESTION_CONFLICT",
+        "value": "event.rsvp_question_conflict",
+        "params": []
+      },
+      {
+        "name": "RSVP_QUESTION_OPTIONS_REQUIRED",
+        "value": "event.rsvp_question_options_required",
+        "params": []
+      },
+      {
+        "name": "RSVP_QUESTION_OPTION_NO_COMMA",
+        "value": "event.rsvp_question_option_no_comma",
+        "params": []
+      },
+      {
+        "name": "RSVP_ANSWER_REQUIRED",
+        "value": "event.rsvp_answer_required",
+        "params": [
+          "label"
+        ]
+      },
+      {
+        "name": "RSVP_ANSWER_INVALID_OPTION",
+        "value": "event.rsvp_answer_invalid_option",
+        "params": [
+          "label"
+        ]
+      },
+      {
+        "name": "RSVP_ANSWER_TOO_LONG",
+        "value": "event.rsvp_answer_too_long",
+        "params": [
+          "label",
+          "max"
+        ]
+      },
+      {
         "name": "ATTENDANCE_OPENS_LATER",
         "value": "event.attendance_opens_later",
         "params": []

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -1579,6 +1579,14 @@
             "title": "Rsvp Enabled",
             "type": "boolean"
           },
+          "rsvp_questions": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/EventRsvpQuestionIn"
+            },
+            "title": "Rsvp Questions",
+            "type": "array"
+          },
           "start_datetime": {
             "anyOf": [
               {
@@ -2132,6 +2140,12 @@
             ],
             "title": "My Rsvp"
           },
+          "my_rsvp_answers": {
+            "additionalProperties": true,
+            "default": {},
+            "title": "My Rsvp Answers",
+            "type": "object"
+          },
           "other_link": {
             "default": "",
             "title": "Other Link",
@@ -2175,6 +2189,14 @@
             "default": false,
             "title": "Rsvp Enabled",
             "type": "boolean"
+          },
+          "rsvp_questions": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/EventRsvpQuestionOut"
+            },
+            "title": "Rsvp Questions",
+            "type": "array"
           },
           "slug": {
             "default": "",
@@ -2770,6 +2792,208 @@
           "votes"
         ],
         "title": "EventPollVoteIn",
+        "type": "object"
+      },
+      "EventRsvpQuestionExpectedIn": {
+        "properties": {
+          "field_type": {
+            "enum": [
+              "textarea",
+              "dropdown",
+              "multiselect"
+            ],
+            "title": "Field Type",
+            "type": "string"
+          },
+          "id": {
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
+          "label": {
+            "maxLength": 300,
+            "title": "Label",
+            "type": "string"
+          },
+          "options": {
+            "default": [],
+            "items": {
+              "maxLength": 200,
+              "type": "string"
+            },
+            "title": "Options",
+            "type": "array"
+          },
+          "required": {
+            "default": false,
+            "title": "Required",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "label",
+          "field_type",
+          "id"
+        ],
+        "title": "EventRsvpQuestionExpectedIn",
+        "type": "object"
+      },
+      "EventRsvpQuestionIn": {
+        "properties": {
+          "field_type": {
+            "enum": [
+              "textarea",
+              "dropdown",
+              "multiselect"
+            ],
+            "title": "Field Type",
+            "type": "string"
+          },
+          "label": {
+            "maxLength": 300,
+            "title": "Label",
+            "type": "string"
+          },
+          "options": {
+            "default": [],
+            "items": {
+              "maxLength": 200,
+              "type": "string"
+            },
+            "title": "Options",
+            "type": "array"
+          },
+          "required": {
+            "default": false,
+            "title": "Required",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "label",
+          "field_type"
+        ],
+        "title": "EventRsvpQuestionIn",
+        "type": "object"
+      },
+      "EventRsvpQuestionOut": {
+        "properties": {
+          "display_order": {
+            "title": "Display Order",
+            "type": "integer"
+          },
+          "field_type": {
+            "enum": [
+              "textarea",
+              "dropdown",
+              "multiselect"
+            ],
+            "title": "Field Type",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "label": {
+            "title": "Label",
+            "type": "string"
+          },
+          "options": {
+            "default": [],
+            "items": {
+              "type": "string"
+            },
+            "title": "Options",
+            "type": "array"
+          },
+          "required": {
+            "title": "Required",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "id",
+          "label",
+          "field_type",
+          "required",
+          "display_order"
+        ],
+        "title": "EventRsvpQuestionOut",
+        "type": "object"
+      },
+      "EventRsvpQuestionSyncIn": {
+        "properties": {
+          "field_type": {
+            "enum": [
+              "textarea",
+              "dropdown",
+              "multiselect"
+            ],
+            "title": "Field Type",
+            "type": "string"
+          },
+          "id": {
+            "anyOf": [
+              {
+                "format": "uuid",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "label": {
+            "maxLength": 300,
+            "title": "Label",
+            "type": "string"
+          },
+          "options": {
+            "default": [],
+            "items": {
+              "maxLength": 200,
+              "type": "string"
+            },
+            "title": "Options",
+            "type": "array"
+          },
+          "required": {
+            "default": false,
+            "title": "Required",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "label",
+          "field_type"
+        ],
+        "title": "EventRsvpQuestionSyncIn",
+        "type": "object"
+      },
+      "EventRsvpQuestionSyncPayload": {
+        "properties": {
+          "expected": {
+            "items": {
+              "$ref": "#/components/schemas/EventRsvpQuestionExpectedIn"
+            },
+            "title": "Expected",
+            "type": "array"
+          },
+          "questions": {
+            "items": {
+              "$ref": "#/components/schemas/EventRsvpQuestionSyncIn"
+            },
+            "title": "Questions",
+            "type": "array"
+          }
+        },
+        "required": [
+          "expected",
+          "questions"
+        ],
+        "title": "EventRsvpQuestionSyncPayload",
         "type": "object"
       },
       "EventStatsOut": {
@@ -4716,6 +4940,15 @@
       },
       "RSVPIn": {
         "properties": {
+          "answers": {
+            "additionalProperties": {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            "description": "Question UUID to answer; multiselect values are comma-separated.",
+            "title": "Answers",
+            "type": "object"
+          },
           "comment": {
             "anyOf": [
               {
@@ -8641,6 +8874,16 @@
             },
             "description": "Forbidden"
           },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Unprocessable Content"
+          },
           "429": {
             "content": {
               "application/json": {
@@ -10798,6 +11041,98 @@
         ]
       }
     },
+    "/api/community/events/{event_id}/rsvp-questions/": {
+      "put": {
+        "operationId": "community__event_rsvp_questions_replace_event_rsvp_questions",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "event_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Event Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventRsvpQuestionSyncPayload"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/EventRsvpQuestionOut"
+                  },
+                  "title": "Response",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Unprocessable Content"
+          }
+        },
+        "security": [
+          {
+            "GatedJWTAuth": []
+          }
+        ],
+        "summary": "Replace Event Rsvp Questions",
+        "tags": [
+          "community"
+        ]
+      }
+    },
     "/api/community/events/{event_id}/rsvp/": {
       "delete": {
         "operationId": "community__event_rsvps_delete_rsvp",
@@ -10932,6 +11267,16 @@
               }
             },
             "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Unprocessable Content"
           },
           "429": {
             "content": {

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -2799,8 +2799,8 @@
           "field_type": {
             "enum": [
               "textarea",
-              "dropdown",
-              "multiselect"
+              "select",
+              "checkbox"
             ],
             "title": "Field Type",
             "type": "string"
@@ -2843,8 +2843,8 @@
           "field_type": {
             "enum": [
               "textarea",
-              "dropdown",
-              "multiselect"
+              "select",
+              "checkbox"
             ],
             "title": "Field Type",
             "type": "string"
@@ -2885,8 +2885,8 @@
           "field_type": {
             "enum": [
               "textarea",
-              "dropdown",
-              "multiselect"
+              "select",
+              "checkbox"
             ],
             "title": "Field Type",
             "type": "string"
@@ -2927,8 +2927,8 @@
           "field_type": {
             "enum": [
               "textarea",
-              "dropdown",
-              "multiselect"
+              "select",
+              "checkbox"
             ],
             "title": "Field Type",
             "type": "string"
@@ -4945,7 +4945,7 @@
               "maxLength": 2000,
               "type": "string"
             },
-            "description": "Question UUID to answer; multiselect values are comma-separated.",
+            "description": "Question UUID to answer; checkbox values are comma-separated.",
             "title": "Answers",
             "type": "object"
           },

--- a/backend/tests/test_event_rsvp_question_sync.py
+++ b/backend/tests/test_event_rsvp_question_sync.py
@@ -22,7 +22,7 @@ def rsvp_event(db, test_user):
 def _create_question(event, **overrides):
     data = {
         "label": "how are you getting there?",
-        "field_type": "dropdown",
+        "field_type": "select",
         "options": ["driving", "transit"],
         "required": True,
         "display_order": event.rsvp_questions.count(),
@@ -56,7 +56,7 @@ class TestEventRsvpQuestionSync:
                     {
                         "id": None,
                         "label": "new",
-                        "field_type": "dropdown",
+                        "field_type": "select",
                         "options": ["a", "b"],
                         "required": True,
                     },

--- a/backend/tests/test_event_rsvp_question_sync.py
+++ b/backend/tests/test_event_rsvp_question_sync.py
@@ -1,0 +1,186 @@
+from unittest.mock import patch
+
+import pytest
+from community._validation import Code
+from community.models import Event, EventRsvpQuestion
+
+from tests._asserts import assert_error_code
+from tests.conftest import future_iso
+
+
+@pytest.fixture
+def rsvp_event(db, test_user):
+    return Event.objects.create(
+        title="Questions Event",
+        start_datetime=future_iso(days=30),
+        end_datetime=future_iso(days=30, hours=2),
+        rsvp_enabled=True,
+        created_by=test_user,
+    )
+
+
+def _create_question(event, **overrides):
+    data = {
+        "label": "how are you getting there?",
+        "field_type": "dropdown",
+        "options": ["driving", "transit"],
+        "required": True,
+        "display_order": event.rsvp_questions.count(),
+        **overrides,
+    }
+    question = EventRsvpQuestion.objects.create(event=event, **data)
+    return {
+        "id": str(question.id),
+        **data,
+    }
+
+
+@pytest.mark.django_db
+class TestEventRsvpQuestionSync:
+    def test_host_can_atomically_replace_questions(self, api_client, auth_headers, rsvp_event):
+        existing = _create_question(rsvp_event)
+        removed = _create_question(rsvp_event, label="remove me")
+
+        response = api_client.put(
+            f"/api/community/events/{rsvp_event.id}/rsvp-questions/",
+            {
+                "expected": [existing, removed],
+                "questions": [
+                    {
+                        "id": existing["id"],
+                        "label": "updated",
+                        "field_type": "textarea",
+                        "options": [],
+                        "required": False,
+                    },
+                    {
+                        "id": None,
+                        "label": "new",
+                        "field_type": "dropdown",
+                        "options": ["a", "b"],
+                        "required": True,
+                    },
+                ],
+            },
+            content_type="application/json",
+            **auth_headers,
+        )
+
+        assert response.status_code == 200
+        assert [q["label"] for q in response.json()] == ["updated", "new"]
+        assert [q["display_order"] for q in response.json()] == [0, 1]
+        assert not EventRsvpQuestion.objects.filter(id=removed["id"]).exists()
+
+    def test_replace_questions_rolls_back_when_id_is_unknown(
+        self, api_client, auth_headers, rsvp_event
+    ):
+        existing = _create_question(rsvp_event)
+        response = api_client.put(
+            f"/api/community/events/{rsvp_event.id}/rsvp-questions/",
+            {
+                "expected": [existing],
+                "questions": [
+                    {**existing, "label": "changed"},
+                    {
+                        "id": "00000000-0000-0000-0000-000000000001",
+                        "label": "missing",
+                        "field_type": "textarea",
+                        "options": [],
+                        "required": False,
+                    },
+                ],
+            },
+            content_type="application/json",
+            **auth_headers,
+        )
+
+        assert response.status_code == 404
+        assert EventRsvpQuestion.objects.get(id=existing["id"]).label == existing["label"]
+
+    def test_replace_questions_rejects_stale_baseline(self, api_client, auth_headers, rsvp_event):
+        existing = _create_question(rsvp_event)
+        _create_question(rsvp_event, label="concurrent")
+
+        response = api_client.put(
+            f"/api/community/events/{rsvp_event.id}/rsvp-questions/",
+            {"expected": [existing], "questions": [existing]},
+            content_type="application/json",
+            **auth_headers,
+        )
+
+        assert response.status_code == 409
+        assert EventRsvpQuestion.objects.filter(event=rsvp_event).count() == 2
+
+    def test_replace_questions_rejects_duplicate_ids(self, api_client, auth_headers, rsvp_event):
+        existing = _create_question(rsvp_event)
+        response = api_client.put(
+            f"/api/community/events/{rsvp_event.id}/rsvp-questions/",
+            {"expected": [existing], "questions": [existing, existing]},
+            content_type="application/json",
+            **auth_headers,
+        )
+
+        assert response.status_code == 400
+        assert_error_code(response, Code.Event.RSVP_QUESTION_DUPLICATE)
+
+    def test_replace_questions_rolls_back_after_write_failure(
+        self, api_client, auth_headers, rsvp_event
+    ):
+        existing = _create_question(rsvp_event)
+        real_save = EventRsvpQuestion.save
+        save_count = 0
+
+        def fail_second_save(question, *args, **kwargs):
+            nonlocal save_count
+            save_count += 1
+            if save_count == 2:
+                raise RuntimeError("simulated write failure")
+            return real_save(question, *args, **kwargs)
+
+        with (
+            patch.object(EventRsvpQuestion, "save", fail_second_save),
+            pytest.raises(RuntimeError, match="simulated write failure"),
+        ):
+            api_client.put(
+                f"/api/community/events/{rsvp_event.id}/rsvp-questions/",
+                {
+                    "expected": [existing],
+                    "questions": [
+                        {**existing, "label": "changed"},
+                        {
+                            "id": None,
+                            "label": "new",
+                            "field_type": "textarea",
+                            "options": [],
+                            "required": False,
+                        },
+                    ],
+                },
+                content_type="application/json",
+                **auth_headers,
+            )
+
+        assert EventRsvpQuestion.objects.get(id=existing["id"]).label == existing["label"]
+        assert EventRsvpQuestion.objects.filter(event=rsvp_event).count() == 1
+
+    def test_create_event_saves_questions_atomically(self, api_client, auth_headers):
+        response = api_client.post(
+            "/api/community/events/",
+            {
+                "title": "draft with questions",
+                "status": "draft",
+                "rsvp_questions": [
+                    {
+                        "label": "dietary?",
+                        "field_type": "textarea",
+                        "options": [],
+                        "required": True,
+                    }
+                ],
+            },
+            content_type="application/json",
+            **auth_headers,
+        )
+
+        assert response.status_code == 201
+        assert response.json()["rsvp_questions"][0]["label"] == "dietary?"

--- a/backend/tests/test_event_rsvp_questions.py
+++ b/backend/tests/test_event_rsvp_questions.py
@@ -1,0 +1,201 @@
+"""Tests for per-event RSVP questions and answers on RSVP."""
+
+import pytest
+from community._validation import Code
+from community.models import Event, EventRSVP, EventRsvpQuestion, RSVPStatus
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
+
+from tests._asserts import assert_error_code
+from tests.conftest import future_iso
+
+
+@pytest.fixture
+def rsvp_event(db, test_user):
+    return Event.objects.create(
+        title="Questions Event",
+        start_datetime=future_iso(days=30),
+        end_datetime=future_iso(days=30, hours=2),
+        rsvp_enabled=True,
+        created_by=test_user,
+    )
+
+
+@pytest.fixture
+def other_user(db):
+    return User.objects.create_user(
+        phone_number="+12025550999",
+        password="otherpass",
+        first_name="Other",
+        last_name="Guest",
+    )
+
+
+@pytest.fixture
+def other_headers(other_user):
+    refresh = RefreshToken.for_user(other_user)
+    return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
+
+
+def _question_data(**overrides):
+    return {
+        "label": "how are you getting there?",
+        "field_type": "dropdown",
+        "options": ["driving", "transit"],
+        "required": True,
+        **overrides,
+    }
+
+
+def _create_question(event, **overrides):
+    question = EventRsvpQuestion.objects.create(event=event, **_question_data(**overrides))
+    return {"id": str(question.id)}
+
+
+def _replace_question(api_client, auth_headers, event_id, **overrides):
+    return api_client.put(
+        f"/api/community/events/{event_id}/rsvp-questions/",
+        {"expected": [], "questions": [{"id": None, **_question_data(**overrides)}]},
+        content_type="application/json",
+        **auth_headers,
+    )
+
+
+@pytest.mark.django_db
+def test_event_out_includes_questions(api_client, auth_headers, rsvp_event):
+    _create_question(rsvp_event)
+    response = api_client.get(f"/api/community/events/{rsvp_event.id}/", **auth_headers)
+    assert response.status_code == 200
+    questions = response.json()["rsvp_questions"]
+    assert len(questions) == 1
+    assert questions[0]["label"] == "how are you getting there?"
+
+
+@pytest.mark.django_db
+class TestRsvpWithAnswers:
+    def test_required_answer_blocks_attending(
+        self, api_client, other_headers, auth_headers, rsvp_event
+    ):
+        q = _create_question(rsvp_event)
+        response = api_client.post(
+            f"/api/community/events/{rsvp_event.id}/rsvp/",
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": False},
+            content_type="application/json",
+            **other_headers,
+        )
+        assert response.status_code == 422
+        assert_error_code(response, Code.Event.RSVP_ANSWER_REQUIRED)
+
+        ok = api_client.post(
+            f"/api/community/events/{rsvp_event.id}/rsvp/",
+            {
+                "status": RSVPStatus.ATTENDING,
+                "has_plus_one": False,
+                "answers": {q["id"]: "driving"},
+            },
+            content_type="application/json",
+            **other_headers,
+        )
+        assert ok.status_code == 200
+        rsvp = EventRSVP.objects.get(event=rsvp_event)
+        assert rsvp.answers[q["id"]]["answer"] == "driving"
+        assert ok.json()["my_rsvp_answers"][q["id"]]["answer"] == "driving"
+
+    def test_cant_go_skips_required_answers(
+        self, api_client, other_headers, auth_headers, rsvp_event
+    ):
+        _create_question(rsvp_event)
+        response = api_client.post(
+            f"/api/community/events/{rsvp_event.id}/rsvp/",
+            {"status": RSVPStatus.CANT_GO, "has_plus_one": False},
+            content_type="application/json",
+            **other_headers,
+        )
+        assert response.status_code == 200
+
+    def test_invalid_option_rejected(self, api_client, other_headers, auth_headers, rsvp_event):
+        q = _create_question(rsvp_event)
+        response = api_client.post(
+            f"/api/community/events/{rsvp_event.id}/rsvp/",
+            {
+                "status": RSVPStatus.MAYBE,
+                "answers": {q["id"]: "helicopter"},
+            },
+            content_type="application/json",
+            **other_headers,
+        )
+        assert response.status_code == 422
+        assert_error_code(response, Code.Event.RSVP_ANSWER_INVALID_OPTION)
+
+
+@pytest.mark.django_db
+class TestRsvpAnswerEdgeCases:
+    def test_multiselect_comma_only_required_rejected(
+        self, api_client, other_headers, auth_headers, rsvp_event
+    ):
+        q = _create_question(
+            rsvp_event,
+            field_type="multiselect",
+            options=["a", "b"],
+        )
+        response = api_client.post(
+            f"/api/community/events/{rsvp_event.id}/rsvp/",
+            {"status": RSVPStatus.ATTENDING, "answers": {q["id"]: ",,,"}},
+            content_type="application/json",
+            **other_headers,
+        )
+        assert response.status_code == 422
+        assert_error_code(response, Code.Event.RSVP_ANSWER_REQUIRED)
+
+    def test_multiselect_option_with_comma_rejected(self, api_client, auth_headers, rsvp_event):
+        response = _replace_question(
+            api_client,
+            auth_headers,
+            rsvp_event.id,
+            field_type="multiselect",
+            options=["a, b", "c"],
+        )
+        assert response.status_code == 400
+        assert_error_code(response, Code.Event.RSVP_QUESTION_OPTION_NO_COMMA)
+
+    def test_dropdown_option_with_comma_allowed(self, api_client, auth_headers, rsvp_event):
+        response = _replace_question(
+            api_client,
+            auth_headers,
+            rsvp_event.id,
+            options=["yes, with a guest", "no"],
+        )
+
+        assert response.status_code == 200
+
+    def test_choice_option_over_max_length_rejected(self, api_client, auth_headers, rsvp_event):
+        response = _replace_question(
+            api_client,
+            auth_headers,
+            rsvp_event.id,
+            options=["x" * 201],
+        )
+
+        assert response.status_code == 422
+
+    def test_answer_too_long_uses_question_label(
+        self, api_client, other_headers, auth_headers, rsvp_event
+    ):
+        q = _create_question(
+            rsvp_event,
+            field_type="textarea",
+            options=[],
+            label="travel details",
+        )
+
+        response = api_client.post(
+            f"/api/community/events/{rsvp_event.id}/rsvp/",
+            {"status": RSVPStatus.ATTENDING, "answers": {q["id"]: "x" * 2001}},
+            content_type="application/json",
+            **other_headers,
+        )
+
+        assert response.status_code == 422
+        error = response.json()["detail"][0]
+        assert error["code"] == Code.Event.RSVP_ANSWER_TOO_LONG
+        assert error["params"]["label"] == "travel details"

--- a/backend/tests/test_event_rsvp_questions.py
+++ b/backend/tests/test_event_rsvp_questions.py
@@ -40,7 +40,7 @@ def other_headers(other_user):
 def _question_data(**overrides):
     return {
         "label": "how are you getting there?",
-        "field_type": "dropdown",
+        "field_type": "select",
         "options": ["driving", "transit"],
         "required": True,
         **overrides,
@@ -130,12 +130,12 @@ class TestRsvpWithAnswers:
 
 @pytest.mark.django_db
 class TestRsvpAnswerEdgeCases:
-    def test_multiselect_comma_only_required_rejected(
+    def test_checkbox_comma_only_required_rejected(
         self, api_client, other_headers, auth_headers, rsvp_event
     ):
         q = _create_question(
             rsvp_event,
-            field_type="multiselect",
+            field_type="checkbox",
             options=["a", "b"],
         )
         response = api_client.post(
@@ -147,18 +147,18 @@ class TestRsvpAnswerEdgeCases:
         assert response.status_code == 422
         assert_error_code(response, Code.Event.RSVP_ANSWER_REQUIRED)
 
-    def test_multiselect_option_with_comma_rejected(self, api_client, auth_headers, rsvp_event):
+    def test_checkbox_option_with_comma_rejected(self, api_client, auth_headers, rsvp_event):
         response = _replace_question(
             api_client,
             auth_headers,
             rsvp_event.id,
-            field_type="multiselect",
+            field_type="checkbox",
             options=["a, b", "c"],
         )
         assert response.status_code == 400
         assert_error_code(response, Code.Event.RSVP_QUESTION_OPTION_NO_COMMA)
 
-    def test_dropdown_option_with_comma_allowed(self, api_client, auth_headers, rsvp_event):
+    def test_select_option_with_comma_allowed(self, api_client, auth_headers, rsvp_event):
         response = _replace_question(
             api_client,
             auth_headers,

--- a/backend/tests/test_rsvp_question_types.py
+++ b/backend/tests/test_rsvp_question_types.py
@@ -1,0 +1,33 @@
+"""Unit tests for the RSVP question-type subset of the shared catalog."""
+
+import pytest
+from community.models import RSVP_CHOICE_TYPES, RsvpQuestionType, SurveyQuestionType
+from community.models.choices import QuestionType, QuestionTypeDefinition
+
+
+@pytest.mark.unit
+def test_rsvp_question_type_enum_matches_canonical_subset():
+    canonical = {
+        name: definition
+        for name, definition in vars(QuestionType).items()
+        if isinstance(definition, QuestionTypeDefinition)
+    }
+    survey = {
+        question_type.name: (question_type.value, question_type.label)
+        for question_type in SurveyQuestionType
+    }
+    rsvp = {
+        question_type.name: (question_type.value, question_type.label)
+        for question_type in RsvpQuestionType
+    }
+
+    assert survey == canonical
+    assert rsvp == {name: canonical[name] for name in ("TEXTAREA", "DROPDOWN", "MULTISELECT")}
+    assert [question_type.value for question_type in RsvpQuestionType] == [
+        "textarea",
+        "dropdown",
+        "multiselect",
+    ]
+    assert RSVP_CHOICE_TYPES == frozenset(
+        {RsvpQuestionType.DROPDOWN, RsvpQuestionType.MULTISELECT},
+    )

--- a/backend/tests/test_rsvp_question_types.py
+++ b/backend/tests/test_rsvp_question_types.py
@@ -1,28 +1,21 @@
 """Unit tests for the RSVP question-type subset of the shared catalog."""
 
 import pytest
-from community.models import RSVP_CHOICE_TYPES, RsvpQuestionType, SurveyQuestionType
-from community.models.choices import QuestionType, QuestionTypeDefinition
+from community.models import RSVP_CHOICE_TYPES, QuestionType, RsvpQuestionType
 
 
 @pytest.mark.unit
 def test_rsvp_question_type_enum_matches_canonical_subset():
-    canonical = {
-        name: definition
-        for name, definition in vars(QuestionType).items()
-        if isinstance(definition, QuestionTypeDefinition)
-    }
-    survey = {
+    catalog = {
         question_type.name: (question_type.value, question_type.label)
-        for question_type in SurveyQuestionType
+        for question_type in QuestionType
     }
     rsvp = {
         question_type.name: (question_type.value, question_type.label)
         for question_type in RsvpQuestionType
     }
 
-    assert survey == canonical
-    assert rsvp == {name: canonical[name] for name in ("TEXTAREA", "SELECT", "CHECKBOX")}
+    assert rsvp == {name: catalog[name] for name in ("TEXTAREA", "SELECT", "CHECKBOX")}
     assert [question_type.value for question_type in RsvpQuestionType] == [
         "textarea",
         "select",

--- a/backend/tests/test_rsvp_question_types.py
+++ b/backend/tests/test_rsvp_question_types.py
@@ -22,12 +22,12 @@ def test_rsvp_question_type_enum_matches_canonical_subset():
     }
 
     assert survey == canonical
-    assert rsvp == {name: canonical[name] for name in ("TEXTAREA", "DROPDOWN", "MULTISELECT")}
+    assert rsvp == {name: canonical[name] for name in ("TEXTAREA", "SELECT", "CHECKBOX")}
     assert [question_type.value for question_type in RsvpQuestionType] == [
         "textarea",
-        "dropdown",
-        "multiselect",
+        "select",
+        "checkbox",
     ]
     assert RSVP_CHOICE_TYPES == frozenset(
-        {RsvpQuestionType.DROPDOWN, RsvpQuestionType.MULTISELECT},
+        {RsvpQuestionType.SELECT, RsvpQuestionType.CHECKBOX},
     )

--- a/frontend/src/api/eventMapper.ts
+++ b/frontend/src/api/eventMapper.ts
@@ -64,7 +64,7 @@ export interface WireEvent {
   rsvp_questions?: {
     id: string;
     label: string;
-    field_type: 'textarea' | 'dropdown' | 'multiselect';
+    field_type: 'textarea' | 'select' | 'checkbox';
     options?: string[];
     required: boolean;
     display_order?: number;

--- a/frontend/src/api/eventMapper.ts
+++ b/frontend/src/api/eventMapper.ts
@@ -7,6 +7,8 @@ import type {
 } from '@/models/event';
 import { AttendanceStatus } from '@/models/event';
 
+import { mapRsvpQuestion } from './eventRsvpQuestions';
+
 interface WireGuest {
   user_id: string;
   name: string;
@@ -58,6 +60,15 @@ export interface WireEvent {
 
   guests?: WireGuest[];
   my_rsvp?: string | null;
+  my_rsvp_answers?: Record<string, { label?: string; answer?: string }>;
+  rsvp_questions?: {
+    id: string;
+    label: string;
+    field_type: 'textarea' | 'dropdown' | 'multiselect';
+    options?: string[];
+    required: boolean;
+    display_order?: number;
+  }[];
   viewer_user_id?: string | null;
   survey_slugs?: string[];
   invited_user_ids?: string[];
@@ -126,6 +137,17 @@ function mapPendingCohostInvite(w: WirePendingCohostInvite): PendingCohostInvite
   };
 }
 
+function mapMyRsvpAnswers(
+  raw: Record<string, { label?: string; answer?: string }> | undefined,
+): Event['myRsvpAnswers'] {
+  return Object.fromEntries(
+    Object.entries(raw ?? {}).map(([id, snap]) => [
+      id,
+      { label: snap.label ?? '', answer: snap.answer ?? '' },
+    ]),
+  );
+}
+
 export function mapEvent(e: WireEvent): Event {
   return {
     id: e.id,
@@ -167,6 +189,8 @@ export function mapEvent(e: WireEvent): Event {
 
     guests: (e.guests ?? []).map(mapGuest),
     myRsvp: e.my_rsvp ?? null,
+    myRsvpAnswers: mapMyRsvpAnswers(e.my_rsvp_answers),
+    rsvpQuestions: (e.rsvp_questions ?? []).map(mapRsvpQuestion),
     viewerUserId: e.viewer_user_id ?? null,
     surveySlugs: e.survey_slugs ?? [],
     invitedUserIds: e.invited_user_ids ?? [],

--- a/frontend/src/api/eventRsvpQuestions.test.ts
+++ b/frontend/src/api/eventRsvpQuestions.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { EventRsvpQuestion } from '@/models/event';
+
+import { apiClient } from './client';
+import { syncEventRsvpQuestions } from './eventRsvpQuestions';
+
+vi.mock('./client', () => ({
+  apiClient: {
+    put: vi.fn(),
+  },
+}));
+
+const q = (
+  partial: Partial<EventRsvpQuestion> & Pick<EventRsvpQuestion, 'id'>,
+): EventRsvpQuestion => ({
+  label: 'q',
+  fieldType: 'textarea',
+  options: [],
+  required: false,
+  ...partial,
+});
+
+describe('syncEventRsvpQuestions', () => {
+  beforeEach(() => {
+    vi.mocked(apiClient.put).mockReset();
+  });
+
+  it('should replace all questions in one request', async () => {
+    vi.mocked(apiClient.put).mockResolvedValue({
+      data: [
+        {
+          id: 'keep',
+          label: 'updated',
+          field_type: 'textarea',
+          options: [],
+          required: false,
+          display_order: 0,
+        },
+        {
+          id: 'new',
+          label: 'new',
+          field_type: 'textarea',
+          options: [],
+          required: false,
+          display_order: 1,
+        },
+      ],
+    });
+
+    const previous = [q({ id: 'keep', label: 'old' })];
+    const result = await syncEventRsvpQuestions(
+      'evt',
+      [q({ id: 'keep', label: 'updated' }), q({ id: 'q-temp-new', label: 'new' })],
+      previous,
+    );
+
+    expect(apiClient.put).toHaveBeenCalledWith('/api/community/events/evt/rsvp-questions/', {
+      expected: [
+        {
+          id: 'keep',
+          label: 'old',
+          field_type: 'textarea',
+          options: [],
+          required: false,
+        },
+      ],
+      questions: [
+        {
+          id: 'keep',
+          label: 'updated',
+          field_type: 'textarea',
+          options: [],
+          required: false,
+        },
+        {
+          id: null,
+          label: 'new',
+          field_type: 'textarea',
+          options: [],
+          required: false,
+        },
+      ],
+    });
+    expect(result.map((question) => question.id)).toEqual(['keep', 'new']);
+  });
+});

--- a/frontend/src/api/eventRsvpQuestions.ts
+++ b/frontend/src/api/eventRsvpQuestions.ts
@@ -1,11 +1,15 @@
-import type { EventRsvpQuestion, EventRsvpQuestionType } from '@/models/event';
+import type { EventRsvpQuestion } from '@/models/event';
 
 import { apiClient } from './client';
+import type { components } from './types.gen';
+
+export type RsvpQuestionType = components['schemas']['EventRsvpQuestionIn']['field_type'];
+export const DEFAULT_RSVP_QUESTION_TYPE: RsvpQuestionType = 'textarea';
 
 interface WireQuestion {
   id: string;
   label: string;
-  field_type: EventRsvpQuestionType;
+  field_type: RsvpQuestionType;
   options?: string[];
   required: boolean;
   display_order?: number;

--- a/frontend/src/api/eventRsvpQuestions.ts
+++ b/frontend/src/api/eventRsvpQuestions.ts
@@ -1,0 +1,48 @@
+import type { EventRsvpQuestion, EventRsvpQuestionType } from '@/models/event';
+
+import { apiClient } from './client';
+
+interface WireQuestion {
+  id: string;
+  label: string;
+  field_type: EventRsvpQuestionType;
+  options?: string[];
+  required: boolean;
+  display_order?: number;
+}
+
+export function mapRsvpQuestion(w: WireQuestion): EventRsvpQuestion {
+  return {
+    id: w.id,
+    label: w.label,
+    fieldType: w.field_type,
+    options: w.options ?? [],
+    required: w.required,
+  };
+}
+
+function questionPayload(question: EventRsvpQuestion, newIdsAsNull: boolean) {
+  return {
+    id: newIdsAsNull && question.id.startsWith('q-') ? null : question.id,
+    label: question.label,
+    field_type: question.fieldType,
+    options: question.options,
+    required: question.required,
+  };
+}
+
+/** Replace questions atomically and return canonical server ids/order. */
+export async function syncEventRsvpQuestions(
+  eventId: string,
+  next: readonly EventRsvpQuestion[],
+  previous: readonly EventRsvpQuestion[],
+): Promise<EventRsvpQuestion[]> {
+  const { data } = await apiClient.put<WireQuestion[]>(
+    `/api/community/events/${eventId}/rsvp-questions/`,
+    {
+      expected: previous.map((question) => questionPayload(question, false)),
+      questions: next.map((question) => questionPayload(question, true)),
+    },
+  );
+  return data.map(mapRsvpQuestion);
+}

--- a/frontend/src/api/eventWrites.test.ts
+++ b/frontend/src/api/eventWrites.test.ts
@@ -24,6 +24,7 @@ import { apiClient } from '@/api/client';
 import {
   eventToFormValues,
   toPartialWireBody,
+  useCreateEvent,
   useInviteToEvent,
   useUploadEventPhoto,
 } from './eventWrites';
@@ -116,6 +117,45 @@ describe('toPartialWireBody', () => {
   it('maps tagIds to tag_ids, including an empty list (clears tags)', () => {
     expect(toPartialWireBody({ tagIds: ['t1', 't2'] })).toEqual({ tag_ids: ['t1', 't2'] });
     expect(toPartialWireBody({ tagIds: [] })).toEqual({ tag_ids: [] });
+  });
+});
+
+describe('useCreateEvent', () => {
+  it('creates the event and RSVP questions in one request', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({ data: makeEvent() });
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const Wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: qc }, children);
+    const { result } = renderHook(() => useCreateEvent(), { wrapper: Wrapper });
+    const values = eventToFormValues(makeEvent());
+
+    result.current.mutate({
+      ...values,
+      rsvpQuestions: [
+        {
+          id: 'q-new',
+          label: 'dietary?',
+          fieldType: 'textarea',
+          options: [],
+          required: true,
+        },
+      ],
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/api/community/events/',
+      expect.objectContaining({
+        rsvp_questions: [
+          {
+            label: 'dietary?',
+            field_type: 'textarea',
+            options: [],
+            required: true,
+          },
+        ],
+      }),
+    );
   });
 });
 

--- a/frontend/src/api/eventWrites.ts
+++ b/frontend/src/api/eventWrites.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuthStore } from '@/auth/store';
 import {
   type Event,
+  type EventRsvpQuestion,
   EventStatus as EventStatusEnum,
   EventType as EventTypeEnum,
   EventVisibility,
@@ -47,6 +48,10 @@ export interface EventFormValues {
   tagIds: string[];
   status: EventStatus;
 }
+
+type CreateEventValues = EventFormValues & {
+  rsvpQuestions?: readonly EventRsvpQuestion[];
+};
 
 type WireBody = Record<string, unknown>;
 
@@ -128,11 +133,15 @@ export function useCreateEvent() {
   const qc = useQueryClient();
   const isAuthed = useAuthStore((s) => s.status === 'authed');
   return useMutation({
-    mutationFn: async (values: EventFormValues) => {
-      const { data } = await apiClient.post<WireEvent>(
-        '/api/community/events/',
-        toWireBody(values),
-      );
+    mutationFn: async ({ rsvpQuestions = [], ...values }: CreateEventValues) => {
+      const body = toWireBody(values);
+      body.rsvp_questions = rsvpQuestions.map((question) => ({
+        label: question.label,
+        field_type: question.fieldType,
+        options: question.options,
+        required: question.required,
+      }));
+      const { data } = await apiClient.post<WireEvent>('/api/community/events/', body);
       return mapEvent(data);
     },
     onSuccess: (event) => {

--- a/frontend/src/api/rsvp.ts
+++ b/frontend/src/api/rsvp.ts
@@ -19,6 +19,7 @@ interface SetRsvpArgs {
   // Not persisted server-side — a non-empty comment is posted once, as a
   // public EventComment or a host-only decline notification.
   comment?: string;
+  answers?: Record<string, string | string[]>;
 }
 
 function updateCaches(qc: ReturnType<typeof useQueryClient>, event: Event, isAuthed: boolean) {
@@ -35,10 +36,17 @@ export function useSetRsvp() {
   const qc = useQueryClient();
   const isAuthed = useAuthStore((s) => s.status === 'authed');
   return useMutation({
-    mutationFn: async ({ eventId, status, hasPlusOne = false, comment }: SetRsvpArgs) => {
+    mutationFn: async ({
+      eventId,
+      status,
+      hasPlusOne = false,
+      comment,
+      answers = {},
+    }: SetRsvpArgs) => {
       const { data } = await apiClient.post<WireEvent>(`/api/community/events/${eventId}/rsvp/`, {
         status,
         has_plus_one: hasPlusOne,
+        answers,
         ...(comment === undefined ? {} : { comment }),
       });
       return mapEvent(data);

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -1079,6 +1079,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/community/events/{event_id}/rsvp-questions/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        /** Replace Event Rsvp Questions */
+        put: operations["community__event_rsvp_questions_replace_event_rsvp_questions"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/community/events/{event_id}/rsvp/": {
         parameters: {
             query?: never;
@@ -2728,6 +2745,11 @@ export interface components {
              * @default false
              */
             rsvp_enabled: boolean;
+            /**
+             * Rsvp Questions
+             * @default []
+             */
+            rsvp_questions: components["schemas"]["EventRsvpQuestionIn"][];
             /** Start Datetime */
             start_datetime?: string | null;
             /**
@@ -3034,6 +3056,13 @@ export interface components {
             /** My Rsvp */
             my_rsvp?: string | null;
             /**
+             * My Rsvp Answers
+             * @default {}
+             */
+            my_rsvp_answers: {
+                [key: string]: unknown;
+            };
+            /**
              * Other Link
              * @default
              */
@@ -3065,6 +3094,11 @@ export interface components {
              * @default false
              */
             rsvp_enabled: boolean;
+            /**
+             * Rsvp Questions
+             * @default []
+             */
+            rsvp_questions: components["schemas"]["EventRsvpQuestionOut"][];
             /**
              * Slug
              * @default
@@ -3253,6 +3287,101 @@ export interface components {
             votes: {
                 [key: string]: string;
             };
+        };
+        /** EventRsvpQuestionExpectedIn */
+        EventRsvpQuestionExpectedIn: {
+            /**
+             * Field Type
+             * @enum {string}
+             */
+            field_type: "textarea" | "dropdown" | "multiselect";
+            /**
+             * Id
+             * Format: uuid
+             */
+            id: string;
+            /** Label */
+            label: string;
+            /**
+             * Options
+             * @default []
+             */
+            options: string[];
+            /**
+             * Required
+             * @default false
+             */
+            required: boolean;
+        };
+        /** EventRsvpQuestionIn */
+        EventRsvpQuestionIn: {
+            /**
+             * Field Type
+             * @enum {string}
+             */
+            field_type: "textarea" | "dropdown" | "multiselect";
+            /** Label */
+            label: string;
+            /**
+             * Options
+             * @default []
+             */
+            options: string[];
+            /**
+             * Required
+             * @default false
+             */
+            required: boolean;
+        };
+        /** EventRsvpQuestionOut */
+        EventRsvpQuestionOut: {
+            /** Display Order */
+            display_order: number;
+            /**
+             * Field Type
+             * @enum {string}
+             */
+            field_type: "textarea" | "dropdown" | "multiselect";
+            /** Id */
+            id: string;
+            /** Label */
+            label: string;
+            /**
+             * Options
+             * @default []
+             */
+            options: string[];
+            /** Required */
+            required: boolean;
+        };
+        /** EventRsvpQuestionSyncIn */
+        EventRsvpQuestionSyncIn: {
+            /**
+             * Field Type
+             * @enum {string}
+             */
+            field_type: "textarea" | "dropdown" | "multiselect";
+            /** Id */
+            id?: string | null;
+            /** Label */
+            label: string;
+            /**
+             * Options
+             * @default []
+             */
+            options: string[];
+            /**
+             * Required
+             * @default false
+             */
+            required: boolean;
+        };
+        /** EventRsvpQuestionSyncPayload */
+        EventRsvpQuestionSyncPayload: {
+            /** Expected */
+            expected: components["schemas"]["EventRsvpQuestionExpectedIn"][];
+            /** Questions */
+            questions: components["schemas"]["EventRsvpQuestionSyncIn"][];
         };
         /** EventStatsOut */
         EventStatsOut: {
@@ -4124,6 +4253,13 @@ export interface components {
         };
         /** RSVPIn */
         RSVPIn: {
+            /**
+             * Answers
+             * @description Question UUID to answer; multiselect values are comma-separated.
+             */
+            answers?: {
+                [key: string]: string;
+            };
             /** Comment */
             comment?: string | null;
             /**
@@ -6571,6 +6707,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorOut"];
                 };
             };
+            /** @description Unprocessable Content */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
             /** @description Too Many Requests */
             429: {
                 headers: {
@@ -8049,6 +8194,68 @@ export interface operations {
             };
         };
     };
+    community__event_rsvp_questions_replace_event_rsvp_questions: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                event_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["EventRsvpQuestionSyncPayload"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EventRsvpQuestionOut"][];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Unprocessable Content */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
     community__event_rsvps_upsert_rsvp: {
         parameters: {
             query?: never;
@@ -8093,6 +8300,15 @@ export interface operations {
             };
             /** @description Not Found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Unprocessable Content */
+            422: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -3294,7 +3294,7 @@ export interface components {
              * Field Type
              * @enum {string}
              */
-            field_type: "textarea" | "dropdown" | "multiselect";
+            field_type: "textarea" | "select" | "checkbox";
             /**
              * Id
              * Format: uuid
@@ -3319,7 +3319,7 @@ export interface components {
              * Field Type
              * @enum {string}
              */
-            field_type: "textarea" | "dropdown" | "multiselect";
+            field_type: "textarea" | "select" | "checkbox";
             /** Label */
             label: string;
             /**
@@ -3341,7 +3341,7 @@ export interface components {
              * Field Type
              * @enum {string}
              */
-            field_type: "textarea" | "dropdown" | "multiselect";
+            field_type: "textarea" | "select" | "checkbox";
             /** Id */
             id: string;
             /** Label */
@@ -3360,7 +3360,7 @@ export interface components {
              * Field Type
              * @enum {string}
              */
-            field_type: "textarea" | "dropdown" | "multiselect";
+            field_type: "textarea" | "select" | "checkbox";
             /** Id */
             id?: string | null;
             /** Label */
@@ -4255,7 +4255,7 @@ export interface components {
         RSVPIn: {
             /**
              * Answers
-             * @description Question UUID to answer; multiselect values are comma-separated.
+             * @description Question UUID to answer; checkbox values are comma-separated.
              */
             answers?: {
                 [key: string]: string;

--- a/frontend/src/api/validationCodes.gen.ts
+++ b/frontend/src/api/validationCodes.gen.ts
@@ -31,6 +31,14 @@ export const Code = {
     RsvpNotFound: 'event.rsvp_not_found',
     MemberContactMustSignIn: 'event.member_contact_must_sign_in',
     RsvpCouldNotBeCreated: 'event.rsvp_could_not_be_created',
+    RsvpQuestionNotFound: 'event.rsvp_question_not_found',
+    RsvpQuestionDuplicate: 'event.rsvp_question_duplicate',
+    RsvpQuestionConflict: 'event.rsvp_question_conflict',
+    RsvpQuestionOptionsRequired: 'event.rsvp_question_options_required',
+    RsvpQuestionOptionNoComma: 'event.rsvp_question_option_no_comma',
+    RsvpAnswerRequired: 'event.rsvp_answer_required',
+    RsvpAnswerInvalidOption: 'event.rsvp_answer_invalid_option',
+    RsvpAnswerTooLong: 'event.rsvp_answer_too_long',
     AttendanceOpensLater: 'event.attendance_opens_later',
     AttendanceOnlyForGoingRsvps: 'event.attendance_only_for_going_rsvps',
     PermDenied: 'event.perm_denied',
@@ -251,6 +259,14 @@ export type ValidationCode =
   | 'event.rsvp_not_found'
   | 'event.member_contact_must_sign_in'
   | 'event.rsvp_could_not_be_created'
+  | 'event.rsvp_question_not_found'
+  | 'event.rsvp_question_duplicate'
+  | 'event.rsvp_question_conflict'
+  | 'event.rsvp_question_options_required'
+  | 'event.rsvp_question_option_no_comma'
+  | 'event.rsvp_answer_required'
+  | 'event.rsvp_answer_invalid_option'
+  | 'event.rsvp_answer_too_long'
   | 'event.attendance_opens_later'
   | 'event.attendance_only_for_going_rsvps'
   | 'event.perm_denied'
@@ -411,6 +427,14 @@ export const CODE_PARAMS: Record<ValidationCode, readonly string[]> = {
   'event.rsvp_not_found': [],
   'event.member_contact_must_sign_in': [],
   'event.rsvp_could_not_be_created': [],
+  'event.rsvp_question_not_found': [],
+  'event.rsvp_question_duplicate': [],
+  'event.rsvp_question_conflict': [],
+  'event.rsvp_question_options_required': [],
+  'event.rsvp_question_option_no_comma': [],
+  'event.rsvp_answer_required': ['label'],
+  'event.rsvp_answer_invalid_option': ['label'],
+  'event.rsvp_answer_too_long': ['label', 'max'],
   'event.attendance_opens_later': [],
   'event.attendance_only_for_going_rsvps': [],
   'event.perm_denied': ['action'],

--- a/frontend/src/api/validationCodes.ts
+++ b/frontend/src/api/validationCodes.ts
@@ -96,6 +96,28 @@ function messageForKnownCode(code: KnownCode, err: FieldError): string {
       return 'rsvp not found';
     case Code.Event.MemberContactMustSignIn:
       return 'looks like you already have an account — sign in to rsvp';
+    case Code.Event.RsvpQuestionNotFound:
+      return "that question wasn't found";
+    case Code.Event.RsvpQuestionDuplicate:
+      return 'each question can only appear once';
+    case Code.Event.RsvpQuestionConflict:
+      return 'questions changed elsewhere — reload and try again';
+    case Code.Event.RsvpQuestionOptionsRequired:
+      return 'add at least one option';
+    case Code.Event.RsvpQuestionOptionNoComma:
+      return 'options cannot contain commas';
+    case Code.Event.RsvpAnswerRequired: {
+      const label = typeof err.params?.label === 'string' ? err.params.label : null;
+      return label ? `answer required: ${label}` : 'answer required';
+    }
+    case Code.Event.RsvpAnswerInvalidOption: {
+      const label = typeof err.params?.label === 'string' ? err.params.label : null;
+      return label ? `invalid answer for ${label}` : 'invalid answer';
+    }
+    case Code.Event.RsvpAnswerTooLong: {
+      const label = typeof err.params?.label === 'string' ? err.params.label : null;
+      return label ? `answer too long for ${label}` : 'answer too long';
+    }
     case Code.Event.RsvpCouldNotBeCreated:
       return "we couldn't set up your rsvp with those details — reach out and we'll help";
     case Code.Event.AttendanceOpensLater:

--- a/frontend/src/components/questions/QuestionField.tsx
+++ b/frontend/src/components/questions/QuestionField.tsx
@@ -12,7 +12,7 @@ interface Props {
   readOnly?: boolean;
 }
 
-/** Shared answer field for surveys and join form questions. */
+/** Shared answer field for surveys, RSVP questions, and join form questions. */
 export function QuestionField({ question, value, onChange, error, readOnly }: Props) {
   const label = question.required ? question.label : `${question.label} (optional)`;
   const common = { label, error, disabled: readOnly };

--- a/frontend/src/components/ui/Dialog.test.tsx
+++ b/frontend/src/components/ui/Dialog.test.tsx
@@ -1,0 +1,43 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { Dialog } from './Dialog';
+
+describe('Dialog', () => {
+  it('renders into document.body instead of the parent node', () => {
+    const { container } = render(
+      <div data-testid="parent">
+        <Dialog open onClose={() => {}} title="ported">
+          <p>body</p>
+        </Dialog>
+      </div>,
+    );
+
+    expect(container.querySelector('[role="dialog"]')).toBeNull();
+    expect(document.body.querySelector('[role="dialog"]')).toBeTruthy();
+  });
+
+  it('shows a visible close button that calls onClose', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <Dialog open onClose={onClose} title="sample">
+        <p>body</p>
+      </Dialog>,
+    );
+    await user.click(screen.getByRole('button', { name: /^close$/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('should allow the narrow panel body to scroll when content exceeds max height', () => {
+    render(
+      <Dialog open onClose={() => {}} title="tall">
+        <p>{'line\n'.repeat(80)}</p>
+      </Dialog>,
+    );
+    const panel = document.body.querySelector('[role="dialog"] > div.bg-surface');
+    expect(panel?.className).toMatch(/overflow-y-auto/);
+    expect(panel?.className).not.toMatch(/overflow-hidden/);
+  });
+});

--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -1,13 +1,16 @@
 import { type ReactNode, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 
 interface Props {
   open: boolean;
   onClose: () => void;
   title: string;
   children: ReactNode;
+  /** Wider panel for tables / multi-column content. */
+  wide?: boolean;
 }
 
-export function Dialog({ open, onClose, title, children }: Props) {
+export function Dialog({ open, onClose, title, children, wide = false }: Props) {
   useEffect(() => {
     if (!open) return;
     function onKey(e: KeyboardEvent) {
@@ -20,7 +23,10 @@ export function Dialog({ open, onClose, title, children }: Props) {
   }, [open, onClose]);
 
   if (!open) return null;
-  return (
+
+  // Portal to body so dialog content (including nested <form>s) is not inside
+  // a parent page form — HTML forbids nested forms and browsers submit the outer one.
+  return createPortal(
     <div
       role="dialog"
       aria-modal="true"
@@ -29,14 +35,39 @@ export function Dialog({ open, onClose, title, children }: Props) {
     >
       <button
         type="button"
-        aria-label="close"
+        aria-label="dismiss"
         onClick={onClose}
         className="absolute inset-0 cursor-default bg-black/60"
       />
-      <div className="bg-surface relative w-full max-w-md rounded-lg p-5 shadow-(--shadow-xl)">
-        <h2 className="mb-4 text-base font-medium">{title}</h2>
+      <div
+        className={
+          wide
+            ? 'bg-surface relative max-h-[min(90vh,40rem)] w-full max-w-2xl overflow-y-auto rounded-lg p-5 shadow-(--shadow-xl)'
+            : 'bg-surface relative max-h-[min(90vh,40rem)] w-full max-w-md overflow-y-auto rounded-lg p-5 shadow-(--shadow-xl)'
+        }
+      >
+        <div className="mb-4 flex items-start justify-between gap-3">
+          <h2 className="text-base font-medium">{title}</h2>
+          <button
+            type="button"
+            aria-label="close"
+            onClick={onClose}
+            className="text-foreground-secondary hover:bg-surface-dim hover:text-foreground -me-1 -mt-1 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md transition-colors"
+          >
+            <CloseIcon />
+          </button>
+        </div>
         {children}
       </div>
-    </div>
+    </div>,
+    document.body,
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" />
+    </svg>
   );
 }

--- a/frontend/src/components/ui/Select.tsx
+++ b/frontend/src/components/ui/Select.tsx
@@ -62,7 +62,7 @@ export const Select = forwardRef<HTMLSelectElement, Props>(function Select(
         </svg>
       </div>
       {error ? (
-        <p id={`${inputId}-error`} className="text-destructive text-xs">
+        <p id={`${inputId}-error`} role="alert" className="text-destructive text-xs">
           {error}
         </p>
       ) : null}

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -75,7 +75,7 @@ export interface EventTag {
   slug: string;
 }
 
-export type EventRsvpQuestionType = 'textarea' | 'dropdown' | 'multiselect';
+export type EventRsvpQuestionType = 'textarea' | 'select' | 'checkbox';
 
 export interface EventRsvpQuestion {
   id: string;

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -75,6 +75,16 @@ export interface EventTag {
   slug: string;
 }
 
+export type EventRsvpQuestionType = 'textarea' | 'dropdown' | 'multiselect';
+
+export interface EventRsvpQuestion {
+  id: string;
+  label: string;
+  fieldType: EventRsvpQuestionType;
+  options: string[];
+  required: boolean;
+}
+
 export interface EventGuest {
   userId: string;
   name: string;
@@ -150,6 +160,9 @@ export interface Event {
 
   guests: EventGuest[];
   myRsvp: string | null;
+  /** Snapshot answers for the viewer's RSVP: questionId → { label, answer }. */
+  myRsvpAnswers: Record<string, { label: string; answer: string }>;
+  rsvpQuestions: EventRsvpQuestion[];
   // The resolved viewer's own user id — carried from the backend so a
   // token-holding (logged-out) viewer can find their own entry in `guests`,
   // since useAuthStore has no user for them.

--- a/frontend/src/screens/events/AddCoHostDialog.test.tsx
+++ b/frontend/src/screens/events/AddCoHostDialog.test.tsx
@@ -56,6 +56,8 @@ const BASE_EVENT: Event = {
   coHostPhotoUrls: [],
   guests: [],
   myRsvp: null,
+  myRsvpAnswers: {},
+  rsvpQuestions: [],
   viewerUserId: null,
   surveySlugs: [],
   invitedUserIds: [],

--- a/frontend/src/screens/events/MyRsvpSection.tsx
+++ b/frontend/src/screens/events/MyRsvpSection.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/models/event';
 
 import { RsvpBox } from './RsvpBox';
+import type { RsvpAnswerValue } from './rsvpQuestions';
 
 interface Props {
   event: Event;
@@ -71,6 +72,7 @@ export function MyRsvpSection({ event, token, locked = false }: Props) {
     status: RsvpInputStatus;
     comment?: string;
     hasPlusOne: boolean;
+    answers: Record<string, RsvpAnswerValue>;
   }) {
     setError(null);
     try {
@@ -86,6 +88,7 @@ export function MyRsvpSection({ event, token, locked = false }: Props) {
           eventId: event.id,
           status: args.status,
           hasPlusOne: args.hasPlusOne,
+          answers: args.answers,
           ...(args.comment === undefined ? {} : { comment: args.comment }),
         });
       }
@@ -166,6 +169,10 @@ export function MyRsvpSection({ event, token, locked = false }: Props) {
           allowComment={Boolean(token) || box.mode === 'create'}
           atCapacity={atCapacity}
           busy={busy}
+          questions={token ? [] : event.rsvpQuestions}
+          initialAnswers={Object.fromEntries(
+            Object.entries(event.myRsvpAnswers).map(([id, snap]) => [id, snap.answer]),
+          )}
           onConfirm={(args) => void confirmRsvp(args)}
           onRemove={box.mode === 'edit' ? () => void removeMyRsvp() : undefined}
           onClose={() => {

--- a/frontend/src/screens/events/RsvpBox.test.tsx
+++ b/frontend/src/screens/events/RsvpBox.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { RsvpStatus } from '@/models/event';
 
 import { RsvpBox } from './RsvpBox';
+import type { RsvpQuestionDraft } from './rsvpQuestions';
 
 const base = {
   open: true,
@@ -11,6 +12,22 @@ const base = {
   initialHasPlusOne: false,
   allowPlusOnes: true,
   onClose: () => {},
+};
+
+const requiredSelect: RsvpQuestionDraft = {
+  id: 'q-transport',
+  label: 'how are you getting there?',
+  fieldType: 'dropdown',
+  options: ['driving', 'transit'],
+  required: true,
+};
+
+const optionalText: RsvpQuestionDraft = {
+  id: 'q-notes',
+  label: 'anything else?',
+  fieldType: 'textarea',
+  options: [],
+  required: false,
 };
 
 describe('RsvpBox', () => {
@@ -34,6 +51,7 @@ describe('RsvpBox', () => {
         status: RsvpStatus.Attending,
         comment: 'snacks',
         hasPlusOne: false,
+        answers: {},
       }),
     );
   });
@@ -150,5 +168,55 @@ describe('RsvpBox', () => {
     expect(onConfirm).toHaveBeenCalledWith(
       expect.objectContaining({ status: RsvpStatus.Attending }),
     );
+  });
+
+  it('shows questions when attending', () => {
+    render(
+      <RsvpBox
+        {...base}
+        mode="create"
+        questions={[requiredSelect, optionalText]}
+        onConfirm={() => {}}
+      />,
+    );
+    expect(screen.getByText('how are you getting there?')).toBeInTheDocument();
+    expect(screen.getByLabelText('anything else? (optional)')).toBeInTheDocument();
+  });
+
+  it('hides questions when status is can’t go', () => {
+    render(<RsvpBox {...base} mode="create" questions={[requiredSelect]} onConfirm={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /can't go/i }));
+    expect(screen.queryByText('how are you getting there?')).not.toBeInTheDocument();
+  });
+
+  it('blocks confirm when a required question is unanswered', () => {
+    const onConfirm = vi.fn();
+    render(<RsvpBox {...base} mode="create" questions={[requiredSelect]} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent(/required/i);
+  });
+
+  it('confirms after answering required questions', () => {
+    const onConfirm = vi.fn();
+    render(<RsvpBox {...base} mode="create" questions={[requiredSelect]} onConfirm={onConfirm} />);
+    fireEvent.change(screen.getByRole('combobox', { name: 'how are you getting there?' }), {
+      target: { value: 'driving' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: RsvpStatus.Attending,
+        answers: { 'q-transport': 'driving' },
+      }),
+    );
+  });
+
+  it('allows confirm for can’t go without answering required questions', () => {
+    const onConfirm = vi.fn();
+    render(<RsvpBox {...base} mode="create" questions={[requiredSelect]} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByRole('button', { name: /can't go/i }));
+    fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
+    expect(onConfirm).toHaveBeenCalledWith(expect.objectContaining({ status: RsvpStatus.CantGo }));
   });
 });

--- a/frontend/src/screens/events/RsvpBox.test.tsx
+++ b/frontend/src/screens/events/RsvpBox.test.tsx
@@ -17,7 +17,7 @@ const base = {
 const requiredSelect: RsvpQuestionDraft = {
   id: 'q-transport',
   label: 'how are you getting there?',
-  fieldType: 'dropdown',
+  fieldType: 'select',
   options: ['driving', 'transit'],
   required: true,
 };

--- a/frontend/src/screens/events/RsvpBox.tsx
+++ b/frontend/src/screens/events/RsvpBox.tsx
@@ -6,11 +6,18 @@ import { RsvpStatusPicker } from '@/components/ui/RsvpStatusPicker';
 import { type RsvpInputStatus, RsvpStatus } from '@/models/event';
 
 import { RsvpCommentField } from './RsvpCommentField';
+import { RsvpQuestionFields } from './RsvpQuestionFields';
+import {
+  missingRequiredQuestionIds,
+  type RsvpAnswerValue,
+  type RsvpQuestionDraft,
+} from './rsvpQuestions';
 
 interface ConfirmArgs {
   status: RsvpInputStatus;
   comment?: string;
   hasPlusOne: boolean;
+  answers: Record<string, RsvpAnswerValue>;
 }
 
 interface Props {
@@ -22,6 +29,8 @@ interface Props {
   allowComment?: boolean;
   atCapacity?: boolean;
   busy?: boolean;
+  questions?: readonly RsvpQuestionDraft[];
+  initialAnswers?: Readonly<Record<string, RsvpAnswerValue | undefined>>;
   onConfirm: (args: ConfirmArgs) => void;
   onRemove?: (() => void) | undefined;
   onClose: () => void;
@@ -36,6 +45,8 @@ export function RsvpBox({
   allowComment,
   atCapacity = false,
   busy = false,
+  questions = [],
+  initialAnswers = {},
   onConfirm,
   onRemove,
   onClose,
@@ -43,48 +54,92 @@ export function RsvpBox({
   const [status, setStatus] = useState<RsvpInputStatus>(initialStatus);
   const [comment, setComment] = useState('');
   const [hasPlusOne, setHasPlusOne] = useState(initialHasPlusOne);
+  const [answers, setAnswers] = useState<Record<string, RsvpAnswerValue | undefined>>(() => ({
+    ...initialAnswers,
+  }));
+  const [questionErrors, setQuestionErrors] = useState<Record<string, string | undefined>>({});
 
   const showComment = allowComment ?? mode === 'create';
   const showPlusOne = allowPlusOnes;
   const joiningWaitlist = status === RsvpStatus.Attending && atCapacity;
+  const showQuestions =
+    questions.length > 0 && (status === RsvpStatus.Attending || status === RsvpStatus.Maybe);
 
   function confirm() {
+    if (showQuestions) {
+      const missing = missingRequiredQuestionIds(questions, answers);
+      if (missing.length > 0) {
+        const next: Record<string, string | undefined> = {};
+        for (const id of missing) next[id] = 'required';
+        setQuestionErrors(next);
+        return;
+      }
+    }
+    setQuestionErrors({});
     const trimmed = comment.trim();
-    const args: ConfirmArgs = { status, hasPlusOne };
+    const filledAnswers: Record<string, RsvpAnswerValue> = {};
+    if (showQuestions) {
+      for (const q of questions) {
+        const value = answers[q.id];
+        if (value?.trim()) {
+          filledAnswers[q.id] = value;
+        }
+      }
+    }
+    const args: ConfirmArgs = { status, hasPlusOne, answers: filledAnswers };
     if (showComment && trimmed) args.comment = trimmed;
     onConfirm(args);
   }
 
   return (
     <Dialog open={open} onClose={onClose} title="rsvp">
-      <div className="flex flex-col gap-4">
-        <RsvpStatusPicker
-          value={status}
-          onSelect={setStatus}
-          disabled={busy}
-          labelFor={(s, defaultLabel) =>
-            s === RsvpStatus.Attending && atCapacity ? 'join the waitlist' : defaultLabel
-          }
-        />
+      <div className="flex max-h-[min(70vh,32rem)] flex-col gap-4">
+        <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pe-1">
+          <RsvpStatusPicker
+            value={status}
+            onSelect={setStatus}
+            disabled={busy}
+            labelFor={(s, defaultLabel) =>
+              s === RsvpStatus.Attending && atCapacity ? 'join the waitlist' : defaultLabel
+            }
+          />
 
-        {showPlusOne ? (
-          <div className="flex justify-center">
-            <Button
-              type="button"
-              variant={hasPlusOne ? 'primary' : 'secondary'}
-              onClick={() => {
-                setHasPlusOne(!hasPlusOne);
-              }}
+          {showPlusOne ? (
+            <div className="flex justify-center">
+              <Button
+                type="button"
+                variant={hasPlusOne ? 'primary' : 'secondary'}
+                onClick={() => {
+                  setHasPlusOne(!hasPlusOne);
+                }}
+                disabled={busy}
+              >
+                {hasPlusOne ? 'remove +1' : 'add +1'}
+              </Button>
+            </div>
+          ) : null}
+
+          {showQuestions ? (
+            <RsvpQuestionFields
+              questions={questions}
+              answers={answers}
+              errors={questionErrors}
               disabled={busy}
-            >
-              {hasPlusOne ? 'remove +1' : 'add +1'}
-            </Button>
-          </div>
-        ) : null}
+              onChange={(questionId, value) => {
+                setAnswers((prev) => ({ ...prev, [questionId]: value }));
+                setQuestionErrors((prev) => {
+                  if (!prev[questionId]) return prev;
+                  const { [questionId]: _removed, ...rest } = prev;
+                  return rest;
+                });
+              }}
+            />
+          ) : null}
 
-        {showComment ? <RsvpCommentField value={comment} onChange={setComment} /> : null}
+          {showComment ? <RsvpCommentField value={comment} onChange={setComment} /> : null}
+        </div>
 
-        <div className="flex items-center justify-between gap-2">
+        <div className="border-border flex shrink-0 items-center justify-between gap-2 border-t pt-3">
           {mode === 'edit' && onRemove ? (
             <Button type="button" variant="secondary" onClick={onRemove} disabled={busy}>
               remove rsvp

--- a/frontend/src/screens/events/RsvpQuestionFields.test.tsx
+++ b/frontend/src/screens/events/RsvpQuestionFields.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { RsvpQuestionFields } from './RsvpQuestionFields';
+import type { RsvpQuestionDraft } from './rsvpQuestions';
+
+const questions: RsvpQuestionDraft[] = [
+  {
+    id: 'q-text',
+    label: 'notes',
+    fieldType: 'textarea',
+    options: [],
+    required: false,
+  },
+  {
+    id: 'q-one',
+    label: 'transport',
+    fieldType: 'dropdown',
+    options: ['car', 'bus'],
+    required: true,
+  },
+  {
+    id: 'q-multi',
+    label: 'help with',
+    fieldType: 'multiselect',
+    options: ['setup', 'cleanup'],
+    required: false,
+  },
+];
+
+describe('RsvpQuestionFields', () => {
+  it('marks optional free response in the label', () => {
+    render(
+      <RsvpQuestionFields questions={questions} answers={{}} onChange={vi.fn()} errors={{}} />,
+    );
+    expect(screen.getByLabelText('notes (optional)')).toBeInTheDocument();
+  });
+
+  it('renders select one as a dropdown and reports changes', () => {
+    const onChange = vi.fn();
+    render(
+      <RsvpQuestionFields questions={questions} answers={{}} onChange={onChange} errors={{}} />,
+    );
+    const select = screen.getByRole('combobox', { name: 'transport' });
+    fireEvent.change(select, { target: { value: 'car' } });
+    expect(onChange).toHaveBeenCalledWith('q-one', 'car');
+  });
+
+  it('toggles multiselect options as csv', () => {
+    const onChange = vi.fn();
+    render(
+      <RsvpQuestionFields
+        questions={questions}
+        answers={{ 'q-multi': 'setup' }}
+        onChange={onChange}
+        errors={{}}
+      />,
+    );
+    fireEvent.click(screen.getByRole('checkbox', { name: 'cleanup' }));
+    expect(onChange).toHaveBeenCalledWith('q-multi', 'setup,cleanup');
+    fireEvent.click(screen.getByRole('checkbox', { name: 'setup' }));
+    expect(onChange).toHaveBeenCalledWith('q-multi', '');
+  });
+
+  it('shows per-question errors', () => {
+    render(
+      <RsvpQuestionFields
+        questions={questions}
+        answers={{}}
+        onChange={vi.fn()}
+        errors={{ 'q-one': 'required' }}
+      />,
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent('required');
+  });
+});

--- a/frontend/src/screens/events/RsvpQuestionFields.test.tsx
+++ b/frontend/src/screens/events/RsvpQuestionFields.test.tsx
@@ -15,14 +15,14 @@ const questions: RsvpQuestionDraft[] = [
   {
     id: 'q-one',
     label: 'transport',
-    fieldType: 'dropdown',
+    fieldType: 'select',
     options: ['car', 'bus'],
     required: true,
   },
   {
     id: 'q-multi',
     label: 'help with',
-    fieldType: 'multiselect',
+    fieldType: 'checkbox',
     options: ['setup', 'cleanup'],
     required: false,
   },
@@ -36,7 +36,7 @@ describe('RsvpQuestionFields', () => {
     expect(screen.getByLabelText('notes (optional)')).toBeInTheDocument();
   });
 
-  it('renders select one as a dropdown and reports changes', () => {
+  it('renders select one as a select and reports changes', () => {
     const onChange = vi.fn();
     render(
       <RsvpQuestionFields questions={questions} answers={{}} onChange={onChange} errors={{}} />,
@@ -46,7 +46,7 @@ describe('RsvpQuestionFields', () => {
     expect(onChange).toHaveBeenCalledWith('q-one', 'car');
   });
 
-  it('toggles multiselect options as csv', () => {
+  it('toggles checkbox options as csv', () => {
     const onChange = vi.fn();
     render(
       <RsvpQuestionFields

--- a/frontend/src/screens/events/RsvpQuestionFields.tsx
+++ b/frontend/src/screens/events/RsvpQuestionFields.tsx
@@ -1,0 +1,39 @@
+import { QuestionField } from '@/components/questions/QuestionField';
+
+import type { RsvpAnswerValue, RsvpQuestionDraft } from './rsvpQuestions';
+
+interface Props {
+  questions: readonly RsvpQuestionDraft[];
+  answers: Readonly<Record<string, RsvpAnswerValue | undefined>>;
+  onChange: (questionId: string, value: RsvpAnswerValue) => void;
+  errors: Readonly<Record<string, string | undefined>>;
+  disabled?: boolean;
+}
+
+/** RSVP answers reuse the shared QuestionField so survey/RSVP UX stays aligned. */
+export function RsvpQuestionFields({
+  questions,
+  answers,
+  onChange,
+  errors,
+  disabled = false,
+}: Props) {
+  if (questions.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {questions.map((question) => (
+        <QuestionField
+          key={question.id}
+          question={question}
+          value={answers[question.id] ?? ''}
+          onChange={(v) => {
+            onChange(question.id, typeof v === 'string' ? v : '');
+          }}
+          error={errors[question.id]}
+          readOnly={disabled}
+        />
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/screens/events/form/EventForm.tsx
+++ b/frontend/src/screens/events/form/EventForm.tsx
@@ -4,6 +4,7 @@ import { toast } from 'sonner';
 
 import { getErrorParams, hasErrorCode } from '@/api/apiErrors';
 import { apiClient } from '@/api/client';
+import { syncEventRsvpQuestions } from '@/api/eventRsvpQuestions';
 import {
   emptyEventFormValues,
   type EventFormValues,
@@ -23,10 +24,12 @@ import { useConfirm } from '@/components/ui/useConfirm';
 import { type Event, eventPath, EventType } from '@/models/event';
 import { hasPermission, Permission } from '@/models/permissions';
 
+import { type RsvpQuestionDraft } from '../rsvpQuestions';
 import { EventFormBasics } from './EventFormBasics';
 import { EventFormDetails } from './EventFormDetails';
 import { EventFormLinks, EventFormMoney } from './EventFormLinksAndCost';
 import { EventFormPhoto } from './EventFormPhoto';
+import { EventFormQuestions } from './EventFormQuestions';
 import { EventFormRsvp } from './EventFormRsvp';
 import { EventFormTags } from './EventFormTags';
 import { validateEventForm } from './validateEventForm';
@@ -102,6 +105,12 @@ export function EventForm({ existing }: Props) {
   // then POST the poll. If the poll POST fails we still land on the new
   // event's detail page and the host can retry from there.
   const [bufferedPollOptions, setBufferedPollOptions] = useState<Date[] | null>(null);
+  const [rsvpQuestions, setRsvpQuestions] = useState<RsvpQuestionDraft[]>(
+    () => existing?.rsvpQuestions ?? [],
+  );
+  const [savedRsvpQuestions, setSavedRsvpQuestions] = useState<RsvpQuestionDraft[]>(
+    () => existing?.rsvpQuestions ?? [],
+  );
 
   const create = useCreateEvent();
   const update = useUpdateEvent(existing?.id ?? '');
@@ -176,11 +185,23 @@ export function EventForm({ existing }: Props) {
           if (!ok) return;
           await update.mutateAsync({ ...patchBody, force: true });
         }
+        try {
+          const synced = await syncEventRsvpQuestions(
+            existing.id,
+            rsvpQuestions,
+            savedRsvpQuestions,
+          );
+          setRsvpQuestions(synced);
+          setSavedRsvpQuestions(synced);
+        } catch (err) {
+          setServerError(extractEventError(err));
+          return;
+        }
         if (nextStatus === 'draft') toast.success('saved draft');
         void navigate(eventPath(existing));
         return;
       }
-      const created = await create.mutateAsync(merged);
+      const created = await create.mutateAsync({ ...merged, rsvpQuestions });
       if (pendingPhoto) {
         try {
           await uploadPhoto.mutateAsync({ eventId: created.id, blob: pendingPhoto });
@@ -321,6 +342,21 @@ export function EventForm({ existing }: Props) {
           forceOpen={hasAnyError(errors, RSVP_FIELDS)}
         >
           <EventFormRsvp values={values} onChange={patch} errors={errors} />
+        </CollapsibleCard>
+
+        <CollapsibleCard
+          title="questions"
+          summary={
+            rsvpQuestions.length > 0
+              ? `${String(rsvpQuestions.length)} question${rsvpQuestions.length === 1 ? '' : 's'}`
+              : undefined
+          }
+        >
+          <EventFormQuestions
+            rsvpEnabled={values.rsvpEnabled}
+            questions={rsvpQuestions}
+            onQuestionsChange={setRsvpQuestions}
+          />
         </CollapsibleCard>
 
         <CollapsibleCard

--- a/frontend/src/screens/events/form/EventFormQuestions.test.tsx
+++ b/frontend/src/screens/events/form/EventFormQuestions.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { SyntheticEvent } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { RsvpQuestionDraft } from '../rsvpQuestions';
+import { EventFormQuestions } from './EventFormQuestions';
+
+const sample: RsvpQuestionDraft = {
+  id: 'q1',
+  label: 'bring anything?',
+  fieldType: 'textarea',
+  options: [],
+  required: true,
+};
+
+describe('EventFormQuestions', () => {
+  it('prompts to enable rsvp when rsvp is off', () => {
+    render(<EventFormQuestions rsvpEnabled={false} questions={[]} onQuestionsChange={vi.fn()} />);
+    expect(
+      screen.getByText(/enable rsvp to ask guests questions when they respond/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /add question/i })).not.toBeInTheDocument();
+  });
+
+  it('shows empty state and add button when rsvp is on', () => {
+    render(<EventFormQuestions rsvpEnabled questions={[]} onQuestionsChange={vi.fn()} />);
+    expect(screen.getByText('no questions yet')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add question/i })).toBeInTheDocument();
+  });
+
+  it('lists questions with type and required marker', () => {
+    render(<EventFormQuestions rsvpEnabled questions={[sample]} onQuestionsChange={vi.fn()} />);
+    expect(screen.getByText('bring anything?')).toBeInTheDocument();
+    expect(screen.getByText(/long text/)).toBeInTheDocument();
+    expect(screen.getByText(/required/)).toBeInTheDocument();
+  });
+
+  it('removes a question when delete is clicked', () => {
+    const onQuestionsChange = vi.fn();
+    render(
+      <EventFormQuestions rsvpEnabled questions={[sample]} onQuestionsChange={onQuestionsChange} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+    expect(onQuestionsChange).toHaveBeenCalledWith([]);
+  });
+
+  it('opens add dialog from add question', () => {
+    render(<EventFormQuestions rsvpEnabled questions={[]} onQuestionsChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /add question/i }));
+    expect(screen.getByRole('dialog', { name: /add question/i })).toBeInTheDocument();
+  });
+
+  it('saving a question does not submit a wrapping event form', () => {
+    const onParentSubmit = vi.fn((e: SyntheticEvent) => {
+      e.preventDefault();
+    });
+    const onQuestionsChange = vi.fn();
+    render(
+      <form onSubmit={onParentSubmit}>
+        <EventFormQuestions rsvpEnabled questions={[]} onQuestionsChange={onQuestionsChange} />
+      </form>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /add question/i }));
+    fireEvent.change(screen.getByLabelText('question'), { target: { value: 'dietary needs' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    expect(onQuestionsChange).toHaveBeenCalledWith([
+      expect.objectContaining({ label: 'dietary needs' }),
+    ]);
+    expect(onParentSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/screens/events/form/EventFormQuestions.tsx
+++ b/frontend/src/screens/events/form/EventFormQuestions.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/Button';
+
+import { RSVP_QUESTION_TYPE_LABELS, type RsvpQuestionDraft } from '../rsvpQuestions';
+import { EventRsvpQuestionDialog } from './EventRsvpQuestionDialog';
+
+interface Props {
+  rsvpEnabled: boolean;
+  questions: RsvpQuestionDraft[];
+  onQuestionsChange: (next: RsvpQuestionDraft[]) => void;
+}
+
+export function EventFormQuestions({ rsvpEnabled, questions, onQuestionsChange }: Props) {
+  const [dialogQuestion, setDialogQuestion] = useState<RsvpQuestionDraft | null | undefined>(
+    undefined,
+  );
+  const dialogOpen = dialogQuestion !== undefined;
+
+  if (!rsvpEnabled) {
+    return (
+      <p className="text-muted text-sm">enable rsvp to ask guests questions when they respond</p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-muted text-sm">shown when guests rsvp as going or maybe</p>
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={() => {
+            setDialogQuestion(null);
+          }}
+        >
+          add question
+        </Button>
+      </div>
+      {questions.length === 0 ? (
+        <p className="text-muted text-sm">no questions yet</p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {questions.map((q) => (
+            <li key={q.id}>
+              <article className="border-border bg-surface flex items-center justify-between gap-3 rounded-lg border p-3">
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium">
+                    {q.label}
+                    {q.required ? (
+                      <span className="text-muted ms-1 text-xs">· required</span>
+                    ) : null}
+                  </p>
+                  <p className="text-muted text-xs">
+                    {RSVP_QUESTION_TYPE_LABELS[q.fieldType]}
+                    {q.options.length > 0 ? ` · ${String(q.options.length)} options` : ''}
+                  </p>
+                </div>
+                <div className="flex shrink-0 gap-1">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={() => {
+                      setDialogQuestion(q);
+                    }}
+                  >
+                    edit
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={() => {
+                      onQuestionsChange(questions.filter((item) => item.id !== q.id));
+                    }}
+                  >
+                    delete
+                  </Button>
+                </div>
+              </article>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <EventRsvpQuestionDialog
+        open={dialogOpen}
+        existing={dialogQuestion ?? undefined}
+        onClose={() => {
+          setDialogQuestion(undefined);
+        }}
+        onSave={(question) => {
+          if (dialogQuestion) {
+            onQuestionsChange(questions.map((item) => (item.id === question.id ? question : item)));
+          } else {
+            onQuestionsChange([...questions, question]);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/screens/events/form/EventRsvpQuestionDialog.test.tsx
+++ b/frontend/src/screens/events/form/EventRsvpQuestionDialog.test.tsx
@@ -17,7 +17,7 @@ describe('EventRsvpQuestionDialog', () => {
     const onSave = vi.fn();
     render(<EventRsvpQuestionDialog open onClose={() => {}} onSave={onSave} />);
     fireEvent.change(screen.getByLabelText('question'), { target: { value: 'pick one' } });
-    fireEvent.change(screen.getByLabelText('type'), { target: { value: 'dropdown' } });
+    fireEvent.change(screen.getByLabelText('type'), { target: { value: 'select' } });
     fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
     expect(screen.getByRole('alert')).toHaveTextContent(/at least one option/i);
     expect(onSave).not.toHaveBeenCalled();
@@ -46,7 +46,7 @@ describe('EventRsvpQuestionDialog', () => {
     const existing: RsvpQuestionDraft = {
       id: 'q-existing',
       label: 'help',
-      fieldType: 'multiselect',
+      fieldType: 'checkbox',
       options: ['a'],
       required: false,
     };
@@ -57,7 +57,7 @@ describe('EventRsvpQuestionDialog', () => {
     expect(onSave).toHaveBeenCalledWith({
       id: 'q-existing',
       label: 'help',
-      fieldType: 'multiselect',
+      fieldType: 'checkbox',
       options: ['setup', 'cleanup'],
       required: false,
     });
@@ -67,7 +67,7 @@ describe('EventRsvpQuestionDialog', () => {
     const onSave = vi.fn();
     render(<EventRsvpQuestionDialog open onClose={() => {}} onSave={onSave} />);
     fireEvent.change(screen.getByLabelText('question'), { target: { value: 'help' } });
-    fireEvent.change(screen.getByLabelText('type'), { target: { value: 'multiselect' } });
+    fireEvent.change(screen.getByLabelText('type'), { target: { value: 'checkbox' } });
     fireEvent.change(screen.getByLabelText('options'), { target: { value: 'yes, with a guest' } });
     fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
 
@@ -79,7 +79,7 @@ describe('EventRsvpQuestionDialog', () => {
     const onSave = vi.fn();
     render(<EventRsvpQuestionDialog open onClose={() => {}} onSave={onSave} />);
     fireEvent.change(screen.getByLabelText('question'), { target: { value: 'bringing someone?' } });
-    fireEvent.change(screen.getByLabelText('type'), { target: { value: 'dropdown' } });
+    fireEvent.change(screen.getByLabelText('type'), { target: { value: 'select' } });
     fireEvent.change(screen.getByLabelText('options'), {
       target: { value: 'yes, with a guest\nno' },
     });
@@ -94,7 +94,7 @@ describe('EventRsvpQuestionDialog', () => {
     const onSave = vi.fn();
     render(<EventRsvpQuestionDialog open onClose={() => {}} onSave={onSave} />);
     fireEvent.change(screen.getByLabelText('question'), { target: { value: 'pick one' } });
-    fireEvent.change(screen.getByLabelText('type'), { target: { value: 'dropdown' } });
+    fireEvent.change(screen.getByLabelText('type'), { target: { value: 'select' } });
     fireEvent.change(screen.getByLabelText('options'), { target: { value: 'x'.repeat(201) } });
     fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
 

--- a/frontend/src/screens/events/form/EventRsvpQuestionDialog.test.tsx
+++ b/frontend/src/screens/events/form/EventRsvpQuestionDialog.test.tsx
@@ -1,0 +1,104 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { RsvpQuestionDraft } from '../rsvpQuestions';
+import { EventRsvpQuestionDialog } from './EventRsvpQuestionDialog';
+
+describe('EventRsvpQuestionDialog', () => {
+  it('requires a question', () => {
+    const onSave = vi.fn();
+    render(<EventRsvpQuestionDialog open onClose={() => {}} onSave={onSave} />);
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    expect(screen.getByRole('alert')).toHaveTextContent(/question required/i);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('requires options for select one', () => {
+    const onSave = vi.fn();
+    render(<EventRsvpQuestionDialog open onClose={() => {}} onSave={onSave} />);
+    fireEvent.change(screen.getByLabelText('question'), { target: { value: 'pick one' } });
+    fireEvent.change(screen.getByLabelText('type'), { target: { value: 'dropdown' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    expect(screen.getByRole('alert')).toHaveTextContent(/at least one option/i);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('saves a free response question', () => {
+    const onSave = vi.fn();
+    const onClose = vi.fn();
+    render(<EventRsvpQuestionDialog open onClose={onClose} onSave={onSave} />);
+    fireEvent.change(screen.getByLabelText('question'), { target: { value: 'notes' } });
+    fireEvent.click(screen.getByLabelText('required'));
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        label: 'notes',
+        fieldType: 'textarea',
+        options: [],
+        required: true,
+        id: expect.any(String) as string,
+      }),
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('saves select multiple with parsed options when editing', () => {
+    const existing: RsvpQuestionDraft = {
+      id: 'q-existing',
+      label: 'help',
+      fieldType: 'multiselect',
+      options: ['a'],
+      required: false,
+    };
+    const onSave = vi.fn();
+    render(<EventRsvpQuestionDialog open existing={existing} onClose={() => {}} onSave={onSave} />);
+    fireEvent.change(screen.getByLabelText('options'), { target: { value: 'setup\ncleanup' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    expect(onSave).toHaveBeenCalledWith({
+      id: 'q-existing',
+      label: 'help',
+      fieldType: 'multiselect',
+      options: ['setup', 'cleanup'],
+      required: false,
+    });
+  });
+
+  it('rejects commas in select multiple options', () => {
+    const onSave = vi.fn();
+    render(<EventRsvpQuestionDialog open onClose={() => {}} onSave={onSave} />);
+    fireEvent.change(screen.getByLabelText('question'), { target: { value: 'help' } });
+    fireEvent.change(screen.getByLabelText('type'), { target: { value: 'multiselect' } });
+    fireEvent.change(screen.getByLabelText('options'), { target: { value: 'yes, with a guest' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/options cannot contain commas/i);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('allows commas in select one options', () => {
+    const onSave = vi.fn();
+    render(<EventRsvpQuestionDialog open onClose={() => {}} onSave={onSave} />);
+    fireEvent.change(screen.getByLabelText('question'), { target: { value: 'bringing someone?' } });
+    fireEvent.change(screen.getByLabelText('type'), { target: { value: 'dropdown' } });
+    fireEvent.change(screen.getByLabelText('options'), {
+      target: { value: 'yes, with a guest\nno' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ options: ['yes, with a guest', 'no'] }),
+    );
+  });
+
+  it('rejects options over the answer length limit', () => {
+    const onSave = vi.fn();
+    render(<EventRsvpQuestionDialog open onClose={() => {}} onSave={onSave} />);
+    fireEvent.change(screen.getByLabelText('question'), { target: { value: 'pick one' } });
+    fireEvent.change(screen.getByLabelText('type'), { target: { value: 'dropdown' } });
+    fireEvent.change(screen.getByLabelText('options'), { target: { value: 'x'.repeat(201) } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/options must be 200 characters or fewer/i);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/screens/events/form/EventRsvpQuestionDialog.tsx
+++ b/frontend/src/screens/events/form/EventRsvpQuestionDialog.tsx
@@ -1,6 +1,8 @@
 import type { SyntheticEvent } from 'react';
 import { useState } from 'react';
 
+import { DEFAULT_RSVP_QUESTION_TYPE } from '@/api/eventRsvpQuestions';
+import { questionOptionsError } from '@/components/questions/questionTypeOptions';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import { Select } from '@/components/ui/Select';
@@ -33,7 +35,7 @@ export function EventRsvpQuestionDialog(props: Props) {
 function EventRsvpQuestionDialogBody({ open, onClose, onSave, existing }: Props) {
   const [label, setLabel] = useState(() => existing?.label ?? '');
   const [fieldType, setFieldType] = useState<RsvpQuestionType>(
-    () => existing?.fieldType ?? 'textarea',
+    () => existing?.fieldType ?? DEFAULT_RSVP_QUESTION_TYPE,
   );
   const [required, setRequired] = useState(() => existing?.required ?? false);
   const [optionsText, setOptionsText] = useState(() => existing?.options.join('\n') ?? '');
@@ -47,9 +49,11 @@ function EventRsvpQuestionDialogBody({ open, onClose, onSave, existing }: Props)
       setError('question required');
       return;
     }
-    const options = wantsOptions(fieldType) ? parseOptionsText(optionsText) : [];
-    if (wantsOptions(fieldType) && options.length === 0) {
-      setError('add at least one option');
+    const needsOptions = wantsOptions(fieldType);
+    const options = needsOptions ? parseOptionsText(optionsText) : [];
+    const optionsError = questionOptionsError(needsOptions, options);
+    if (optionsError) {
+      setError(optionsError);
       return;
     }
     if (options.some((option) => option.length > MAX_OPTION_LENGTH)) {

--- a/frontend/src/screens/events/form/EventRsvpQuestionDialog.tsx
+++ b/frontend/src/screens/events/form/EventRsvpQuestionDialog.tsx
@@ -1,7 +1,6 @@
 import type { SyntheticEvent } from 'react';
 import { useState } from 'react';
 
-import { RSVP_QUESTION_TYPE_OPTIONS } from '@/components/questions/questionTypeOptions';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import { Select } from '@/components/ui/Select';
@@ -11,6 +10,7 @@ import { TextField } from '@/components/ui/TextField';
 import {
   newQuestionId,
   parseOptionsText,
+  RSVP_QUESTION_TYPE_OPTIONS,
   type RsvpQuestionDraft,
   type RsvpQuestionType,
   wantsOptions,

--- a/frontend/src/screens/events/form/EventRsvpQuestionDialog.tsx
+++ b/frontend/src/screens/events/form/EventRsvpQuestionDialog.tsx
@@ -60,7 +60,7 @@ function EventRsvpQuestionDialogBody({ open, onClose, onSave, existing }: Props)
       setError(`options must be ${String(MAX_OPTION_LENGTH)} characters or fewer`);
       return;
     }
-    if (fieldType === 'multiselect' && options.some((option) => option.includes(','))) {
+    if (fieldType === 'checkbox' && options.some((option) => option.includes(','))) {
       setError('options cannot contain commas');
       return;
     }

--- a/frontend/src/screens/events/form/EventRsvpQuestionDialog.tsx
+++ b/frontend/src/screens/events/form/EventRsvpQuestionDialog.tsx
@@ -1,0 +1,130 @@
+import type { SyntheticEvent } from 'react';
+import { useState } from 'react';
+
+import { RSVP_QUESTION_TYPE_OPTIONS } from '@/components/questions/questionTypeOptions';
+import { Button } from '@/components/ui/Button';
+import { Dialog } from '@/components/ui/Dialog';
+import { Select } from '@/components/ui/Select';
+import { Textarea } from '@/components/ui/Textarea';
+import { TextField } from '@/components/ui/TextField';
+
+import {
+  newQuestionId,
+  parseOptionsText,
+  type RsvpQuestionDraft,
+  type RsvpQuestionType,
+  wantsOptions,
+} from '../rsvpQuestions';
+
+const MAX_OPTION_LENGTH = 200;
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onSave: (question: RsvpQuestionDraft) => void;
+  existing?: RsvpQuestionDraft | undefined;
+}
+
+export function EventRsvpQuestionDialog(props: Props) {
+  if (!props.open) return null;
+  return <EventRsvpQuestionDialogBody key={props.existing?.id ?? 'new'} {...props} />;
+}
+
+function EventRsvpQuestionDialogBody({ open, onClose, onSave, existing }: Props) {
+  const [label, setLabel] = useState(() => existing?.label ?? '');
+  const [fieldType, setFieldType] = useState<RsvpQuestionType>(
+    () => existing?.fieldType ?? 'textarea',
+  );
+  const [required, setRequired] = useState(() => existing?.required ?? false);
+  const [optionsText, setOptionsText] = useState(() => existing?.options.join('\n') ?? '');
+  const [error, setError] = useState<string | null>(null);
+
+  function onSubmit(e: SyntheticEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    setError(null);
+    if (!label.trim()) {
+      setError('question required');
+      return;
+    }
+    const options = wantsOptions(fieldType) ? parseOptionsText(optionsText) : [];
+    if (wantsOptions(fieldType) && options.length === 0) {
+      setError('add at least one option');
+      return;
+    }
+    if (options.some((option) => option.length > MAX_OPTION_LENGTH)) {
+      setError(`options must be ${String(MAX_OPTION_LENGTH)} characters or fewer`);
+      return;
+    }
+    if (fieldType === 'multiselect' && options.some((option) => option.includes(','))) {
+      setError('options cannot contain commas');
+      return;
+    }
+    onSave({
+      id: existing?.id ?? newQuestionId(),
+      label: label.trim(),
+      fieldType,
+      options,
+      required,
+    });
+    onClose();
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} title={existing ? 'edit question' : 'add question'}>
+      <form onSubmit={onSubmit} className="flex flex-col gap-3">
+        <TextField
+          label="question"
+          value={label}
+          onChange={(e) => {
+            setLabel(e.target.value);
+          }}
+          maxLength={200}
+        />
+        <Select
+          label="type"
+          value={fieldType}
+          onChange={(e) => {
+            setFieldType(e.target.value as RsvpQuestionType);
+          }}
+          options={RSVP_QUESTION_TYPE_OPTIONS.map((o) => ({
+            value: o.value,
+            label: o.label,
+          }))}
+        />
+        {wantsOptions(fieldType) ? (
+          <Textarea
+            label="options"
+            value={optionsText}
+            onChange={(e) => {
+              setOptionsText(e.target.value);
+            }}
+            hint="one per line"
+            rows={5}
+          />
+        ) : null}
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={required}
+            onChange={(e) => {
+              setRequired(e.target.checked);
+            }}
+          />
+          <span>required</span>
+        </label>
+        {error ? (
+          <p role="alert" className="text-destructive text-sm">
+            {error}
+          </p>
+        ) : null}
+        <div className="mt-2 flex justify-end gap-2">
+          <Button variant="ghost" onClick={onClose} type="button">
+            cancel
+          </Button>
+          <Button type="submit">save</Button>
+        </div>
+      </form>
+    </Dialog>
+  );
+}

--- a/frontend/src/screens/events/rsvpQuestions.test.ts
+++ b/frontend/src/screens/events/rsvpQuestions.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isAnswerFilled,
+  missingRequiredQuestionIds,
+  parseOptionsText,
+  type RsvpQuestionDraft,
+  wantsOptions,
+} from './rsvpQuestions';
+
+const q = (
+  overrides: Partial<RsvpQuestionDraft> & Pick<RsvpQuestionDraft, 'id'>,
+): RsvpQuestionDraft => ({
+  label: 'q',
+  fieldType: 'textarea',
+  options: [],
+  required: false,
+  ...overrides,
+});
+
+describe('wantsOptions', () => {
+  it('is true only for choice types', () => {
+    expect(wantsOptions('textarea')).toBe(false);
+    expect(wantsOptions('dropdown')).toBe(true);
+    expect(wantsOptions('multiselect')).toBe(true);
+  });
+});
+
+describe('parseOptionsText', () => {
+  it('splits trimmed non-empty lines', () => {
+    expect(parseOptionsText('  a\n\nb  \n')).toEqual(['a', 'b']);
+  });
+});
+
+describe('isAnswerFilled', () => {
+  it('treats empty or whitespace as unfilled', () => {
+    expect(isAnswerFilled(undefined)).toBe(false);
+    expect(isAnswerFilled('')).toBe(false);
+    expect(isAnswerFilled('  ')).toBe(false);
+    expect(isAnswerFilled('yes')).toBe(true);
+  });
+});
+
+describe('missingRequiredQuestionIds', () => {
+  it('returns ids of required questions without answers', () => {
+    const questions = [
+      q({ id: 'a', required: true }),
+      q({ id: 'b', required: false }),
+      q({ id: 'c', required: true, fieldType: 'multiselect' }),
+    ];
+    expect(missingRequiredQuestionIds(questions, { a: 'ok', c: '' })).toEqual(['c']);
+    expect(missingRequiredQuestionIds(questions, { a: 'ok', c: 'x' })).toEqual([]);
+  });
+});

--- a/frontend/src/screens/events/rsvpQuestions.test.ts
+++ b/frontend/src/screens/events/rsvpQuestions.test.ts
@@ -29,8 +29,8 @@ describe('RSVP_QUESTION_TYPE_OPTIONS', () => {
   it('should project the RSVP subset from catalog metadata', () => {
     expect(RSVP_QUESTION_TYPE_OPTIONS.map((o) => o.value)).toEqual([
       'textarea',
-      'dropdown',
-      'multiselect',
+      'select',
+      'checkbox',
     ]);
   });
 });
@@ -38,8 +38,8 @@ describe('RSVP_QUESTION_TYPE_OPTIONS', () => {
 describe('wantsOptions', () => {
   it('is true only for choice types', () => {
     expect(wantsOptions('textarea')).toBe(false);
-    expect(wantsOptions('dropdown')).toBe(true);
-    expect(wantsOptions('multiselect')).toBe(true);
+    expect(wantsOptions('select')).toBe(true);
+    expect(wantsOptions('checkbox')).toBe(true);
   });
 });
 
@@ -63,7 +63,7 @@ describe('missingRequiredQuestionIds', () => {
     const questions = [
       q({ id: 'a', required: true }),
       q({ id: 'b', required: false }),
-      q({ id: 'c', required: true, fieldType: 'multiselect' }),
+      q({ id: 'c', required: true, fieldType: 'checkbox' }),
     ];
     expect(missingRequiredQuestionIds(questions, { a: 'ok', c: '' })).toEqual(['c']);
     expect(missingRequiredQuestionIds(questions, { a: 'ok', c: 'x' })).toEqual([]);

--- a/frontend/src/screens/events/rsvpQuestions.test.ts
+++ b/frontend/src/screens/events/rsvpQuestions.test.ts
@@ -1,12 +1,19 @@
 import { describe, expect, it } from 'vitest';
 
+import type { RsvpQuestionType } from '@/api/eventRsvpQuestions';
+import type { QuestionType } from '@/api/questionTypes';
+
 import {
   isAnswerFilled,
   missingRequiredQuestionIds,
   parseOptionsText,
+  RSVP_QUESTION_TYPE_OPTIONS,
   type RsvpQuestionDraft,
   wantsOptions,
 } from './rsvpQuestions';
+
+type AssertExtends<_A extends B, B> = true;
+type _RsvpSubsetOfCatalog = AssertExtends<RsvpQuestionType, QuestionType>;
 
 const q = (
   overrides: Partial<RsvpQuestionDraft> & Pick<RsvpQuestionDraft, 'id'>,
@@ -16,6 +23,16 @@ const q = (
   options: [],
   required: false,
   ...overrides,
+});
+
+describe('RSVP_QUESTION_TYPE_OPTIONS', () => {
+  it('should project the RSVP subset from catalog metadata', () => {
+    expect(RSVP_QUESTION_TYPE_OPTIONS.map((o) => o.value)).toEqual([
+      'textarea',
+      'dropdown',
+      'multiselect',
+    ]);
+  });
 });
 
 describe('wantsOptions', () => {

--- a/frontend/src/screens/events/rsvpQuestions.ts
+++ b/frontend/src/screens/events/rsvpQuestions.ts
@@ -1,15 +1,24 @@
 /** Draft / wire-aligned RSVP question helpers used by authoring + RSVP dialog. */
 
+import type { RsvpQuestionType } from '@/api/eventRsvpQuestions';
 import {
+  QUESTION_TYPE_OPTION_BY_TYPE,
   questionTypeWantsOptions,
-  RSVP_QUESTION_TYPE_OPTIONS,
-  type RsvpQuestionType,
+  type QuestionTypeOption,
 } from '@/components/questions/questionTypeOptions';
 import type { EventRsvpQuestion } from '@/models/event';
 
 export type { RsvpQuestionType };
 export type RsvpQuestionDraft = EventRsvpQuestion;
 export type RsvpAnswerValue = string;
+
+const RSVP_QUESTION_TYPE_OPTION_BY_TYPE = {
+  textarea: QUESTION_TYPE_OPTION_BY_TYPE.textarea,
+  dropdown: QUESTION_TYPE_OPTION_BY_TYPE.dropdown,
+  multiselect: QUESTION_TYPE_OPTION_BY_TYPE.multiselect,
+} satisfies Record<RsvpQuestionType, QuestionTypeOption>;
+
+export const RSVP_QUESTION_TYPE_OPTIONS = Object.values(RSVP_QUESTION_TYPE_OPTION_BY_TYPE);
 
 export const RSVP_QUESTION_TYPE_LABELS: Record<RsvpQuestionType, string> = Object.fromEntries(
   RSVP_QUESTION_TYPE_OPTIONS.map((o) => [o.value, o.label]),

--- a/frontend/src/screens/events/rsvpQuestions.ts
+++ b/frontend/src/screens/events/rsvpQuestions.ts
@@ -3,8 +3,8 @@
 import type { RsvpQuestionType } from '@/api/eventRsvpQuestions';
 import {
   QUESTION_TYPE_OPTION_BY_TYPE,
-  questionTypeWantsOptions,
   type QuestionTypeOption,
+  questionTypeWantsOptions,
 } from '@/components/questions/questionTypeOptions';
 import type { EventRsvpQuestion } from '@/models/event';
 
@@ -14,8 +14,8 @@ export type RsvpAnswerValue = string;
 
 const RSVP_QUESTION_TYPE_OPTION_BY_TYPE = {
   textarea: QUESTION_TYPE_OPTION_BY_TYPE.textarea,
-  dropdown: QUESTION_TYPE_OPTION_BY_TYPE.dropdown,
-  multiselect: QUESTION_TYPE_OPTION_BY_TYPE.multiselect,
+  select: QUESTION_TYPE_OPTION_BY_TYPE.select,
+  checkbox: QUESTION_TYPE_OPTION_BY_TYPE.checkbox,
 } satisfies Record<RsvpQuestionType, QuestionTypeOption>;
 
 export const RSVP_QUESTION_TYPE_OPTIONS = Object.values(RSVP_QUESTION_TYPE_OPTION_BY_TYPE);

--- a/frontend/src/screens/events/rsvpQuestions.ts
+++ b/frontend/src/screens/events/rsvpQuestions.ts
@@ -1,0 +1,40 @@
+/** Draft / wire-aligned RSVP question helpers used by authoring + RSVP dialog. */
+
+import {
+  questionTypeWantsOptions,
+  RSVP_QUESTION_TYPE_OPTIONS,
+  type RsvpQuestionType,
+} from '@/components/questions/questionTypeOptions';
+import type { EventRsvpQuestion } from '@/models/event';
+
+export type { RsvpQuestionType };
+export type RsvpQuestionDraft = EventRsvpQuestion;
+export type RsvpAnswerValue = string;
+
+export const RSVP_QUESTION_TYPE_LABELS: Record<RsvpQuestionType, string> = Object.fromEntries(
+  RSVP_QUESTION_TYPE_OPTIONS.map((o) => [o.value, o.label]),
+) as Record<RsvpQuestionType, string>;
+
+export function parseOptionsText(text: string): string[] {
+  return text
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export function isAnswerFilled(value: RsvpAnswerValue | undefined): boolean {
+  return Boolean(value?.trim());
+}
+
+export function missingRequiredQuestionIds(
+  questions: readonly RsvpQuestionDraft[],
+  answers: Readonly<Record<string, RsvpAnswerValue | undefined>>,
+): string[] {
+  return questions.filter((q) => q.required && !isAnswerFilled(answers[q.id])).map((q) => q.id);
+}
+
+export function newQuestionId(): string {
+  return `q-${crypto.randomUUID()}`;
+}
+
+export { questionTypeWantsOptions as wantsOptions };

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -85,6 +85,8 @@ export function makeEvent(overrides: Partial<Event> = {}): Event {
       },
     ],
     myRsvp: null,
+    myRsvpAnswers: {},
+    rsvpQuestions: [],
     viewerUserId: null,
     surveySlugs: [],
     invitedUserIds: [],


### PR DESCRIPTION
## Summary
- let hosts author and atomically sync per-event RSVP questions
- validate and persist authenticated members’ answers with question snapshots
- render questions in event forms and member RSVP flows

## Test plan
- [x] `make agent-ci`
- [x] generated API and validation contracts are current

## Stack
- 2 of 4
- depends on #1220

Made with [Cursor](https://cursor.com)