### PR TITLE
feat: 1045 - host payment confirm/revoke endpoint (5/6)

### DIFF
--- a/backend/community/_event_cohost_invites.py
+++ b/backend/community/_event_cohost_invites.py
@@ -13,12 +13,12 @@ from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
-from notifications.service import (
-    broadcast_cohost_change,
+from notifications._cohost_notifications import (
     create_cohost_invite_accepted_notification,
     create_cohost_invite_declined_notification,
     create_cohost_removed_notification,
 )
+from notifications.service import broadcast_cohost_change
 
 from community._cohost_invite_helpers import expire_stale_cohost_invites
 from community._event_helpers import _can_manage_cohost_invites, _event_out

--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -5,10 +5,10 @@ from uuid import UUID
 
 from config.media_proxy import media_path
 from django.db import transaction
+from notifications._cohost_notifications import create_cohost_invite_notifications
 from notifications.service import (
     broadcast_cohost_change,
     broadcast_event_update,
-    create_cohost_invite_notifications,
     create_event_invite_notifications,
     create_waitlist_promoted_notifications,
 )
@@ -76,7 +76,7 @@ def broadcast_capacity_change(event_id: UUID, *, exclude_user_ids: set[str] | No
     transaction.on_commit(_run)
 
 
-def _is_cohost(requesting_user, co_host_ids: set[str]) -> bool:
+def is_cohost(requesting_user, co_host_ids: set[str]) -> bool:
     """Creator is always a co-host (added on event creation), so this covers both."""
     if requesting_user is None:
         return False
@@ -313,8 +313,10 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
     is_authed = auth_user is not None
     show_payment_details = can_see_payment_details(event, is_authed)
     co_host_ids = {str(u.id) for u in co_hosts}
-    is_cohost = _is_cohost(auth_user, co_host_ids)
-    payment_status_visible = is_cohost and flag_enabled(FeatureFlag.EVENT_PAYMENT_CONFIRMATION)
+    viewer_is_cohost = is_cohost(auth_user, co_host_ids)
+    payment_status_visible = viewer_is_cohost and flag_enabled(
+        FeatureFlag.EVENT_PAYMENT_CONFIRMATION
+    )
     rsvps = list(event.rsvps.all()) if (event.rsvp_enabled and is_authed) else []
     all_invited = list(event.invited_users.all())
     invited = all_invited if _can_see_invited(auth_user, creator, co_host_ids) else []
@@ -356,7 +358,7 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
         co_host_names=[visible_display_name(u, auth_user) for u in co_hosts],
         co_host_photo_urls=[media_path(u.profile_photo) for u in co_hosts],
         guests=_gated(
-            _build_guest_list(rsvps, is_cohost, auth_user, payment_status_visible),
+            _build_guest_list(rsvps, viewer_is_cohost, auth_user, payment_status_visible),
             [],
             is_authed,
         ),

--- a/backend/community/_event_host_rsvps.py
+++ b/backend/community/_event_host_rsvps.py
@@ -5,8 +5,10 @@ from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.ratelimit import rate_limit
 from django.db import transaction
+from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
+from notifications.service import create_payment_revoked_notification
 from users.models import User as UserModel
 
 from community._event_helpers import (
@@ -17,10 +19,11 @@ from community._event_helpers import (
 )
 from community._event_rsvps import (
     _resolve_cancelled_at,
+    _resolve_paid_confirmed_at,
     _resolve_rsvp_status,
     _validate_rsvp_status,
 )
-from community._event_schemas import EventOut, HostRSVPIn
+from community._event_schemas import EventOut, HostRSVPIn, HostRSVPPaymentIn
 from community._events import _can_edit_event
 from community._public_rsvp_shared import _email_promoted_non_members
 from community._shared import ErrorOut
@@ -31,16 +34,9 @@ router = Router()
 
 
 def _apply_host_rsvp_in_transaction(
-    event_id, target_user, status: str, has_plus_one: bool
+    event_id, target_user, status: str, has_plus_one: bool, paid_confirmed: bool = False
 ) -> tuple[str, list[str]]:
-    """Execute a host-driven RSVP upsert for another user inside a locked transaction.
-
-    Unlike _apply_rsvp_in_transaction, access is already gated on the acting
-    host (_can_edit_event) by the caller — this only enforces that the event
-    still accepts RSVPs, not the target user's own read-visibility.
-
-    Returns (final_status, promoted_user_ids). Raises ValidationException on failure.
-    """
+    """Host-driven RSVP upsert; unlike _apply_rsvp_in_transaction, never subject to the payment gate."""
     event = (
         Event.objects.select_for_update()
         .prefetch_related("co_hosts", "invited_users")
@@ -57,11 +53,13 @@ def _apply_host_rsvp_in_transaction(
     existing = EventRSVP.objects.filter(event=event, user=target_user).first()
     was_attending = existing is not None and existing.status == RSVPStatus.ATTENDING
     had_plus_one = existing is not None and existing.has_plus_one
+    new_confirmed_at = _resolve_paid_confirmed_at(existing, paid_confirmed, final_status)
 
     if (
         existing is not None
         and existing.status == final_status
         and existing.has_plus_one == final_plus_one
+        and existing.paid_confirmed_at == new_confirmed_at
     ):
         return final_status, []
 
@@ -72,6 +70,7 @@ def _apply_host_rsvp_in_transaction(
             "status": final_status,
             "has_plus_one": final_plus_one,
             "cancelled_at": _resolve_cancelled_at(existing, final_status),
+            "paid_confirmed_at": new_confirmed_at,
         },
     )
 
@@ -111,7 +110,7 @@ def set_guest_rsvp(request, event_id: UUID, user_id: UUID, payload: HostRSVPIn):
 
     with transaction.atomic():
         final_status, promoted_user_ids = _apply_host_rsvp_in_transaction(
-            event_id, target_user, payload.status, payload.has_plus_one
+            event_id, target_user, payload.status, payload.has_plus_one, payload.paid_confirmed
         )
 
     audit_log(
@@ -120,13 +119,73 @@ def set_guest_rsvp(request, event_id: UUID, user_id: UUID, payload: HostRSVPIn):
         request,
         target_type=AuditTargetType.EVENT,
         target_id=str(event_id),
-        details={"user_id": str(user_id), "status": final_status},
+        details={
+            "user_id": str(user_id),
+            "status": final_status,
+            "paid_confirmed": payload.paid_confirmed,
+        },
     )
     event = load_event_with_stats_prefetch(event_id)
     if event is None:
         raise_validation(Code.Event.NOT_FOUND, status_code=404)
     broadcast_capacity_change(event_id, exclude_user_ids={str(request.auth.pk)})
     _email_promoted_non_members(request, event, promoted_user_ids)
+    return Status(200, _event_out(event, request.auth))
+
+
+def _apply_payment_change_in_transaction(event_id, user_id, paid_confirmed: bool) -> bool:
+    """Set or clear the payment stamp on a locked rsvp row. Returns whether it was paid before.
+
+    Clearing re-gates the guest on their next attending write. The record that
+    they once paid, and who retracted it, lives in the audit log.
+    """
+    rsvp = EventRSVP.objects.select_for_update().filter(event_id=event_id, user_id=user_id).first()
+    if rsvp is None:
+        raise_validation(Code.Event.RSVP_NOT_FOUND, status_code=404)
+    was_paid = rsvp.paid_confirmed_at is not None
+    if paid_confirmed:
+        rsvp.paid_confirmed_at = rsvp.paid_confirmed_at or timezone.now()
+    else:
+        rsvp.paid_confirmed_at = None
+    rsvp.save(update_fields=["paid_confirmed_at", "updated_at"])
+    return was_paid
+
+
+@router.patch(
+    "/events/{event_id}/rsvps/{user_id}/payment/",
+    response={200: EventOut, 403: ErrorOut, 404: ErrorOut, 429: ErrorOut},
+    auth=gated_jwt,
+)
+@rate_limit(key_func=lambda r: str(r.auth.pk), rate="30/m")
+def set_guest_payment(request, event_id: UUID, user_id: UUID, payload: HostRSVPPaymentIn):
+    """Let a host confirm or retract a guest's payment without touching their rsvp status."""
+    event = (
+        Event.objects.select_related("created_by")
+        .prefetch_related("co_hosts", "invited_users", "rsvps__user")
+        .filter(id=event_id)
+        .first()
+    )
+    if event is None:
+        raise_validation(Code.Event.NOT_FOUND, status_code=404)
+    if not _can_edit_event(request.auth, event):
+        raise_validation(Code.Perm.DENIED, status_code=403, action="set_guest_payment")
+
+    with transaction.atomic():
+        was_paid = _apply_payment_change_in_transaction(event_id, user_id, payload.paid_confirmed)
+
+    audit_log(
+        logging.INFO,
+        "guest_payment_changed",
+        request,
+        target_type=AuditTargetType.EVENT,
+        target_id=str(event_id),
+        details={"user_id": str(user_id), "paid_confirmed": payload.paid_confirmed},
+    )
+    if was_paid and not payload.paid_confirmed:
+        create_payment_revoked_notification(event, str(user_id))
+    event = load_event_with_stats_prefetch(event_id)
+    if event is None:
+        raise_validation(Code.Event.NOT_FOUND, status_code=404)
     return Status(200, _event_out(event, request.auth))
 
 

--- a/backend/community/_event_report.py
+++ b/backend/community/_event_report.py
@@ -8,7 +8,7 @@ from ninja import Router
 from ninja.responses import Status
 from users._helpers import visible_display_name
 
-from community._event_helpers import _is_cohost, load_event_with_stats_prefetch
+from community._event_helpers import is_cohost, load_event_with_stats_prefetch
 from community._event_report_schemas import (
     REPORT_CSV_COLUMNS,
     AttendedPersonOut,
@@ -54,7 +54,7 @@ def _person(rsvp, viewer, can_see_phones: bool) -> CheckInReportPersonOut:
 
 def _build_report(event: Event, viewer) -> CheckInReportOut:
     co_host_ids = {str(c.id) for c in event.co_hosts.all()}
-    can_see_phones = _is_cohost(viewer, co_host_ids)
+    can_see_phones = is_cohost(viewer, co_host_ids)
 
     attended, no_shows, canceled, unmarked = [], [], [], []
     for rsvp in _report_rsvps(event):
@@ -141,7 +141,7 @@ def get_check_in_report_csv(request, event_id: UUID, columns: str = ",".join(REP
     selected = _parse_columns(columns)
 
     co_host_ids = {str(c.id) for c in event.co_hosts.all()}
-    can_see_phones = _is_cohost(request.auth, co_host_ids)
+    can_see_phones = is_cohost(request.auth, co_host_ids)
 
     buf = io.StringIO()
     writer = csv.writer(buf)

--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -234,6 +234,11 @@ class RSVPIn(BaseModel):
 class HostRSVPIn(BaseModel):
     status: RSVPStatus
     has_plus_one: bool = False
+    paid_confirmed: bool = False
+
+
+class HostRSVPPaymentIn(BaseModel):
+    paid_confirmed: bool
 
 
 class TextRecipientsOut(BaseModel):

--- a/backend/community/_event_transitions.py
+++ b/backend/community/_event_transitions.py
@@ -6,9 +6,9 @@ from config.audit import AuditTargetType, audit_log
 from django.db import transaction
 from django.utils import timezone
 from ninja.responses import Status
+from notifications._cohost_notifications import create_cohost_invite_notifications
 from notifications.service import (
     broadcast_event_created,
-    create_cohost_invite_notifications,
     create_event_cancellation_notifications,
     create_event_invite_notifications,
 )

--- a/backend/community/api.py
+++ b/backend/community/api.py
@@ -15,7 +15,7 @@ from community._event_flags import router as event_flags_router
 from community._event_helpers import (  # noqa: F401
     _build_guest_list,
     _find_my_rsvp,
-    _is_cohost,
+    is_cohost,
 )
 from community._event_host_actions import router as event_host_actions_router
 from community._event_host_rsvps import router as event_host_rsvps_router

--- a/backend/notifications/_cohost_notifications.py
+++ b/backend/notifications/_cohost_notifications.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from users._helpers import visible_display_name
+from users.models import User
+
+from notifications.models import Notification, NotificationType
+from notifications.service import notify_users
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from community.models import Event
+
+
+def create_cohost_invite_notifications(
+    event: Event,
+    new_user_ids: Iterable[str],
+    invited_by: User,
+) -> None:
+    """Notify users who just received a co-host invite for this event."""
+    invited_by_id = str(invited_by.pk)
+    invited_by_name = visible_display_name(invited_by, None)
+    notified_ids = [str(uid) for uid in new_user_ids if str(uid) != invited_by_id]
+    if not notified_ids:
+        return
+    Notification.objects.bulk_create(
+        [
+            Notification(
+                recipient_id=user_id,
+                notification_type=NotificationType.COHOST_INVITE,
+                event=event,
+                related_user=invited_by,
+                message=(
+                    f"{invited_by_name} invited you to co-host {event.title} — tap to respond"
+                ),
+            )
+            for user_id in notified_ids
+        ]
+    )
+    notify_users(notified_ids)
+
+
+def create_cohost_invite_accepted_notification(
+    event: Event,
+    invitee: User,
+    inviter_id: str | None,
+) -> None:
+    """Notify the inviter that an invitee accepted their co-host invite."""
+    if inviter_id is None or str(inviter_id) == str(invitee.pk):
+        return
+    invitee_name = visible_display_name(invitee, None)
+    Notification.objects.create(
+        recipient_id=str(inviter_id),
+        notification_type=NotificationType.COHOST_INVITE_ACCEPTED,
+        event=event,
+        related_user=invitee,
+        message=f"{invitee_name} accepted your co-host invite for {event.title}",
+    )
+    notify_users([str(inviter_id)])
+
+
+def create_cohost_invite_declined_notification(
+    event: Event,
+    invitee: User,
+    inviter_id: str | None,
+) -> None:
+    """Notify the inviter that an invitee declined their co-host invite."""
+    if inviter_id is None or str(inviter_id) == str(invitee.pk):
+        return
+    invitee_name = visible_display_name(invitee, None)
+    Notification.objects.create(
+        recipient_id=str(inviter_id),
+        notification_type=NotificationType.COHOST_INVITE_DECLINED,
+        event=event,
+        related_user=invitee,
+        message=f"{invitee_name} declined your co-host invite for {event.title}",
+    )
+    notify_users([str(inviter_id)])
+
+
+def create_cohost_removed_notification(event: Event, removed_user: User, remover: User) -> None:
+    """Notify a co-host that they've been removed from an event by someone else.
+
+    Caller is responsible for skipping self-removal — no need to notify
+    yourself that you stepped down.
+    """
+    if str(remover.pk) == str(removed_user.pk):
+        return
+    remover_name = visible_display_name(remover, None)
+    Notification.objects.create(
+        recipient_id=str(removed_user.pk),
+        notification_type=NotificationType.COHOST_REMOVED,
+        event=event,
+        related_user=remover,
+        message=f"{remover_name} removed you as a co-host of {event.title}",
+    )
+    notify_users([str(removed_user.pk)])

--- a/backend/notifications/migrations/0017_alter_notification_notification_type.py
+++ b/backend/notifications/migrations/0017_alter_notification_notification_type.py
@@ -29,6 +29,7 @@ class Migration(migrations.Migration):
                     ("rsvp_status_changed", "RSVP Status Changed"),
                     ("rsvp_declined_note", "RSVP Declined Note"),
                     ("checkin_nudge", "Check-in Nudge"),
+                    ("payment_revoked", "Payment Confirmation Revoked"),
                 ],
                 default="event_invite",
                 max_length=32,

--- a/backend/notifications/models.py
+++ b/backend/notifications/models.py
@@ -28,6 +28,7 @@ class NotificationType(models.TextChoices):
     RSVP_STATUS_CHANGED = "rsvp_status_changed", "RSVP Status Changed"
     RSVP_DECLINED_NOTE = "rsvp_declined_note", "RSVP Declined Note"
     CHECKIN_NUDGE = "checkin_nudge", "Check-in Nudge"
+    PAYMENT_REVOKED = "payment_revoked", "Payment Confirmation Revoked"
 
 
 class Notification(models.Model):

--- a/backend/notifications/service.py
+++ b/backend/notifications/service.py
@@ -17,7 +17,7 @@ if TYPE_CHECKING:
     from community.models import Event
 
 
-def _notify_users(user_ids: Iterable[str]) -> None:
+def notify_users(user_ids: Iterable[str]) -> None:
     """Fire pg_notify on the notifications channel (for new notification rows)."""
     if connection.vendor != "postgresql":
         return
@@ -142,7 +142,7 @@ def create_join_request_notifications(full_name: str) -> None:
             for user in recipients
         ]
     )
-    _notify_users(str(user.pk) for user in recipients)
+    notify_users(str(user.pk) for user in recipients)
 
 
 def create_event_flag_notifications(event: Event, flagger: User) -> None:
@@ -160,7 +160,7 @@ def create_event_flag_notifications(event: Event, flagger: User) -> None:
             for user in recipients
         ]
     )
-    _notify_users(str(user.pk) for user in recipients)
+    notify_users(str(user.pk) for user in recipients)
 
 
 def create_magic_link_request_notifications(user: User) -> None:
@@ -178,92 +178,7 @@ def create_magic_link_request_notifications(user: User) -> None:
             for recipient in recipients
         ]
     )
