### PR TITLE
refactor(audit): add AuditTargetType enum for audit target_type

### DIFF
--- a/backend/community/_dev_tools.py
+++ b/backend/community/_dev_tools.py
@@ -2,7 +2,7 @@ import logging
 import os
 from datetime import timedelta
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.ratelimit import rate_limit
 from django.utils import timezone
@@ -157,7 +157,7 @@ def create_dev_test_event(request, payload: DevTestEventIn):
         logging.INFO,
         "dev_test_event_created",
         request,
-        target_type="event",
+        target_type=AuditTargetType.EVENT,
         target_id=str(event.id),
     )
     return Status(201, _event_out(event, request.auth))

--- a/backend/community/_docs.py
+++ b/backend/community/_docs.py
@@ -8,7 +8,7 @@ helpers stay here so they're imported from a single place.
 import logging
 from datetime import datetime
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
@@ -187,7 +187,7 @@ def create_folder(request, payload: FolderIn):
         logging.INFO,
         "doc_folder_created",
         request,
-        target_type="doc_folder",
+        target_type=AuditTargetType.DOC_FOLDER,
         target_id=str(folder.id),
         details={"name": folder.name, "parent_id": str(parent.id) if parent else None},
     )
@@ -229,7 +229,7 @@ def update_folder(request, folder_id: str, payload: FolderPatchIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="doc_folder",
+            target_type=AuditTargetType.DOC_FOLDER,
             target_id=folder_id,
             details={
                 "endpoint": "update_folder",
@@ -263,7 +263,7 @@ def update_folder(request, folder_id: str, payload: FolderPatchIn):
         logging.INFO,
         "doc_folder_updated",
         request,
-        target_type="doc_folder",
+        target_type=AuditTargetType.DOC_FOLDER,
         target_id=folder_id,
         details={"fields_changed": list(updates.keys())},
     )
@@ -281,7 +281,7 @@ def delete_folder(request, folder_id: str):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="doc_folder",
+            target_type=AuditTargetType.DOC_FOLDER,
             target_id=folder_id,
             details={
                 "endpoint": "delete_folder",
@@ -301,7 +301,7 @@ def delete_folder(request, folder_id: str):
         logging.INFO,
         "doc_folder_deleted",
         request,
-        target_type="doc_folder",
+        target_type=AuditTargetType.DOC_FOLDER,
         target_id=folder_id,
         details={"name": folder_name},
     )

--- a/backend/community/_docs_documents.py
+++ b/backend/community/_docs_documents.py
@@ -7,7 +7,7 @@ from there — single source of truth.
 
 import logging
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
@@ -68,7 +68,7 @@ def create_document(request, payload: DocumentIn):
         logging.INFO,
         "document_created",
         request,
-        target_type="document",
+        target_type=AuditTargetType.DOCUMENT,
         target_id=str(doc.id),
         details={"title": doc.title, "folder_id": str(folder.id)},
     )
@@ -135,7 +135,7 @@ def update_document(request, doc_id: str, payload: DocumentPatchIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="document",
+            target_type=AuditTargetType.DOCUMENT,
             target_id=doc_id,
             details={
                 "endpoint": "update_document",
@@ -171,7 +171,7 @@ def update_document(request, doc_id: str, payload: DocumentPatchIn):
         logging.INFO,
         "document_updated",
         request,
-        target_type="document",
+        target_type=AuditTargetType.DOCUMENT,
         target_id=doc_id,
         details={"fields_changed": list(updates.keys())},
     )
@@ -189,7 +189,7 @@ def delete_document(request, doc_id: str):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="document",
+            target_type=AuditTargetType.DOCUMENT,
             target_id=doc_id,
             details={
                 "endpoint": "delete_document",
@@ -209,7 +209,7 @@ def delete_document(request, doc_id: str):
         logging.INFO,
         "document_deleted",
         request,
-        target_type="document",
+        target_type=AuditTargetType.DOCUMENT,
         target_id=doc_id,
         details={"title": title},
     )

--- a/backend/community/_event_actions.py
+++ b/backend/community/_event_actions.py
@@ -2,7 +2,7 @@ import logging
 import time
 from uuid import UUID
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.ratelimit import rate_limit
 from django.utils import timezone
@@ -56,7 +56,7 @@ def upload_event_photo(request, event_id: UUID, photo: UploadedFile = File(...))
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="event",
+            target_type=AuditTargetType.EVENT,
             target_id=str(event_id),
             details={"endpoint": "upload_event_photo"},
         )
@@ -72,6 +72,10 @@ def upload_event_photo(request, event_id: UUID, photo: UploadedFile = File(...))
     event.photo_updated_at = timezone.now()
     event.save(update_fields=["photo", "photo_updated_at"])
     audit_log(
-        logging.INFO, "event_photo_uploaded", request, target_type="event", target_id=str(event_id)
+        logging.INFO,
+        "event_photo_uploaded",
+        request,
+        target_type=AuditTargetType.EVENT,
+        target_id=str(event_id),
     )
     return Status(200, _event_out(event, request.auth))

--- a/backend/community/_event_blasts.py
+++ b/backend/community/_event_blasts.py
@@ -1,7 +1,7 @@
 import logging
 from uuid import UUID
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.ratelimit import rate_limit
 from ninja import Router, Schema
@@ -110,7 +110,7 @@ def send_email_blast(request, event_id: UUID, payload: EmailBlastIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="event",
+            target_type=AuditTargetType.EVENT,
             target_id=str(event_id),
             details={"endpoint": "send_email_blast"},
         )
@@ -142,7 +142,7 @@ def send_email_blast(request, event_id: UUID, payload: EmailBlastIn):
         logging.INFO,
         "event_email_blast_sent",
         request,
-        target_type="event",
+        target_type=AuditTargetType.EVENT,
         target_id=str(event_id),
         details={
             "sent_count": sent_count,

--- a/backend/community/_event_host_actions.py
+++ b/backend/community/_event_host_actions.py
@@ -2,7 +2,7 @@ import logging
 from datetime import timedelta
 from uuid import UUID
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.ratelimit import rate_limit
 from django.db import transaction
@@ -165,7 +165,7 @@ def set_attendance(request, event_id: UUID, user_id: UUID, payload: AttendanceIn
         logging.INFO,
         "attendance_marked",
         request,
-        target_type="event",
+        target_type=AuditTargetType.EVENT,
         target_id=str(event_id),
         details={"user_id": str(user_id), "attendance": payload.attendance},
     )

--- a/backend/community/_event_host_rsvps.py
+++ b/backend/community/_event_host_rsvps.py
@@ -1,7 +1,7 @@
 import logging
 from uuid import UUID
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.ratelimit import rate_limit
 from django.db import transaction
@@ -118,7 +118,7 @@ def set_guest_rsvp(request, event_id: UUID, user_id: UUID, payload: HostRSVPIn):
         logging.INFO,
         "guest_rsvp_changed",
         request,
-        target_type="event",
+        target_type=AuditTargetType.EVENT,
         target_id=str(event_id),
         details={"user_id": str(user_id), "status": final_status},
     )
