### PR TITLE
feat(events): add host RSVP response reporting

### DIFF
--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -84,8 +84,21 @@ def _can_see_phones(requesting_user, creator, co_host_ids: set[str]) -> bool:
     return str(requesting_user.pk) in co_host_ids
 
 
-def _build_guest_list(rsvps, can_see_phones: bool, viewer=None) -> list[RSVPGuestOut]:
-    """Build guest list with optional phone visibility."""
+def _can_see_guest_answers(requesting_user, creator, co_host_ids: set[str]) -> bool:
+    """Hosts, co-hosts, and event managers can see RSVP question answers."""
+    if requesting_user is None:
+        return False
+    if requesting_user.has_permission(PermissionKey.MANAGE_EVENTS):
+        return True
+    if creator is not None and requesting_user.pk == creator.pk:
+        return True
+    return str(requesting_user.pk) in co_host_ids
+
+
+def _build_guest_list(
+    rsvps, can_see_phones: bool, viewer=None, *, include_answers: bool = False
+) -> list[RSVPGuestOut]:
+    """Build guest list with optional phone / answer visibility."""
     return [
         RSVPGuestOut(
             user_id=str(r.user_id),
@@ -97,6 +110,7 @@ def _build_guest_list(rsvps, can_see_phones: bool, viewer=None) -> list[RSVPGues
             attendance=r.attendance,
             checked_in_at=r.checked_in_at,
             is_member=r.user.is_member,
+            answers=dict(r.answers or {}) if include_answers else {},
         )
         for r in rsvps
     ]
@@ -319,7 +333,8 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
     is_authed = auth_user is not None
     co_host_ids = {str(u.id) for u in co_hosts}
     phones_visible = _can_see_phones(auth_user, creator, co_host_ids)
-    rsvps = list(event.rsvps.all()) if (event.rsvp_enabled and is_authed) else []
+    answers_visible = _can_see_guest_answers(auth_user, creator, co_host_ids)
+    rsvps = list(event.rsvps.all()) if is_authed and (event.rsvp_enabled or answers_visible) else []
     all_invited = list(event.invited_users.all())
     invited = all_invited if _can_see_invited(auth_user, creator, co_host_ids) else []
 
@@ -358,7 +373,11 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
         co_host_ids=[str(u.id) for u in co_hosts],
         co_host_names=[visible_display_name(u, auth_user) for u in co_hosts],
         co_host_photo_urls=[media_path(u.profile_photo) for u in co_hosts],
-        guests=_members_only(_build_guest_list(rsvps, phones_visible, auth_user), [], is_authed),
+        guests=_members_only(
+            _build_guest_list(rsvps, phones_visible, auth_user, include_answers=answers_visible),
+            [],
+            is_authed,
+        ),
         my_rsvp=_find_my_rsvp(rsvps, auth_user),
         my_rsvp_answers=_find_my_rsvp_answers(rsvps, auth_user),
         viewer_user_id=str(auth_user.pk) if auth_user else None,

--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -182,6 +182,8 @@ class RSVPGuestOut(BaseModel):
     attendance: AttendanceStatus = AttendanceStatus.UNKNOWN
     checked_in_at: datetime | None = None
     is_member: bool = True
+    # Host/co-host/manage-events only — empty for other viewers.
+    answers: dict = {}
 
 
 class PendingCoHostInviteOut(BaseModel):

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -4897,6 +4897,12 @@
       },
       "RSVPGuestOut": {
         "properties": {
+          "answers": {
+            "additionalProperties": true,
+            "default": {},
+            "title": "Answers",
+            "type": "object"
+          },
           "attendance": {
             "allOf": [
               {

--- a/backend/tests/test_event_helpers.py
+++ b/backend/tests/test_event_helpers.py
@@ -57,6 +57,7 @@ class TestBuildGuestList:
             has_plus_one=False,
             attendance=AttendanceStatus.UNKNOWN,
             checked_in_at=None,
+            answers={},
         )
 
     def test_empty_rsvps(self):
@@ -81,6 +82,14 @@ class TestBuildGuestList:
         rsvp = self._make_rsvp("u1", None, RSVPStatus.ATTENDING, "+1555000", show_phone=False)
         result = _build_guest_list([rsvp], can_see_phones=False)
         assert result[0].name == "member"
+
+    def test_includes_answers_only_when_requested(self):
+        rsvp = self._make_rsvp("u1", "Alice", RSVPStatus.ATTENDING, "+1555000")
+        rsvp.answers = {"qid": {"label": "q", "answer": "yes"}}
+        hidden = _build_guest_list([rsvp], can_see_phones=False, include_answers=False)
+        assert hidden[0].answers == {}
+        shown = _build_guest_list([rsvp], can_see_phones=False, include_answers=True)
+        assert shown[0].answers == {"qid": {"label": "q", "answer": "yes"}}
 
 
 class TestFindMyRsvp:

--- a/backend/tests/test_event_rsvp_questions.py
+++ b/backend/tests/test_event_rsvp_questions.py
@@ -127,6 +127,33 @@ class TestRsvpWithAnswers:
         assert response.status_code == 422
         assert_error_code(response, Code.Event.RSVP_ANSWER_INVALID_OPTION)
 
+    def test_host_sees_guest_answers_member_does_not(
+        self, api_client, other_headers, auth_headers, rsvp_event, other_user
+    ):
+        q = _create_question(rsvp_event)
+        assert (
+            api_client.post(
+                f"/api/community/events/{rsvp_event.id}/rsvp/",
+                {
+                    "status": RSVPStatus.ATTENDING,
+                    "answers": {q["id"]: "transit"},
+                },
+                content_type="application/json",
+                **other_headers,
+            ).status_code
+            == 200
+        )
+
+        host_view = api_client.get(f"/api/community/events/{rsvp_event.id}/", **auth_headers).json()
+        host_guest = next(g for g in host_view["guests"] if g["user_id"] == str(other_user.pk))
+        assert host_guest["answers"][q["id"]]["answer"] == "transit"
+
+        member_view = api_client.get(
+            f"/api/community/events/{rsvp_event.id}/", **other_headers
+        ).json()
+        member_guest = next(g for g in member_view["guests"] if g["user_id"] == str(other_user.pk))
+        assert member_guest["answers"] == {}
+
 
 @pytest.mark.django_db
 class TestRsvpAnswerEdgeCases:
@@ -199,3 +226,22 @@ class TestRsvpAnswerEdgeCases:
         error = response.json()["detail"][0]
         assert error["code"] == Code.Event.RSVP_ANSWER_TOO_LONG
         assert error["params"]["label"] == "travel details"
+
+    def test_host_sees_guests_when_rsvp_disabled(
+        self, api_client, other_headers, auth_headers, rsvp_event, other_user
+    ):
+        q = _create_question(rsvp_event)
+        assert (
+            api_client.post(
+                f"/api/community/events/{rsvp_event.id}/rsvp/",
+                {"status": RSVPStatus.ATTENDING, "answers": {q["id"]: "driving"}},
+                content_type="application/json",
+                **other_headers,
+            ).status_code
+            == 200
+        )
+        rsvp_event.rsvp_enabled = False
+        rsvp_event.save(update_fields=["rsvp_enabled"])
+        host_view = api_client.get(f"/api/community/events/{rsvp_event.id}/", **auth_headers).json()
+        assert len(host_view["guests"]) == 1
+        assert host_view["guests"][0]["answers"][q["id"]]["answer"] == "driving"

--- a/frontend/src/api/eventMapper.ts
+++ b/frontend/src/api/eventMapper.ts
@@ -18,6 +18,7 @@ interface WireGuest {
   has_plus_one?: boolean;
   attendance?: string;
   is_member?: boolean;
+  answers?: Record<string, { label?: string; answer?: string }>;
 }
 
 export interface WireEvent {
@@ -116,6 +117,7 @@ function mapGuest(g: WireGuest): EventGuest {
     name: g.name,
     status: g.status,
     phone: g.phone ?? null,
+    answers: mapMyRsvpAnswers(g.answers),
     photoUrl: g.photo_url ?? '',
     hasPlusOne: g.has_plus_one ?? false,
     attendance: mapAttendance(g.attendance),

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -4238,6 +4238,13 @@ export interface components {
         QuestionType: "text" | "textarea" | "radio" | "select" | "checkbox" | "number" | "boolean" | "rating" | "datetime_poll";
         /** RSVPGuestOut */
         RSVPGuestOut: {
+            /**
+             * Answers
+             * @default {}
+             */
+            answers: {
+                [key: string]: unknown;
+            };
             /** @default unknown */
             attendance: components["schemas"]["AttendanceStatus"];
             /** Checked In At */

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -94,6 +94,8 @@ export interface EventGuest {
   hasPlusOne: boolean;
   attendance: AttendanceStatusValue;
   isMember: boolean;
+  /** Host-only RSVP question snapshots; empty for non-hosts. */
+  answers: Record<string, { label: string; answer: string }>;
 }
 
 export interface EventCancellation {

--- a/frontend/src/screens/events/EmailBlastDialog.test.tsx
+++ b/frontend/src/screens/events/EmailBlastDialog.test.tsx
@@ -37,6 +37,7 @@ function guest(status: string, i: number): EventGuest {
     hasPlusOne: false,
     attendance: 'unknown',
     isMember: true,
+    answers: {},
   };
 }
 

--- a/frontend/src/screens/events/EventDetailKebabMenu.test.tsx
+++ b/frontend/src/screens/events/EventDetailKebabMenu.test.tsx
@@ -18,7 +18,7 @@ vi.mock('./GroupTextDialog', () => ({
 import { useFlag } from '@/api/featureFlags';
 import type { Event } from '@/models/event';
 import { EventStatus } from '@/models/event';
-import { makeEvent } from '@/test/fixtures';
+import { makeEvent, makeGuest } from '@/test/fixtures';
 
 import { EventDetailKebabMenu } from './EventDetailKebabMenu';
 
@@ -88,12 +88,80 @@ describe('EventDetailKebabMenu', () => {
     expect(manageRsvps).toHaveAttribute('href', '/events/ev1/manage-rsvps');
   });
 
-  it('hides "manage rsvps" once the event has ended', async () => {
+  it('hides rsvp management once the event has ended without question history', async () => {
     vi.mocked(useFlag).mockReturnValue(false);
     renderMenu({ eventHasEnded: true, canManageRsvps: true });
     await openMenu();
 
     expect(screen.queryByRole('menuitem', { name: /manage rsvps/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: /question responses/i })).not.toBeInTheDocument();
+  });
+
+  it('links past-event question responses to rsvp management', async () => {
+    vi.mocked(useFlag).mockReturnValue(false);
+    renderMenu({
+      eventHasEnded: true,
+      canManageRsvps: true,
+      event: {
+        rsvpQuestions: [
+          {
+            id: 'q1',
+            label: 'dietary?',
+            fieldType: 'textarea',
+            options: [],
+            required: false,
+          },
+        ],
+      },
+    });
+    await openMenu();
+
+    expect(screen.getByRole('menuitem', { name: /question responses/i })).toHaveAttribute(
+      'href',
+      '/events/ev1/manage-rsvps',
+    );
+  });
+
+  it('links saved answer history to rsvp management', async () => {
+    vi.mocked(useFlag).mockReturnValue(false);
+    renderMenu({
+      eventHasEnded: true,
+      canManageRsvps: true,
+      event: {
+        rsvpQuestions: [],
+        guests: [
+          makeGuest({
+            answers: { deleted: { label: 'deleted question', answer: 'saved answer' } },
+          }),
+        ],
+      },
+    });
+    await openMenu();
+
+    expect(screen.getByRole('menuitem', { name: /question responses/i })).toHaveAttribute(
+      'href',
+      '/events/ev1/manage-rsvps',
+    );
+  });
+
+  it('hides "question responses" when only declined snapshots remain', async () => {
+    vi.mocked(useFlag).mockReturnValue(false);
+    renderMenu({
+      eventHasEnded: true,
+      canManageRsvps: true,
+      event: {
+        rsvpQuestions: [],
+        guests: [
+          makeGuest({
+            status: 'cant_go',
+            answers: { deleted: { label: 'deleted question', answer: 'saved answer' } },
+          }),
+        ],
+      },
+    });
+    await openMenu();
+
+    expect(screen.queryByRole('menuitem', { name: /question responses/i })).not.toBeInTheDocument();
   });
 
   it('hides "manage rsvps" when the viewer cannot manage rsvps', async () => {

--- a/frontend/src/screens/events/EventDetailKebabMenu.tsx
+++ b/frontend/src/screens/events/EventDetailKebabMenu.tsx
@@ -8,6 +8,7 @@ import { Feature } from '@/models/featureFlags';
 
 import { EmailBlastDialog } from './EmailBlastDialog';
 import { GroupTextDialog } from './GroupTextDialog';
+import { hasSavedRsvpAnswers } from './rsvpQuestions';
 
 interface Props {
   event: Event;
@@ -23,7 +24,8 @@ export function EventDetailKebabMenu({ event, eventHasEnded, canManageRsvps }: P
   const rootRef = useRef<HTMLDivElement>(null);
   const reportFlagOn = useFlag(Feature.HostAttendanceReport);
   const showCheckInReport = eventHasEnded && reportFlagOn;
-  const showManageRsvps = canManageRsvps && !eventHasEnded;
+  const hasQuestionHistory = event.rsvpQuestions.length > 0 || hasSavedRsvpAnswers(event);
+  const showManageRsvps = canManageRsvps && (!eventHasEnded || hasQuestionHistory);
   const showEmailBlast = event.status !== EventStatus.Draft && event.guests.length > 0;
 
   useEffect(() => {
@@ -70,7 +72,7 @@ export function EventDetailKebabMenu({ event, eventHasEnded, canManageRsvps }: P
                 setOpen(false);
               }}
             >
-              manage rsvps
+              {eventHasEnded ? 'question responses' : 'manage rsvps'}
             </MenuLink>
           ) : null}
           <MenuLink

--- a/frontend/src/screens/events/EventManageRsvpsPanel.tsx
+++ b/frontend/src/screens/events/EventManageRsvpsPanel.tsx
@@ -10,26 +10,37 @@ import { RsvpStatusPicker } from '@/components/ui/RsvpStatusPicker';
 import type { Event, EventGuest, RsvpInputStatus } from '@/models/event';
 import { isRsvpInputStatus, RSVP_GROUP_LABELS, RsvpServerStatus } from '@/models/event';
 
-export function EventManageRsvpsPanel({ event }: { event: Event }) {
+import { EventRsvpResponsesSection } from './EventRsvpResponsesSection';
+
+export function EventManageRsvpsPanel({
+  event,
+  readOnly = false,
+}: {
+  event: Event;
+  /** Past events: hide add/edit controls; still show question responses. */
+  readOnly?: boolean;
+}) {
   const setGuestRsvp = useSetGuestRsvp(event.id);
   const removeGuestRsvp = useRemoveGuestRsvp(event.id);
 
   return (
-    <div className="flex flex-col gap-6">
-      <AddMemberSection
-        event={event}
-        isPending={setGuestRsvp.isPending}
-        onAdd={(userId) => {
-          setGuestRsvp.mutate(
-            { userId, status: RsvpServerStatus.Attending, hasPlusOne: false },
-            {
-              onError: (err) => {
-                toast.error(extractApiErrorOr(err, "couldn't add them — try again"));
+    <div className="flex flex-col gap-8">
+      {readOnly ? null : (
+        <AddMemberSection
+          event={event}
+          isPending={setGuestRsvp.isPending}
+          onAdd={(userId) => {
+            setGuestRsvp.mutate(
+              { userId, status: RsvpServerStatus.Attending, hasPlusOne: false },
+              {
+                onError: (err) => {
+                  toast.error(extractApiErrorOr(err, "couldn't add them — try again"));
+                },
               },
-            },
-          );
-        }}
-      />
+            );
+          }}
+        />
+      )}
       {event.guests.length === 0 ? (
         <p className="text-muted text-sm">no one yet 🌿</p>
       ) : (
@@ -41,6 +52,7 @@ export function EventManageRsvpsPanel({ event }: { event: Event }) {
               key={group.status}
               label={group.label}
               guests={guests}
+              readOnly={readOnly}
               onChangeStatus={(userId, status, hasPlusOne) => {
                 setGuestRsvp.mutate(
                   { userId, status, hasPlusOne },
@@ -66,6 +78,7 @@ export function EventManageRsvpsPanel({ event }: { event: Event }) {
           );
         })
       )}
+      <EventRsvpResponsesSection event={event} />
     </div>
   );
 }
@@ -111,12 +124,14 @@ function GuestGroup({
   onChangeStatus,
   onRemove,
   isPending,
+  readOnly,
 }: {
   label: string;
   guests: EventGuest[];
   onChangeStatus: (userId: string, status: RsvpInputStatus, hasPlusOne: boolean) => void;
   onRemove: (userId: string) => void;
   isPending: boolean;
+  readOnly: boolean;
 }) {
   return (
     <div className="flex flex-col gap-2">
@@ -128,6 +143,7 @@ function GuestGroup({
           <GuestRow
             key={g.userId}
             guest={g}
+            readOnly={readOnly}
             onChangeStatus={onChangeStatus}
             onRemove={onRemove}
             isPending={isPending}
@@ -143,11 +159,13 @@ function GuestRow({
   onChangeStatus,
   onRemove,
   isPending,
+  readOnly,
 }: {
   guest: EventGuest;
   onChangeStatus: (userId: string, status: RsvpInputStatus, hasPlusOne: boolean) => void;
   onRemove: (userId: string) => void;
   isPending: boolean;
+  readOnly: boolean;
 }) {
   const currentStatus = isRsvpInputStatus(guest.status) ? guest.status : null;
 
@@ -155,6 +173,18 @@ function GuestRow({
     return (
       <li className="border-border flex items-center justify-between gap-2 rounded-md border p-2 opacity-60">
         <span className="text-foreground text-sm">{guest.name} (not a member)</span>
+      </li>
+    );
+  }
+
+  if (readOnly) {
+    return (
+      <li className="border-border flex items-center justify-between gap-2 rounded-md border p-2">
+        <span className="text-foreground text-sm">{guest.name}</span>
+        <span className="text-muted text-xs">
+          {currentStatus ?? guest.status}
+          {guest.hasPlusOne ? ' · +1' : ''}
+        </span>
       </li>
     );
   }

--- a/frontend/src/screens/events/EventManageRsvpsScreen.test.tsx
+++ b/frontend/src/screens/events/EventManageRsvpsScreen.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAuthStore } from '@/auth/store';
-import { makeEvent, makeUser } from '@/test/fixtures';
+import { makeEvent, makeGuest, makeUser } from '@/test/fixtures';
 
 vi.mock('@/api/events', () => ({
   useEvent: vi.fn(),
@@ -55,7 +55,7 @@ describe('EventManageRsvpsScreen', () => {
     expect(screen.getByText(/only the host or a co-host/i)).toBeInTheDocument();
   });
 
-  it('shows a forbidden notice for a past event', () => {
+  it('shows a forbidden notice for a past event with no questions', () => {
     vi.mocked(useEvent).mockReturnValue({
       data: makeEvent({
         createdById: 'user-creator',
@@ -70,6 +70,34 @@ describe('EventManageRsvpsScreen', () => {
     renderScreen();
 
     expect(screen.getByText(/event has already happened/i)).toBeInTheDocument();
+  });
+
+  it('lets a host review question responses on a past event', () => {
+    vi.mocked(useEvent).mockReturnValue({
+      data: makeEvent({
+        createdById: 'user-creator',
+        coHostIds: ['user-creator'],
+        guests: [],
+        isPast: true,
+        rsvpQuestions: [
+          {
+            id: 'q1',
+            label: 'dietary?',
+            fieldType: 'textarea',
+            options: [],
+            required: false,
+          },
+        ],
+      }),
+      isPending: false,
+      isError: false,
+    } as ReturnType<typeof useEvent>);
+    useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
+    renderScreen();
+
+    expect(screen.getByRole('heading', { name: /manage rsvps/i })).toBeInTheDocument();
+    expect(screen.getByText(/guest edits are closed/i)).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: /question responses/i })).toBeInTheDocument();
   });
 
   it('shows a forbidden notice when rsvps are disabled', () => {
@@ -87,6 +115,56 @@ describe('EventManageRsvpsScreen', () => {
     renderScreen();
 
     expect(screen.getByText(/rsvps are off/i)).toBeInTheDocument();
+  });
+
+  it('lets a host review responses when rsvps are off but questions remain', () => {
+    vi.mocked(useEvent).mockReturnValue({
+      data: makeEvent({
+        createdById: 'user-creator',
+        coHostIds: ['user-creator'],
+        guests: [],
+        rsvpEnabled: false,
+        rsvpQuestions: [
+          {
+            id: 'q1',
+            label: 'dietary?',
+            fieldType: 'textarea',
+            options: [],
+            required: false,
+          },
+        ],
+      }),
+      isPending: false,
+      isError: false,
+    } as ReturnType<typeof useEvent>);
+    useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
+    renderScreen();
+
+    expect(screen.getByRole('heading', { name: /manage rsvps/i })).toBeInTheDocument();
+    expect(screen.getByText(/reviewing question responses/i)).toBeInTheDocument();
+  });
+
+  it('lets a host review responses when only saved answer snapshots remain', () => {
+    vi.mocked(useEvent).mockReturnValue({
+      data: makeEvent({
+        createdById: 'user-creator',
+        coHostIds: ['user-creator'],
+        rsvpEnabled: false,
+        rsvpQuestions: [],
+        guests: [
+          makeGuest({
+            answers: { deleted: { label: 'deleted question', answer: 'saved answer' } },
+          }),
+        ],
+      }),
+      isPending: false,
+      isError: false,
+    } as ReturnType<typeof useEvent>);
+    useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
+    renderScreen();
+
+    expect(screen.getByRole('heading', { name: /manage rsvps/i })).toBeInTheDocument();
+    expect(screen.getByText('saved answer')).toBeInTheDocument();
   });
 
   it('renders the panel heading for a host on a future rsvp-enabled event', () => {

--- a/frontend/src/screens/events/EventManageRsvpsScreen.tsx
+++ b/frontend/src/screens/events/EventManageRsvpsScreen.tsx
@@ -7,6 +7,7 @@ import { canManageEvent } from '@/models/event';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 
 import { EventManageRsvpsPanel } from './EventManageRsvpsPanel';
+import { hasSavedRsvpAnswers } from './rsvpQuestions';
 
 export default function EventManageRsvpsScreen() {
   const { id } = useParams<{ id: string }>();
@@ -27,10 +28,8 @@ export default function EventManageRsvpsScreen() {
       <ForbiddenNotice eventId={event.id} message="only the host or a co-host can manage rsvps" />
     );
   }
-  if (event.isPast) {
-    return <ForbiddenNotice eventId={event.id} message="this event has already happened" />;
-  }
-  if (!event.rsvpEnabled) {
+  const hasQuestionHistory = event.rsvpQuestions.length > 0 || hasSavedRsvpAnswers(event);
+  if (!event.rsvpEnabled && !hasQuestionHistory) {
     return (
       <ForbiddenNotice
         eventId={event.id}
@@ -38,13 +37,23 @@ export default function EventManageRsvpsScreen() {
       />
     );
   }
+  // Past events / RSVPs-off with questions stay open so hosts can review responses.
+  if (event.isPast && !hasQuestionHistory) {
+    return <ForbiddenNotice eventId={event.id} message="this event has already happened" />;
+  }
 
   return (
     <ContentContainer>
       <BackLink eventId={event.id} />
       <h1 className="mb-1 text-2xl font-medium tracking-tight">manage rsvps</h1>
       <p className="text-foreground-secondary mb-6 text-sm">{event.title}</p>
-      <EventManageRsvpsPanel event={event} />
+      {event.isPast ? (
+        <p className="text-muted mb-4 text-sm">this event is over — guest edits are closed</p>
+      ) : null}
+      {!event.rsvpEnabled ? (
+        <p className="text-muted mb-4 text-sm">rsvps are off — reviewing question responses</p>
+      ) : null}
+      <EventManageRsvpsPanel event={event} readOnly={event.isPast || !event.rsvpEnabled} />
     </ContentContainer>
   );
 }

--- a/frontend/src/screens/events/EventRsvpResponsesSection.test.tsx
+++ b/frontend/src/screens/events/EventRsvpResponsesSection.test.tsx
@@ -20,7 +20,7 @@ describe('EventRsvpResponsesSection', () => {
         {
           id: 'q1',
           label: 'how are you getting there?',
-          fieldType: 'dropdown',
+          fieldType: 'select',
           options: ['driving', 'transit'],
           required: true,
         },

--- a/frontend/src/screens/events/EventRsvpResponsesSection.test.tsx
+++ b/frontend/src/screens/events/EventRsvpResponsesSection.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { RsvpServerStatus } from '@/models/event';
+import { makeEvent, makeGuest } from '@/test/fixtures';
+
+import { EventRsvpResponsesSection } from './EventRsvpResponsesSection';
+
+describe('EventRsvpResponsesSection', () => {
+  it('renders nothing when the event has no questions', () => {
+    const { container } = render(
+      <EventRsvpResponsesSection event={makeEvent({ rsvpQuestions: [] })} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows per-guest answers and choice tallies', () => {
+    const event = makeEvent({
+      rsvpQuestions: [
+        {
+          id: 'q1',
+          label: 'how are you getting there?',
+          fieldType: 'dropdown',
+          options: ['driving', 'transit'],
+          required: true,
+        },
+        {
+          id: 'q2',
+          label: 'notes',
+          fieldType: 'textarea',
+          options: [],
+          required: false,
+        },
+      ],
+      guests: [
+        makeGuest({
+          userId: 'a',
+          name: 'alice',
+          status: RsvpServerStatus.Attending,
+          answers: {
+            q1: { label: 'how are you getting there?', answer: 'driving' },
+            q2: { label: 'notes', answer: 'bringing chips' },
+          },
+        }),
+        makeGuest({
+          userId: 'b',
+          name: 'bob',
+          status: RsvpServerStatus.Maybe,
+          answers: {
+            q1: { label: 'how are you getting there?', answer: 'transit' },
+          },
+        }),
+        makeGuest({
+          userId: 'c',
+          name: 'cara',
+          status: RsvpServerStatus.CantGo,
+          answers: {},
+        }),
+      ],
+    });
+
+    render(<EventRsvpResponsesSection event={event} />);
+
+    expect(screen.getByRole('heading', { name: /question responses/i })).toBeInTheDocument();
+    expect(screen.getByText('2 guests with going / maybe / waitlist')).toBeInTheDocument();
+    expect(screen.getByText('alice')).toBeInTheDocument();
+    expect(screen.getByText('bob')).toBeInTheDocument();
+    expect(screen.queryByText('cara')).not.toBeInTheDocument();
+    expect(screen.getByText('bringing chips')).toBeInTheDocument();
+    const tallies = screen.getByRole('list');
+    expect(tallies).toHaveTextContent(/driving\s*1/);
+    expect(tallies).toHaveTextContent(/transit\s*1/);
+  });
+
+  it('shows empty state when no going/maybe guests', () => {
+    render(
+      <EventRsvpResponsesSection
+        event={makeEvent({
+          rsvpQuestions: [
+            {
+              id: 'q1',
+              label: 'q',
+              fieldType: 'textarea',
+              options: [],
+              required: false,
+            },
+          ],
+          guests: [makeGuest({ status: RsvpServerStatus.CantGo })],
+        })}
+      />,
+    );
+    expect(screen.getByText('no responses yet')).toBeInTheDocument();
+  });
+
+  it('keeps deleted-question answers visible via snapshot labels', () => {
+    render(
+      <EventRsvpResponsesSection
+        event={makeEvent({
+          rsvpQuestions: [],
+          guests: [
+            makeGuest({
+              userId: 'a',
+              name: 'alice',
+              status: RsvpServerStatus.Attending,
+              answers: {
+                orphan: { label: 'old dietary question', answer: 'vegan' },
+              },
+            }),
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByText('old dietary question')).toBeInTheDocument();
+    expect(screen.getByText('vegan')).toBeInTheDocument();
+  });
+
+  it('keeps edited-question answers under their snapshot labels', () => {
+    render(
+      <EventRsvpResponsesSection
+        event={makeEvent({
+          rsvpQuestions: [
+            {
+              id: 'q1',
+              label: 'new question',
+              fieldType: 'textarea',
+              options: [],
+              required: false,
+            },
+          ],
+          guests: [
+            makeGuest({
+              userId: 'a',
+              name: 'alice',
+              answers: {
+                q1: { label: 'old question', answer: 'old answer' },
+              },
+            }),
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText('new question')).toBeInTheDocument();
+    expect(screen.getByText('old question')).toBeInTheDocument();
+    expect(screen.getByText('old answer')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/events/EventRsvpResponsesSection.tsx
+++ b/frontend/src/screens/events/EventRsvpResponsesSection.tsx
@@ -1,0 +1,158 @@
+import type { Event, EventGuest, EventRsvpQuestion } from '@/models/event';
+import { RsvpServerStatus } from '@/models/event';
+
+import { isRsvpRespondentStatus } from './rsvpQuestions';
+
+interface ResponseColumn {
+  key: string;
+  id: string;
+  label: string;
+  fieldType?: EventRsvpQuestion['fieldType'];
+  options: string[];
+}
+
+interface Props {
+  event: Event;
+}
+
+/** Live questions plus orphaned snapshot keys so edits/deletes keep history visible. */
+function responseColumns(
+  questions: readonly EventRsvpQuestion[],
+  guests: readonly EventGuest[],
+): ResponseColumn[] {
+  const cols: ResponseColumn[] = questions.map((q) => ({
+    key: `${q.id}:${q.label}`,
+    id: q.id,
+    label: q.label,
+    fieldType: q.fieldType,
+    options: q.options,
+  }));
+  const seen = new Set(cols.map((column) => column.key));
+  for (const g of guests) {
+    for (const [qid, snap] of Object.entries(g.answers)) {
+      const key = `${qid}:${snap.label}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      cols.push({ key, id: qid, label: snap.label, options: [] });
+    }
+  }
+  return cols;
+}
+
+export function EventRsvpResponsesSection({ event }: Props) {
+  const respondents = event.guests.filter((guest) => isRsvpRespondentStatus(guest.status));
+  const columns = responseColumns(event.rsvpQuestions, respondents);
+  if (columns.length === 0) return null;
+
+  const choiceColumns = columns.filter(
+    (q) => q.fieldType === 'dropdown' || q.fieldType === 'multiselect',
+  );
+
+  return (
+    <section aria-label="question responses" className="flex flex-col gap-4">
+      <div>
+        <h2 className="text-base font-medium">question responses</h2>
+        <p className="text-muted text-sm">
+          {String(respondents.length)} guest{respondents.length === 1 ? '' : 's'} with going / maybe
+          / waitlist
+        </p>
+      </div>
+
+      {choiceColumns.length > 0 ? (
+        <div className="flex flex-col gap-3">
+          <h3 className="text-muted text-xs font-medium tracking-wide">tallies</h3>
+          {choiceColumns.map((q) => (
+            <ChoiceTallyCard key={q.key} question={q} guests={respondents} />
+          ))}
+        </div>
+      ) : null}
+
+      {respondents.length === 0 ? (
+        <p className="text-muted text-sm">no responses yet</p>
+      ) : (
+        <div className="border-border bg-surface overflow-x-auto rounded-lg border">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-background text-muted text-xs">
+              <tr>
+                <th className="px-3 py-2">guest</th>
+                <th className="px-3 py-2">status</th>
+                {columns.map((q) => (
+                  <th key={q.key} className="px-3 py-2">
+                    {q.label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {respondents.map((g) => (
+                <tr key={g.userId} className="border-border border-t align-top">
+                  <td className="text-foreground px-3 py-2">{g.name}</td>
+                  <td className="text-muted px-3 py-2 text-xs">{statusLabel(g.status)}</td>
+                  {columns.map((q) => (
+                    <td key={q.key} className="text-foreground px-3 py-2 whitespace-pre-wrap">
+                      {renderAnswerForColumn(g.answers[q.id], q)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ChoiceTallyCard({ question, guests }: { question: ResponseColumn; guests: EventGuest[] }) {
+  const counts = new Map<string, number>();
+  for (const opt of question.options) counts.set(opt, 0);
+
+  let answered = 0;
+  for (const g of guests) {
+    const snap = g.answers[question.id];
+    if (snap?.label !== question.label) continue;
+    const values =
+      question.fieldType === 'multiselect'
+        ? snap.answer.split(',').filter(Boolean)
+        : snap.answer
+          ? [snap.answer]
+          : [];
+    if (values.length === 0) continue;
+    answered += 1;
+    for (const v of values) {
+      counts.set(v, (counts.get(v) ?? 0) + 1);
+    }
+  }
+
+  return (
+    <div className="border-border bg-surface rounded-lg border p-3">
+      <p className="text-foreground mb-1 text-sm font-medium">{question.label}</p>
+      <p className="text-muted mb-2 text-xs">
+        {String(answered)} answer{answered === 1 ? '' : 's'}
+      </p>
+      <ul className="flex flex-col gap-1 text-sm">
+        {[...counts.entries()].map(([opt, n]) => (
+          <li key={opt} className="flex justify-between gap-4">
+            <span className="text-foreground">{opt}</span>
+            <span className="text-muted tabular-nums">{String(n)}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function statusLabel(status: string): string {
+  if (status === RsvpServerStatus.Attending) return 'going';
+  if (status === RsvpServerStatus.Maybe) return 'maybe';
+  if (status === RsvpServerStatus.Waitlisted) return 'waitlist';
+  return status;
+}
+
+function renderAnswerForColumn(
+  snap: { label: string; answer: string } | undefined,
+  column: ResponseColumn,
+): string {
+  if (snap?.label !== column.label) return '—';
+  return snap.answer.trim().replaceAll(',', ', ') || '—';
+}

--- a/frontend/src/screens/events/EventRsvpResponsesSection.tsx
+++ b/frontend/src/screens/events/EventRsvpResponsesSection.tsx
@@ -45,7 +45,7 @@ export function EventRsvpResponsesSection({ event }: Props) {
   if (columns.length === 0) return null;
 
   const choiceColumns = columns.filter(
-    (q) => q.fieldType === 'dropdown' || q.fieldType === 'multiselect',
+    (q) => q.fieldType === 'select' || q.fieldType === 'checkbox',
   );
 
   return (
@@ -112,7 +112,7 @@ function ChoiceTallyCard({ question, guests }: { question: ResponseColumn; guest
     const snap = g.answers[question.id];
     if (snap?.label !== question.label) continue;
     const values =
-      question.fieldType === 'multiselect'
+      question.fieldType === 'checkbox'
         ? snap.answer.split(',').filter(Boolean)
         : snap.answer
           ? [snap.answer]

--- a/frontend/src/screens/events/RsvpGuestList.tsx
+++ b/frontend/src/screens/events/RsvpGuestList.tsx
@@ -162,6 +162,7 @@ export function InvitedList({ event }: { event: Event }) {
               hasPlusOne: false,
               attendance: AttendanceStatus.Unknown,
               isMember: true,
+              answers: {},
             }}
           />
         );

--- a/frontend/src/screens/events/rsvpQuestions.ts
+++ b/frontend/src/screens/events/rsvpQuestions.ts
@@ -6,7 +6,7 @@ import {
   type QuestionTypeOption,
   questionTypeWantsOptions,
 } from '@/components/questions/questionTypeOptions';
-import type { EventRsvpQuestion } from '@/models/event';
+import { type Event, type EventRsvpQuestion, RsvpServerStatus } from '@/models/event';
 
 export type { RsvpQuestionType };
 export type RsvpQuestionDraft = EventRsvpQuestion;
@@ -19,6 +19,12 @@ const RSVP_QUESTION_TYPE_OPTION_BY_TYPE = {
 } satisfies Record<RsvpQuestionType, QuestionTypeOption>;
 
 export const RSVP_QUESTION_TYPE_OPTIONS = Object.values(RSVP_QUESTION_TYPE_OPTION_BY_TYPE);
+
+const RESPONDENT_STATUSES = new Set<string>([
+  RsvpServerStatus.Attending,
+  RsvpServerStatus.Maybe,
+  RsvpServerStatus.Waitlisted,
+]);
 
 export const RSVP_QUESTION_TYPE_LABELS: Record<RsvpQuestionType, string> = Object.fromEntries(
   RSVP_QUESTION_TYPE_OPTIONS.map((o) => [o.value, o.label]),
@@ -40,6 +46,16 @@ export function missingRequiredQuestionIds(
   answers: Readonly<Record<string, RsvpAnswerValue | undefined>>,
 ): string[] {
   return questions.filter((q) => q.required && !isAnswerFilled(answers[q.id])).map((q) => q.id);
+}
+
+export function isRsvpRespondentStatus(status: string): boolean {
+  return RESPONDENT_STATUSES.has(status);
+}
+
+export function hasSavedRsvpAnswers(event: Event): boolean {
+  return event.guests.some(
+    (guest) => isRsvpRespondentStatus(guest.status) && Object.keys(guest.answers).length > 0,
+  );
 }
 
 export function newQuestionId(): string {

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -25,6 +25,7 @@ export function makeGuest(overrides: Partial<EventGuest> = {}): EventGuest {
     hasPlusOne: false,
     attendance: AttendanceStatus.Unknown,
     isMember: true,
+    answers: {},
     ...overrides,
   };
 }
@@ -72,6 +73,7 @@ export function makeEvent(overrides: Partial<Event> = {}): Event {
         hasPlusOne: false,
         attendance: AttendanceStatus.Unknown,
         isMember: true,
+        answers: {},
       },
       {
         userId: 'b',
@@ -82,6 +84,7 @@ export function makeEvent(overrides: Partial<Event> = {}): Event {
         hasPlusOne: false,
         isMember: true,
         attendance: AttendanceStatus.Unknown,
+        answers: {},
       },
     ],
     myRsvp: null,


### PR DESCRIPTION
## Summary
- expose RSVP answer snapshots only to hosts, co-hosts, and event managers
- add response tables and choice tallies to RSVP management
- retain read-only reporting for past events, disabled RSVPs, and deleted questions

## Test plan
- [x] `make agent-ci`
- [x] generated API contracts are current

## Stack
- 4 of 4
- depends on #1222

Made with [Cursor](https://cursor.com)