-    _notify_users(str(recipient.pk) for recipient in recipients)
-
-
-def create_cohost_invite_notifications(
-    event: Event,
-    new_user_ids: Iterable[str],
-    invited_by: User,
-) -> None:
-    """Notify users who just received a co-host invite for this event."""
-    invited_by_id = str(invited_by.pk)
-    invited_by_name = visible_display_name(invited_by, None)
-    notified_ids = [str(uid) for uid in new_user_ids if str(uid) != invited_by_id]
-    if not notified_ids:
-        return
-    Notification.objects.bulk_create(
-        [
-            Notification(
-                recipient_id=user_id,
-                notification_type=NotificationType.COHOST_INVITE,
-                event=event,
-                related_user=invited_by,
-                message=(
-                    f"{invited_by_name} invited you to co-host {event.title} — tap to respond"
-                ),
-            )
-            for user_id in notified_ids
-        ]
-    )
-    _notify_users(notified_ids)
-
-
-def create_cohost_invite_accepted_notification(
-    event: Event,
-    invitee: User,
-    inviter_id: str | None,
-) -> None:
-    """Notify the inviter that an invitee accepted their co-host invite."""
-    if inviter_id is None or str(inviter_id) == str(invitee.pk):
-        return
-    invitee_name = visible_display_name(invitee, None)
-    Notification.objects.create(
-        recipient_id=str(inviter_id),
-        notification_type=NotificationType.COHOST_INVITE_ACCEPTED,
-        event=event,
-        related_user=invitee,
-        message=f"{invitee_name} accepted your co-host invite for {event.title}",
-    )
-    _notify_users([str(inviter_id)])
-
-
-def create_cohost_invite_declined_notification(
-    event: Event,
-    invitee: User,
-    inviter_id: str | None,
-) -> None:
-    """Notify the inviter that an invitee declined their co-host invite."""
-    if inviter_id is None or str(inviter_id) == str(invitee.pk):
-        return
-    invitee_name = visible_display_name(invitee, None)
-    Notification.objects.create(
-        recipient_id=str(inviter_id),
-        notification_type=NotificationType.COHOST_INVITE_DECLINED,
-        event=event,
-        related_user=invitee,
-        message=f"{invitee_name} declined your co-host invite for {event.title}",
-    )
-    _notify_users([str(inviter_id)])
-
-
-def create_cohost_removed_notification(event: Event, removed_user: User, remover: User) -> None:
-    """Notify a co-host that they've been removed from an event by someone else.
-
-    Caller is responsible for skipping self-removal — no need to notify
-    yourself that you stepped down.
-    """
-    if str(remover.pk) == str(removed_user.pk):
-        return
-    remover_name = visible_display_name(remover, None)
-    Notification.objects.create(
-        recipient_id=str(removed_user.pk),
-        notification_type=NotificationType.COHOST_REMOVED,
-        event=event,
-        related_user=remover,
-        message=f"{remover_name} removed you as a co-host of {event.title}",
-    )
-    _notify_users([str(removed_user.pk)])
+    notify_users(str(recipient.pk) for recipient in recipients)
 
 
 def create_event_cancellation_notifications(event: Event, canceller: User) -> None:
