### PR TITLE
feat: 1045 - record payment confirmations in the audit trail (6/6)

### DIFF
--- a/backend/community/_event_host_rsvps.py
+++ b/backend/community/_event_host_rsvps.py
@@ -22,6 +22,7 @@ from community._event_rsvps import (
     _resolve_paid_confirmed_at,
     _resolve_rsvp_status,
     _validate_rsvp_status,
+    payment_audit_details,
 )
 from community._event_schemas import EventOut, HostRSVPIn, HostRSVPPaymentIn
 from community._events import _can_edit_event
@@ -122,7 +123,7 @@ def set_guest_rsvp(request, event_id: UUID, user_id: UUID, payload: HostRSVPIn):
         details={
             "user_id": str(user_id),
             "status": final_status,
-            "paid_confirmed": payload.paid_confirmed,
+            **payment_audit_details(event_id, user_id),
         },
     )
     event = load_event_with_stats_prefetch(event_id)
@@ -173,15 +174,20 @@ def set_guest_payment(request, event_id: UUID, user_id: UUID, payload: HostRSVPP
     with transaction.atomic():
         was_paid = _apply_payment_change_in_transaction(event_id, user_id, payload.paid_confirmed)
 
+    is_revoke = was_paid and not payload.paid_confirmed
     audit_log(
         logging.INFO,
-        "guest_payment_changed",
+        "guest_payment_revoked" if is_revoke else "guest_payment_changed",
         request,
         target_type=AuditTargetType.EVENT,
         target_id=str(event_id),
-        details={"user_id": str(user_id), "paid_confirmed": payload.paid_confirmed},
+        details={
+            "user_id": str(user_id),
+            "was_paid": was_paid,
+            **payment_audit_details(event_id, user_id),
+        },
     )
-    if was_paid and not payload.paid_confirmed:
+    if is_revoke:
         create_payment_revoked_notification(event, str(user_id))
     event = load_event_with_stats_prefetch(event_id)
     if event is None:

--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -149,6 +149,24 @@ def _resolve_paid_confirmed_at(
     return None
 
 
+def payment_audit_details(event_id, user_id) -> dict:
+    """Audit fields describing the payment stamp actually stored for this rsvp.
+
+    Read back from the row rather than echoing the request payload — a
+    `paid_confirmed: true` on an already-stamped or ungated write changes
+    nothing, and the audit trail has to record what happened, not what was asked.
+    """
+    stamped_at = (
+        EventRSVP.objects.filter(event_id=event_id, user_id=user_id)
+        .values_list("paid_confirmed_at", flat=True)
+        .first()
+    )
+    return {
+        "paid_confirmed": stamped_at is not None,
+        "paid_confirmed_at": stamped_at.isoformat() if stamped_at else None,
+    }
+
+
 def _apply_rsvp_in_transaction(
     event_id, user, status: str, has_plus_one: bool, paid_confirmed: bool = False
 ) -> tuple[str, list[str], bool]:
@@ -238,7 +256,10 @@ def upsert_rsvp(request, event_id: UUID, payload: RSVPIn):
         request,
         target_type=AuditTargetType.EVENT,
         target_id=str(event_id),
-        details={"status": final_status},
+        details={
+            "status": final_status,
+            **payment_audit_details(event_id, request.auth.pk),
+        },
     )
     event = load_event_with_stats_prefetch(event_id)
     if event is None:

--- a/backend/community/_public_rsvp_manage.py
+++ b/backend/community/_public_rsvp_manage.py
@@ -18,6 +18,7 @@ from community._event_rsvps import (
     _apply_rsvp_in_transaction,
     _post_rsvp_comment,
     _validate_rsvp_status,
+    payment_audit_details,
 )
 from community._event_schemas import EventOut
 from community._field_limits import FieldLimit
@@ -171,7 +172,7 @@ def update_my_rsvp(request, event_id, payload: PublicRsvpManageIn, token: str = 
         details={
             "user_id": str(user.pk),
             "status": final_status,
-            "paid_confirmed": payload.paid_confirmed,
+            **payment_audit_details(event.id, user.pk),
         },
     )
     sent_decline_note = _post_rsvp_comment(event.id, user, final_status, payload.comment)

--- a/backend/community/_public_rsvp_submit.py
+++ b/backend/community/_public_rsvp_submit.py
@@ -19,6 +19,7 @@ from community._event_rsvps import (
     _apply_rsvp_in_transaction,
     _post_rsvp_comment,
     _validate_rsvp_status,
+    payment_audit_details,
 )
 from community._field_limits import FieldLimit
 from community._public_rsvp_shared import (
@@ -254,7 +255,7 @@ def submit_public_rsvp(request, event_id, payload: PublicRsvpIn):
         details={
             "user_id": str(user.pk),
             "status": final_status,
-            "paid_confirmed": payload.paid_confirmed,
+            **payment_audit_details(event.id, user.pk),
         },
     )
 

--- a/backend/tests/test_payment_audit_trail.py
+++ b/backend/tests/test_payment_audit_trail.py
@@ -1,0 +1,234 @@
+import pytest
+from audit.models import AuditLogEntry, AuditTargetType
+from community.models import Event, EventRSVP, RSVPStatus
+from django.utils import timezone
+
+from tests._payment_helpers import create_paid_event, set_payment_flag
+from tests._public_rsvp_helpers import make_official_event
+from tests._public_rsvp_helpers import payload as public_payload
+from tests._public_rsvp_helpers import url as public_url
+
+RSVP_URL = "/api/community/events/{event_id}/rsvp/"
+HOST_RSVP_URL = "/api/community/events/{event_id}/rsvps/{user_id}/rsvp/"
+PAYMENT_URL = "/api/community/events/{event_id}/rsvps/{user_id}/payment/"
+
+
+@pytest.fixture(autouse=True)
+def _flag_on(db):
+    set_payment_flag(True)
+
+
+@pytest.fixture
+def commit(django_capture_on_commit_callbacks, fake_email_sender):
+    """audit_log persists via transaction.on_commit, which the test transaction never fires.
+
+    fake_email_sender because executing the callbacks also fires queued sends.
+    """
+
+    def run(fn):
+        with django_capture_on_commit_callbacks(execute=True):
+            return fn()
+
+    return run
+
+
+def _paid_event(creator, **overrides) -> Event:
+    return create_paid_event(created_by=creator, **overrides)
+
+
+def _entry(action: str) -> AuditLogEntry:
+    return AuditLogEntry.objects.filter(action=action).latest("created_at")
+
+
+def _post(commit, api_client, url, body, headers=None):
+    return commit(
+        lambda: api_client.post(url, body, content_type="application/json", **(headers or {}))
+    )
+
+
+def _patch(commit, api_client, url, body, headers=None):
+    return commit(
+        lambda: api_client.patch(url, body, content_type="application/json", **(headers or {}))
+    )
+
+
+@pytest.mark.django_db
+class TestMemberRsvpPaymentAudit:
+    def test_confirming_payment_is_audited(self, commit, api_client, auth_headers, test_user):
+        event = _paid_event(test_user)
+        _post(
+            commit,
+            api_client,
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.ATTENDING, "paid_confirmed": True},
+            auth_headers,
+        )
+
+        entry = _entry("rsvp_changed")
+        assert entry.actor_id == test_user.pk
+        assert entry.target_type == AuditTargetType.EVENT
+        assert entry.target_id == str(event.id)
+        assert entry.details["paid_confirmed"] is True
+        assert entry.details["paid_confirmed_at"] is not None
+
+    def test_unpaid_rsvp_is_audited_as_unpaid(self, commit, api_client, auth_headers, test_user):
+        event = _paid_event(test_user)
+        _post(
+            commit,
+            api_client,
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.MAYBE},
+            auth_headers,
+        )
+
+        entry = _entry("rsvp_changed")
+        assert entry.details["paid_confirmed"] is False
+        assert entry.details["paid_confirmed_at"] is None
+
+    def test_paid_confirmed_on_an_ungated_status_is_not_audited_as_paid(
+        self, commit, api_client, auth_headers, test_user
+    ):
+        """maybe never banks a stamp, so the trail must not claim they paid."""
+        event = _paid_event(test_user)
+        _post(
+            commit,
+            api_client,
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.MAYBE, "paid_confirmed": True},
+            auth_headers,
+        )
+
+        assert _entry("rsvp_changed").details["paid_confirmed"] is False
+
+    def test_audited_stamp_matches_the_stored_row(
+        self, commit, api_client, auth_headers, test_user
+    ):
+        event = _paid_event(test_user)
+        _post(
+            commit,
+            api_client,
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.ATTENDING, "paid_confirmed": True},
+            auth_headers,
+        )
+
+        stored = EventRSVP.objects.get(event=event, user=test_user).paid_confirmed_at
+        assert _entry("rsvp_changed").details["paid_confirmed_at"] == stored.isoformat()
+
+
+@pytest.mark.django_db
+class TestHostPaymentChangeAudit:
+    def _guest(self, django_user_model, event, **rsvp_fields):
+        guest = django_user_model.objects.create_user(
+            phone_number="+14155550142", first_name="Guest", is_member=True
+        )
+        EventRSVP.objects.create(
+            event=event, user=guest, status=RSVPStatus.ATTENDING, **rsvp_fields
+        )
+        return guest
+
+    def test_revoking_is_audited_with_the_transition(
+        self, commit, api_client, auth_headers, test_user, django_user_model
+    ):
+        """The row is left with no stamp, so only the audit row records that they had paid."""
+        event = _paid_event(test_user)
+        guest = self._guest(django_user_model, event, paid_confirmed_at=timezone.now())
+
+        _patch(
+            commit,
+            api_client,
+            PAYMENT_URL.format(event_id=event.id, user_id=guest.id),
+            {"paid_confirmed": False},
+            auth_headers,
+        )
+
+        entry = _entry("guest_payment_revoked")
+        assert entry.actor_id == test_user.pk, "the host who revoked must be recorded"
+        assert entry.details["user_id"] == str(guest.id)
+        assert entry.details["was_paid"] is True
+        assert entry.details["paid_confirmed"] is False
+        assert entry.details["paid_confirmed_at"] is None
+        assert not AuditLogEntry.objects.filter(action="guest_payment_changed").exists(), (
+            "a real revoke must not also log under the generic action name"
+        )
+
+    def test_confirming_is_audited(
+        self, commit, api_client, auth_headers, test_user, django_user_model
+    ):
+        event = _paid_event(test_user)
+        guest = self._guest(django_user_model, event)
+
+        _patch(
+            commit,
+            api_client,
+            PAYMENT_URL.format(event_id=event.id, user_id=guest.id),
+            {"paid_confirmed": True},
+            auth_headers,
+        )
+
+        entry = _entry("guest_payment_changed")
+        assert entry.details["was_paid"] is False
+        assert entry.details["paid_confirmed"] is True
+        assert entry.details["paid_confirmed_at"] is not None
+
+    def test_redundant_revoke_records_no_prior_payment(
+        self, commit, api_client, auth_headers, test_user, django_user_model
+    ):
+        event = _paid_event(test_user)
+        guest = self._guest(django_user_model, event)
+
+        _patch(
+            commit,
+            api_client,
+            PAYMENT_URL.format(event_id=event.id, user_id=guest.id),
+            {"paid_confirmed": False},
+            auth_headers,
+        )
+
+        assert _entry("guest_payment_changed").details["was_paid"] is False
+        assert not AuditLogEntry.objects.filter(action="guest_payment_revoked").exists(), (
+            "a no-op on an unpaid guest must not log as a revoke"
+        )
+
+    def test_host_seating_a_guest_audits_the_stamp(
+        self, commit, api_client, auth_headers, test_user, django_user_model
+    ):
+        event = _paid_event(test_user)
+        guest = django_user_model.objects.create_user(
+            phone_number="+14155550143", first_name="Cash", is_member=True
+        )
+
+        _post(
+            commit,
+            api_client,
+            HOST_RSVP_URL.format(event_id=event.id, user_id=guest.id),
+            {"status": RSVPStatus.ATTENDING, "paid_confirmed": True},
+            auth_headers,
+        )
+
+        entry = _entry("guest_rsvp_changed")
+        assert entry.details["paid_confirmed"] is True
+        assert entry.details["paid_confirmed_at"] is not None
+
+
+@pytest.mark.django_db
+class TestPublicRsvpPaymentAudit:
+    @pytest.fixture
+    def paid_public_event(self, db):
+        return make_official_event(
+            title="Paid Official Event",
+            price="$10",
+            venmo_link="https://venmo.com/u/host",
+        )
+
+    def test_new_person_confirming_payment_is_audited(self, commit, api_client, paid_public_event):
+        _post(
+            commit,
+            api_client,
+            public_url(paid_public_event),
+            public_payload(status=RSVPStatus.ATTENDING, paid_confirmed=True),
+        )
+
+        entry = _entry("public_rsvp_created")
+        assert entry.details["paid_confirmed"] is True
+        assert entry.details["paid_confirmed_at"] is not None


