### PR TITLE
feat: 1045 - enforce payment confirmation on rsvp write paths (2/6)

### DIFF
--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -159,6 +159,17 @@ def _resolve_paid_confirmed_at(
     return None
 
 
+def _resolve_paid_confirmed_at(
+    existing: EventRSVP | None, paid_confirmed: bool, final_status: str
+) -> datetime | None:
+    """Preserve a standing stamp; otherwise stamp only on a confirmed attending/waitlisted write."""
+    if existing is not None and existing.paid_confirmed_at is not None:
+        return existing.paid_confirmed_at
+    if paid_confirmed and final_status in (RSVPStatus.ATTENDING, RSVPStatus.WAITLISTED):
+        return timezone.now()
+    return None
+
+
 def _apply_rsvp_in_transaction(
     event_id, user, status: str, has_plus_one: bool, paid_confirmed: bool = False
 ) -> tuple[str, list[str], bool]:

--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 from uuid import UUID
 
 from config.audit import AuditTargetType, audit_log
@@ -25,6 +26,7 @@ from community._event_schemas import EventOut, RSVPIn
 from community._events import _can_edit_event, _enforce_event_read_visibility
 from community._public_rsvp_shared import _email_promoted_non_members
 from community._rsvp_counts import _attending_headcount_db
+from community._rsvp_payment import requires_payment_gate
 from community._shared import ErrorOut
 from community._validation import Code, raise_validation
 from community.models import Event, EventComment, EventRSVP, RSVPStatus
@@ -136,8 +138,29 @@ def _post_rsvp_comment(event_id, user, final_status: str, comment: str | None) -
         return False
 
 
+def _resolve_paid_confirmed_at(
+    existing: EventRSVP | None, paid_confirmed: bool, final_status: str
+) -> datetime | None:
+    """Resolve paid_confirmed_at for this write.
+
+    Attending or waitlisted both stamp: at capacity an attending request
+    resolves to waitlisted, but it was still a gated, confirmed write and must
+    keep its stamp through promotion. Maybe/can't-go are ungated statuses —
+    `paid_confirmed` there must not bank a stamp that disarms a later
+    attending write (see requires_payment_gate).
+
+    A standing confirmation is preserved untouched, so a host-revoked row that
+    pays again re-stamps without needing the rsvp deleted.
+    """
+    if existing is not None and existing.paid_confirmed_at is not None:
+        return existing.paid_confirmed_at
+    if paid_confirmed and final_status in (RSVPStatus.ATTENDING, RSVPStatus.WAITLISTED):
+        return timezone.now()
+    return None
+
+
 def _apply_rsvp_in_transaction(
-    event_id, user, status: str, has_plus_one: bool
+    event_id, user, status: str, has_plus_one: bool, paid_confirmed: bool = False
 ) -> tuple[str, list[str], bool]:
     """Execute RSVP upsert inside a locked transaction.
 
@@ -158,17 +181,24 @@ def _apply_rsvp_in_transaction(
 
     _validate_rsvp_access(user, event)
 
-    final_status, final_plus_one = _resolve_rsvp_status(event, user, status, has_plus_one)
-
     existing = EventRSVP.objects.filter(event=event, user=user).first()
     created = existing is None
+
+    # Gate on the *requested* status, not the post-capacity one — else it slips through unconfirmed.
+    if not paid_confirmed and requires_payment_gate(event, existing, status):
+        raise_validation(Code.Event.PAYMENT_CONFIRMATION_REQUIRED, status_code=400)
+
+    final_status, final_plus_one = _resolve_rsvp_status(event, user, status, has_plus_one)
+
     was_attending = existing is not None and existing.status == RSVPStatus.ATTENDING
     had_plus_one = existing is not None and existing.has_plus_one
+    new_confirmed_at = _resolve_paid_confirmed_at(existing, paid_confirmed, final_status)
 
     if (
         existing is not None
         and existing.status == final_status
         and existing.has_plus_one == final_plus_one
+        and existing.paid_confirmed_at == new_confirmed_at
     ):
         return final_status, [], False
 
@@ -179,6 +209,7 @@ def _apply_rsvp_in_transaction(
             "status": final_status,
             "has_plus_one": final_plus_one,
             "cancelled_at": _resolve_cancelled_at(existing, final_status),
+            "paid_confirmed_at": new_confirmed_at,
         },
     )
 
@@ -206,7 +237,7 @@ def upsert_rsvp(request, event_id: UUID, payload: RSVPIn):
 
     with transaction.atomic():
         final_status, promoted_user_ids, _created = _apply_rsvp_in_transaction(
-            event_id, request.auth, payload.status, payload.has_plus_one
+            event_id, request.auth, payload.status, payload.has_plus_one, payload.paid_confirmed
         )
 
     sent_decline_note = _post_rsvp_comment(event_id, request.auth, final_status, payload.comment)

--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -225,6 +225,7 @@ class EventOut(BaseModel):
 class RSVPIn(BaseModel):
     status: RSVPStatus
     has_plus_one: bool = False
+    paid_confirmed: bool = False
     # Not persisted on the RSVP — a non-empty value is a one-time post: a
     # public EventComment (going/maybe) or a host-only notification (can't go).
     comment: str | None = Field(default=None, max_length=FieldLimit.SHORT_TEXT)

--- a/backend/community/_public_rsvp_manage.py
+++ b/backend/community/_public_rsvp_manage.py
@@ -57,6 +57,7 @@ class PublicRsvpManageOut(BaseModel):
 class PublicRsvpManageIn(BaseModel):
     status: str
     has_plus_one: bool = False
+    paid_confirmed: bool = False
     comment: str | None = Field(default=None, max_length=FieldLimit.SHORT_TEXT)
 
 
@@ -157,7 +158,7 @@ def update_my_rsvp(request, event_id, payload: PublicRsvpManageIn, token: str = 
 
     with transaction.atomic():
         final_status, promoted_user_ids, created = _apply_rsvp_in_transaction(
-            event.id, user, payload.status, False
+            event.id, user, payload.status, False, payload.paid_confirmed
         )
         rsvp_token = NonMemberRsvpToken.issue_or_extend(user)
 
@@ -167,7 +168,11 @@ def update_my_rsvp(request, event_id, payload: PublicRsvpManageIn, token: str = 
         request,
         target_type=AuditTargetType.EVENT,
         target_id=str(event.id),
-        details={"user_id": str(user.pk), "status": final_status},
+        details={
+            "user_id": str(user.pk),
+            "status": final_status,
+            "paid_confirmed": payload.paid_confirmed,
+        },
     )
     sent_decline_note = _post_rsvp_comment(event.id, user, final_status, payload.comment)
     email_error = _send_manage_rsvp_email(

--- a/backend/community/_public_rsvp_submit.py
+++ b/backend/community/_public_rsvp_submit.py
@@ -43,6 +43,7 @@ class PublicRsvpIn(BaseModel):
     phone_number: str = Field(max_length=FieldLimit.PHONE)
     status: str = Field(max_length=FieldLimit.CHOICE)
     has_plus_one: bool = False
+    paid_confirmed: bool = False
     comment: str | None = Field(default=None, max_length=FieldLimit.SHORT_TEXT)
     # Honeypot: hidden field humans never fill in. A non-empty value is spam.
     website: str = Field(default="", max_length=FieldLimit.DISPLAY_NAME)
@@ -240,7 +241,7 @@ def submit_public_rsvp(request, event_id, payload: PublicRsvpIn):
             phone=validated_phone,
         )
         final_status, promoted_user_ids, _rsvp_created = _apply_rsvp_in_transaction(
-            event.id, user, payload.status, False
+            event.id, user, payload.status, False, payload.paid_confirmed
         )
         token = NonMemberRsvpToken.issue_or_extend(user)
 
@@ -250,7 +251,11 @@ def submit_public_rsvp(request, event_id, payload: PublicRsvpIn):
         request,
         target_type=AuditTargetType.EVENT,
         target_id=str(event.id),
-        details={"user_id": str(user.pk), "status": final_status},
+        details={
+            "user_id": str(user.pk),
+            "status": final_status,
+            "paid_confirmed": payload.paid_confirmed,
+        },
     )
 
     _post_rsvp_comment(event.id, user, final_status, payload.comment)

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -4424,6 +4424,11 @@
             "title": "Last Name",
             "type": "string"
           },
+          "paid_confirmed": {
+            "default": false,
+            "title": "Paid Confirmed",
+            "type": "boolean"
+          },
           "phone_number": {
             "maxLength": 20,
             "title": "Phone Number",
@@ -4467,6 +4472,11 @@
           "has_plus_one": {
             "default": false,
             "title": "Has Plus One",
+            "type": "boolean"
+          },
+          "paid_confirmed": {
+            "default": false,
+            "title": "Paid Confirmed",
             "type": "boolean"
           },
           "status": {
@@ -4704,6 +4714,11 @@
           "has_plus_one": {
             "default": false,
             "title": "Has Plus One",
+            "type": "boolean"
+          },
+          "paid_confirmed": {
+            "default": false,
+            "title": "Paid Confirmed",
             "type": "boolean"
           },
           "status": {

--- a/backend/tests/test_rsvp_payment_gate.py
+++ b/backend/tests/test_rsvp_payment_gate.py
@@ -1,0 +1,216 @@
+import pytest
+from community._validation import Code
+from community.models import EventRSVP, RSVPStatus
+from django.utils import timezone
+from users.models import NonMemberRsvpToken
+
+from tests._asserts import assert_error_code
+from tests._payment_helpers import create_paid_event, set_payment_flag
+from tests._public_rsvp_helpers import make_non_member, make_official_event
+from tests._public_rsvp_helpers import payload as public_payload
+from tests._public_rsvp_helpers import url as public_url
+
+RSVP_URL = "/api/community/events/{event_id}/rsvp/"
+
+
+@pytest.fixture(autouse=True)
+def _flag_on(db):
+    """Flag-OFF behavior is covered by test_payment_confirmation_flag_off.py."""
+    set_payment_flag(True)
+
+
+@pytest.fixture
+def paid_event(db, test_user):
+    return create_paid_event(created_by=test_user)
+
+
+@pytest.mark.django_db
+class TestMemberRsvpPaymentGate:
+    def test_attending_without_confirmation_is_rejected(self, api_client, paid_event, auth_headers):
+        response = api_client.post(
+            RSVP_URL.format(event_id=paid_event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 400
+        assert_error_code(response, Code.Event.PAYMENT_CONFIRMATION_REQUIRED)
+        assert not EventRSVP.objects.filter(event=paid_event).exists()
+
+    def test_attending_with_confirmation_succeeds_and_stamps(
+        self, api_client, paid_event, auth_headers
+    ):
+        response = api_client.post(
+            RSVP_URL.format(event_id=paid_event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": False, "paid_confirmed": True},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+        rsvp = EventRSVP.objects.get(event=paid_event)
+        assert rsvp.status == RSVPStatus.ATTENDING
+        assert rsvp.paid_confirmed_at is not None
+
+    def test_maybe_without_confirmation_succeeds(self, api_client, paid_event, auth_headers):
+        response = api_client.post(
+            RSVP_URL.format(event_id=paid_event.id),
+            {"status": RSVPStatus.MAYBE, "has_plus_one": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+        assert EventRSVP.objects.get(event=paid_event).paid_confirmed_at is None
+
+    def test_confirmed_attendee_can_toggle_plus_one_without_reconfirming(
+        self, api_client, paid_event, auth_headers, test_user
+    ):
+        paid_event.allow_plus_ones = True
+        paid_event.save(update_fields=["allow_plus_ones"])
+        EventRSVP.objects.create(
+            event=paid_event,
+            user=test_user,
+            status=RSVPStatus.ATTENDING,
+            paid_confirmed_at=timezone.now(),
+        )
+        response = api_client.post(
+            RSVP_URL.format(event_id=paid_event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": True},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+
+    def test_unconfirmed_attendee_is_gated_on_next_write(
+        self, api_client, paid_event, auth_headers, test_user
+    ):
+        """A row seated by waitlist promotion carries no stamp and must still gate."""
+        paid_event.allow_plus_ones = True
+        paid_event.save(update_fields=["allow_plus_ones"])
+        EventRSVP.objects.create(event=paid_event, user=test_user, status=RSVPStatus.ATTENDING)
+        response = api_client.post(
+            RSVP_URL.format(event_id=paid_event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": True},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 400
+        assert_error_code(response, Code.Event.PAYMENT_CONFIRMATION_REQUIRED)
+
+    def test_confirmation_persists_across_later_status_changes(
+        self, api_client, paid_event, auth_headers
+    ):
+        api_client.post(
+            RSVP_URL.format(event_id=paid_event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": False, "paid_confirmed": True},
+            content_type="application/json",
+            **auth_headers,
+        )
+        stamped = EventRSVP.objects.get(event=paid_event).paid_confirmed_at
+        api_client.post(
+            RSVP_URL.format(event_id=paid_event.id),
+            {"status": RSVPStatus.MAYBE, "has_plus_one": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+        response = api_client.post(
+            RSVP_URL.format(event_id=paid_event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+        assert EventRSVP.objects.get(event=paid_event).paid_confirmed_at == stamped
+
+    def test_free_event_needs_no_confirmation(self, api_client, paid_event, auth_headers):
+        paid_event.price = ""
+        paid_event.venmo_link = ""
+        paid_event.save(update_fields=["price", "venmo_link"])
+        response = api_client.post(
+            RSVP_URL.format(event_id=paid_event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+
+
+@pytest.fixture
+def paid_public_event(db):
+    return make_official_event(
+        title="Paid Official Event",
+        price="$10",
+        venmo_link="https://venmo.com/u/host",
+    )
+
+
+@pytest.mark.django_db
+class TestPublicSubmitPaymentGate:
+    def test_new_person_attending_without_confirmation_is_rejected(
+        self, api_client, paid_public_event
+    ):
+        response = api_client.post(
+            public_url(paid_public_event),
+            public_payload(status=RSVPStatus.ATTENDING),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        assert_error_code(response, Code.Event.PAYMENT_CONFIRMATION_REQUIRED)
+
+    def test_new_person_attending_with_confirmation_succeeds(self, api_client, paid_public_event):
+        response = api_client.post(
+            public_url(paid_public_event),
+            public_payload(status=RSVPStatus.ATTENDING, paid_confirmed=True),
+            content_type="application/json",
+        )
+        assert response.status_code in (200, 201)
+        assert EventRSVP.objects.get(event=paid_public_event).paid_confirmed_at is not None
+
+    def test_new_person_maybe_needs_no_confirmation(self, api_client, paid_public_event):
+        response = api_client.post(
+            public_url(paid_public_event),
+            public_payload(status=RSVPStatus.MAYBE),
+            content_type="application/json",
+        )
+        assert response.status_code in (200, 201)
+
+
+@pytest.mark.django_db
+class TestPublicManagePaymentGate:
+    def _setup(self, event, phone="+14155550199"):
+        user = make_non_member(phone, "token@example.com", name="Token Holder")
+        EventRSVP.objects.create(event=event, user=user, status=RSVPStatus.MAYBE)
+        return user, NonMemberRsvpToken.issue_or_extend(user).token
+
+    def test_maybe_to_attending_without_confirmation_is_rejected(
+        self, api_client, paid_public_event
+    ):
+        _user, token = self._setup(paid_public_event)
+        response = api_client.post(
+            f"/api/community/public/my-rsvps/{paid_public_event.id}/?token={token}",
+            {"status": RSVPStatus.ATTENDING},
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        assert_error_code(response, Code.Event.PAYMENT_CONFIRMATION_REQUIRED)
+
+    def test_maybe_to_attending_with_confirmation_succeeds(self, api_client, paid_public_event):
+        user, token = self._setup(paid_public_event, phone="+14155550198")
+        response = api_client.post(
+            f"/api/community/public/my-rsvps/{paid_public_event.id}/?token={token}",
+            {"status": RSVPStatus.ATTENDING, "paid_confirmed": True},
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        rsvp = EventRSVP.objects.get(event=paid_public_event, user=user)
+        assert rsvp.paid_confirmed_at is not None
+
+    def test_switching_to_maybe_needs_no_confirmation(self, api_client, paid_public_event):
+        user = make_non_member("+14155550197", "t2@example.com", name="Token Two")
+        EventRSVP.objects.create(event=paid_public_event, user=user, status=RSVPStatus.ATTENDING)
+        token = NonMemberRsvpToken.issue_or_extend(user).token
+        response = api_client.post(
+            f"/api/community/public/my-rsvps/{paid_public_event.id}/?token={token}",
+            {"status": RSVPStatus.MAYBE},
+            content_type="application/json",
+        )
+        assert response.status_code == 200

--- a/backend/tests/test_rsvp_payment_gate_bypass.py
+++ b/backend/tests/test_rsvp_payment_gate_bypass.py
@@ -1,0 +1,199 @@
+"""Regression tests for payment-gate bypasses caught in code review."""
+
+import pytest
+from community._validation import Code
+from community.models import Event, EventRSVP, RSVPStatus
+from django.utils import timezone
+
+from tests._asserts import assert_error_code
+from tests._payment_helpers import create_paid_event, set_payment_flag
+from tests.conftest import future_iso
+
+RSVP_URL = "/api/community/events/{event_id}/rsvp/"
+
+
+@pytest.fixture(autouse=True)
+def _flag_on(db):
+    set_payment_flag(True)
+
+
+def _paid_event(creator, **overrides) -> Event:
+    return create_paid_event(created_by=creator, **overrides)
+
+
+@pytest.mark.django_db
+class TestWaitlistPromotionBypass:
+    def test_unconfirmed_attending_at_capacity_is_rejected_before_waitlisting(
+        self, api_client, auth_headers, test_user, django_user_model
+    ):
+        """The gate must check the requested status, not the capacity-resolved
+        one — otherwise an unconfirmed request queues as an unconfirmed
+        waitlist row that later gets promoted with no gate ever having run."""
+        event = _paid_event(test_user, max_attendees=1)
+        seated = django_user_model.objects.create_user(
+            phone_number="+14155550111", first_name="Seated", is_member=True
+        )
+        EventRSVP.objects.create(event=event, user=seated, status=RSVPStatus.ATTENDING)
+
+        response = api_client.post(
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 400
+        assert_error_code(response, Code.Event.PAYMENT_CONFIRMATION_REQUIRED)
+        assert not EventRSVP.objects.filter(event=event, user=test_user).exists()
+
+
+@pytest.mark.django_db
+class TestPaidConfirmedOnUngatedStatus:
+    def test_maybe_with_paid_confirmed_does_not_bank_a_stamp(
+        self, api_client, auth_headers, test_user
+    ):
+        """paid_confirmed on an ungated status must not pre-authorize a later attending."""
+        event = _paid_event(test_user)
+        response = api_client.post(
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.MAYBE, "paid_confirmed": True},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+        assert EventRSVP.objects.get(event=event, user=test_user).paid_confirmed_at is None
+
+        response = api_client.post(
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 400
+        assert_error_code(response, Code.Event.PAYMENT_CONFIRMATION_REQUIRED)
+
+    def test_cant_go_with_paid_confirmed_does_not_bank_a_stamp(
+        self, api_client, auth_headers, test_user
+    ):
+        event = _paid_event(test_user)
+        api_client.post(
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.CANT_GO, "paid_confirmed": True},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert EventRSVP.objects.get(event=event, user=test_user).paid_confirmed_at is None
+
+    def test_a_real_confirmation_still_stamps_and_persists(
+        self, api_client, auth_headers, test_user
+    ):
+        event = _paid_event(test_user)
+        api_client.post(
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.ATTENDING, "paid_confirmed": True},
+            content_type="application/json",
+            **auth_headers,
+        )
+        stamped = EventRSVP.objects.get(event=event, user=test_user).paid_confirmed_at
+        assert stamped is not None
+
+        api_client.post(
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.MAYBE},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert EventRSVP.objects.get(event=event, user=test_user).paid_confirmed_at == stamped
+
+
+@pytest.mark.django_db
+class TestPollFinalizeDoesNotBypassGate:
+    def test_yes_voter_seated_unconfirmed_is_gated_on_next_write(
+        self, api_client, auth_headers, test_user
+    ):
+        from community.models import EventPoll, PollAvailability, PollOption, PollVote
+
+        event = _paid_event(test_user, datetime_tbd=True)
+        poll = EventPoll.objects.create(event=event, created_by=test_user)
+        option = PollOption.objects.create(poll=poll, datetime=future_iso(days=120))
+        PollVote.objects.create(option=option, user=test_user, availability=PollAvailability.YES)
+
+        response = api_client.post(
+            f"/api/community/events/{event.id}/poll/finalize/",
+            {"winning_option_id": str(option.id)},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+        rsvp = EventRSVP.objects.get(event=event, user=test_user)
+        assert rsvp.status == RSVPStatus.ATTENDING
+        assert rsvp.paid_confirmed_at is None
+
+        response = api_client.post(
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 400
+        assert_error_code(response, Code.Event.PAYMENT_CONFIRMATION_REQUIRED)
+
+    def test_yes_voter_with_existing_confirmation_keeps_it(
+        self, api_client, auth_headers, test_user
+    ):
+        from community.models import EventPoll, PollAvailability, PollOption, PollVote
+
+        event = _paid_event(test_user, datetime_tbd=True)
+        EventRSVP.objects.create(
+            event=event,
+            user=test_user,
+            status=RSVPStatus.MAYBE,
+            paid_confirmed_at=timezone.now(),
+        )
+        poll = EventPoll.objects.create(event=event, created_by=test_user)
+        option = PollOption.objects.create(poll=poll, datetime=future_iso(days=120))
+        PollVote.objects.create(option=option, user=test_user, availability=PollAvailability.YES)
+
+        api_client.post(
+            f"/api/community/events/{event.id}/poll/finalize/",
+            {"winning_option_id": str(option.id)},
+            content_type="application/json",
+            **auth_headers,
+        )
+        rsvp = EventRSVP.objects.get(event=event, user=test_user)
+        assert rsvp.status == RSVPStatus.ATTENDING
+        assert rsvp.paid_confirmed_at is not None
+
+
+@pytest.mark.django_db
+class TestNoOpEarlyReturnStillStamps:
+    def test_confirming_an_already_seated_unconfirmed_row_persists_the_stamp(
+        self, api_client, auth_headers, test_user
+    ):
+        """An unconfirmed attending row (e.g. from waitlist promotion) confirmed
+        via the same status/plus-one must still get the stamp written — the
+        unchanged-state early return must not discard it."""
+        event = _paid_event(test_user)
+        EventRSVP.objects.create(event=event, user=test_user, status=RSVPStatus.ATTENDING)
+
+        response = api_client.post(
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": False, "paid_confirmed": True},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+        assert EventRSVP.objects.get(event=event, user=test_user).paid_confirmed_at is not None
+
+
+@pytest.mark.django_db
+def test_stamp_is_a_real_datetime(api_client, auth_headers, test_user):
+    """Guards against asserting on a truthy ISO string instead of a datetime."""
+    event = _paid_event(test_user)
+    api_client.post(
+        RSVP_URL.format(event_id=event.id),
+        {"status": RSVPStatus.ATTENDING, "paid_confirmed": True},
+        content_type="application/json",
+        **auth_headers,
+    )
+    stamped = EventRSVP.objects.get(event=event, user=test_user).paid_confirmed_at
+    assert timezone.is_aware(stamped)

--- a/frontend/src/api/publicRsvp.test.ts
+++ b/frontend/src/api/publicRsvp.test.ts
@@ -43,6 +43,7 @@ describe('useSubmitPublicRsvp', () => {
       status: 'attending',
       has_plus_one: false,
       website: '',
+      paid_confirmed: false,
     };
     result.current.mutate({ eventId: 'ev1', payload });
 

--- a/frontend/src/api/publicRsvp.ts
+++ b/frontend/src/api/publicRsvp.ts
@@ -130,6 +130,7 @@ export function useUpdatePublicMyRsvp(token: string) {
         status,
         has_plus_one: hasPlusOne,
         comment: comment ?? null,
+        paid_confirmed: false,
       };
       const { data } = await apiClient.post<PublicRsvpOut>(`${MANAGE_BASE}${eventId}/`, body, {
         params: { token },

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -4012,6 +4012,11 @@ export interface components {
              * @default
              */
             last_name: string;
+            /**
+             * Paid Confirmed
+             * @default false
+             */
+            paid_confirmed: boolean;
             /** Phone Number */
             phone_number: string;
             /** Status */
@@ -4031,6 +4036,11 @@ export interface components {
              * @default false
              */
             has_plus_one: boolean;
+            /**
+             * Paid Confirmed
+             * @default false
+             */
+            paid_confirmed: boolean;
             /** Status */
             status: string;
         };
@@ -4123,6 +4133,11 @@ export interface components {
              * @default false
              */
             has_plus_one: boolean;
+            /**
+             * Paid Confirmed
+             * @default false
+             */
+            paid_confirmed: boolean;
             status: components["schemas"]["RSVPStatus"];
         };
         /**

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -119,6 +119,7 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
           has_plus_one: false,
           comment: comment.trim() || null,
           website,
+          paid_confirmed: false,
         },
       });
       onSuccess(result);


### PR DESCRIPTION
## Overview

**2 of 6** in the split of #1213 (Issue 1045). The actual gate. Ships dark behind `EVENT_PAYMENT_CONFIRMATION` (added in #1132, defaults `False`).

**Stacked on #1224** — review that first; this PR's diff is against it.

### What's here

Enforcement lands in `_apply_rsvp_in_transaction`, the single shared write path behind the member, new-person, and token-holder rsvp flows, so one guard covers all three.

- **`_resolve_paid_confirmed_at`** decides the stamp per write. Attending *and* waitlisted both stamp: at capacity an attending request resolves to waitlisted, and must keep its stamp through promotion. Maybe/can't-go never bank a stamp that would disarm a later attending write.
- **`paid_confirmed`** on `RSVPIn`, `PublicRsvpIn`, `PublicRsvpManageIn`. Frontend callers pass `false` until the confirm UI lands (that's the follow-up frontend PR).
- Uses `payment_enforced_for_event` (flag AND has-cost) from #1224 to decide whether the gate applies — the gate itself stays flag-controlled even though visibility no longer is.

### Behavior

| Rule | Behavior |
|---|---|
| Which statuses gate | Only `attending` |
| Keyed on | The **stamp**, not the status transition — waitlist promotion seats a row as attending without passing the gate, so "already attending" is not proof of payment |
| Checked against | The **requested** status, not the post-capacity one — otherwise an at-capacity attending request queues an unconfirmed row that later gets promoted with no gate ever having run |
| "Has a cost" | `price` non-empty AND at least one payment method set |
| Existing RSVPs | No backfill; the stamp rule protects them |
| Host/admin on behalf of a guest | Exempt — separate path, untouched here |

### Notes for review

- The guard sits **before** the no-op early-return, so an identical re-submit still short-circuits as it did before.
- Test files now use the shared `create_paid_event` / `set_payment_flag` helpers from `tests/_payment_helpers.py` (added in #1224) instead of a private factory.

## Test plan

- [x] `tests/test_rsvp_payment_gate.py` — 13 tests across all three endpoints
- [x] `tests/test_rsvp_payment_gate_bypass.py` — 8 tests: capacity/waitlist, ungated-status stamping, poll-finalize, no-op early return
- [x] `tests/test_payment_confirmation_flag_off.py` passes unmodified
- [x] 854 rsvp/event/poll tests pass; the one `test_rsvp_capacity_race.py` failure is the pre-existing SQLite limitation
- [x] Full backend suite: **1898 passed**, same known SQLite failures
- [x] `make agent-lint`, `agent-typecheck` clean

Part of Issue 1045. Split out of #1213.