@@ -161,7 +161,7 @@ def remove_guest_rsvp(request, event_id: UUID, user_id: UUID):
         logging.INFO,
         "guest_rsvp_removed",
         request,
-        target_type="event",
+        target_type=AuditTargetType.EVENT,
         target_id=str(event_id),
         details={"user_id": str(user_id)},
     )

--- a/backend/community/_event_invitations.py
+++ b/backend/community/_event_invitations.py
@@ -12,7 +12,7 @@ Co-host invites are a different flow — see _event_cohost_invites.py.
 import logging
 from uuid import UUID
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from django.shortcuts import get_object_or_404
 from ninja import Router
@@ -67,7 +67,7 @@ def invite_to_event(request, event_id: UUID, payload: InviteIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="event",
+            target_type=AuditTargetType.EVENT,
             target_id=str(event_id),
             details={"endpoint": "invite_to_event"},
         )
@@ -94,7 +94,7 @@ def invite_to_event(request, event_id: UUID, payload: InviteIn):
         logging.INFO,
         "event_invitations_added",
         request,
-        target_type="event",
+        target_type=AuditTargetType.EVENT,
         target_id=str(event_id),
         details={
             "requested_count": len(requested_ids),

--- a/backend/community/_event_invite_email.py
+++ b/backend/community/_event_invite_email.py
@@ -1,6 +1,6 @@
 import logging
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from django.conf import settings
 from django.utils import timezone
 from notifications._email_helpers import EventInviteEmailDetails, send_event_invite_email
@@ -54,7 +54,7 @@ def email_invited_members(request, event: Event, new_user_ids: list[str], invite
                 logging.WARNING,
                 "event_invite_email_failed",
                 request,
-                target_type="event",
+                target_type=AuditTargetType.EVENT,
                 target_id=str(event.id),
                 details={"user_id": str(user.pk), "error": str(exc)},
             )

--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -1,7 +1,7 @@
 import logging
 from uuid import UUID
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.ratelimit import rate_limit
 from django.db import transaction
@@ -210,7 +210,7 @@ def upsert_rsvp(request, event_id: UUID, payload: RSVPIn):
         logging.INFO,
         "rsvp_changed",
         request,
-        target_type="event",
+        target_type=AuditTargetType.EVENT,
         target_id=str(event_id),
         details={"status": final_status},
     )
@@ -238,7 +238,13 @@ def delete_rsvp(request, event_id: UUID):
     with transaction.atomic():
         event, promoted_user_ids = _delete_rsvp_in_transaction(event_id, request.auth)
 
-    audit_log(logging.INFO, "rsvp_deleted", request, target_type="event", target_id=str(event_id))
+    audit_log(
+        logging.INFO,
+        "rsvp_deleted",
+        request,
+        target_type=AuditTargetType.EVENT,
+        target_id=str(event_id),
+    )
     _email_promoted_non_members(request, event, promoted_user_ids)
     return Status(204, None)
 

--- a/backend/community/_event_tags.py
+++ b/backend/community/_event_tags.py
@@ -9,7 +9,7 @@ Django admin.
 import logging
 from uuid import UUID
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.ratelimit import rate_limit
 from django.db import IntegrityError, transaction
@@ -33,7 +33,7 @@ def _require_manage_tags(request, endpoint: str, target_id: str = "") -> None:
         logging.WARNING,
         "permission_denied",
         request,
-        target_type="event_tag",
+        target_type=AuditTargetType.EVENT_TAG,
         target_id=target_id,
         details={
             "endpoint": endpoint,
@@ -75,7 +75,7 @@ def create_event_tag(request, payload: TagIn):
         logging.INFO,
         "event_tag_created",
         request,
-        target_type="event_tag",
+        target_type=AuditTargetType.EVENT_TAG,
         target_id=str(tag.id),
         details={"name": tag.name, "slug": tag.slug},
     )
@@ -99,7 +99,7 @@ def delete_event_tag(request, tag_id: UUID):
         logging.WARNING,
         "event_tag_deleted",
         request,
-        target_type="event_tag",
+        target_type=AuditTargetType.EVENT_TAG,
         target_id=str(tag_id),
         details={"name": name},
     )

--- a/backend/community/_event_transitions.py
+++ b/backend/community/_event_transitions.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from django.db import transaction
 from django.utils import timezone
 from ninja.responses import Status
@@ -34,7 +34,7 @@ def _cancel_event(request, event: Event, notify: bool) -> None:
         logging.INFO,
         "event_cancelled",
         request,
-        target_type="event",
+        target_type=AuditTargetType.EVENT,
         target_id=str(event.id),
         details={"title": event.title, "notify_attendees": notify},
     )
@@ -51,7 +51,7 @@ def _delete_event(request, event: Event) -> None:
         logging.INFO,
         "event_deleted",
         request,
-        target_type="event",
+        target_type=AuditTargetType.EVENT,
         target_id=str(event.id),
         details={"title": event.title},
     )
@@ -66,7 +66,7 @@ def _uncancel_event(request, event: Event) -> None:
         logging.INFO,
         "event_uncancelled",
         request,
-        target_type="event",
+        target_type=AuditTargetType.EVENT,
         target_id=str(event.id),
         details={"title": event.title},
     )
@@ -112,7 +112,7 @@ def _publish_draft(request, event: Event) -> None:
         logging.INFO,
         "event_published",
         request,
-        target_type="event",
+        target_type=AuditTargetType.EVENT,
         target_id=str(event.id),
         details={"title": event.title},
     )

--- a/backend/community/_events.py
+++ b/backend/community/_events.py
@@ -3,7 +3,7 @@
 import logging
 from uuid import UUID
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.media_proxy import media_path
 from config.ratelimit import rate_limit
@@ -88,7 +88,7 @@ def _enforce_type_tag_permission(request, event_type: str, endpoint: str, event_
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="event",
+            target_type=AuditTargetType.EVENT,
             target_id=str(event_id),
             details=details,
         )
@@ -366,7 +366,7 @@ def create_event(request, payload: EventIn):
         logging.INFO,
         "event_created_draft" if event.is_draft else "event_created",
         request,
-        target_type="event",
+        target_type=AuditTargetType.EVENT,
         target_id=str(event.id),
         details={
             "title": event.title,
@@ -401,7 +401,7 @@ def _apply_field_updates(request, event: Event, event_id: UUID, updates: dict) -
         logging.INFO,
         "event_updated",
         request,
-        target_type="event",
+        target_type=AuditTargetType.EVENT,
         target_id=str(event_id),
         details={"fields_changed": changed_fields},
     )