### PR DESCRIPTION
## Overview

**6 of 6** in the split of #1213 (Issue 1045). Makes every payment stamp change land in the audit table.

**Stacked on #1228.**

### Why

The rsvp row only carries current state — `paid_confirmed_at`, nulled on revoke. That was a deliberate simplification (see the discussion on #1224): revocation history moved to `AuditLogEntry`, which records *who* retracted a payment and from what IP, things a second timestamp column never could. This PR makes good on that — without it, a revoked payment leaves no trace anywhere.

### What's here

- **`payment_audit_details()`** reads the stamp back from the stored row rather than echoing the request payload. A `paid_confirmed: true` on an already-stamped or ungated write changes nothing, and the trail has to record what *happened*, not what was *asked*.
- **`rsvp_changed`** — the main member path — carried no payment fields at all. Fixed.
- **`guest_payment_changed`** now records `was_paid` alongside the result, so a real revocation is distinguishable from a redundant one.
- **`public_rsvp_created`, `public_rsvp_updated`, `guest_rsvp_changed`** switch from the payload value to the stored one.

### Notes for review

- Audit rows are written via `transaction.on_commit` (from #1230), so a rolled-back rsvp leaves no audit row — correct, and why the tests wrap each request in `django_capture_on_commit_callbacks`.
- `_persist` swallows exceptions by design, so a successful action whose audit insert fails logs but doesn't 500. Worth knowing the audit table isn't a hard guarantee; out of scope here.

## Test plan

- [x] `tests/test_payment_audit_trail.py` — 9 tests across the member, host-seat, host-payment, and public-submit paths
- [x] Covers the cases where payload and stored state diverge: `paid_confirmed: true` on `maybe` must not be audited as paid; the audited timestamp must equal the stored one
- [x] Mutation-checked — gutting `payment_audit_details()` fails 8 of 9
- [x] Full backend suite: **1939 passed**. The 6 failures (`test_sse.py` ×5, `test_rsvp_capacity_race.py`) are the pre-existing SQLite/`pg_notify` limitations
- [x] `make agent-lint`, `agent-typecheck`, `agent-complexity` clean

Part of Issue 1045. Split out of #1213.