@@ -288,7 +203,7 @@ def create_event_cancellation_notifications(event: Event, canceller: User) -> No
             for user_id in recipient_ids
         ]
     )
-    _notify_users(recipient_ids)
+    notify_users(recipient_ids)
 
 
 def create_event_invite_notifications(
@@ -310,7 +225,7 @@ def create_event_invite_notifications(
             for user_id in notified_ids
         ]
     )
-    _notify_users(notified_ids)
+    notify_users(notified_ids)
 
 
 def create_waitlist_promoted_notifications(
@@ -339,7 +254,22 @@ def create_waitlist_promoted_notifications(
             for user_id in user_ids
         ]
     )
-    _notify_users(user_ids)
+    notify_users(user_ids)
+
+
+def create_payment_revoked_notification(event: Event, user_id: str) -> None:
+    """Tell a guest a host retracted their payment confirmation.
+
+    Silence here would leave them believing they're seated — they'd show up
+    unpaid, which is the outcome the whole gate exists to prevent.
+    """
+    Notification.objects.create(
+        recipient_id=user_id,
+        notification_type=NotificationType.PAYMENT_REVOKED,
+        event=event,
+        message=f"your payment for {event.title} needs attention — please confirm payment again.",
+    )
+    notify_users([user_id])
 
 
 def notify_comment_reply(reply) -> None:
@@ -362,7 +292,7 @@ def notify_comment_reply(reply) -> None:
         related_user=reply.author,
         message=f"{replier_name} replied to your comment on {event_title}",
     )
-    _notify_users([str(parent_author_id)])
+    notify_users([str(parent_author_id)])
 
 
 def notify_comment_reaction(comment, reactor: User) -> None:
@@ -378,7 +308,7 @@ def notify_comment_reaction(comment, reactor: User) -> None:
         related_user=reactor,
         message=f"{reactor_name} reacted to your comment on {event_title}",
     )
-    _notify_users([str(comment.author_id)])
+    notify_users([str(comment.author_id)])
 
 
 def _event_recipient_ids(event, *, exclude: str) -> list[str]:
@@ -414,7 +344,7 @@ def notify_rsvp_declined_note(event, author, note: str) -> None:
             for rid in recipient_id_list
         ]
     )
-    _notify_users(recipient_id_list)
+    notify_users(recipient_id_list)
 
 
 def notify_checkin_reminder(event: Event) -> None:
@@ -434,7 +364,7 @@ def notify_checkin_reminder(event: Event) -> None:
             for rid in recipient_id_list
         ]
     )
-    _notify_users(recipient_id_list)
+    notify_users(recipient_id_list)
 
 
 def notify_event_comment(comment) -> None:
@@ -459,7 +389,7 @@ def notify_event_comment(comment) -> None:
             for rid in recipient_id_list
         ]
     )
-    _notify_users(recipient_id_list)
+    notify_users(recipient_id_list)
 
 
 _RSVP_STATUS_WORDS: dict[str, str] = {
@@ -496,4 +426,4 @@ def notify_rsvp_status_changed(event: Event, rsvper: User, status: str) -> None:
             for rid in recipient_id_list
         ]
     )
-    _notify_users(recipient_id_list)
+    notify_users(recipient_id_list)

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -3251,6 +3251,11 @@
             "title": "Has Plus One",
             "type": "boolean"
           },
+          "paid_confirmed": {
+            "default": false,
+            "title": "Paid Confirmed",
+            "type": "boolean"
+          },
           "status": {
             "$ref": "#/components/schemas/RSVPStatus"
           }
@@ -3259,6 +3264,19 @@
           "status"
         ],
         "title": "HostRSVPIn",
+        "type": "object"
+      },
+      "HostRSVPPaymentIn": {
+        "properties": {
+          "paid_confirmed": {
+            "title": "Paid Confirmed",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "paid_confirmed"
+        ],
+        "title": "HostRSVPPaymentIn",
         "type": "object"
       },
       "InviteIn": {
@@ -11050,6 +11068,95 @@
           }
         ],
         "summary": "Set Attendance",
+        "tags": [
+          "community"
+        ]
+      }
+    },
+    "/api/community/events/{event_id}/rsvps/{user_id}/payment/": {
+      "patch": {
+        "description": "Let a host confirm or retract a guest's payment without touching their rsvp status.",
+        "operationId": "community__event_host_rsvps_set_guest_payment",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "event_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Event Id",
+              "type": "string"
+            }
+          },
+          {
+            "in": "path",
+            "name": "user_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "User Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/HostRSVPPaymentIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventOut"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          }
+        },
+        "security": [
+          {
+            "GatedJWTAuth": []
+          }
+        ],
+        "summary": "Set Guest Payment",
         "tags": [
           "community"
         ]

--- a/backend/tests/test_event_helpers.py
+++ b/backend/tests/test_event_helpers.py
@@ -1,25 +1,25 @@
-"""Unit tests for event helper functions (_is_cohost, _build_guest_list, _find_my_rsvp)."""
+"""Unit tests for event helper functions (is_cohost, _build_guest_list, _find_my_rsvp)."""
 
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from community.api import _build_guest_list, _find_my_rsvp, _is_cohost
+from community.api import _build_guest_list, _find_my_rsvp, is_cohost
 from community.models import AttendanceStatus, RSVPStatus
 
 
 class TestIsCohost:
     def test_returns_false_when_no_requesting_user(self):
-        assert _is_cohost(None, {"id1"}) is False
+        assert is_cohost(None, {"id1"}) is False
 
     def test_returns_true_when_user_is_co_host(self):
         requesting = MagicMock()
         requesting.pk = "user-2"
-        assert _is_cohost(requesting, {"user-2"}) is True
+        assert is_cohost(requesting, {"user-2"}) is True
 
     def test_returns_false_when_user_is_not_a_co_host(self):
         requesting = MagicMock()
         requesting.pk = "user-3"
-        assert _is_cohost(requesting, {"user-2"}) is False
+        assert is_cohost(requesting, {"user-2"}) is False
 
 
 class TestBuildGuestList:

--- a/backend/tests/test_in_app_notifications.py
+++ b/backend/tests/test_in_app_notifications.py
@@ -7,9 +7,9 @@ from community.models import Event, PageVisibility
 from ninja_jwt.tokens import RefreshToken
 from notifications.models import Notification, NotificationType
 from notifications.service import (
-    _notify_users,
     create_event_invite_notifications,
     create_join_request_notifications,
+    notify_users,
 )
 from users.models import User
 from users.permissions import PermissionKey
@@ -277,17 +277,17 @@ class TestCreateJoinRequestNotifications:
 
 @pytest.mark.django_db
 class TestPgNotifyIntegration:
-    """Verify that _notify_users is called when notifications are created."""
+    """Verify that notify_users is called when notifications are created."""
 
-    def test_event_invite_calls_notify_users(self, inviter, invitee, sample_event):
-        with patch("notifications.service._notify_users") as mock_notify:
+    def test_event_invite_callsnotify_users(self, inviter, invitee, sample_event):
+        with patch("notifications.service.notify_users") as mock_notify:
             create_event_invite_notifications(sample_event, [str(invitee.pk)], inviter)
         mock_notify.assert_called_once()
         called_ids = list(mock_notify.call_args[0][0])
         assert str(invitee.pk) in called_ids
 
     def test_event_invite_excludes_inviter_from_notify(self, inviter, invitee, sample_event):
