### PR TITLE
feat: 1045 - payment link + status visibility in serializers (3/6)

### DIFF
--- a/backend/community/_calendar.py
+++ b/backend/community/_calendar.py
@@ -16,7 +16,7 @@ from users.models import User as UserModel
 
 from community._event_helpers import _can_see_invite_only
 from community._events import _enforce_event_read_visibility
-from community._shared import _authenticated_user, _members_only, _optional_jwt
+from community._shared import _authenticated_user, _gated, _optional_jwt
 from community._validation import ValidationException
 from community.models import Event, EventStatus, PageVisibility, RSVPStatus
 
@@ -197,9 +197,9 @@ def _event_ics_description(event, target_url: str, is_authed: bool) -> str:
     parts = []
     if event.description:
         parts.append(event.description)
-    whatsapp = _members_only(event.whatsapp_link, "", is_authed)
-    partiful = _members_only(event.partiful_link, "", is_authed)
-    other = _members_only(event.other_link, "", is_authed)
+    whatsapp = _gated(event.whatsapp_link, "", is_authed)
+    partiful = _gated(event.partiful_link, "", is_authed)
+    other = _gated(event.other_link, "", is_authed)
     if whatsapp:
         parts.append(f"WhatsApp: {whatsapp}")
     if partiful:

--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -34,13 +34,16 @@ from community._rsvp_counts import (
     _attending_headcount_db,
     _waitlisted_count,
 )
-from community._shared import _authenticated_user, _members_only
+from community._rsvp_payment import can_see_payment_details
+from community._shared import _authenticated_user, _gated
 from community.models import (
     Event,
     EventRSVP,
     EventTag,
+    FeatureFlag,
     RSVPStatus,
     SurveyQuestionType,
+    flag_enabled,
 )
 
 if TYPE_CHECKING:
@@ -73,17 +76,17 @@ def broadcast_capacity_change(event_id: UUID, *, exclude_user_ids: set[str] | No
     transaction.on_commit(_run)
 
 
-def _can_see_phones(requesting_user, creator, co_host_ids: set[str]) -> bool:
-    """Check if requesting user can see guest phone numbers."""
+def _is_cohost(requesting_user, co_host_ids: set[str]) -> bool:
+    """Creator is always a co-host (added on event creation), so this covers both."""
     if requesting_user is None:
         return False
-    if creator is not None and requesting_user.pk == creator.pk:
-        return True
     return str(requesting_user.pk) in co_host_ids
 
 
-def _build_guest_list(rsvps, can_see_phones: bool, viewer=None) -> list[RSVPGuestOut]:
-    """Build guest list with optional phone visibility."""
+def _build_guest_list(
+    rsvps, can_see_phones: bool, viewer=None, can_see_payment_status: bool = False
+) -> list[RSVPGuestOut]:
+    """Build guest list with optional phone and payment-status visibility."""
     return [
         RSVPGuestOut(
             user_id=str(r.user_id),
@@ -95,19 +98,28 @@ def _build_guest_list(rsvps, can_see_phones: bool, viewer=None) -> list[RSVPGues
             attendance=r.attendance,
             checked_in_at=r.checked_in_at,
             is_member=r.user.is_member,
+            paid_confirmed=bool(r.paid_confirmed_at) if can_see_payment_status else False,
         )
         for r in rsvps
     ]
 
 
-def _find_my_rsvp(rsvps, user) -> str | None:
-    """Find requesting user's RSVP status."""
+def _find_my_rsvp(rsvps, user):
+    """Find requesting user's own RSVP row."""
     if user is None:
         return None
     for r in rsvps:
         if r.user_id == user.pk:
-            return r.status
+            return r
     return None
+
+
+def _my_rsvp_fields(rsvps, user) -> tuple[str | None, bool]:
+    """(my_rsvp status, my_paid_confirmed) for the requesting user, or (None, False)."""
+    my_rsvp = _find_my_rsvp(rsvps, user)
+    if my_rsvp is None:
+        return None, False
+    return my_rsvp.status, bool(my_rsvp.paid_confirmed_at)
 
 
 def _cancellations(event: Event, viewer=None) -> list[CancellationOut]:
@@ -295,8 +307,10 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
     creator = event.created_by
     auth_user = _authenticated_user(requesting_user)
     is_authed = auth_user is not None
+    show_payment_details = can_see_payment_details(event, is_authed)
     co_host_ids = {str(u.id) for u in co_hosts}
-    phones_visible = _can_see_phones(auth_user, creator, co_host_ids)
+    is_cohost = _is_cohost(auth_user, co_host_ids)
+    payment_status_visible = is_cohost and flag_enabled(FeatureFlag.EVENT_PAYMENT_CONFIRMATION)
     rsvps = list(event.rsvps.all()) if (event.rsvp_enabled and is_authed) else []
     all_invited = list(event.invited_users.all())
     invited = all_invited if _can_see_invited(auth_user, creator, co_host_ids) else []
@@ -305,6 +319,7 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
     my_pending_invite = get_my_pending_invite(event, auth_user)
     my_pending_invite_id = str(my_pending_invite.id) if my_pending_invite else None
     comment_count = _resolve_comment_count(event)
+    my_rsvp_status, my_paid_confirmed = _my_rsvp_fields(rsvps, auth_user)
     return EventOut(
         id=str(event.id),
         slug=event.slug,
@@ -315,13 +330,13 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
         location=event.location,
         latitude=float(event.latitude) if event.latitude is not None else None,
         longitude=float(event.longitude) if event.longitude is not None else None,
-        whatsapp_link=_members_only(event.whatsapp_link, "", is_authed),
-        partiful_link=_members_only(event.partiful_link, "", is_authed),
-        other_link=_members_only(event.other_link, "", is_authed),
+        whatsapp_link=_gated(event.whatsapp_link, "", is_authed),
+        partiful_link=_gated(event.partiful_link, "", is_authed),
+        other_link=_gated(event.other_link, "", is_authed),
         price=event.price,
-        venmo_link=_members_only(event.venmo_link, "", is_authed),
-        cashapp_link=_members_only(event.cashapp_link, "", is_authed),
-        zelle_info=_members_only(event.zelle_info, "", is_authed),
+        venmo_link=_gated(event.venmo_link, "", show_payment_details),
+        cashapp_link=_gated(event.cashapp_link, "", show_payment_details),
+        zelle_info=_gated(event.zelle_info, "", show_payment_details),
         rsvp_enabled=event.rsvp_enabled,
         datetime_tbd=event.datetime_tbd,
         allow_plus_ones=event.allow_plus_ones,
@@ -336,8 +351,13 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
         co_host_ids=[str(u.id) for u in co_hosts],
         co_host_names=[visible_display_name(u, auth_user) for u in co_hosts],
         co_host_photo_urls=[media_path(u.profile_photo) for u in co_hosts],
-        guests=_members_only(_build_guest_list(rsvps, phones_visible, auth_user), [], is_authed),
-        my_rsvp=_find_my_rsvp(rsvps, auth_user),
+        guests=_gated(
+            _build_guest_list(rsvps, is_cohost, auth_user, payment_status_visible),
+            [],
+            is_authed,
+        ),
+        my_rsvp=my_rsvp_status,
+        my_paid_confirmed=my_paid_confirmed,
         viewer_user_id=str(auth_user.pk) if auth_user else None,
         event_type=event.event_type,
         visibility=event.visibility,

--- a/backend/community/_event_report.py
+++ b/backend/community/_event_report.py
@@ -8,7 +8,7 @@ from ninja import Router
 from ninja.responses import Status
 from users._helpers import visible_display_name
 
-from community._event_helpers import _can_see_phones, load_event_with_stats_prefetch
+from community._event_helpers import _is_cohost, load_event_with_stats_prefetch
 from community._event_report_schemas import (
     REPORT_CSV_COLUMNS,
     AttendedPersonOut,
@@ -53,9 +53,8 @@ def _person(rsvp, viewer, can_see_phones: bool) -> CheckInReportPersonOut:
 
 
 def _build_report(event: Event, viewer) -> CheckInReportOut:
-    creator = event.created_by
     co_host_ids = {str(c.id) for c in event.co_hosts.all()}
-    can_see_phones = _can_see_phones(viewer, creator, co_host_ids)
+    can_see_phones = _is_cohost(viewer, co_host_ids)
 
     attended, no_shows, canceled, unmarked = [], [], [], []
     for rsvp in _report_rsvps(event):
@@ -141,9 +140,8 @@ def get_check_in_report_csv(request, event_id: UUID, columns: str = ",".join(REP
     event = _load_and_authorize(request, event_id)
     selected = _parse_columns(columns)
 
-    creator = event.created_by
     co_host_ids = {str(c.id) for c in event.co_hosts.all()}
-    can_see_phones = _can_see_phones(request.auth, creator, co_host_ids)
+    can_see_phones = _is_cohost(request.auth, co_host_ids)
 
     buf = io.StringIO()
     writer = csv.writer(buf)

--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -159,6 +159,17 @@ def _resolve_paid_confirmed_at(
     return None
 
 
+def _resolve_paid_confirmed_at(
+    existing: EventRSVP | None, paid_confirmed: bool, final_status: str
+) -> datetime | None:
+    """Preserve a standing stamp; otherwise stamp only on a confirmed attending/waitlisted write."""
+    if existing is not None and existing.paid_confirmed_at is not None:
+        return existing.paid_confirmed_at
+    if paid_confirmed and final_status in (RSVPStatus.ATTENDING, RSVPStatus.WAITLISTED):
+        return timezone.now()
+    return None
+
+
 def _apply_rsvp_in_transaction(
     event_id, user, status: str, has_plus_one: bool, paid_confirmed: bool = False
 ) -> tuple[str, list[str], bool]:

--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -1,4 +1,5 @@
 import logging
+from datetime import datetime
 from uuid import UUID
 
 from config.audit import AuditTargetType, audit_log
@@ -25,6 +26,7 @@ from community._event_schemas import EventOut, RSVPIn
 from community._events import _can_edit_event, _enforce_event_read_visibility
 from community._public_rsvp_shared import _email_promoted_non_members
 from community._rsvp_counts import _attending_headcount_db
+from community._rsvp_payment import requires_payment_gate
 from community._shared import ErrorOut
 from community._validation import Code, raise_validation
 from community.models import Event, EventComment, EventRSVP, RSVPStatus
@@ -136,8 +138,29 @@ def _post_rsvp_comment(event_id, user, final_status: str, comment: str | None) -
         return False
 
 
+def _resolve_paid_confirmed_at(
+    existing: EventRSVP | None, paid_confirmed: bool, final_status: str
+) -> datetime | None:
+    """Resolve paid_confirmed_at for this write.
+
+    Attending or waitlisted both stamp: at capacity an attending request
+    resolves to waitlisted, but it was still a gated, confirmed write and must
+    keep its stamp through promotion. Maybe/can't-go are ungated statuses —
+    `paid_confirmed` there must not bank a stamp that disarms a later
+    attending write (see requires_payment_gate).
+
+    A standing confirmation is preserved untouched, so a host-revoked row that
+    pays again re-stamps without needing the rsvp deleted.
+    """
+    if existing is not None and existing.paid_confirmed_at is not None:
+        return existing.paid_confirmed_at
+    if paid_confirmed and final_status in (RSVPStatus.ATTENDING, RSVPStatus.WAITLISTED):
+        return timezone.now()
+    return None
+
+
 def _apply_rsvp_in_transaction(
-    event_id, user, status: str, has_plus_one: bool
+    event_id, user, status: str, has_plus_one: bool, paid_confirmed: bool = False
 ) -> tuple[str, list[str], bool]:
     """Execute RSVP upsert inside a locked transaction.
 
@@ -158,17 +181,24 @@ def _apply_rsvp_in_transaction(
 
     _validate_rsvp_access(user, event)
 
-    final_status, final_plus_one = _resolve_rsvp_status(event, user, status, has_plus_one)
-
     existing = EventRSVP.objects.filter(event=event, user=user).first()
     created = existing is None
+
+    # Gate on the *requested* status, not the post-capacity one — else it slips through unconfirmed.
+    if not paid_confirmed and requires_payment_gate(event, existing, status):
+        raise_validation(Code.Event.PAYMENT_CONFIRMATION_REQUIRED, status_code=400)
+
+    final_status, final_plus_one = _resolve_rsvp_status(event, user, status, has_plus_one)
+
     was_attending = existing is not None and existing.status == RSVPStatus.ATTENDING
     had_plus_one = existing is not None and existing.has_plus_one
+    new_confirmed_at = _resolve_paid_confirmed_at(existing, paid_confirmed, final_status)
 
     if (
         existing is not None
         and existing.status == final_status
         and existing.has_plus_one == final_plus_one
+        and existing.paid_confirmed_at == new_confirmed_at
     ):
         return final_status, [], False
 
@@ -179,6 +209,7 @@ def _apply_rsvp_in_transaction(
             "status": final_status,
             "has_plus_one": final_plus_one,
             "cancelled_at": _resolve_cancelled_at(existing, final_status),
+            "paid_confirmed_at": new_confirmed_at,
         },
     )
 
@@ -206,7 +237,7 @@ def upsert_rsvp(request, event_id: UUID, payload: RSVPIn):
 
     with transaction.atomic():
         final_status, promoted_user_ids, _created = _apply_rsvp_in_transaction(
-            event_id, request.auth, payload.status, payload.has_plus_one
+            event_id, request.auth, payload.status, payload.has_plus_one, payload.paid_confirmed
         )
 
     sent_decline_note = _post_rsvp_comment(event_id, request.auth, final_status, payload.comment)

--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -225,6 +225,7 @@ class EventOut(BaseModel):
 class RSVPIn(BaseModel):
     status: RSVPStatus
     has_plus_one: bool = False
+    paid_confirmed: bool = False
     # Not persisted on the RSVP — a non-empty value is a one-time post: a
     # public EventComment (going/maybe) or a host-only notification (can't go).
     comment: str | None = Field(default=None, max_length=FieldLimit.SHORT_TEXT)

--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -116,6 +116,7 @@ class RSVPGuestOut(BaseModel):
     attendance: AttendanceStatus = AttendanceStatus.UNKNOWN
     checked_in_at: datetime | None = None
     is_member: bool = True
+    paid_confirmed: bool = False
 
 
 class PendingCoHostInviteOut(BaseModel):
@@ -162,6 +163,7 @@ class EventListOut(BaseModel):
     invited_count: int = 0
     comment_count: int = 0
     my_rsvp: str | None = None
+    my_paid_confirmed: bool = False
     is_past: bool = False
     status: str = "active"
     tags: list[TagOut] = []
@@ -193,9 +195,7 @@ class EventOut(BaseModel):
     co_host_photo_urls: list[str] = []
     guests: list[RSVPGuestOut] = []
     my_rsvp: str | None = None
-    # Same gating as my_rsvp (both derive from the resolved viewer in
-    # _event_out) — lets a token-holding, not-logged-in viewer identify their
-    # own entry in `guests` without a real auth session to key off of.
+    my_paid_confirmed: bool = False
     viewer_user_id: str | None = None
     event_type: str = EventType.COMMUNITY
     visibility: str = PageVisibility.PUBLIC

--- a/backend/community/_events.py
+++ b/backend/community/_events.py
@@ -20,8 +20,8 @@ from community._cohost_invite_helpers import has_pending_cohost_invite
 from community._event_helpers import (
     _can_see_invite_only,
     _event_out,
-    _find_my_rsvp,
     _get_creator_name,
+    _my_rsvp_fields,
     _set_event_tags,
     _tags_out,
     _update_co_hosts,
@@ -42,7 +42,8 @@ from community._event_transitions import (
 )
 from community._event_viewer import resolve_event_viewer
 from community._rsvp_counts import _attending_headcount, _waitlisted_count
-from community._shared import ErrorOut, _authenticated_user, _members_only, _optional_jwt
+from community._rsvp_payment import can_see_payment_details
+from community._shared import ErrorOut, _authenticated_user, _gated, _optional_jwt
 from community._validation import Code, raise_validation
 from community.models import (
     Event,
@@ -194,6 +195,8 @@ def _filter_invite_only(events, auth_user, status: str):
 
 
 def _event_list_out(e, auth_user, is_authed: bool) -> EventListOut:
+    show_payment_details = can_see_payment_details(e, is_authed)
+    my_rsvp_status, my_paid_confirmed = _my_rsvp_fields(e.rsvps.all(), auth_user)
     return EventListOut(
         id=str(e.id),
         slug=e.slug,
@@ -208,13 +211,13 @@ def _event_list_out(e, auth_user, is_authed: bool) -> EventListOut:
         visibility=e.visibility,
         photo_url=media_path(e.photo),
         photo_updated_at=(e.photo_updated_at.isoformat() if e.photo_updated_at else None),
-        whatsapp_link=_members_only(e.whatsapp_link, "", is_authed),
-        partiful_link=_members_only(e.partiful_link, "", is_authed),
-        other_link=_members_only(e.other_link, "", is_authed),
+        whatsapp_link=_gated(e.whatsapp_link, "", is_authed),
+        partiful_link=_gated(e.partiful_link, "", is_authed),
+        other_link=_gated(e.other_link, "", is_authed),
         price=e.price,
-        venmo_link=_members_only(e.venmo_link, "", is_authed),
-        cashapp_link=_members_only(e.cashapp_link, "", is_authed),
-        zelle_info=_members_only(e.zelle_info, "", is_authed),
+        venmo_link=_gated(e.venmo_link, "", show_payment_details),
+        cashapp_link=_gated(e.cashapp_link, "", show_payment_details),
+        zelle_info=_gated(e.zelle_info, "", show_payment_details),
         created_by_id=str(e.created_by_id) if e.created_by_id else None,
         created_by_name=_get_creator_name(e.created_by, auth_user),
         created_by_photo_url=media_path(e.created_by.profile_photo) if e.created_by else "",
@@ -227,7 +230,8 @@ def _event_list_out(e, auth_user, is_authed: bool) -> EventListOut:
         waitlisted_count=_waitlisted_count(e),
         invited_count=e.invited_users.count(),
         comment_count=e.comment_count,
-        my_rsvp=_find_my_rsvp(e.rsvps.all(), auth_user),
+        my_rsvp=my_rsvp_status,
+        my_paid_confirmed=my_paid_confirmed,
         co_host_ids=[str(c.id) for c in e.co_hosts.all()],
         co_host_names=[visible_display_name(c, auth_user) for c in e.co_hosts.all()],
         is_past=e.is_past,

--- a/backend/community/_events.py
+++ b/backend/community/_events.py
@@ -193,6 +193,49 @@ def _filter_invite_only(events, auth_user, status: str):
     ]
 
 
+def _event_list_out(e, auth_user, is_authed: bool) -> EventListOut:
+    return EventListOut(
+        id=str(e.id),
+        slug=e.slug,
+        title=e.title,
+        description=e.description,
+        start_datetime=e.start_datetime,
+        end_datetime=e.end_datetime,
+        location=e.location,
+        latitude=float(e.latitude) if e.latitude is not None else None,
+        longitude=float(e.longitude) if e.longitude is not None else None,
+        event_type=e.event_type,
+        visibility=e.visibility,
+        photo_url=media_path(e.photo),
+        photo_updated_at=(e.photo_updated_at.isoformat() if e.photo_updated_at else None),
+        whatsapp_link=_members_only(e.whatsapp_link, "", is_authed),
+        partiful_link=_members_only(e.partiful_link, "", is_authed),
+        other_link=_members_only(e.other_link, "", is_authed),
+        price=e.price,
+        venmo_link=_members_only(e.venmo_link, "", is_authed),
+        cashapp_link=_members_only(e.cashapp_link, "", is_authed),
+        zelle_info=_members_only(e.zelle_info, "", is_authed),
+        created_by_id=str(e.created_by_id) if e.created_by_id else None,
+        created_by_name=_get_creator_name(e.created_by, auth_user),
+        created_by_photo_url=media_path(e.created_by.profile_photo) if e.created_by else "",
+        co_host_photo_urls=[media_path(c.profile_photo) for c in e.co_hosts.all()],
+        datetime_tbd=e.datetime_tbd,
+        has_poll=hasattr(e, "poll"),
+        allow_plus_ones=e.allow_plus_ones,
+        max_attendees=e.max_attendees,
+        attending_count=_attending_headcount(e),
+        waitlisted_count=_waitlisted_count(e),
+        invited_count=e.invited_users.count(),
+        comment_count=e.comment_count,
+        my_rsvp=_find_my_rsvp(e.rsvps.all(), auth_user),
+        co_host_ids=[str(c.id) for c in e.co_hosts.all()],
+        co_host_names=[visible_display_name(c, auth_user) for c in e.co_hosts.all()],
+        is_past=e.is_past,
+        status=e.status,
+        tags=_tags_out(e),
+    )
+
+
 @router.get("/events/", response={200: list[EventListOut], 403: ErrorOut}, auth=_optional_jwt)
 def list_events(request, status: str = EventStatus.ACTIVE):
     auth_user = _authenticated_user(request.auth)
@@ -206,49 +249,7 @@ def list_events(request, status: str = EventStatus.ACTIVE):
     )
     return Status(
         200,
-        [
-            EventListOut(
-                id=str(e.id),
-                slug=e.slug,
-                title=e.title,
-                description=e.description,
-                start_datetime=e.start_datetime,
-                end_datetime=e.end_datetime,
-                location=e.location,
-                latitude=float(e.latitude) if e.latitude is not None else None,
-                longitude=float(e.longitude) if e.longitude is not None else None,
-                event_type=e.event_type,
-                visibility=e.visibility,
-                photo_url=media_path(e.photo),
-                photo_updated_at=(e.photo_updated_at.isoformat() if e.photo_updated_at else None),
-                whatsapp_link=_members_only(e.whatsapp_link, "", is_authed),
-                partiful_link=_members_only(e.partiful_link, "", is_authed),
-                other_link=_members_only(e.other_link, "", is_authed),
-                price=e.price,
-                venmo_link=_members_only(e.venmo_link, "", is_authed),
-                cashapp_link=_members_only(e.cashapp_link, "", is_authed),
-                zelle_info=_members_only(e.zelle_info, "", is_authed),
-                created_by_id=str(e.created_by_id) if e.created_by_id else None,
-                created_by_name=_get_creator_name(e.created_by, auth_user),
-                created_by_photo_url=media_path(e.created_by.profile_photo) if e.created_by else "",
-                co_host_photo_urls=[media_path(c.profile_photo) for c in e.co_hosts.all()],
-                datetime_tbd=e.datetime_tbd,
-                has_poll=hasattr(e, "poll"),
-                allow_plus_ones=e.allow_plus_ones,
-                max_attendees=e.max_attendees,
-                attending_count=_attending_headcount(e),
-                waitlisted_count=_waitlisted_count(e),
-                invited_count=e.invited_users.count(),
-                comment_count=e.comment_count,
-                my_rsvp=_find_my_rsvp(e.rsvps.all(), auth_user),
-                co_host_ids=[str(c.id) for c in e.co_hosts.all()],
-                co_host_names=[visible_display_name(c, auth_user) for c in e.co_hosts.all()],
-                is_past=e.is_past,
-                status=e.status,
-                tags=_tags_out(e),
-            )
-            for e in events
-        ],
+        [_event_list_out(e, auth_user, is_authed) for e in events],
     )
 
 

--- a/backend/community/_public_rsvp_manage.py
+++ b/backend/community/_public_rsvp_manage.py
@@ -57,6 +57,7 @@ class PublicRsvpManageOut(BaseModel):
 class PublicRsvpManageIn(BaseModel):
     status: str
     has_plus_one: bool = False
+    paid_confirmed: bool = False
     comment: str | None = Field(default=None, max_length=FieldLimit.SHORT_TEXT)
 
 
@@ -157,7 +158,7 @@ def update_my_rsvp(request, event_id, payload: PublicRsvpManageIn, token: str = 
 
     with transaction.atomic():
         final_status, promoted_user_ids, created = _apply_rsvp_in_transaction(
-            event.id, user, payload.status, False
+            event.id, user, payload.status, False, payload.paid_confirmed
         )
         rsvp_token = NonMemberRsvpToken.issue_or_extend(user)
 
@@ -167,7 +168,11 @@ def update_my_rsvp(request, event_id, payload: PublicRsvpManageIn, token: str = 
         request,
         target_type=AuditTargetType.EVENT,
         target_id=str(event.id),
-        details={"user_id": str(user.pk), "status": final_status},
+        details={
+            "user_id": str(user.pk),
+            "status": final_status,
+            "paid_confirmed": payload.paid_confirmed,
+        },
     )
     sent_decline_note = _post_rsvp_comment(event.id, user, final_status, payload.comment)
     email_error = _send_manage_rsvp_email(

--- a/backend/community/_public_rsvp_submit.py
+++ b/backend/community/_public_rsvp_submit.py
@@ -43,6 +43,7 @@ class PublicRsvpIn(BaseModel):
     phone_number: str = Field(max_length=FieldLimit.PHONE)
     status: str = Field(max_length=FieldLimit.CHOICE)
     has_plus_one: bool = False
+    paid_confirmed: bool = False
     comment: str | None = Field(default=None, max_length=FieldLimit.SHORT_TEXT)
     # Honeypot: hidden field humans never fill in. A non-empty value is spam.
     website: str = Field(default="", max_length=FieldLimit.DISPLAY_NAME)
@@ -240,7 +241,7 @@ def submit_public_rsvp(request, event_id, payload: PublicRsvpIn):
             phone=validated_phone,
         )
         final_status, promoted_user_ids, _rsvp_created = _apply_rsvp_in_transaction(
-            event.id, user, payload.status, False
+            event.id, user, payload.status, False, payload.paid_confirmed
         )
         token = NonMemberRsvpToken.issue_or_extend(user)
 
@@ -250,7 +251,11 @@ def submit_public_rsvp(request, event_id, payload: PublicRsvpIn):
         request,
         target_type=AuditTargetType.EVENT,
         target_id=str(event.id),
-        details={"user_id": str(user.pk), "status": final_status},
+        details={
+            "user_id": str(user.pk),
+            "status": final_status,
+            "paid_confirmed": payload.paid_confirmed,
+        },
     )
 
     _post_rsvp_comment(event.id, user, final_status, payload.comment)

--- a/backend/community/_shared.py
+++ b/backend/community/_shared.py
@@ -141,6 +141,6 @@ def _authenticated_user(requesting_user) -> "UserModel | None":
     return requesting_user
 
 
-def _members_only(value, default, is_authed: bool):
-    """Return value if user is authenticated, default otherwise."""
-    return value if is_authed else default
+def _gated(value, default, visible: bool):
+    """Return value if visible, default otherwise."""
+    return value if visible else default

--- a/backend/community/api.py
+++ b/backend/community/api.py
@@ -14,8 +14,8 @@ from community._event_flags import router as event_flags_router
 # Re-export symbols imported directly in tests
 from community._event_helpers import (  # noqa: F401
     _build_guest_list,
-    _can_see_phones,
     _find_my_rsvp,
+    _is_cohost,
 )
 from community._event_host_actions import router as event_host_actions_router
 from community._event_host_rsvps import router as event_host_rsvps_router

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -1796,6 +1796,11 @@
             ],
             "title": "Max Attendees"
           },
+          "my_paid_confirmed": {
+            "default": false,
+            "title": "My Paid Confirmed",
+            "type": "boolean"
+          },
           "my_rsvp": {
             "anyOf": [
               {
@@ -2109,6 +2114,11 @@
               }
             ],
             "title": "Max Attendees"
+          },
+          "my_paid_confirmed": {
+            "default": false,
+            "title": "My Paid Confirmed",
+            "type": "boolean"
           },
           "my_pending_cohost_invite_id": {
             "anyOf": [
@@ -4664,6 +4674,11 @@
           "name": {
             "title": "Name",
             "type": "string"
+          },
+          "paid_confirmed": {
+            "default": false,
+            "title": "Paid Confirmed",
+            "type": "boolean"
           },
           "phone": {
             "anyOf": [

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -4424,6 +4424,11 @@
             "title": "Last Name",
             "type": "string"
           },
+          "paid_confirmed": {
+            "default": false,
+            "title": "Paid Confirmed",
+            "type": "boolean"
+          },
           "phone_number": {
             "maxLength": 20,
             "title": "Phone Number",
@@ -4467,6 +4472,11 @@
           "has_plus_one": {
             "default": false,
             "title": "Has Plus One",
+            "type": "boolean"
+          },
+          "paid_confirmed": {
+            "default": false,
+            "title": "Paid Confirmed",
             "type": "boolean"
           },
           "status": {
@@ -4704,6 +4714,11 @@
           "has_plus_one": {
             "default": false,
             "title": "Has Plus One",
+            "type": "boolean"
+          },
+          "paid_confirmed": {
+            "default": false,
+            "title": "Paid Confirmed",
             "type": "boolean"
           },
           "status": {

--- a/backend/tests/test_event_helpers.py
+++ b/backend/tests/test_event_helpers.py
@@ -1,41 +1,25 @@
-"""Unit tests for event helper functions (_can_see_phones, _build_guest_list, _find_my_rsvp)."""
+"""Unit tests for event helper functions (_is_cohost, _build_guest_list, _find_my_rsvp)."""
 
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from community.api import _build_guest_list, _can_see_phones, _find_my_rsvp
+from community.api import _build_guest_list, _find_my_rsvp, _is_cohost
 from community.models import AttendanceStatus, RSVPStatus
 
 
-class TestCanSeePhones:
+class TestIsCohost:
     def test_returns_false_when_no_requesting_user(self):
-        assert _can_see_phones(None, MagicMock(), {"id1"}) is False
-
-    def test_returns_true_when_user_is_creator(self):
-        creator = MagicMock()
-        creator.pk = "user-1"
-        requesting = MagicMock()
-        requesting.pk = "user-1"
-        assert _can_see_phones(requesting, creator, set()) is True
+        assert _is_cohost(None, {"id1"}) is False
 
     def test_returns_true_when_user_is_co_host(self):
-        creator = MagicMock()
-        creator.pk = "user-1"
         requesting = MagicMock()
         requesting.pk = "user-2"
-        assert _can_see_phones(requesting, creator, {"user-2"}) is True
+        assert _is_cohost(requesting, {"user-2"}) is True
 
-    def test_returns_false_when_user_is_neither(self):
-        creator = MagicMock()
-        creator.pk = "user-1"
+    def test_returns_false_when_user_is_not_a_co_host(self):
         requesting = MagicMock()
         requesting.pk = "user-3"
-        assert _can_see_phones(requesting, creator, {"user-2"}) is False
-
-    def test_returns_false_when_creator_is_none(self):
-        requesting = MagicMock()
-        requesting.pk = "user-1"
-        assert _can_see_phones(requesting, None, set()) is False
+        assert _is_cohost(requesting, {"user-2"}) is False
 
 
 class TestBuildGuestList:
@@ -57,6 +41,7 @@ class TestBuildGuestList:
             has_plus_one=False,
             attendance=AttendanceStatus.UNKNOWN,
             checked_in_at=None,
+            paid_confirmed_at=None,
         )
 
     def test_empty_rsvps(self):
@@ -94,9 +79,12 @@ class TestFindMyRsvp:
         user = SimpleNamespace(pk="u2")
         assert _find_my_rsvp([self._make_rsvp("u1", RSVPStatus.ATTENDING)], user) is None
 
-    def test_returns_status_when_user_found(self):
+    def test_returns_row_when_user_found(self):
         user = SimpleNamespace(pk="u1")
-        assert _find_my_rsvp([self._make_rsvp("u1", RSVPStatus.MAYBE)], user) == RSVPStatus.MAYBE
+        assert (
+            _find_my_rsvp([self._make_rsvp("u1", RSVPStatus.MAYBE)], user).status
+            == RSVPStatus.MAYBE
+        )
 
     def test_returns_first_match(self):
         user = SimpleNamespace(pk="u1")
@@ -104,4 +92,4 @@ class TestFindMyRsvp:
             self._make_rsvp("u1", RSVPStatus.ATTENDING),
             self._make_rsvp("u1", RSVPStatus.MAYBE),
         ]
-        assert _find_my_rsvp(rsvps, user) == RSVPStatus.ATTENDING
+        assert _find_my_rsvp(rsvps, user).status == RSVPStatus.ATTENDING

--- a/backend/tests/test_payment_link_visibility.py
+++ b/backend/tests/test_payment_link_visibility.py
@@ -1,0 +1,157 @@
+"""Tests for payment-link and payment-status visibility in the event serializers."""
+
+import pytest
+from community.models import Event, EventType
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+
+from tests._payment_helpers import create_paid_event, set_payment_flag
+from tests._public_rsvp_helpers import make_official_event
+
+
+@pytest.fixture(autouse=True)
+def _flag_on(db):
+    set_payment_flag(True)
+
+
+def _paid_event(creator, **overrides) -> Event:
+    return create_paid_event(created_by=creator, **overrides)
+
+
+@pytest.fixture
+def paid_public_event(db):
+    return make_official_event(
+        title="Paid Official Event",
+        price="$10",
+        venmo_link="https://venmo.com/u/host",
+    )
+
+
+@pytest.mark.django_db
+class TestPublicPaymentLinkVisibility:
+    def _get(self, api_client, event):
+        return api_client.get(f"/api/community/events/{event.id}/")
+
+    def test_anon_sees_payment_links_on_public_rsvp_eligible_event(
+        self, api_client, paid_public_event
+    ):
+        response = self._get(api_client, paid_public_event)
+        assert response.status_code == 200
+        body = response.json()
+        assert body["venmo_link"] == "https://venmo.com/u/host"
+        assert body["price"] == "$10"
+
+    def test_anon_does_not_see_payment_links_on_non_eligible_event(
+        self, api_client, paid_public_event
+    ):
+        paid_public_event.rsvp_enabled = False
+        paid_public_event.save(update_fields=["rsvp_enabled"])
+        response = self._get(api_client, paid_public_event)
+        assert response.status_code == 200
+        assert response.json()["venmo_link"] == ""
+
+    def test_anon_does_not_see_payment_links_on_community_event(
+        self, api_client, paid_public_event
+    ):
+        paid_public_event.event_type = EventType.COMMUNITY
+        paid_public_event.save(update_fields=["event_type"])
+        response = self._get(api_client, paid_public_event)
+        assert response.status_code == 200
+        assert response.json()["venmo_link"] == ""
+
+    def test_anon_still_does_not_see_other_member_only_links(self, api_client, paid_public_event):
+        paid_public_event.whatsapp_link = "https://chat.whatsapp.com/abc"
+        paid_public_event.save(update_fields=["whatsapp_link"])
+        response = self._get(api_client, paid_public_event)
+        assert response.json()["whatsapp_link"] == ""
+
+    def test_member_still_sees_payment_links_on_non_eligible_event(
+        self, api_client, paid_public_event, auth_headers
+    ):
+        paid_public_event.rsvp_enabled = False
+        paid_public_event.save(update_fields=["rsvp_enabled"])
+        response = api_client.get(f"/api/community/events/{paid_public_event.id}/", **auth_headers)
+        assert response.json()["venmo_link"] == "https://venmo.com/u/host"
+
+
+@pytest.mark.django_db
+class TestListSerializerPaymentParity:
+    def _list(self, api_client, **headers):
+        return api_client.get("/api/community/events/", **headers).json()
+
+    def _find(self, body, event):
+        return next(item for item in body if item["id"] == str(event.id))
+
+    def test_anon_sees_payment_links_in_list_for_eligible_event(self, api_client, test_user):
+        from community.models import EventType
+
+        event = _paid_event(test_user, event_type=EventType.OFFICIAL)
+        row = self._find(self._list(api_client), event)
+        assert row["venmo_link"] == "https://venmo.com/u/host"
+
+    def test_list_and_detail_agree_for_anon(self, api_client, test_user):
+        from community.models import EventType
+
+        event = _paid_event(test_user, event_type=EventType.OFFICIAL)
+        row = self._find(self._list(api_client), event)
+        detail = api_client.get(f"/api/community/events/{event.id}/").json()
+        assert row["venmo_link"] == detail["venmo_link"]
+
+    def test_anon_does_not_see_payment_links_in_list_for_community_event(
+        self, api_client, test_user
+    ):
+        from community.models import EventType
+
+        event = _paid_event(test_user, event_type=EventType.COMMUNITY)
+        row = self._find(self._list(api_client), event)
+        assert row["venmo_link"] == ""
+
+    def test_anon_still_does_not_see_other_links_in_list(self, api_client, test_user):
+        from community.models import EventType
+
+        event = _paid_event(
+            test_user,
+            event_type=EventType.OFFICIAL,
+            whatsapp_link="https://chat.whatsapp.com/abc",
+        )
+        row = self._find(self._list(api_client), event)
+        assert row["whatsapp_link"] == ""
+
+
+@pytest.mark.django_db
+class TestPaymentLinkVisibilityIgnoresTheGateFlag:
+    """EVENT_PAYMENT_CONFIRMATION governs whether payment is enforced, not who
+    may see the cost — visibility must be identical either way."""
+
+    def _venmo(self, api_client, event, **headers):
+        return api_client.get(f"/api/community/events/{event.id}/", **headers).json()["venmo_link"]
+
+    @pytest.mark.parametrize("flag", [True, False])
+    def test_anon_sees_payment_links_on_an_eligible_event(self, api_client, test_user, flag):
+        set_payment_flag(flag)
+        event = _paid_event(test_user, event_type=EventType.OFFICIAL)
+        assert self._venmo(api_client, event) == "https://venmo.com/u/host"
+
+    @pytest.mark.parametrize("flag", [True, False])
+    def test_anon_does_not_see_them_on_an_ineligible_event(self, api_client, test_user, flag):
+        set_payment_flag(flag)
+        event = _paid_event(test_user, event_type=EventType.COMMUNITY)
+        assert self._venmo(api_client, event) == ""
+
+    @pytest.mark.parametrize("flag", [True, False])
+    def test_member_always_sees_them(self, api_client, auth_headers, test_user, flag):
+        set_payment_flag(flag)
+        event = _paid_event(test_user)
+        assert self._venmo(api_client, event, **auth_headers) == "https://venmo.com/u/host"
+
+
+@pytest.mark.django_db
+class TestListEndpointFlagQueryCount:
+    def test_payment_visibility_costs_no_flag_query(self, api_client, test_user):
+        """can_see_payment_details reads no flag, so listing events must not
+        query FeatureFlagState once per event — or at all."""
+        for _ in range(6):
+            _paid_event(test_user, event_type=EventType.OFFICIAL)
+        with CaptureQueriesContext(connection) as ctx:
+            assert api_client.get("/api/community/events/").status_code == 200
+        assert not [q for q in ctx.captured_queries if "featureflagstate" in q["sql"].lower()]

--- a/backend/tests/test_rsvp_payment_gate.py
+++ b/backend/tests/test_rsvp_payment_gate.py
@@ -1,0 +1,216 @@
+import pytest
+from community._validation import Code
+from community.models import EventRSVP, RSVPStatus
+from django.utils import timezone
+from users.models import NonMemberRsvpToken
+
+from tests._asserts import assert_error_code
+from tests._payment_helpers import create_paid_event, set_payment_flag
+from tests._public_rsvp_helpers import make_non_member, make_official_event
+from tests._public_rsvp_helpers import payload as public_payload
+from tests._public_rsvp_helpers import url as public_url
+
+RSVP_URL = "/api/community/events/{event_id}/rsvp/"
+
+
+@pytest.fixture(autouse=True)
+def _flag_on(db):
+    """Flag-OFF behavior is covered by test_payment_confirmation_flag_off.py."""
+    set_payment_flag(True)
+
+
+@pytest.fixture
+def paid_event(db, test_user):
+    return create_paid_event(created_by=test_user)
+
+
+@pytest.mark.django_db
+class TestMemberRsvpPaymentGate:
+    def test_attending_without_confirmation_is_rejected(self, api_client, paid_event, auth_headers):
+        response = api_client.post(
+            RSVP_URL.format(event_id=paid_event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 400
+        assert_error_code(response, Code.Event.PAYMENT_CONFIRMATION_REQUIRED)
+        assert not EventRSVP.objects.filter(event=paid_event).exists()
+
+    def test_attending_with_confirmation_succeeds_and_stamps(
+        self, api_client, paid_event, auth_headers
+    ):
+        response = api_client.post(
+            RSVP_URL.format(event_id=paid_event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": False, "paid_confirmed": True},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+        rsvp = EventRSVP.objects.get(event=paid_event)
+        assert rsvp.status == RSVPStatus.ATTENDING
+        assert rsvp.paid_confirmed_at is not None
+
+    def test_maybe_without_confirmation_succeeds(self, api_client, paid_event, auth_headers):
+        response = api_client.post(
+            RSVP_URL.format(event_id=paid_event.id),
+            {"status": RSVPStatus.MAYBE, "has_plus_one": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+        assert EventRSVP.objects.get(event=paid_event).paid_confirmed_at is None
+
+    def test_confirmed_attendee_can_toggle_plus_one_without_reconfirming(
+        self, api_client, paid_event, auth_headers, test_user
+    ):
+        paid_event.allow_plus_ones = True
+        paid_event.save(update_fields=["allow_plus_ones"])
+        EventRSVP.objects.create(
+            event=paid_event,
+            user=test_user,
+            status=RSVPStatus.ATTENDING,
+            paid_confirmed_at=timezone.now(),
+        )
+        response = api_client.post(
+            RSVP_URL.format(event_id=paid_event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": True},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+
+    def test_unconfirmed_attendee_is_gated_on_next_write(
+        self, api_client, paid_event, auth_headers, test_user
+    ):
+        """A row seated by waitlist promotion carries no stamp and must still gate."""
+        paid_event.allow_plus_ones = True
+        paid_event.save(update_fields=["allow_plus_ones"])
+        EventRSVP.objects.create(event=paid_event, user=test_user, status=RSVPStatus.ATTENDING)
+        response = api_client.post(
+            RSVP_URL.format(event_id=paid_event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": True},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 400
+        assert_error_code(response, Code.Event.PAYMENT_CONFIRMATION_REQUIRED)
+
+    def test_confirmation_persists_across_later_status_changes(
+        self, api_client, paid_event, auth_headers
+    ):
+        api_client.post(
+            RSVP_URL.format(event_id=paid_event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": False, "paid_confirmed": True},
+            content_type="application/json",
+            **auth_headers,
+        )
+        stamped = EventRSVP.objects.get(event=paid_event).paid_confirmed_at
+        api_client.post(
+            RSVP_URL.format(event_id=paid_event.id),
+            {"status": RSVPStatus.MAYBE, "has_plus_one": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+        response = api_client.post(
+            RSVP_URL.format(event_id=paid_event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+        assert EventRSVP.objects.get(event=paid_event).paid_confirmed_at == stamped
+
+    def test_free_event_needs_no_confirmation(self, api_client, paid_event, auth_headers):
+        paid_event.price = ""
+        paid_event.venmo_link = ""
+        paid_event.save(update_fields=["price", "venmo_link"])
+        response = api_client.post(
+            RSVP_URL.format(event_id=paid_event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+
+
+@pytest.fixture
+def paid_public_event(db):
+    return make_official_event(
+        title="Paid Official Event",
+        price="$10",
+        venmo_link="https://venmo.com/u/host",
+    )
+
+
+@pytest.mark.django_db
+class TestPublicSubmitPaymentGate:
+    def test_new_person_attending_without_confirmation_is_rejected(
+        self, api_client, paid_public_event
+    ):
+        response = api_client.post(
+            public_url(paid_public_event),
+            public_payload(status=RSVPStatus.ATTENDING),
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        assert_error_code(response, Code.Event.PAYMENT_CONFIRMATION_REQUIRED)
+
+    def test_new_person_attending_with_confirmation_succeeds(self, api_client, paid_public_event):
+        response = api_client.post(
+            public_url(paid_public_event),
+            public_payload(status=RSVPStatus.ATTENDING, paid_confirmed=True),
+            content_type="application/json",
+        )
+        assert response.status_code in (200, 201)
+        assert EventRSVP.objects.get(event=paid_public_event).paid_confirmed_at is not None
+
+    def test_new_person_maybe_needs_no_confirmation(self, api_client, paid_public_event):
+        response = api_client.post(
+            public_url(paid_public_event),
+            public_payload(status=RSVPStatus.MAYBE),
+            content_type="application/json",
+        )
+        assert response.status_code in (200, 201)
+
+
+@pytest.mark.django_db
+class TestPublicManagePaymentGate:
+    def _setup(self, event, phone="+14155550199"):
+        user = make_non_member(phone, "token@example.com", name="Token Holder")
+        EventRSVP.objects.create(event=event, user=user, status=RSVPStatus.MAYBE)
+        return user, NonMemberRsvpToken.issue_or_extend(user).token
+
+    def test_maybe_to_attending_without_confirmation_is_rejected(
+        self, api_client, paid_public_event
+    ):
+        _user, token = self._setup(paid_public_event)
+        response = api_client.post(
+            f"/api/community/public/my-rsvps/{paid_public_event.id}/?token={token}",
+            {"status": RSVPStatus.ATTENDING},
+            content_type="application/json",
+        )
+        assert response.status_code == 400
+        assert_error_code(response, Code.Event.PAYMENT_CONFIRMATION_REQUIRED)
+
+    def test_maybe_to_attending_with_confirmation_succeeds(self, api_client, paid_public_event):
+        user, token = self._setup(paid_public_event, phone="+14155550198")
+        response = api_client.post(
+            f"/api/community/public/my-rsvps/{paid_public_event.id}/?token={token}",
+            {"status": RSVPStatus.ATTENDING, "paid_confirmed": True},
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        rsvp = EventRSVP.objects.get(event=paid_public_event, user=user)
+        assert rsvp.paid_confirmed_at is not None
+
+    def test_switching_to_maybe_needs_no_confirmation(self, api_client, paid_public_event):
+        user = make_non_member("+14155550197", "t2@example.com", name="Token Two")
+        EventRSVP.objects.create(event=paid_public_event, user=user, status=RSVPStatus.ATTENDING)
+        token = NonMemberRsvpToken.issue_or_extend(user).token
+        response = api_client.post(
+            f"/api/community/public/my-rsvps/{paid_public_event.id}/?token={token}",
+            {"status": RSVPStatus.MAYBE},
+            content_type="application/json",
+        )
+        assert response.status_code == 200

--- a/backend/tests/test_rsvp_payment_gate_bypass.py
+++ b/backend/tests/test_rsvp_payment_gate_bypass.py
@@ -1,0 +1,199 @@
+"""Regression tests for payment-gate bypasses caught in code review."""
+
+import pytest
+from community._validation import Code
+from community.models import Event, EventRSVP, RSVPStatus
+from django.utils import timezone
+
+from tests._asserts import assert_error_code
+from tests._payment_helpers import create_paid_event, set_payment_flag
+from tests.conftest import future_iso
+
+RSVP_URL = "/api/community/events/{event_id}/rsvp/"
+
+
+@pytest.fixture(autouse=True)
+def _flag_on(db):
+    set_payment_flag(True)
+
+
+def _paid_event(creator, **overrides) -> Event:
+    return create_paid_event(created_by=creator, **overrides)
+
+
+@pytest.mark.django_db
+class TestWaitlistPromotionBypass:
+    def test_unconfirmed_attending_at_capacity_is_rejected_before_waitlisting(
+        self, api_client, auth_headers, test_user, django_user_model
+    ):
+        """The gate must check the requested status, not the capacity-resolved
+        one — otherwise an unconfirmed request queues as an unconfirmed
+        waitlist row that later gets promoted with no gate ever having run."""
+        event = _paid_event(test_user, max_attendees=1)
+        seated = django_user_model.objects.create_user(
+            phone_number="+14155550111", first_name="Seated", is_member=True
+        )
+        EventRSVP.objects.create(event=event, user=seated, status=RSVPStatus.ATTENDING)
+
+        response = api_client.post(
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 400
+        assert_error_code(response, Code.Event.PAYMENT_CONFIRMATION_REQUIRED)
+        assert not EventRSVP.objects.filter(event=event, user=test_user).exists()
+
+
+@pytest.mark.django_db
+class TestPaidConfirmedOnUngatedStatus:
+    def test_maybe_with_paid_confirmed_does_not_bank_a_stamp(
+        self, api_client, auth_headers, test_user
+    ):
+        """paid_confirmed on an ungated status must not pre-authorize a later attending."""
+        event = _paid_event(test_user)
+        response = api_client.post(
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.MAYBE, "paid_confirmed": True},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+        assert EventRSVP.objects.get(event=event, user=test_user).paid_confirmed_at is None
+
+        response = api_client.post(
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 400
+        assert_error_code(response, Code.Event.PAYMENT_CONFIRMATION_REQUIRED)
+
+    def test_cant_go_with_paid_confirmed_does_not_bank_a_stamp(
+        self, api_client, auth_headers, test_user
+    ):
+        event = _paid_event(test_user)
+        api_client.post(
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.CANT_GO, "paid_confirmed": True},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert EventRSVP.objects.get(event=event, user=test_user).paid_confirmed_at is None
+
+    def test_a_real_confirmation_still_stamps_and_persists(
+        self, api_client, auth_headers, test_user
+    ):
+        event = _paid_event(test_user)
+        api_client.post(
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.ATTENDING, "paid_confirmed": True},
+            content_type="application/json",
+            **auth_headers,
+        )
+        stamped = EventRSVP.objects.get(event=event, user=test_user).paid_confirmed_at
+        assert stamped is not None
+
+        api_client.post(
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.MAYBE},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert EventRSVP.objects.get(event=event, user=test_user).paid_confirmed_at == stamped
+
+
+@pytest.mark.django_db
+class TestPollFinalizeDoesNotBypassGate:
+    def test_yes_voter_seated_unconfirmed_is_gated_on_next_write(
+        self, api_client, auth_headers, test_user
+    ):
+        from community.models import EventPoll, PollAvailability, PollOption, PollVote
+
+        event = _paid_event(test_user, datetime_tbd=True)
+        poll = EventPoll.objects.create(event=event, created_by=test_user)
+        option = PollOption.objects.create(poll=poll, datetime=future_iso(days=120))
+        PollVote.objects.create(option=option, user=test_user, availability=PollAvailability.YES)
+
+        response = api_client.post(
+            f"/api/community/events/{event.id}/poll/finalize/",
+            {"winning_option_id": str(option.id)},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+        rsvp = EventRSVP.objects.get(event=event, user=test_user)
+        assert rsvp.status == RSVPStatus.ATTENDING
+        assert rsvp.paid_confirmed_at is None
+
+        response = api_client.post(
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 400
+        assert_error_code(response, Code.Event.PAYMENT_CONFIRMATION_REQUIRED)
+
+    def test_yes_voter_with_existing_confirmation_keeps_it(
+        self, api_client, auth_headers, test_user
+    ):
+        from community.models import EventPoll, PollAvailability, PollOption, PollVote
+
+        event = _paid_event(test_user, datetime_tbd=True)
+        EventRSVP.objects.create(
+            event=event,
+            user=test_user,
+            status=RSVPStatus.MAYBE,
+            paid_confirmed_at=timezone.now(),
+        )
+        poll = EventPoll.objects.create(event=event, created_by=test_user)
+        option = PollOption.objects.create(poll=poll, datetime=future_iso(days=120))
+        PollVote.objects.create(option=option, user=test_user, availability=PollAvailability.YES)
+
+        api_client.post(
+            f"/api/community/events/{event.id}/poll/finalize/",
+            {"winning_option_id": str(option.id)},
+            content_type="application/json",
+            **auth_headers,
+        )
+        rsvp = EventRSVP.objects.get(event=event, user=test_user)
+        assert rsvp.status == RSVPStatus.ATTENDING
+        assert rsvp.paid_confirmed_at is not None
+
+
+@pytest.mark.django_db
+class TestNoOpEarlyReturnStillStamps:
+    def test_confirming_an_already_seated_unconfirmed_row_persists_the_stamp(
+        self, api_client, auth_headers, test_user
+    ):
+        """An unconfirmed attending row (e.g. from waitlist promotion) confirmed
+        via the same status/plus-one must still get the stamp written — the
+        unchanged-state early return must not discard it."""
+        event = _paid_event(test_user)
+        EventRSVP.objects.create(event=event, user=test_user, status=RSVPStatus.ATTENDING)
+
+        response = api_client.post(
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": False, "paid_confirmed": True},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+        assert EventRSVP.objects.get(event=event, user=test_user).paid_confirmed_at is not None
+
+
+@pytest.mark.django_db
+def test_stamp_is_a_real_datetime(api_client, auth_headers, test_user):
+    """Guards against asserting on a truthy ISO string instead of a datetime."""
+    event = _paid_event(test_user)
+    api_client.post(
+        RSVP_URL.format(event_id=event.id),
+        {"status": RSVPStatus.ATTENDING, "paid_confirmed": True},
+        content_type="application/json",
+        **auth_headers,
+    )
+    stamped = EventRSVP.objects.get(event=event, user=test_user).paid_confirmed_at
+    assert timezone.is_aware(stamped)

--- a/frontend/src/api/publicRsvp.test.ts
+++ b/frontend/src/api/publicRsvp.test.ts
@@ -43,6 +43,7 @@ describe('useSubmitPublicRsvp', () => {
       status: 'attending',
       has_plus_one: false,
       website: '',
+      paid_confirmed: false,
     };
     result.current.mutate({ eventId: 'ev1', payload });
 

--- a/frontend/src/api/publicRsvp.ts
+++ b/frontend/src/api/publicRsvp.ts
@@ -130,6 +130,7 @@ export function useUpdatePublicMyRsvp(token: string) {
         status,
         has_plus_one: hasPlusOne,
         comment: comment ?? null,
+        paid_confirmed: false,
       };
       const { data } = await apiClient.post<PublicRsvpOut>(`${MANAGE_BASE}${eventId}/`, body, {
         params: { token },

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -2848,6 +2848,11 @@ export interface components {
             longitude?: number | null;
             /** Max Attendees */
             max_attendees?: number | null;
+            /**
+             * My Paid Confirmed
+             * @default false
+             */
+            my_paid_confirmed: boolean;
             /** My Rsvp */
             my_rsvp?: string | null;
             /**
@@ -3029,6 +3034,11 @@ export interface components {
             longitude?: number | null;
             /** Max Attendees */
             max_attendees?: number | null;
+            /**
+             * My Paid Confirmed
+             * @default false
+             */
+            my_paid_confirmed: boolean;
             /** My Pending Cohost Invite Id */
             my_pending_cohost_invite_id?: string | null;
             /** My Rsvp */
@@ -4113,6 +4123,11 @@ export interface components {
             is_member: boolean;
             /** Name */
             name: string;
+            /**
+             * Paid Confirmed
+             * @default false
+             */
+            paid_confirmed: boolean;
             /** Phone */
             phone?: string | null;
             /**

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -4012,6 +4012,11 @@ export interface components {
              * @default
              */
             last_name: string;
+            /**
+             * Paid Confirmed
+             * @default false
+             */
+            paid_confirmed: boolean;
             /** Phone Number */
             phone_number: string;
             /** Status */
@@ -4031,6 +4036,11 @@ export interface components {
              * @default false
              */
             has_plus_one: boolean;
+            /**
+             * Paid Confirmed
+             * @default false
+             */
+            paid_confirmed: boolean;
             /** Status */
             status: string;
         };
@@ -4123,6 +4133,11 @@ export interface components {
              * @default false
              */
             has_plus_one: boolean;
+            /**
+             * Paid Confirmed
+             * @default false
+             */
+            paid_confirmed: boolean;
             status: components["schemas"]["RSVPStatus"];
         };
         /**

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -119,6 +119,7 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
           has_plus_one: false,
           comment: comment.trim() || null,
           website,
+          paid_confirmed: false,
         },
       });
       onSuccess(result);


### PR DESCRIPTION
## Overview

**3 of 5** in the split of #1213 (Issue 1045). Serializer-side visibility.

**Stacked on #1225.**

### Read the two commits separately

1. **`refactor: extract _event_list_out`** — pure move, the `EventListOut(...)` body lifted out of the list comprehension verbatim. Split out so commit 2 reads as a few lines rather than a rewritten 40-line literal.
2. **`feat: expose payment links and payment status`** — the actual change.

### What's here

- **Payment links widen to anonymous viewers**, but only on `Event.is_public_rsvp_eligible` events that actually cost money. Otherwise a stranger hits a "did you pay?" prompt with no way to pay. Community/club/draft/past events keep them member-gated, and while the flag is off nothing widens at all.
- **List and detail serializers now agree** — previously only the detail path would have gained the wider visibility.
- **`my_paid_confirmed`** on `EventOut`/`EventListOut`, **`paid_confirmed`** per guest. Guest payment status is host bookkeeping, scoped to the same audience as guest phone numbers rather than the whole membership.
- **`_find_my_rsvp` returns the row** instead of the status so callers read both fields in one pass; `_my_rsvp_fields` wraps the common case.

### Notes for review

- `list_events` resolves the flag once and threads it down. `flag_enabled()` is a query — calling it per event reintroduces an N+1.

## Test plan

- [x] `tests/test_payment_link_visibility.py` — 12 tests: anon vs member, eligible vs community, free vs paid, list/detail parity, flag-off
- [x] `tests/test_event_helpers.py` updated for the `_find_my_rsvp` return-type change
- [x] 613 event tests pass on the extraction commit alone, confirming it's a pure move
- [x] 876 rsvp/event/poll/payment tests pass; the one `test_rsvp_capacity_race.py` failure is the pre-existing SQLite limitation
- [x] `make agent-lint`, `agent-typecheck`, `agent-complexity`, frontend typecheck + lint clean

Part of Issue 1045. Split out of #1213.
