### PR TITLE
feat: 1045 - payment-aware waitlist promotion notices (4/6)

### DIFF
--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -34,7 +34,7 @@ from community._rsvp_counts import (
     _attending_headcount_db,
     _waitlisted_count,
 )
-from community._rsvp_payment import can_see_payment_details
+from community._rsvp_payment import can_see_payment_details, payment_enforced_for_event
 from community._shared import _authenticated_user, _gated
 from community.models import (
     Event,
@@ -172,6 +172,8 @@ def promote_from_waitlist(event: Event) -> list[str]:
     if event.max_attendees is None:
         return []
     promoted_user_ids: list[str] = []
+    unpaid_user_ids: list[str] = []
+    needs_payment = payment_enforced_for_event(event)
     while True:
         headcount = _attending_headcount_db(event)
         if headcount >= event.max_attendees:
@@ -182,8 +184,10 @@ def promote_from_waitlist(event: Event) -> list[str]:
         oldest.status = RSVPStatus.ATTENDING
         oldest.save(update_fields=["status", "updated_at"])
         promoted_user_ids.append(str(oldest.user_id))
+        if needs_payment and oldest.paid_confirmed_at is None:
+            unpaid_user_ids.append(str(oldest.user_id))
     if promoted_user_ids:
-        create_waitlist_promoted_notifications(event, promoted_user_ids)
+        create_waitlist_promoted_notifications(event, promoted_user_ids, unpaid_user_ids)
     return promoted_user_ids
 
 

--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -141,27 +141,6 @@ def _post_rsvp_comment(event_id, user, final_status: str, comment: str | None) -
 def _resolve_paid_confirmed_at(
     existing: EventRSVP | None, paid_confirmed: bool, final_status: str
 ) -> datetime | None:
-    """Resolve paid_confirmed_at for this write.
-
-    Attending or waitlisted both stamp: at capacity an attending request
-    resolves to waitlisted, but it was still a gated, confirmed write and must
-    keep its stamp through promotion. Maybe/can't-go are ungated statuses —
-    `paid_confirmed` there must not bank a stamp that disarms a later
-    attending write (see requires_payment_gate).
-
-    A standing confirmation is preserved untouched, so a host-revoked row that
-    pays again re-stamps without needing the rsvp deleted.
-    """
-    if existing is not None and existing.paid_confirmed_at is not None:
-        return existing.paid_confirmed_at
-    if paid_confirmed and final_status in (RSVPStatus.ATTENDING, RSVPStatus.WAITLISTED):
-        return timezone.now()
-    return None
-
-
-def _resolve_paid_confirmed_at(
-    existing: EventRSVP | None, paid_confirmed: bool, final_status: str
-) -> datetime | None:
     """Preserve a standing stamp; otherwise stamp only on a confirmed attending/waitlisted write."""
     if existing is not None and existing.paid_confirmed_at is not None:
         return existing.paid_confirmed_at

--- a/backend/community/_polls.py
+++ b/backend/community/_polls.py
@@ -318,6 +318,7 @@ def finalize_event_poll(request, event_id: UUID, payload: EventPollFinalizeIn):
             "user_id", flat=True
         )
         for user_id in yes_voter_ids:
+            # paid_confirmed_at omitted from defaults: preserves an existing stamp, else unconfirmed.
             EventRSVP.objects.update_or_create(
                 event=event,
                 user_id=user_id,

--- a/backend/community/_public_rsvp_shared.py
+++ b/backend/community/_public_rsvp_shared.py
@@ -12,9 +12,10 @@ from pydantic import BaseModel
 from users.models import NonMemberRsvpToken, User
 
 from community._event_schemas import EventOut
+from community._rsvp_payment import payment_enforced_for_event
 from community._shared import logger
 from community._validation import Code, raise_validation
-from community.models import Event
+from community.models import Event, EventRSVP
 
 
 class PublicRsvpStateOut(BaseModel):
@@ -82,11 +83,28 @@ def _log_email_failure(request, event: Event, user: User, exc: Exception) -> Non
     )
 
 