@@ -430,7 +430,7 @@ def update_event(request, event_id: UUID, payload: EventPatchIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="event",
+            target_type=AuditTargetType.EVENT,
             target_id=str(event_id),
             details={"endpoint": "update_event"},
         )

--- a/backend/community/_feature_flags.py
+++ b/backend/community/_feature_flags.py
@@ -1,6 +1,6 @@
 import logging
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
@@ -53,7 +53,7 @@ def update_feature_flag(request, key: str, payload: FeatureFlagPatchIn):
         logging.INFO,
         "feature_flag_updated",
         request,
-        target_type="feature_flag",
+        target_type=AuditTargetType.FEATURE_FLAG,
         target_id=key,
         details={"enabled": payload.enabled},
     )

--- a/backend/community/_guidelines.py
+++ b/backend/community/_guidelines.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import datetime
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
@@ -74,7 +74,7 @@ def update_guidelines(request, payload: GuidelinesPatchIn):
         logging.INFO,
         "guidelines_updated",
         request,
-        target_type="guidelines",
+        target_type=AuditTargetType.GUIDELINES,
         details={"format": "prosemirror"},
     )
     return Status(200, _singleton_out(g))
@@ -101,7 +101,7 @@ def update_faq(request, payload: GuidelinesPatchIn):
         logging.INFO,
         "faq_updated",
         request,
-        target_type="faq",
+        target_type=AuditTargetType.FAQ,
         details={"format": "prosemirror"},
     )
     return Status(200, _singleton_out(f))

--- a/backend/community/_home.py
+++ b/backend/community/_home.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import datetime
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
@@ -79,7 +79,7 @@ def update_home(request, payload: HomePagePatchIn):
         logging.INFO,
         "homepage_updated",
         request,
-        target_type="homepage",
+        target_type=AuditTargetType.HOMEPAGE,
         details={"fields_changed": changed},
     )
     return Status(200, _home_out(h))

--- a/backend/community/_join_form.py
+++ b/backend/community/_join_form.py
@@ -3,7 +3,7 @@
 import logging
 from uuid import UUID
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
@@ -84,7 +84,7 @@ def create_join_form_question(request, payload: JoinFormQuestionIn):
         logging.INFO,
         "join_form_question_created",
         request,
-        target_type="join_form_question",
+        target_type=AuditTargetType.JOIN_FORM_QUESTION,
         target_id=str(q.id),
         details={"label": q.label},
     )
@@ -126,7 +126,7 @@ def update_join_form_question(request, question_id: UUID, payload: JoinFormQuest
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="join_form_question",
+            target_type=AuditTargetType.JOIN_FORM_QUESTION,
             target_id=str(question_id),
             details={
                 "endpoint": "update_join_form_question",
@@ -147,7 +147,7 @@ def update_join_form_question(request, question_id: UUID, payload: JoinFormQuest
         logging.INFO,
         "join_form_question_updated",
         request,
-        target_type="join_form_question",
+        target_type=AuditTargetType.JOIN_FORM_QUESTION,
         target_id=str(question_id),
         details={"label": q.label},
     )
@@ -165,7 +165,7 @@ def delete_join_form_question(request, question_id: UUID):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="join_form_question",
+            target_type=AuditTargetType.JOIN_FORM_QUESTION,
             target_id=str(question_id),
             details={
                 "endpoint": "delete_join_form_question",
@@ -183,7 +183,7 @@ def delete_join_form_question(request, question_id: UUID):
         logging.INFO,
         "join_form_question_deleted",
         request,
-        target_type="join_form_question",
+        target_type=AuditTargetType.JOIN_FORM_QUESTION,
         target_id=str(question_id),
         details={"label": label},
     )

--- a/backend/community/_join_request_resend.py
+++ b/backend/community/_join_request_resend.py
@@ -6,7 +6,7 @@ Split from ``_join_requests.py`` to keep that file under the 500-line cap.
 import logging
 from uuid import UUID
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.ratelimit import rate_limit
 from django.db import transaction
@@ -42,7 +42,7 @@ def resend_magic_link(request, id: UUID):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="join_request",
+            target_type=AuditTargetType.JOIN_REQUEST,
             target_id=str(id),
             details={
                 "endpoint": "resend_magic_link",
@@ -78,7 +78,7 @@ def resend_magic_link(request, id: UUID):
         logging.INFO,
         "join_request_magic_link_resent",
         request,
-        target_type="join_request",
+        target_type=AuditTargetType.JOIN_REQUEST,
         target_id=str(join_request.id),
         details={
             "full_name": join_request.full_name,

--- a/backend/community/_join_request_submit.py
+++ b/backend/community/_join_request_submit.py
@@ -3,7 +3,7 @@
 import logging
 from enum import StrEnum
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.ratelimit import client_ip, rate_limit
 from django.conf import settings
 from django.core.mail import send_mail
@@ -258,7 +258,7 @@ def submit_join_request(request, payload: JoinRequestIn):
         logging.INFO,
         "join_request_submitted",
         request,
-        target_type="join_request",
+        target_type=AuditTargetType.JOIN_REQUEST,
         target_id=str(join_request.id),
         details={"full_name": full_name},
     )

--- a/backend/community/_join_requests.py
+++ b/backend/community/_join_requests.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from typing import NamedTuple
 from uuid import UUID
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from django.db import transaction
 from django.db.models import Prefetch
@@ -341,7 +341,7 @@ def update_join_request_status(request, id: UUID, payload: JoinRequestStatusIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="join_request",
+            target_type=AuditTargetType.JOIN_REQUEST,
             target_id=str(id),
             details={
                 "endpoint": "update_join_request_status",
@@ -380,7 +380,7 @@ def update_join_request_status(request, id: UUID, payload: JoinRequestStatusIn):
         logging.INFO,
         action,
         request,
-        target_type="join_request",
+        target_type=AuditTargetType.JOIN_REQUEST,
         target_id=str(join_request.id),
         details={"full_name": join_request.full_name, "user_created": user_created},
     )
@@ -417,7 +417,7 @@ def unreject_join_request(request, id: UUID):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="join_request",
+            target_type=AuditTargetType.JOIN_REQUEST,
             target_id=str(id),
             details={
                 "endpoint": "unreject_join_request",
@@ -441,7 +441,7 @@ def unreject_join_request(request, id: UUID):
         logging.INFO,
         "join_request_unrejected",
         request,
-        target_type="join_request",
+        target_type=AuditTargetType.JOIN_REQUEST,
         target_id=str(join_request.id),
         details={"full_name": join_request.full_name},
     )

--- a/backend/community/_login_link.py
+++ b/backend/community/_login_link.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import timedelta
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.ratelimit import client_ip, rate_limit
 from django.conf import settings
 from django.utils import timezone
@@ -117,7 +117,7 @@ def request_login_link(request, payload: RequestLoginLinkIn):
             logging.INFO,
             "magic_link_request_skipped_recent_token",
             request,
-            target_type="user",
+            target_type=AuditTargetType.USER,
             target_id=str(user.pk),
         )
         retry_after = max(1, round((recent_token.created_at + _COOLDOWN - now).total_seconds()))
@@ -160,7 +160,7 @@ def request_login_link(request, payload: RequestLoginLinkIn):
         logging.INFO,
         "magic_link_requested",
         request,
-        target_type="user",
+        target_type=AuditTargetType.USER,
         target_id=str(user.pk),
     )
 
@@ -189,7 +189,7 @@ def _try_email_delivery(*, request, user, magic_token) -> bool:
                 logging.INFO,
                 "magic_link_email_sent",
                 request,
-                target_type="user",
+                target_type=AuditTargetType.USER,
                 target_id=str(user.pk),
                 details={"provider_message_id": send_result.provider_message_id},
             )
@@ -198,7 +198,7 @@ def _try_email_delivery(*, request, user, magic_token) -> bool:
             logging.WARNING,
             "magic_link_email_failed",
             request,
-            target_type="user",
+            target_type=AuditTargetType.USER,
             target_id=str(user.pk),
             details={"error": send_result.error},
         )

