### PR TITLE
chore: add config-as-code for railway cron jobs

### DIFF
--- a/railway/cron-checkin-nudges.toml
+++ b/railway/cron-checkin-nudges.toml
@@ -1,0 +1,9 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+startCommand = "cd backend && uv run python manage.py send_checkin_nudges"
+cronSchedule = "*/15 * * * *"
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10

--- a/railway/cron-daily.toml
+++ b/railway/cron-daily.toml
@@ -1,0 +1,9 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+startCommand = "sh scripts/cron_daily.sh"
+cronSchedule = "0 3 * * *"
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10

--- a/scripts/cron_daily.sh
+++ b/scripts/cron_daily.sh
@@ -2,8 +2,9 @@
 cd backend
 
 status=0
-uv run python manage.py hard_delete_old_events || status=1
-uv run python manage.py cleanup_notifications || status=1
-uv run python manage.py purge_audit_logs || status=1
+timeout 300 uv run python manage.py hard_delete_old_events || status=1
+timeout 300 uv run python manage.py cleanup_notifications || status=1
+timeout 300 uv run python manage.py purge_audit_logs || status=1
+timeout 300 uv run python manage.py send_attendance_reminders || status=1
 
 exit $status

--- a/scripts/cron_daily.sh
+++ b/scripts/cron_daily.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+set -e
+
+cd backend
+uv run python manage.py hard_delete_old_events
+uv run python manage.py cleanup_notifications
+uv run python manage.py purge_audit_logs

--- a/scripts/cron_daily.sh
+++ b/scripts/cron_daily.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env sh
-set -e
-
 cd backend
-uv run python manage.py hard_delete_old_events
-uv run python manage.py cleanup_notifications
-uv run python manage.py purge_audit_logs
+
+status=0
+uv run python manage.py hard_delete_old_events || status=1
+uv run python manage.py cleanup_notifications || status=1
+uv run python manage.py purge_audit_logs || status=1
+
+exit $status


### PR DESCRIPTION
## Overview

Adds version-controlled Railway config-as-code for the cron jobs discussed with the user: a daily 3am service running `hard_delete_old_events`, `cleanup_notifications`, `purge_audit_logs`, and `send_attendance_reminders` via `scripts/cron_daily.sh`, and a 15-minute service running `send_checkin_nudges`.

Each step in `cron_daily.sh` runs independently (a failing command doesn't skip the rest) and is capped at `timeout 300` (5 min) so a hung step can't block the others or run indefinitely. The script exits non-zero if any step failed, preserving Railway's ON_FAILURE retry/alerting behavior.

`send_attendance_reminders` closes Issue 1236 — it's gated behind `FeatureFlag.ADMIN_ATTENDANCE_ANALYTICS` so it no-ops safely if the flag is off, and it shares the daily service's env vars since it builds from the same Dockerfile.

Each service needs its Railway Settings → "Config-as-code file path" pointed at the corresponding `railway/*.toml` file.

## Test plan

- [ ] Point each Railway service's config-as-code file path at its `railway/*.toml` and confirm the schedule/start command shown in the dashboard matches
- [ ] Trigger a manual run of each service and confirm it exits 0