-        with patch("notifications.service._notify_users") as mock_notify:
+        with patch("notifications.service.notify_users") as mock_notify:
             create_event_invite_notifications(
                 sample_event, [str(inviter.pk), str(invitee.pk)], inviter
             )
@@ -295,17 +295,17 @@ class TestPgNotifyIntegration:
         assert str(inviter.pk) not in called_ids
         assert str(invitee.pk) in called_ids
 
-    def test_join_request_calls_notify_users(self, db):
+    def test_join_request_callsnotify_users(self, db):
         user = _make_user("+12025550301")
         admin_role = Role.objects.get(name="admin", is_default=True)
         user.roles.add(admin_role)
-        with patch("notifications.service._notify_users") as mock_notify:
+        with patch("notifications.service.notify_users") as mock_notify:
             create_join_request_notifications("Sprout")
         mock_notify.assert_called_once()
         called_ids = list(mock_notify.call_args[0][0])
         assert str(user.pk) in called_ids
 
-    def test_notify_users_skips_on_non_postgresql(self, db):
-        """_notify_users is a no-op when not on PostgreSQL (e.g. SQLite in tests)."""
+    def testnotify_users_skips_on_non_postgresql(self, db):
+        """notify_users is a no-op when not on PostgreSQL (e.g. SQLite in tests)."""
         # Should not raise even though no pg_notify is available
-        _notify_users(["fake-uuid"])
+        notify_users(["fake-uuid"])