--- a/backend/community/_member_promotion_message.py
+++ b/backend/community/_member_promotion_message.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
@@ -70,6 +70,6 @@ def update_member_promotion_message(request, payload: MemberPromotionMessagePatc
         logging.INFO,
         "member_promotion_message_updated",
         request,
-        target_type="member_promotion_message",
+        target_type=AuditTargetType.MEMBER_PROMOTION_MESSAGE,
     )
     return Status(200, _out(template))

--- a/backend/community/_pages.py
+++ b/backend/community/_pages.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import datetime
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from django.contrib.auth.models import AnonymousUser
 from ninja import Router
@@ -68,7 +68,7 @@ def update_page(request, slug: str, payload: EditablePagePatchIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="editable_page",
+            target_type=AuditTargetType.EDITABLE_PAGE,
             target_id=slug,
             details={
                 "endpoint": "update_page",
@@ -103,7 +103,7 @@ def update_page(request, slug: str, payload: EditablePagePatchIn):
         logging.INFO,
         "page_updated",
         request,
-        target_type="editable_page",
+        target_type=AuditTargetType.EDITABLE_PAGE,
         target_id=slug,
         details={"slug": slug, "fields_changed": changed},
     )

--- a/backend/community/_poll_options.py
+++ b/backend/community/_poll_options.py
@@ -3,7 +3,7 @@
 import logging
 from uuid import UUID
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.ratelimit import rate_limit
 from ninja import Router
@@ -62,7 +62,7 @@ def add_poll_option(request, event_id: UUID, payload: PollOptionIn):
         logging.INFO,
         "poll_option_added",
         request,
-        target_type="event_poll",
+        target_type=AuditTargetType.EVENT_POLL,
         target_id=str(poll.id),
         details={"event_id": str(event_id)},
     )
@@ -94,7 +94,7 @@ def update_poll_option(request, event_id: UUID, payload: PollOptionIn, option_id
         logging.INFO,
         "poll_option_updated",
         request,
-        target_type="event_poll",
+        target_type=AuditTargetType.EVENT_POLL,
         target_id=str(poll.id),
         details={"event_id": str(event_id), "option_id": str(option_id)},
     )
@@ -125,7 +125,7 @@ def delete_poll_option(request, event_id: UUID, option_id: UUID):
         logging.INFO,
         "poll_option_deleted",
         request,
-        target_type="event_poll",
+        target_type=AuditTargetType.EVENT_POLL,
         target_id=str(poll.id),
         details={"event_id": str(event_id), "option_id": str(option_id)},
     )

--- a/backend/community/_polls.py
+++ b/backend/community/_polls.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta
 from uuid import UUID
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.media_proxy import media_path
 from config.ratelimit import rate_limit
@@ -167,7 +167,7 @@ def create_event_poll(request, event_id: UUID, payload: EventPollIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="event",
+            target_type=AuditTargetType.EVENT,
             target_id=str(event_id),
             details={"endpoint": "create_event_poll"},
         )
@@ -193,7 +193,7 @@ def create_event_poll(request, event_id: UUID, payload: EventPollIn):
         logging.INFO,
         "poll_created",
         request,
-        target_type="event_poll",
+        target_type=AuditTargetType.EVENT_POLL,
         target_id=str(poll.id),
         details={"event_id": str(event_id), "option_count": len(payload.options)},
     )
@@ -266,7 +266,7 @@ def vote_on_event_poll(request, event_id: UUID, payload: EventPollVoteIn):
         logging.INFO,
         "poll_vote",
         request,
-        target_type="event_poll",
+        target_type=AuditTargetType.EVENT_POLL,
         target_id=str(poll.id),
         details={"event_id": str(event_id)},
     )
@@ -295,7 +295,7 @@ def finalize_event_poll(request, event_id: UUID, payload: EventPollFinalizeIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="event",
+            target_type=AuditTargetType.EVENT,
             target_id=str(event_id),
             details={"endpoint": "finalize_event_poll"},
         )
@@ -326,7 +326,7 @@ def finalize_event_poll(request, event_id: UUID, payload: EventPollFinalizeIn):
         logging.INFO,
         "poll_finalized",
         request,
-        target_type="event_poll",
+        target_type=AuditTargetType.EVENT_POLL,
         target_id=str(poll.id),
         details={
             "event_id": str(event_id),
@@ -357,7 +357,7 @@ def delete_event_poll(request, event_id: UUID):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="event",
+            target_type=AuditTargetType.EVENT,
             target_id=str(event_id),
             details={"endpoint": "delete_event_poll"},
         )
@@ -372,7 +372,7 @@ def delete_event_poll(request, event_id: UUID):
         logging.INFO,
         "poll_deleted",
         request,
-        target_type="event_poll",
+        target_type=AuditTargetType.EVENT_POLL,
         target_id=poll_id,
         details={"event_id": str(event_id)},
     )

--- a/backend/community/_public_rsvp_manage.py
+++ b/backend/community/_public_rsvp_manage.py
@@ -1,6 +1,6 @@
 import logging
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.ratelimit import client_ip, rate_limit
 from django.db import transaction
 from django.db.models import Count, Q
@@ -164,7 +164,7 @@ def update_my_rsvp(request, event_id, payload: PublicRsvpManageIn, token: str = 
         logging.INFO,
         "public_rsvp_updated",
         request,
-        target_type="event",
+        target_type=AuditTargetType.EVENT,
         target_id=str(event.id),
         details={"user_id": str(user.pk), "status": final_status},
     )
@@ -216,7 +216,7 @@ def delete_my_rsvp(request, event_id, token: str = ""):
         logging.INFO,
         "public_rsvp_deleted",
         request,