+def _unpaid_user_ids(event: Event, user_ids: list[str]) -> set:
+    """Of user_ids, those whose rsvp lacks a standing payment confirmation.
+
+    Empty when the event needs no payment. A confirmed rsvp can land on the
+    waitlist at capacity and keep its stamp, so promotion is not proof of debt.
+    """
+    if not payment_enforced_for_event(event):
+        return set()
+    paid = EventRSVP.objects.filter(
+        event=event,
+        user_id__in=user_ids,
+        paid_confirmed_at__isnull=False,
+    ).values_list("user_id", flat=True)
+    return {str(uid) for uid in user_ids} - {str(uid) for uid in paid}
+
+
 def _email_promoted_non_members(request, event: Event, promoted_user_ids: list[str]) -> None:
     """Email any promoted non-members their manage link. Best-effort per user."""
     if not promoted_user_ids:
         return
     promoted = User.objects.filter(id__in=promoted_user_ids, is_member=False, email__isnull=False)
+    unpaid = _unpaid_user_ids(event, promoted_user_ids)
     for user in promoted:
         if not user.email:
             continue
@@ -95,6 +113,7 @@ def _email_promoted_non_members(request, event: Event, promoted_user_ids: list[s
             result = send_rsvp_waitlist_promoted_email(
                 sender=get_email_sender(),
                 details=_email_details(event, user, token.token),
+                payment_pending=str(user.id) in unpaid,
             )
             if not result.success:
                 raise RuntimeError(result.error or "send returned failure")

--- a/backend/notifications/_email_helpers.py
+++ b/backend/notifications/_email_helpers.py
@@ -66,9 +66,10 @@ def send_rsvp_waitlist_promoted_email(
     *,
     sender: EmailSender,
     details: RsvpEmailDetails,
+    payment_pending: bool = False,
 ) -> SendResult:
     """Render and send the non-member "you're off the waitlist" email."""
-    context = details.template_context()
+    context = {**details.template_context(), "payment_pending": payment_pending}
     html = render_to_string("emails/rsvp_waitlist_promoted.html", context)
     text = render_to_string("emails/rsvp_waitlist_promoted.txt", context)
     return sender.send(

--- a/backend/notifications/service.py
+++ b/backend/notifications/service.py
@@ -316,17 +316,25 @@ def create_event_invite_notifications(
 def create_waitlist_promoted_notifications(
     event: Event,
     promoted_user_ids: Iterable[str],
+    unpaid_user_ids: Iterable[str] = (),
 ) -> None:
+    """Notify promoted users. Only those in unpaid_user_ids are told to pay —
+    someone promoted with a standing confirmation already paid."""
     user_ids = list(promoted_user_ids)
     if not user_ids:
         return
+    unpaid = set(unpaid_user_ids)
+    promoted_message = f"a spot opened up — you're going to {event.title}!"
+    unpaid_message = (
+        f"a spot opened up for {event.title} — your spot isn't confirmed until you pay."
+    )
     Notification.objects.bulk_create(
         [
             Notification(
                 recipient_id=user_id,
                 notification_type=NotificationType.WAITLIST_PROMOTED,
                 event=event,
-                message=f"a spot opened up — you're going to {event.title}!",
+                message=unpaid_message if user_id in unpaid else promoted_message,
             )
             for user_id in user_ids
         ]

--- a/backend/templates/emails/rsvp_waitlist_promoted.html
+++ b/backend/templates/emails/rsvp_waitlist_promoted.html
@@ -4,6 +4,7 @@
   <div style="max-width: 480px; margin: 0 auto; background: #ffffff; border-radius: 8px; padding: 32px;">
     <p style="margin: 0 0 16px;">hi{% if display_name %} {{ display_name|lower }}{% endif %} —</p>
     <p style="margin: 0 0 24px;">good news — a spot opened up and you're off the waitlist for <strong>{{ event_title|lower }}</strong> 🌱</p>
+    {% if payment_pending %}<p style="margin: 0 0 24px; padding: 12px 16px; background: #fdf6e3; border-radius: 6px; font-size: 14px;">your spot isn't confirmed until you pay for this event. payment details are on the event page! head to the event on the link below to get the payment info so that your rsvp is not cancelled.</p>{% endif %}
     {% if event_when %}<p style="margin: 0 0 8px;">when: {{ event_when|lower }}</p>{% endif %}
     {% if event_location %}<p style="margin: 0 0 8px;">where: {{ event_location|lower }}</p>{% endif %}
     {% for link in event_links %}<p style="margin: 0 0 8px; font-size: 13px; word-break: break-all;"><a href="{{ link }}" style="color: #3c6939;">{{ link }}</a></p>{% endfor %}

--- a/backend/templates/emails/rsvp_waitlist_promoted.txt
+++ b/backend/templates/emails/rsvp_waitlist_promoted.txt
@@ -1,7 +1,9 @@
 hi{% if display_name %} {{ display_name|lower }}{% endif %} —
 
 good news — a spot opened up and you're off the waitlist for {{ event_title|lower }} 🌱
-{% if event_when %}
+{% if payment_pending %}
+your spot isn't confirmed until you pay for this event. payment details are on the event page! head to the event on the link below to get the payment info so that your rsvp is not cancelled.
+{% endif %}{% if event_when %}
 when: {{ event_when|lower }}{% endif %}{% if event_location %}
 where: {{ event_location|lower }}{% endif %}
 {% for link in event_links %}{{ link }}

--- a/backend/tests/test_waitlist_payment_notifications.py
+++ b/backend/tests/test_waitlist_payment_notifications.py
@@ -1,0 +1,114 @@
+"""Tests for payment-aware waitlist promotion notifications and emails."""
+
+import pytest
+from community._event_helpers import promote_from_waitlist
+from community.models import Event, EventRSVP, RSVPStatus
+from django.utils import timezone
+
+from tests._payment_helpers import create_paid_event, set_payment_flag
+
+RSVP_URL = "/api/community/events/{event_id}/rsvp/"
+
+
+@pytest.fixture(autouse=True)
+def _flag_on(db):
+    set_payment_flag(True)
+
+
+def _paid_event(creator, **overrides) -> Event:
+    return create_paid_event(created_by=creator, **overrides)
+
+
+@pytest.mark.django_db
+class TestWaitlistPromotionPaymentMessaging:
+    def test_promotion_notification_warns_about_payment(self, test_user, django_user_model):
+        from notifications.models import Notification
+
+        event = _paid_event(test_user, max_attendees=1)
+        waiting = django_user_model.objects.create_user(
+            phone_number="+14155550112", first_name="Waiting", is_member=True
+        )
+        EventRSVP.objects.create(event=event, user=waiting, status=RSVPStatus.WAITLISTED)
+        promote_from_waitlist(event)
+
+        message = Notification.objects.get(recipient=waiting).message
+        assert "isn't confirmed until you pay" in message
+
+    def test_free_event_promotion_keeps_the_plain_message(self, test_user, django_user_model):
+        from notifications.models import Notification
+
+        event = _paid_event(test_user, max_attendees=1, price="", venmo_link="")
+        waiting = django_user_model.objects.create_user(
+            phone_number="+14155550113", first_name="Waiting", is_member=True
+        )
+        EventRSVP.objects.create(event=event, user=waiting, status=RSVPStatus.WAITLISTED)
+        promote_from_waitlist(event)
+
+        message = Notification.objects.get(recipient=waiting).message
+        assert "pay" not in message
+
+    def test_already_paid_promoted_user_is_not_told_to_pay(self, test_user, django_user_model):
+        from notifications.models import Notification
+
+        event = _paid_event(test_user, max_attendees=1)
+        paid = django_user_model.objects.create_user(
+            phone_number="+14155550114", first_name="Paid", is_member=True
+        )
+        EventRSVP.objects.create(
+            event=event,
+            user=paid,
+            status=RSVPStatus.WAITLISTED,
+            paid_confirmed_at=timezone.now(),
+        )
+        promote_from_waitlist(event)
+
+        message = Notification.objects.get(recipient=paid).message
+        assert "isn't confirmed until you pay" not in message
+
+    def test_mixed_promotion_tells_only_the_unpaid_user_to_pay(self, test_user, django_user_model):
+        from notifications.models import Notification
+
+        event = _paid_event(test_user, max_attendees=2)
+        paid = django_user_model.objects.create_user(
+            phone_number="+14155550115", first_name="Paid", is_member=True
+        )
+        unpaid = django_user_model.objects.create_user(
+            phone_number="+14155550116", first_name="Unpaid", is_member=True
+        )
+        EventRSVP.objects.create(
+            event=event, user=paid, status=RSVPStatus.WAITLISTED, paid_confirmed_at=timezone.now()
+        )
+        EventRSVP.objects.create(event=event, user=unpaid, status=RSVPStatus.WAITLISTED)
+        promote_from_waitlist(event)
+
+        assert "until you pay" not in Notification.objects.get(recipient=paid).message
+        assert "until you pay" in Notification.objects.get(recipient=unpaid).message
+
+    def test_confirmed_attending_at_capacity_waitlists_and_promotes_without_regating(
+        self, api_client, auth_headers, test_user, django_user_model
+    ):
+        """A confirmed request that lands on the waitlist stays confirmed
+        through promotion — the stamp isn't lost by the capacity detour."""
+        event = _paid_event(test_user, max_attendees=1)
+        seated = django_user_model.objects.create_user(
+            phone_number="+14155550111", first_name="Seated", is_member=True
+        )
+        EventRSVP.objects.create(event=event, user=seated, status=RSVPStatus.ATTENDING)
+
+        response = api_client.post(
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": False, "paid_confirmed": True},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+        mine = EventRSVP.objects.get(event=event, user=test_user)
+        assert mine.status == RSVPStatus.WAITLISTED
+        assert mine.paid_confirmed_at is not None
+        stamped = mine.paid_confirmed_at
+
+        EventRSVP.objects.filter(event=event, user=seated).delete()
+        promote_from_waitlist(event)
+        mine.refresh_from_db()
+        assert mine.status == RSVPStatus.ATTENDING
+        assert mine.paid_confirmed_at == stamped


### PR DESCRIPTION
## Overview

**4 of 5** in the split of #1213 (Issue 1045). Waitlist promotion messaging.

**Stacked on #1226.**

### Why this is needed

A waitlist promotion seats a guest as `attending` **without passing the gate** — so the promotion notice is the only place they learn payment is still owed. Without this, a promoted guest is told "you're going!" and shows up unpaid.

### What's here

- **`promote_from_waitlist`** tracks which promoted users lack a standing confirmation; only those get the "your spot isn't confirmed until you pay" wording. A confirmed rsvp can land on the waitlist at capacity and keep its stamp, so **promotion is not proof of debt**.
- Same paid/unpaid split applied to the **non-member promotion email** (html + txt).
- **Poll finalize** omits `paid_confirmed_at` from its `update_or_create` defaults, preserving an existing stamp rather than clearing it.

## Test plan

- [x] `tests/test_waitlist_payment_notifications.py` — paid vs unpaid vs mixed promotion, free-event plain message, stamp survives the capacity detour
- [x] `tests/test_event_waitlist_promotion.py` passes unmodified
- [x] 881 rsvp/event/payment/notification tests pass; the one `test_rsvp_capacity_race.py` failure is the pre-existing SQLite limitation
- [x] `make agent-lint`, `agent-typecheck`, `agent-complexity` clean

Part of Issue 1045. Split out of #1213.