--- a/backend/tests/test_rsvp_payment_revoke.py
+++ b/backend/tests/test_rsvp_payment_revoke.py
@@ -1,0 +1,303 @@
+"""Host revoke of a payment confirmation, and who may read payment status."""
+
+import pytest
+from community._validation import Code
+from community.models import Event, EventRSVP, FeatureFlag, RSVPStatus
+from django.utils import timezone
+from ninja_jwt.tokens import RefreshToken
+from notifications.models import Notification, NotificationType
+
+from tests._asserts import assert_error_code
+from tests._payment_helpers import create_paid_event, set_payment_flag
+
+RSVP_URL = "/api/community/events/{event_id}/rsvp/"
+PAYMENT_URL = "/api/community/events/{event_id}/rsvps/{user_id}/payment/"
+
+FLAG = FeatureFlag.EVENT_PAYMENT_CONFIRMATION
+
+
+@pytest.fixture(autouse=True)
+def _flag_on(db):
+    set_payment_flag(True)
+
+
+def _paid_event(creator, **overrides) -> Event:
+    return create_paid_event(created_by=creator, **overrides)
+
+
+def _headers(user):
+    return {"HTTP_AUTHORIZATION": f"Bearer {RefreshToken.for_user(user).access_token}"}
+
+
+@pytest.mark.django_db
+class TestHostRevokePayment:
+    def test_revoke_regates_the_guest(self, api_client, auth_headers, test_user, django_user_model):
+        event = _paid_event(test_user)
+        guest = django_user_model.objects.create_user(
+            phone_number="+14155550301", first_name="Guest", is_member=True
+        )
+        EventRSVP.objects.create(
+            event=event,
+            user=guest,
+            status=RSVPStatus.ATTENDING,
+            paid_confirmed_at=timezone.now(),
+        )
+
+        response = api_client.patch(
+            PAYMENT_URL.format(event_id=event.id, user_id=guest.id),
+            {"paid_confirmed": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+
+        rsvp = EventRSVP.objects.get(event=event, user=guest)
+        assert rsvp.paid_confirmed_at is None
+
+        response = api_client.post(
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": False},
+            content_type="application/json",
+            **_headers(guest),
+        )
+        assert response.status_code == 400
+        assert_error_code(response, Code.Event.PAYMENT_CONFIRMATION_REQUIRED)
+
+    def test_guest_can_reconfirm_after_a_revoke(
+        self, api_client, auth_headers, test_user, django_user_model
+    ):
+        event = _paid_event(test_user)
+        guest = django_user_model.objects.create_user(
+            phone_number="+14155550302", first_name="Guest", is_member=True
+        )
+        EventRSVP.objects.create(
+            event=event,
+            user=guest,
+            status=RSVPStatus.ATTENDING,
+            paid_confirmed_at=timezone.now(),
+        )
+        api_client.patch(
+            PAYMENT_URL.format(event_id=event.id, user_id=guest.id),
+            {"paid_confirmed": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+
+        response = api_client.post(
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": False, "paid_confirmed": True},
+            content_type="application/json",
+            **_headers(guest),
+        )
+        assert response.status_code == 200
+        rsvp = EventRSVP.objects.get(event=event, user=guest)
+        assert rsvp.paid_confirmed_at is not None
+
+    def test_revoke_notifies_the_guest(
+        self, api_client, auth_headers, test_user, django_user_model
+    ):
+        event = _paid_event(test_user)
+        guest = django_user_model.objects.create_user(
+            phone_number="+14155550303", first_name="Guest", is_member=True
+        )
+        EventRSVP.objects.create(
+            event=event,
+            user=guest,
+            status=RSVPStatus.ATTENDING,
+            paid_confirmed_at=timezone.now(),
+        )
+        api_client.patch(
+            PAYMENT_URL.format(event_id=event.id, user_id=guest.id),
+            {"paid_confirmed": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+        notification = Notification.objects.get(
+            recipient=guest, notification_type=NotificationType.PAYMENT_REVOKED
+        )
+        assert event.title in notification.message
+
+    def test_revoking_an_unpaid_rsvp_does_not_notify(
+        self, api_client, auth_headers, test_user, django_user_model
+    ):
+        """No confirmation stood, so nothing was taken away."""
+        event = _paid_event(test_user)
+        guest = django_user_model.objects.create_user(
+            phone_number="+14155550304", first_name="Guest", is_member=True
+        )
+        EventRSVP.objects.create(event=event, user=guest, status=RSVPStatus.ATTENDING)
+        api_client.patch(
+            PAYMENT_URL.format(event_id=event.id, user_id=guest.id),
+            {"paid_confirmed": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert not Notification.objects.filter(
+            recipient=guest, notification_type=NotificationType.PAYMENT_REVOKED
+        ).exists()
+
+    def test_host_can_confirm_via_patch(
+        self, api_client, auth_headers, test_user, django_user_model
+    ):
+        event = _paid_event(test_user)
+        guest = django_user_model.objects.create_user(
+            phone_number="+14155550305", first_name="Guest", is_member=True
+        )
+        EventRSVP.objects.create(event=event, user=guest, status=RSVPStatus.ATTENDING)
+        response = api_client.patch(
+            PAYMENT_URL.format(event_id=event.id, user_id=guest.id),
+            {"paid_confirmed": True},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+        assert EventRSVP.objects.get(event=event, user=guest).paid_confirmed_at is not None
+
+    def test_patch_does_not_change_rsvp_status(
+        self, api_client, auth_headers, test_user, django_user_model
+    ):
+        event = _paid_event(test_user)
+        guest = django_user_model.objects.create_user(
+            phone_number="+14155550306", first_name="Guest", is_member=True
+        )
+        EventRSVP.objects.create(
+            event=event, user=guest, status=RSVPStatus.MAYBE, paid_confirmed_at=timezone.now()
+        )
+        api_client.patch(
+            PAYMENT_URL.format(event_id=event.id, user_id=guest.id),
+            {"paid_confirmed": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert EventRSVP.objects.get(event=event, user=guest).status == RSVPStatus.MAYBE
+
+    def test_non_host_cannot_revoke(self, api_client, test_user, django_user_model):
+        event = _paid_event(test_user)
+        guest = django_user_model.objects.create_user(
+            phone_number="+14155550307", first_name="Guest", is_member=True
+        )
+        EventRSVP.objects.create(
+            event=event, user=guest, status=RSVPStatus.ATTENDING, paid_confirmed_at=timezone.now()
+        )
+        response = api_client.patch(
+            PAYMENT_URL.format(event_id=event.id, user_id=guest.id),
+            {"paid_confirmed": False},
+            content_type="application/json",
+            **_headers(guest),
+        )
+        assert response.status_code == 403
+        assert EventRSVP.objects.get(event=event, user=guest).paid_confirmed_at is not None
+
+    def test_missing_rsvp_is_404(self, api_client, auth_headers, test_user, django_user_model):
+        event = _paid_event(test_user)
+        stranger = django_user_model.objects.create_user(
+            phone_number="+14155550308", first_name="Stranger", is_member=True
+        )
+        response = api_client.patch(
+            PAYMENT_URL.format(event_id=event.id, user_id=stranger.id),
+            {"paid_confirmed": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 404
+
+    def test_ordinary_cancel_and_rersvp_needs_no_reconfirmation(
+        self, api_client, test_user, django_user_model
+    ):
+        """Only a host revoke re-gates; a guest's own cancel keeps their confirmation."""
+        event = _paid_event(test_user)
+        guest = django_user_model.objects.create_user(
+            phone_number="+14155550309", first_name="Guest", is_member=True
+        )
+        headers = _headers(guest)
+        api_client.post(
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.ATTENDING, "paid_confirmed": True},
+            content_type="application/json",
+            **headers,
+        )
+        api_client.post(
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.CANT_GO},
+            content_type="application/json",
+            **headers,
+        )
+        response = api_client.post(
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.ATTENDING},
+            content_type="application/json",
+            **headers,
+        )
+        assert response.status_code == 200
+
+
+@pytest.mark.django_db
+class TestPaymentStatusVisibility:
+    def _guests(self, api_client, event, headers):
+        body = api_client.get(f"/api/community/events/{event.id}/", **headers).json()
+        return {g["name"]: g["paid_confirmed"] for g in body["guests"]}
+
+    def _event_with_a_payer(self, host, django_user_model, phone):
+        event = _paid_event(host)
+        payer = django_user_model.objects.create_user(
+            phone_number=phone, first_name="Payer", is_member=True
+        )
+        EventRSVP.objects.create(
+            event=event, user=payer, status=RSVPStatus.ATTENDING, paid_confirmed_at=timezone.now()
+        )
+        return event
+
+    def test_host_sees_payment_status(self, api_client, auth_headers, test_user, django_user_model):
+        event = self._event_with_a_payer(test_user, django_user_model, "+14155550401")
+        assert self._guests(api_client, event, auth_headers)["Payer"] is True
+
+    def test_plain_member_does_not_see_payment_status(
+        self, api_client, test_user, django_user_model
+    ):
+        event = self._event_with_a_payer(test_user, django_user_model, "+14155550402")
+        nosy = django_user_model.objects.create_user(
+            phone_number="+14155550403", first_name="Nosy", is_member=True
+        )
+        assert self._guests(api_client, event, _headers(nosy))["Payer"] is False
+
+    def test_flag_off_hides_payment_status_from_the_host_too(
+        self, api_client, auth_headers, test_user, django_user_model
+    ):
+        set_payment_flag(False)
+        event = self._event_with_a_payer(test_user, django_user_model, "+14155550404")
+        assert self._guests(api_client, event, auth_headers)["Payer"] is False
+
+    def test_revoked_guest_reads_as_unpaid_to_the_host(
+        self, api_client, auth_headers, test_user, django_user_model
+    ):
+        event = self._event_with_a_payer(test_user, django_user_model, "+14155550405")
+        payer = django_user_model.objects.get(phone_number="+14155550405")
+        api_client.patch(
+            PAYMENT_URL.format(event_id=event.id, user_id=payer.id),
+            {"paid_confirmed": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert self._guests(api_client, event, auth_headers)["Payer"] is False
+
+    def test_my_paid_confirmed_goes_false_after_a_revoke(
+        self, api_client, auth_headers, test_user, django_user_model
+    ):
+        event = _paid_event(test_user)
+        guest = django_user_model.objects.create_user(
+            phone_number="+14155550406", first_name="Guest", is_member=True
+        )
+        EventRSVP.objects.create(
+            event=event, user=guest, status=RSVPStatus.ATTENDING, paid_confirmed_at=timezone.now()
+        )
+        body = api_client.get(f"/api/community/events/{event.id}/", **_headers(guest)).json()
+        assert body["my_paid_confirmed"] is True
+
+        api_client.patch(
+            PAYMENT_URL.format(event_id=event.id, user_id=guest.id),
+            {"paid_confirmed": False},
+            content_type="application/json",
+            **auth_headers,
+        )
+        body = api_client.get(f"/api/community/events/{event.id}/", **_headers(guest)).json()
+        assert body["my_paid_confirmed"] is False

--- a/backend/users/_magic_links.py
+++ b/backend/users/_magic_links.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 from ninja import Router
 from ninja.responses import Status
 from notifications.models import Notification, NotificationType
-from notifications.service import _notify_users
+from notifications.service import notify_users
 
 from users._helpers import _create_magic_token
 from users.models import MagicLoginToken, User
@@ -99,7 +99,7 @@ def generate_magic_link(request, user_id: str):
         magic_token = _create_magic_token(user)
 
     if recipient_ids:
-        _notify_users(str(rid) for rid in recipient_ids)
+        notify_users(str(rid) for rid in recipient_ids)
         audit_log(
             logging.INFO,
             "magic_link_notifications_cleared",

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -1114,6 +1114,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/community/events/{event_id}/rsvps/{user_id}/payment/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        /**
+         * Set Guest Payment
+         * @description Let a host confirm or retract a guest's payment without touching their rsvp status.
+         */
+        patch: operations["community__event_host_rsvps_set_guest_payment"];
+        trace?: never;
+    };
     "/api/community/events/{event_id}/rsvps/{user_id}/rsvp/": {
         parameters: {
             query?: never;
@@ -3489,7 +3509,17 @@ export interface components {
              * @default false
              */
             has_plus_one: boolean;
+            /**
+             * Paid Confirmed
+             * @default false
+             */
+            paid_confirmed: boolean;
             status: components["schemas"]["RSVPStatus"];
+        };
+        /** HostRSVPPaymentIn */
+        HostRSVPPaymentIn: {
+            /** Paid Confirmed */
+            paid_confirmed: boolean;
         };
         /** InviteIn */
         InviteIn: {
@@ -8225,6 +8255,60 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
+    community__event_host_rsvps_set_guest_payment: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                event_id: string;
+                user_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["HostRSVPPaymentIn"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EventOut"];
                 };
             };
             /** @description Forbidden */


### PR DESCRIPTION
## Overview

**5 of 5** in the split of #1213 (Issue 1045). Host-side payment reconciliation.

**Stacked on #1227.**

### What's here

Payments taken outside the app (cash at the door, a venmo that never landed) need a way in and a way back out.

- **`PATCH /events/{id}/rsvps/{user_id}/payment/`** — stamps or retracts a guest's confirmation without touching their rsvp status. Host-gated via `_can_edit_event`, rate-limited `30/m`, audit-logged.
- **Clearing `paid_confirmed_at` re-gates** the guest on their next attending write. The record that they once paid, and who retracted it, lives in the audit log (`AuditLogEntry`) rather than a second column.
- **`PAYMENT_REVOKED` notification** (migration `0017`) — silence would leave a guest believing they're seated, so they'd show up unpaid, which is the outcome the whole gate exists to prevent.
- **`paid_confirmed` on `HostRSVPIn`** — a host seating a guest is inherently a manual override, so the host path stamps rather than gating.

### Notes for review

- `_apply_host_rsvp_in_transaction` is deliberately never gated — access is already gated on the acting host by the caller.
- The revoke notification fires only on a true paid→unpaid transition (`was_paid and not payload.paid_confirmed`), so a redundant retract is silent.

## Test plan

- [x] `tests/test_rsvp_payment_revoke.py` — 14 tests: permission gating, stamp/clear semantics, re-gating after revoke, re-paying after revoke, notification fired only on real transitions
- [x] 439 payment/rsvp/host tests pass; the one `test_rsvp_capacity_race.py` failure is the pre-existing SQLite limitation
- [x] Full backend suite at the stack tip: **1919 passed**. The 6 failures (`test_sse.py` ×5, `test_rsvp_capacity_race.py`) are the pre-existing SQLite/`pg_notify` limitations documented in #1213
- [x] Frontend: 1080 vitest tests pass; typecheck + lint clean
- [x] `make agent-lint`, `agent-typecheck`, `agent-complexity` clean

Part of Issue 1045. Split out of #1213.