-        target_type="event",
+        target_type=AuditTargetType.EVENT,
         target_id=str(event_id),
         details={"user_id": str(user.pk)},
     )

--- a/backend/community/_public_rsvp_resend.py
+++ b/backend/community/_public_rsvp_resend.py
@@ -1,6 +1,6 @@
 import logging
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.ratelimit import client_ip, rate_limit
 from django.conf import settings
 from ninja import Router
@@ -65,7 +65,7 @@ def _send_manage_link(request, user: User) -> None:
             logging.WARNING,
             "public_rsvp_resend_email_failed",
             request,
-            target_type="user",
+            target_type=AuditTargetType.USER,
             target_id=str(user.pk),
             details={"error": str(exc)},
         )
@@ -107,7 +107,7 @@ def resend_manage_link(request, payload: ResendManageLinkIn):
             logging.INFO,
             "public_rsvp_resend_sent",
             request,
-            target_type="user",
+            target_type=AuditTargetType.USER,
             target_id=str(user.pk),
         )
     return _neutral()

--- a/backend/community/_public_rsvp_shared.py
+++ b/backend/community/_public_rsvp_shared.py
@@ -1,6 +1,6 @@
 import logging
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from django.conf import settings
 from django.utils import timezone
 from notifications._email_helpers import (
@@ -76,7 +76,7 @@ def _log_email_failure(request, event: Event, user: User, exc: Exception) -> Non
         logging.WARNING,
         "public_rsvp_email_failed",
         request,
-        target_type="event",
+        target_type=AuditTargetType.EVENT,
         target_id=str(event.id),
         details={"user_id": str(user.pk), "error": str(exc)},
     )

--- a/backend/community/_public_rsvp_submit.py
+++ b/backend/community/_public_rsvp_submit.py
@@ -2,7 +2,7 @@ import logging
 from enum import StrEnum
 from typing import NoReturn
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.ratelimit import client_ip, rate_limit
 from django.conf import settings
 from django.core.cache import cache
@@ -171,7 +171,7 @@ def _send_recognized_login_link(request, user: User) -> None:
             logging.WARNING,
             "public_rsvp_recognized_email_failed",
             request,
-            target_type="user",
+            target_type=AuditTargetType.USER,
             target_id=str(user.pk),
             details={"error": str(exc)},
         )
@@ -216,7 +216,7 @@ def submit_public_rsvp(request, event_id, payload: PublicRsvpIn):
             logging.WARNING,
             "public_rsvp_honeypot_tripped",
             request,
-            target_type="event",
+            target_type=AuditTargetType.EVENT,
             target_id=str(event_id),
         )
         return Status(200, _public_rsvp_decoy(event, payload.status, False))
@@ -247,7 +247,7 @@ def submit_public_rsvp(request, event_id, payload: PublicRsvpIn):
         logging.INFO,
         "public_rsvp_created",
         request,
-        target_type="event",
+        target_type=AuditTargetType.EVENT,
         target_id=str(event.id),
         details={"user_id": str(user.pk), "status": final_status},
     )

--- a/backend/community/_surveys.py
+++ b/backend/community/_surveys.py
@@ -3,7 +3,7 @@
 import logging
 from uuid import UUID
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
@@ -114,7 +114,7 @@ def create_survey(request, payload: SurveyIn):
         logging.INFO,
         "survey_created",
         request,
-        target_type="survey",
+        target_type=AuditTargetType.SURVEY,
         target_id=str(survey.id),
         details={"title": survey.title, "slug": survey.slug},
     )
@@ -132,7 +132,7 @@ def get_survey_admin(request, survey_id: UUID):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="survey",
+            target_type=AuditTargetType.SURVEY,
             target_id=str(survey_id),
             details={
                 "endpoint": "get_survey_admin",
@@ -158,7 +158,7 @@ def update_survey(request, survey_id: UUID, payload: SurveyPatchIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="survey",
+            target_type=AuditTargetType.SURVEY,
             target_id=str(survey_id),
             details={
                 "endpoint": "update_survey",
@@ -183,7 +183,7 @@ def update_survey(request, survey_id: UUID, payload: SurveyPatchIn):
         logging.INFO,
         "survey_updated",
         request,
-        target_type="survey",
+        target_type=AuditTargetType.SURVEY,
         target_id=str(survey_id),
         details={"fields_changed": list(updates.keys())},
     )
@@ -201,7 +201,7 @@ def delete_survey(request, survey_id: UUID):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="survey",
+            target_type=AuditTargetType.SURVEY,
             target_id=str(survey_id),
             details={
                 "endpoint": "delete_survey",
@@ -219,7 +219,7 @@ def delete_survey(request, survey_id: UUID):
         logging.WARNING,
         "survey_deleted",
         request,
-        target_type="survey",
+        target_type=AuditTargetType.SURVEY,
         target_id=str(survey_id),
         details={"title": title},
     )
@@ -240,7 +240,7 @@ def create_survey_question(request, survey_id: UUID, payload: SurveyQuestionIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="survey",
+            target_type=AuditTargetType.SURVEY,
             target_id=str(survey_id),
             details={
                 "endpoint": "create_survey_question",
@@ -265,7 +265,7 @@ def create_survey_question(request, survey_id: UUID, payload: SurveyQuestionIn):
         logging.INFO,
         "survey_question_created",
         request,
-        target_type="survey_question",
+        target_type=AuditTargetType.SURVEY_QUESTION,
         target_id=str(q.id),
         details={"survey_id": str(survey_id), "label": q.label},
     )
@@ -283,7 +283,7 @@ def update_survey_question(request, survey_id: UUID, question_id: UUID, payload:
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="survey_question",
+            target_type=AuditTargetType.SURVEY_QUESTION,
             target_id=str(question_id),
             details={
                 "endpoint": "update_survey_question",
@@ -304,7 +304,7 @@ def update_survey_question(request, survey_id: UUID, question_id: UUID, payload:
         logging.INFO,
         "survey_question_updated",
         request,
-        target_type="survey_question",
+        target_type=AuditTargetType.SURVEY_QUESTION,
         target_id=str(question_id),
         details={"survey_id": str(survey_id), "label": q.label},
     )
@@ -322,7 +322,7 @@ def delete_survey_question(request, survey_id: UUID, question_id: UUID):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="survey_question",
+            target_type=AuditTargetType.SURVEY_QUESTION,
             target_id=str(question_id),
             details={
                 "endpoint": "delete_survey_question",
@@ -339,7 +339,7 @@ def delete_survey_question(request, survey_id: UUID, question_id: UUID):
         logging.INFO,
         "survey_question_deleted",
         request,
-        target_type="survey_question",
+        target_type=AuditTargetType.SURVEY_QUESTION,
         target_id=str(question_id),
         details={"survey_id": str(survey_id)},
     )
@@ -357,7 +357,7 @@ def reorder_survey_questions(request, survey_id: UUID, payload: SurveyQuestionOr
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="survey",
+            target_type=AuditTargetType.SURVEY,
             target_id=str(survey_id),
             details={
                 "endpoint": "reorder_survey_questions",
@@ -375,7 +375,7 @@ def reorder_survey_questions(request, survey_id: UUID, payload: SurveyQuestionOr
         logging.INFO,
         "survey_questions_reordered",
         request,
-        target_type="survey",
+        target_type=AuditTargetType.SURVEY,
         target_id=str(survey_id),
     )
     questions = SurveyQuestion.objects.filter(survey_id=survey_id)
@@ -396,7 +396,7 @@ def list_survey_responses(request, survey_id: UUID):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="survey",
+            target_type=AuditTargetType.SURVEY,
             target_id=str(survey_id),
             details={
                 "endpoint": "list_survey_responses",

--- a/backend/community/_surveys_public.py
+++ b/backend/community/_surveys_public.py
@@ -3,7 +3,7 @@
 import logging
 from uuid import UUID
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.ratelimit import auth_or_ip_key, rate_limit
 from ninja import Router
@@ -86,7 +86,7 @@ def submit_survey_response(request, slug: str, payload: SurveyAnswersIn):
                 logging.INFO,
                 "survey_response_updated",
                 request,
-                target_type="survey",
+                target_type=AuditTargetType.SURVEY,
                 target_id=str(survey.id),
                 details={"slug": slug},
             )
@@ -96,7 +96,7 @@ def submit_survey_response(request, slug: str, payload: SurveyAnswersIn):
         logging.INFO,
         "survey_response_submitted",
         request,
-        target_type="survey",
+        target_type=AuditTargetType.SURVEY,
         target_id=str(survey.id),
         details={"slug": slug},
     )
@@ -129,7 +129,7 @@ def get_survey_tallies(request, survey_id: UUID):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="survey",
+            target_type=AuditTargetType.SURVEY,
             target_id=str(survey_id),
             details={"endpoint": "get_survey_tallies"},
         )
@@ -164,7 +164,7 @@ def finalize_poll(request, survey_id: UUID, payload: FinalizePollIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="survey",
+            target_type=AuditTargetType.SURVEY,
             target_id=str(survey_id),
             details={"endpoint": "finalize_poll"},
         )
@@ -201,7 +201,7 @@ def finalize_poll(request, survey_id: UUID, payload: FinalizePollIn):
         logging.INFO,
         "survey_poll_finalized",
         request,
-        target_type="survey",
+        target_type=AuditTargetType.SURVEY,
         target_id=str(survey_id),
         details={
             "winning_datetime": payload.winning_datetime.isoformat(),

--- a/backend/community/_tentative_approval_message.py
+++ b/backend/community/_tentative_approval_message.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
@@ -72,6 +72,6 @@ def update_tentative_approval_message(request, payload: TentativeApprovalMessage
         logging.INFO,
         "tentative_approval_message_updated",
         request,
-        target_type="tentative_approval_message",
+        target_type=AuditTargetType.TENTATIVE_APPROVAL_MESSAGE,
     )
     return Status(200, _out(template))

--- a/backend/community/_welcome_template.py
+++ b/backend/community/_welcome_template.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
@@ -69,6 +69,6 @@ def update_welcome_template(request, payload: WelcomeTemplatePatchIn):
         logging.INFO,
         "welcome_template_updated",
         request,
-        target_type="welcome_template",
+        target_type=AuditTargetType.WELCOME_TEMPLATE,
     )
     return Status(200, _out(template))

--- a/backend/community/_whatsapp_link.py
+++ b/backend/community/_whatsapp_link.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
 
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
@@ -64,6 +64,6 @@ def update_whatsapp_link(request, payload: WhatsAppLinkPatchIn):
         logging.INFO,
         "whatsapp_link_updated",
         request,
-        target_type="whatsapp_link",
+        target_type=AuditTargetType.WHATSAPP_LINK,
     )
     return Status(200, _out(config))

--- a/backend/config/audit.py
+++ b/backend/config/audit.py
@@ -2,16 +2,41 @@
 
 import logging
 
+from django.db import models
+
 from config.ratelimit import client_ip
 
 _audit_logger = logging.getLogger("pda.audit")
+
+
+class AuditTargetType(models.TextChoices):
+    DOC_FOLDER = "doc_folder", "Doc folder"
+    DOCUMENT = "document", "Document"
+    EDITABLE_PAGE = "editable_page", "Editable page"
+    EVENT = "event", "Event"
+    EVENT_POLL = "event_poll", "Event poll"
+    EVENT_TAG = "event_tag", "Event tag"
+    FAQ = "faq", "FAQ"
+    FEATURE_FLAG = "feature_flag", "Feature flag"
+    GUIDELINES = "guidelines", "Guidelines"
+    HOMEPAGE = "homepage", "Homepage"
+    JOIN_FORM_QUESTION = "join_form_question", "Join form question"
+    JOIN_REQUEST = "join_request", "Join request"
+    MEMBER_PROMOTION_MESSAGE = "member_promotion_message", "Member promotion message"
+    ROLE = "role", "Role"
+    SURVEY = "survey", "Survey"
+    SURVEY_QUESTION = "survey_question", "Survey question"
+    TENTATIVE_APPROVAL_MESSAGE = "tentative_approval_message", "Tentative approval message"
+    USER = "user", "User"
+    WELCOME_TEMPLATE = "welcome_template", "Welcome template"
+    WHATSAPP_LINK = "whatsapp_link", "WhatsApp link"
 
 
 def audit_log(  # noqa: PLR0913
     level: int,
     action: str,
     request,
-    target_type: str = "",
+    target_type: AuditTargetType | str = "",
     target_id: str = "",
     details: dict | None = None,
 ) -> None:
@@ -21,7 +46,7 @@ def audit_log(  # noqa: PLR0913
         level: logging.INFO or logging.WARNING
         action: verb describing the event (e.g. 'login_success', 'user_deleted')
         request: the Django/Ninja HttpRequest (used for actor and IP)
-        target_type: type of the affected object (e.g. 'user', 'event', 'role')
+        target_type: AuditTargetType member for the affected object
         target_id: string ID of the affected object
         details: optional context dict (avoid including raw phone numbers or tokens)
     """

--- a/backend/users/_auth.py
+++ b/backend/users/_auth.py
@@ -3,7 +3,7 @@
 import logging
 
 from community._validation import Code, raise_validation
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.ratelimit import client_ip, rate_limit
 from django.contrib.auth import authenticate
@@ -72,18 +72,32 @@ def login(request, payload: LoginIn, response: HttpResponse):
     user = User.objects.get(pk=auth_user.pk)
     if user.archived_at is not None:
         audit_log(
-            logging.WARNING, "login_archived", request, target_type="user", target_id=str(user.pk)
+            logging.WARNING,
+            "login_archived",
+            request,
+            target_type=AuditTargetType.USER,
+            target_id=str(user.pk),
         )
         raise_validation(Code.Auth.ACCOUNT_ARCHIVED, status_code=403)
     if user.is_paused:
         audit_log(
-            logging.WARNING, "login_paused", request, target_type="user", target_id=str(user.pk)
+            logging.WARNING,
+            "login_paused",
+            request,
+            target_type=AuditTargetType.USER,
+            target_id=str(user.pk),
         )
         raise_validation(Code.Auth.ACCOUNT_PAUSED, status_code=403)
     refresh = RefreshToken.for_user(user)
     request.auth = user
     set_refresh_cookie(response, str(refresh))
-    audit_log(logging.INFO, "login_success", request, target_type="user", target_id=str(user.pk))
+    audit_log(
+        logging.INFO,
+        "login_success",
+        request,
+        target_type=AuditTargetType.USER,
+        target_id=str(user.pk),
+    )
     return Status(200, TokenOut(access=str(refresh.access_token)))  # type: ignore
 
 
@@ -179,7 +193,7 @@ def update_me(request, payload: MePatchIn):
             logging.INFO,
             "profile_updated",
             request,
-            target_type="user",
+            target_type=AuditTargetType.USER,
             target_id=str(user.pk),
             details={"fields_changed": changed},
         )
@@ -211,7 +225,11 @@ def upload_photo(request, photo: UploadedFile = File(...)):  # ty: ignore[call-n
     user.photo_updated_at = timezone.now()
     user.save(update_fields=["profile_photo", "photo_updated_at"])
     audit_log(
-        logging.INFO, "profile_photo_uploaded", request, target_type="user", target_id=str(user.pk)
+        logging.INFO,
+        "profile_photo_uploaded",
+        request,
+        target_type=AuditTargetType.USER,
+        target_id=str(user.pk),
     )
     return Status(200, UserOut.from_user(user))
 
@@ -225,7 +243,11 @@ def delete_photo(request):
         user.photo_updated_at = None
         user.save(update_fields=["profile_photo", "photo_updated_at"])
     audit_log(
-        logging.INFO, "profile_photo_deleted", request, target_type="user", target_id=str(user.pk)
+        logging.INFO,
+        "profile_photo_deleted",
+        request,
+        target_type=AuditTargetType.USER,
+        target_id=str(user.pk),
     )
     return Status(200, UserOut.from_user(user))
 
@@ -265,7 +287,11 @@ def complete_onboarding(request, payload: OnboardingIn):
     stamp_consents(user, payload.consent_types)
     user.save()
     audit_log(
-        logging.INFO, "onboarding_completed", request, target_type="user", target_id=str(user.pk)
+        logging.INFO,
+        "onboarding_completed",
+        request,
+        target_type=AuditTargetType.USER,
+        target_id=str(user.pk),
     )
     return Status(200, UserOut.from_user(user))
 
@@ -282,7 +308,7 @@ def accept_consents(request, payload: AcceptConsentsIn):
         logging.INFO,
         "consents_accepted",
         request,
-        target_type="user",
+        target_type=AuditTargetType.USER,
         target_id=str(user.pk),
         details={"consent_types": [str(c) for c in payload.consent_types]},
     )
@@ -297,7 +323,7 @@ def change_password(request, payload: ChangePasswordIn):
             logging.WARNING,
             "password_change_failed",
             request,
-            target_type="user",
+            target_type=AuditTargetType.USER,
             target_id=str(user.pk),
             details={"reason": "wrong_current_password"},
         )
@@ -317,5 +343,11 @@ def change_password(request, payload: ChangePasswordIn):
     # Setting a password also satisfies a pending forced reset.
     user.needs_password_reset = False
     user.save()
-    audit_log(logging.INFO, "password_changed", request, target_type="user", target_id=str(user.pk))
+    audit_log(
+        logging.INFO,
+        "password_changed",
+        request,
+        target_type=AuditTargetType.USER,
+        target_id=str(user.pk),
+    )
     return Status(200, ErrorOut(detail="Password updated successfully."))

--- a/backend/users/_magic_links.py
+++ b/backend/users/_magic_links.py
@@ -4,7 +4,7 @@ import logging
 from datetime import timedelta
 
 from community._validation import Code, raise_validation
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from django.db import transaction
 from django.utils import timezone
@@ -32,7 +32,7 @@ def generate_magic_link(request, user_id: str):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="user",
+            target_type=AuditTargetType.USER,
             target_id=user_id,
             details={
                 "endpoint": "generate_magic_link",
@@ -64,7 +64,7 @@ def generate_magic_link(request, user_id: str):
                 logging.INFO,
                 "magic_link_already_handled",
                 request,
-                target_type="user",
+                target_type=AuditTargetType.USER,
                 target_id=user_id,
             )
             return Status(
@@ -103,7 +103,7 @@ def generate_magic_link(request, user_id: str):
             logging.INFO,
             "magic_link_notifications_cleared",
             request,
-            target_type="user",
+            target_type=AuditTargetType.USER,
             target_id=user_id,
             details={"count": cleared_count},
         )
@@ -111,7 +111,7 @@ def generate_magic_link(request, user_id: str):
         logging.INFO,
         "magic_link_generated",
         request,
-        target_type="user",
+        target_type=AuditTargetType.USER,
         target_id=user_id,
     )
     return Status(

--- a/backend/users/_magic_login.py
+++ b/backend/users/_magic_login.py
@@ -3,7 +3,7 @@
 import logging
 
 from community._validation import Code, raise_validation
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.ratelimit import client_ip, rate_limit
 from django.db import transaction
 from django.http import HttpResponse
@@ -46,7 +46,7 @@ def _validate_magic_user(request, magic: MagicLoginToken) -> None:
             logging.WARNING,
             "magic_login_cross_user_blocked",
             request,
-            target_type="user",
+            target_type=AuditTargetType.USER,
             target_id=str(magic.user.pk),
             details={"current_user_id": str(current_user.pk)},
         )
@@ -56,7 +56,7 @@ def _validate_magic_user(request, magic: MagicLoginToken) -> None:
             logging.WARNING,
             "magic_login_archived",
             request,
-            target_type="user",
+            target_type=AuditTargetType.USER,
             target_id=str(magic.user.pk),
         )
         raise_validation(Code.Auth.ACCOUNT_ARCHIVED, status_code=403)
@@ -65,7 +65,7 @@ def _validate_magic_user(request, magic: MagicLoginToken) -> None:
             logging.WARNING,
             "magic_login_paused",
             request,
-            target_type="user",
+            target_type=AuditTargetType.USER,
             target_id=str(magic.user.pk),
         )
         raise_validation(Code.Auth.ACCOUNT_PAUSED, status_code=403)
@@ -93,7 +93,7 @@ def _consume_magic_token(request, token: str) -> MagicLoginToken:
                 logging.WARNING,
                 "magic_login_failed",
                 request,
-                target_type="user",
+                target_type=AuditTargetType.USER,
                 target_id=str(magic.user.pk),
                 details={"reason": "used_or_expired"},
             )
@@ -115,7 +115,7 @@ def _consume_magic_token(request, token: str) -> MagicLoginToken:
                 logging.INFO,
                 "magic_login_requires_password_reset",
                 request,
-                target_type="user",
+                target_type=AuditTargetType.USER,
                 target_id=str(magic.user.pk),
             )
     return magic
@@ -136,7 +136,7 @@ def magic_login(request, token: str, response: HttpResponse):
         logging.INFO,
         "magic_login_success",
         request,
-        target_type="user",
+        target_type=AuditTargetType.USER,
         target_id=str(magic.user.pk),
     )
     return Status(200, TokenOut(access=str(refresh.access_token)))  # type: ignore

--- a/backend/users/_management.py
+++ b/backend/users/_management.py
@@ -7,7 +7,7 @@ from community._rsvp_counts import attendance_q, reportable_events_q
 from community._shared import validate_display_name
 from community._validation import Code, ValidationException, raise_validation
 from community.models import AttendanceStatus
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from django.db import models as dj_models
 from django.utils import timezone
@@ -79,7 +79,7 @@ def create_user(request, payload: UserCreateIn):
         logging.INFO,
         "user_created",
         request,
-        target_type="user",
+        target_type=AuditTargetType.USER,
         target_id=str(user.id),
         details={
             "full_name": user.full_name,
@@ -276,7 +276,7 @@ def update_user(request, user_id: str, payload: UserPatchIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="user",
+            target_type=AuditTargetType.USER,
             target_id=user_id,
             details={"endpoint": "update_user", "required_permission": PermissionKey.MANAGE_USERS},
         )
@@ -307,7 +307,12 @@ def _audit_user_update(
         action = "user_paused" if payload.is_paused else "user_unpaused"
         details = {"removed_role_ids": _strip_non_member_roles(user)} if payload.is_paused else None
         audit_log(
-            logging.WARNING, action, request, target_type="user", target_id=user_id, details=details
+            logging.WARNING,
+            action,
+            request,
+            target_type=AuditTargetType.USER,
+            target_id=user_id,
+            details=details,
         )
         return
 
@@ -321,7 +326,7 @@ def _audit_user_update(
             logging.INFO,
             "user_updated",
             request,
-            target_type="user",
+            target_type=AuditTargetType.USER,
             target_id=user_id,
             details={"fields_changed": changed},
         )
@@ -366,7 +371,7 @@ def delete_user(request, user_id: str):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="user",
+            target_type=AuditTargetType.USER,
             target_id=user_id,
             details={"endpoint": "delete_user", "required_permission": PermissionKey.MANAGE_USERS},
         )
@@ -388,7 +393,7 @@ def delete_user(request, user_id: str):
         logging.WARNING,
         "user_archived",
         request,
-        target_type="user",
+        target_type=AuditTargetType.USER,
         target_id=user_id,
         details={"full_name": full_name},
     )
@@ -412,7 +417,7 @@ def hard_delete_user(request, user_id: str):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="user",
+            target_type=AuditTargetType.USER,
             target_id=user_id,
             details={
                 "endpoint": "hard_delete_user",
@@ -435,7 +440,7 @@ def hard_delete_user(request, user_id: str):
         logging.WARNING,
         "user_hard_deleted",
         request,
-        target_type="user",
+        target_type=AuditTargetType.USER,
         target_id=user_id,
         details={"full_name": full_name},
     )
@@ -456,7 +461,7 @@ def update_user_roles(request, user_id: str, payload: UserRolesIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="user",
+            target_type=AuditTargetType.USER,
             target_id=user_id,
             details={
                 "endpoint": "update_user_roles",
@@ -483,7 +488,7 @@ def update_user_roles(request, user_id: str, payload: UserRolesIn):
         logging.WARNING,
         "user_roles_changed",
         request,
-        target_type="user",
+        target_type=AuditTargetType.USER,
         target_id=user_id,
         details={"old_role_ids": old_role_ids, "new_role_ids": new_role_ids},
     )

--- a/backend/users/_roles.py
+++ b/backend/users/_roles.py
@@ -3,7 +3,7 @@
 import logging
 
 from community._validation import Code, raise_validation
-from config.audit import audit_log
+from config.audit import AuditTargetType, audit_log
 from config.auth import gated_jwt
 from django.db.models import Count, Q
 from ninja import Router
@@ -74,7 +74,7 @@ def create_role(request, payload: RoleIn):
         logging.INFO,
         "role_created",
         request,
-        target_type="role",
+        target_type=AuditTargetType.ROLE,
         target_id=str(role.id),
         details={"name": role.name, "permissions": role.permissions},
     )
@@ -100,7 +100,7 @@ def update_role(request, role_id: str, payload: RolePatchIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="role",
+            target_type=AuditTargetType.ROLE,
             target_id=role_id,
             details={"endpoint": "update_role", "required_permission": PermissionKey.MANAGE_ROLES},
         )
@@ -133,7 +133,7 @@ def update_role(request, role_id: str, payload: RolePatchIn):
         logging.WARNING,
         "role_updated",
         request,
-        target_type="role",
+        target_type=AuditTargetType.ROLE,
         target_id=role_id,
         details={
             "old_name": old_name,
@@ -164,7 +164,7 @@ def delete_role(request, role_id: str):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type="role",
+            target_type=AuditTargetType.ROLE,
             target_id=role_id,
             details={"endpoint": "delete_role", "required_permission": PermissionKey.MANAGE_ROLES},
         )
@@ -182,7 +182,7 @@ def delete_role(request, role_id: str):
         logging.WARNING,
         "role_deleted",
         request,
-        target_type="role",
+        target_type=AuditTargetType.ROLE,
         target_id=role_id,
         details={"name": role_name, "affected_user_count": affected_user_count},
     )


### PR DESCRIPTION
## Overview

Replaces the raw `target_type` string literals passed to `audit_log()` with an
`AuditTargetType` TextChoices enum. 133 call sites across 39 files.

Values are unchanged, so log output is byte-identical — this is pure mechanical
churn, split out from the behavioral work so it can be skimmed rather than read.

Prep for persisting audit entries to a table (follow-up PR), where `target_type`
becomes a filter axis and a typo like `"event"` vs `"events"` would silently
miss rows. The existing values were already consistent; the enum's value is that
a *new* call site can't drift.

## Test plan

- [x] `make agent-lint`
- [x] `make agent-typecheck`
- [x] `make agent-complexity`
- [ ] CI (runs against Postgres — local runs used per-worktree SQLite, where the
      known `pg_notify`/SSE tests fail regardless of this change)
