### PR TITLE
feat: 1045 - payment confirmation gate (frontend)

### DIFF
--- a/frontend/src/api/eventMapper.test.ts
+++ b/frontend/src/api/eventMapper.test.ts
@@ -37,8 +37,8 @@ describe('mapEvent', () => {
         ],
       }),
     );
-    expect(result.guests[0].paidConfirmed).toBe(true);
-    expect(result.guests[1].paidConfirmed).toBe(false);
+    expect(result.guests[0]!.paidConfirmed).toBe(true);
+    expect(result.guests[1]!.paidConfirmed).toBe(false);
   });
 
   it('converts ISO start_datetime to Date', () => {

--- a/frontend/src/api/eventMapper.test.ts
+++ b/frontend/src/api/eventMapper.test.ts
@@ -20,6 +20,27 @@ describe('mapEvent', () => {
     expect(result.startDatetime!.getUTCHours()).toBe(18);
   });
 
+  it('maps my_paid_confirmed', () => {
+    expect(mapEvent(wireEvent({ my_paid_confirmed: true })).myPaidConfirmed).toBe(true);
+  });
+
+  it('defaults myPaidConfirmed to false when absent', () => {
+    expect(mapEvent(wireEvent()).myPaidConfirmed).toBe(false);
+  });
+
+  it('maps paid_confirmed on guests', () => {
+    const result = mapEvent(
+      wireEvent({
+        guests: [
+          { user_id: 'u1', name: 'Paid Guest', status: 'attending', paid_confirmed: true },
+          { user_id: 'u2', name: 'Unpaid Guest', status: 'attending' },
+        ],
+      }),
+    );
+    expect(result.guests[0].paidConfirmed).toBe(true);
+    expect(result.guests[1].paidConfirmed).toBe(false);
+  });
+
   it('converts ISO start_datetime to Date', () => {
     const result = mapEvent(wireEvent({ start_datetime: '2026-01-05T09:05:03Z' }));
     expect(result.startDatetime!.getUTCFullYear()).toBe(2026);

--- a/frontend/src/api/eventMapper.ts
+++ b/frontend/src/api/eventMapper.ts
@@ -109,6 +109,7 @@ function mapGuest(g: WireGuest): EventGuest {
     hasPlusOne: g.has_plus_one ?? false,
     attendance: mapAttendance(g.attendance),
     isMember: g.is_member ?? true,
+    paidConfirmed: g.paid_confirmed ?? false,
   };
 }
 
@@ -167,6 +168,7 @@ export function mapEvent(e: WireEvent): Event {
 
     guests: (e.guests ?? []).map(mapGuest),
     myRsvp: e.my_rsvp ?? null,
+    myPaidConfirmed: e.my_paid_confirmed ?? false,
     viewerUserId: e.viewer_user_id ?? null,
     surveySlugs: e.survey_slugs ?? [],
     invitedUserIds: e.invited_user_ids ?? [],

--- a/frontend/src/api/eventMapper.ts
+++ b/frontend/src/api/eventMapper.ts
@@ -16,6 +16,7 @@ interface WireGuest {
   has_plus_one?: boolean;
   attendance?: string;
   is_member?: boolean;
+  paid_confirmed?: boolean;
 }
 
 export interface WireEvent {
@@ -58,6 +59,7 @@ export interface WireEvent {
 
   guests?: WireGuest[];
   my_rsvp?: string | null;
+  my_paid_confirmed?: boolean;
   viewer_user_id?: string | null;
   survey_slugs?: string[];
   invited_user_ids?: string[];

--- a/frontend/src/api/publicRsvp.ts
+++ b/frontend/src/api/publicRsvp.ts
@@ -108,6 +108,7 @@ interface UpdateArgs {
   status: RsvpInputStatus;
   hasPlusOne: boolean;
   comment?: string;
+  paidConfirmed?: boolean;
 }
 
 function useManageInvalidate(token: string) {
@@ -125,12 +126,12 @@ function useManageInvalidate(token: string) {
 export function useUpdatePublicMyRsvp(token: string) {
   const invalidate = useManageInvalidate(token);
   return useMutation({
-    mutationFn: async ({ eventId, status, hasPlusOne, comment }: UpdateArgs) => {
+    mutationFn: async ({ eventId, status, hasPlusOne, comment, paidConfirmed }: UpdateArgs) => {
       const body: PublicRsvpManageIn = {
         status,
         has_plus_one: hasPlusOne,
         comment: comment ?? null,
-        paid_confirmed: false,
+        paid_confirmed: paidConfirmed ?? false,
       };
       const { data } = await apiClient.post<PublicRsvpOut>(`${MANAGE_BASE}${eventId}/`, body, {
         params: { token },

--- a/frontend/src/api/rsvp.ts
+++ b/frontend/src/api/rsvp.ts
@@ -19,6 +19,7 @@ interface SetRsvpArgs {
   // Not persisted server-side — a non-empty comment is posted once, as a
   // public EventComment or a host-only decline notification.
   comment?: string;
+  paidConfirmed?: boolean;
 }
 
 function updateCaches(qc: ReturnType<typeof useQueryClient>, event: Event, isAuthed: boolean) {
@@ -35,11 +36,18 @@ export function useSetRsvp() {
   const qc = useQueryClient();
   const isAuthed = useAuthStore((s) => s.status === 'authed');
   return useMutation({
-    mutationFn: async ({ eventId, status, hasPlusOne = false, comment }: SetRsvpArgs) => {
+    mutationFn: async ({
+      eventId,
+      status,
+      hasPlusOne = false,
+      comment,
+      paidConfirmed,
+    }: SetRsvpArgs) => {
       const { data } = await apiClient.post<WireEvent>(`/api/community/events/${eventId}/rsvp/`, {
         status,
         has_plus_one: hasPlusOne,
         ...(comment === undefined ? {} : { comment }),
+        ...(paidConfirmed ? { paid_confirmed: true } : {}),
       });
       return mapEvent(data);
     },

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -84,6 +84,7 @@ export interface EventGuest {
   hasPlusOne: boolean;
   attendance: AttendanceStatusValue;
   isMember: boolean;
+  paidConfirmed: boolean;
 }
 
 export interface EventCancellation {
@@ -150,6 +151,7 @@ export interface Event {
 
   guests: EventGuest[];
   myRsvp: string | null;
+  myPaidConfirmed: boolean;
   // The resolved viewer's own user id — carried from the backend so a
   // token-holding (logged-out) viewer can find their own entry in `guests`,
   // since useAuthStore has no user for them.

--- a/frontend/src/screens/events/AddCoHostDialog.test.tsx
+++ b/frontend/src/screens/events/AddCoHostDialog.test.tsx
@@ -56,6 +56,7 @@ const BASE_EVENT: Event = {
   coHostPhotoUrls: [],
   guests: [],
   myRsvp: null,
+  myPaidConfirmed: false,
   viewerUserId: null,
   surveySlugs: [],
   invitedUserIds: [],

--- a/frontend/src/screens/events/EmailBlastDialog.test.tsx
+++ b/frontend/src/screens/events/EmailBlastDialog.test.tsx
@@ -37,6 +37,7 @@ function guest(status: string, i: number): EventGuest {
     hasPlusOne: false,
     attendance: 'unknown',
     isMember: true,
+    paidConfirmed: false,
   };
 }
 

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -5,6 +5,7 @@ import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import type { Event } from '@/models/event';
 import { spotsLeft } from '@/models/event';
+import { formatPrice } from '@/utils/eventCost';
 import { buildEventLinks } from '@/utils/eventLinks';
 import { ensureHttps } from '@/utils/url';
 
@@ -190,17 +191,6 @@ export function CostSection({ event }: { event: Event }) {
       </ul>
     </Card>
   );
-}
-
-// "free" stays bare. Anything that starts with a digit gets "$" prepended
-// unless the user already typed one. Anything else (e.g. "sliding scale")
-// passes through as-written.
-function formatPrice(price: string): string {
-  const trimmed = price.trim();
-  if (!trimmed) return trimmed;
-  if (/^\$/.test(trimmed)) return trimmed;
-  if (/^\d/.test(trimmed)) return `$${trimmed}`;
-  return trimmed;
 }
 
 function InviteSection({ event }: { event: Event }) {

--- a/frontend/src/screens/events/MyRsvpSection.tsx
+++ b/frontend/src/screens/events/MyRsvpSection.tsx
@@ -71,6 +71,7 @@ export function MyRsvpSection({ event, token, locked = false }: Props) {
     status: RsvpInputStatus;
     comment?: string;
     hasPlusOne: boolean;
+    paidConfirmed?: boolean;
   }) {
     setError(null);
     try {
@@ -80,6 +81,7 @@ export function MyRsvpSection({ event, token, locked = false }: Props) {
           status: args.status,
           hasPlusOne: args.hasPlusOne,
           ...(args.comment !== undefined ? { comment: args.comment } : {}),
+          ...(args.paidConfirmed ? { paidConfirmed: true } : {}),
         });
       } else {
         await setRsvp.mutateAsync({
@@ -87,6 +89,7 @@ export function MyRsvpSection({ event, token, locked = false }: Props) {
           status: args.status,
           hasPlusOne: args.hasPlusOne,
           ...(args.comment === undefined ? {} : { comment: args.comment }),
+          ...(args.paidConfirmed ? { paidConfirmed: true } : {}),
         });
       }
       setBox(null);
@@ -160,6 +163,7 @@ export function MyRsvpSection({ event, token, locked = false }: Props) {
           key={box.mode + box.initialStatus}
           open
           mode={box.mode}
+          event={event}
           initialStatus={box.initialStatus}
           initialHasPlusOne={hasPlusOne}
           allowPlusOnes={event.allowPlusOnes}

--- a/frontend/src/screens/events/MyRsvpSection.tsx
+++ b/frontend/src/screens/events/MyRsvpSection.tsx
@@ -1,8 +1,9 @@
 import { useState } from 'react';
 
-import { extractApiErrorOr } from '@/api/apiErrors';
+import { extractApiErrorOr, hasErrorCode } from '@/api/apiErrors';
 import { useCancelPublicMyRsvp, useUpdatePublicMyRsvp } from '@/api/publicRsvp';
 import { useRemoveRsvp, useSetRsvp } from '@/api/rsvp';
+import { Code } from '@/api/validationCodes.gen';
 import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import {
@@ -260,5 +261,8 @@ function SpotsLeft({ event }: { event: Event }) {
 }
 
 function extractError(err: unknown): string {
+  if (hasErrorCode(err, Code.Event.PaymentConfirmationRequired)) {
+    return 'confirm you paid before rsvping';
+  }
   return extractApiErrorOr(err, "couldn't update your rsvp — try again");
 }

--- a/frontend/src/screens/events/PaymentConfirmStep.test.tsx
+++ b/frontend/src/screens/events/PaymentConfirmStep.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { Event } from '@/models/event';
+
+import { PaymentConfirmStep } from './PaymentConfirmStep';
+
+function makeEvent(overrides: Partial<Event> = {}): Event {
+  return {
+    price: '$10',
+    venmoLink: 'https://venmo.com/u/host',
+    cashappLink: '',
+    zelleInfo: '',
+    ...overrides,
+  } as Event;
+}
+
+describe('PaymentConfirmStep', () => {
+  it('shows the price', () => {
+    render(<PaymentConfirmStep event={makeEvent()} onConfirm={vi.fn()} onBack={vi.fn()} />);
+    expect(screen.getByText(/\$10/)).toBeInTheDocument();
+  });
+
+  it('renders a venmo link', () => {
+    render(<PaymentConfirmStep event={makeEvent()} onConfirm={vi.fn()} onBack={vi.fn()} />);
+    expect(screen.getByRole('link', { name: /venmo/i })).toHaveAttribute(
+      'href',
+      'https://venmo.com/u/host',
+    );
+  });
+
+  it('normalizes a bare venmo handle into a url', () => {
+    render(
+      <PaymentConfirmStep
+        event={makeEvent({ venmoLink: '@host' })}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('link', { name: /venmo/i })).toHaveAttribute(
+      'href',
+      'https://venmo.com/u/host',
+    );
+  });
+
+  it('normalizes a bare cashapp handle into a url', () => {
+    render(
+      <PaymentConfirmStep
+        event={makeEvent({ venmoLink: '', cashappLink: '$host' })}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('link', { name: /cashapp/i })).toHaveAttribute(
+      'href',
+      'https://cash.app/$host',
+    );
+  });
+
+  it('renders zelle info as text, not a link', () => {
+    render(
+      <PaymentConfirmStep
+        event={makeEvent({ venmoLink: '', zelleInfo: 'host@example.com' })}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/host@example\.com/)).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('calls onConfirm when the confirm button is clicked', async () => {
+    const onConfirm = vi.fn();
+    render(<PaymentConfirmStep event={makeEvent()} onConfirm={onConfirm} onBack={vi.fn()} />);
+    await userEvent.click(screen.getByRole('button', { name: /yes, i paid/i }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it('calls onBack when the back button is clicked', async () => {
+    const onBack = vi.fn();
+    render(<PaymentConfirmStep event={makeEvent()} onConfirm={vi.fn()} onBack={onBack} />);
+    await userEvent.click(screen.getByRole('button', { name: /back/i }));
+    expect(onBack).toHaveBeenCalledOnce();
+  });
+
+  it('disables both buttons while busy', () => {
+    render(<PaymentConfirmStep event={makeEvent()} busy onConfirm={vi.fn()} onBack={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /yes, i paid/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /back/i })).toBeDisabled();
+  });
+});

--- a/frontend/src/screens/events/PaymentConfirmStep.tsx
+++ b/frontend/src/screens/events/PaymentConfirmStep.tsx
@@ -1,0 +1,57 @@
+import { Button } from '@/components/ui/Button';
+import type { Event } from '@/models/event';
+import { formatPrice } from '@/utils/eventCost';
+import { toCashAppUrl, toVenmoUrl } from '@/utils/paymentHandle';
+
+interface Props {
+  event: Event;
+  busy?: boolean;
+  onConfirm: () => void;
+  onBack: () => void;
+}
+
+export function PaymentConfirmStep({ event, busy = false, onConfirm, onBack }: Props) {
+  const links: { label: string; url?: string }[] = [];
+  if (event.venmoLink) links.push({ label: 'venmo', url: toVenmoUrl(event.venmoLink) });
+  if (event.cashappLink) links.push({ label: 'cashapp', url: toCashAppUrl(event.cashappLink) });
+  if (event.zelleInfo) links.push({ label: `zelle: ${event.zelleInfo}` });
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <p className="text-foreground text-sm font-medium">{formatPrice(event.price)}</p>
+        <p className="text-foreground-secondary mt-1 text-sm">
+          pay the host before you rsvp — then confirm below
+        </p>
+      </div>
+
+      <ul className="flex flex-col gap-2 text-sm">
+        {links.map((link) => (
+          <li key={link.label}>
+            {link.url ? (
+              <a
+                href={link.url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-info hover:underline"
+              >
+                {link.label}
+              </a>
+            ) : (
+              <span className="text-foreground-secondary">{link.label}</span>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="secondary" onClick={onBack} disabled={busy}>
+          back
+        </Button>
+        <Button type="button" onClick={onConfirm} disabled={busy}>
+          yes, i paid
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/screens/events/PublicRsvp.a11y.test.tsx
+++ b/frontend/src/screens/events/PublicRsvp.a11y.test.tsx
@@ -12,6 +12,8 @@ vi.mock('@/api/publicRsvp', () => ({
   useCheckPublicRsvpPhone: () => ({ mutateAsync: checkPhoneMutate, isPending: false }),
 }));
 
+vi.mock('@/api/featureFlags', () => ({ useFlag: () => false }));
+
 import { PublicRsvpForm } from './PublicRsvpForm';
 
 function renderForm(event: Event) {

--- a/frontend/src/screens/events/PublicRsvpCard.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpCard.test.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { type Event, RsvpServerStatus } from '@/models/event';
 import { makeEvent } from '@/test/fixtures';
@@ -12,6 +12,9 @@ vi.mock('@/api/publicRsvp', () => ({
   useUpdatePublicMyRsvp: () => ({ mutateAsync: updateMutate, isPending: false }),
   useCancelPublicMyRsvp: () => ({ mutateAsync: cancelMutate, isPending: false }),
 }));
+
+const mockUseFlag = vi.hoisted(() => vi.fn(() => true));
+vi.mock('@/api/featureFlags', () => ({ useFlag: mockUseFlag }));
 
 import { PublicRsvpCard } from './PublicRsvpCard';
 
@@ -31,6 +34,13 @@ function renderCard(props: { status: string; event?: Partial<Event> }) {
 }
 
 describe('PublicRsvpCard', () => {
+  beforeEach(() => {
+    updateMutate.mockReset();
+    cancelMutate.mockReset();
+    mockUseFlag.mockReset();
+    mockUseFlag.mockReturnValue(true);
+  });
+
   it('links the event title to the event detail page', () => {
     renderCard({
       status: RsvpServerStatus.Attending,
@@ -79,5 +89,80 @@ describe('PublicRsvpCard', () => {
     expect(updateMutate).toHaveBeenCalledWith(
       expect.objectContaining({ comment: 'bringing snacks' }),
     );
+  });
+});
+
+describe('PublicRsvpCard payment confirmation gate', () => {
+  const paidEventOverrides: Partial<Event> = {
+    price: '$10',
+    venmoLink: 'https://venmo.com/u/host',
+  };
+
+  beforeEach(() => {
+    updateMutate.mockReset();
+    cancelMutate.mockReset();
+    mockUseFlag.mockReset();
+    mockUseFlag.mockReturnValue(true);
+  });
+
+  it('shows the payment step before switching to attending on a paid event', () => {
+    mockUseFlag.mockReturnValue(true);
+    renderCard({ status: RsvpServerStatus.Maybe, event: paidEventOverrides });
+    fireEvent.click(screen.getByRole('button', { name: /^i'm going$/i }));
+    expect(updateMutate).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /yes, i paid/i })).toBeInTheDocument();
+  });
+
+  it('submits with paidConfirmed after the payment step', async () => {
+    mockUseFlag.mockReturnValue(true);
+    updateMutate.mockResolvedValue(undefined);
+    renderCard({ status: RsvpServerStatus.Maybe, event: paidEventOverrides });
+    fireEvent.click(screen.getByRole('button', { name: /^i'm going$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /yes, i paid/i }));
+    await waitFor(() => expect(updateMutate).toHaveBeenCalled());
+    expect(updateMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ status: RsvpServerStatus.Attending, paidConfirmed: true }),
+    );
+  });
+
+  it('returns to the status picker from the payment step', () => {
+    mockUseFlag.mockReturnValue(true);
+    renderCard({ status: RsvpServerStatus.Maybe, event: paidEventOverrides });
+    fireEvent.click(screen.getByRole('button', { name: /^i'm going$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /back/i }));
+    expect(screen.getByRole('button', { name: /^i'm going$/i })).toBeInTheDocument();
+    expect(updateMutate).not.toHaveBeenCalled();
+  });
+
+  it('does not gate switching to maybe', () => {
+    mockUseFlag.mockReturnValue(true);
+    renderCard({ status: RsvpServerStatus.Attending, event: paidEventOverrides });
+    fireEvent.click(screen.getByRole('button', { name: /^maybe$/i }));
+    expect(updateMutate).toHaveBeenCalledOnce();
+  });
+
+  it('does not gate saving a comment while already attending', async () => {
+    mockUseFlag.mockReturnValue(true);
+    updateMutate.mockResolvedValue(undefined);
+    renderCard({ status: RsvpServerStatus.Attending, event: paidEventOverrides });
+    fireEvent.change(screen.getByLabelText('comment (optional)'), {
+      target: { value: 'see you there' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'save comment' }));
+    await waitFor(() => expect(updateMutate).toHaveBeenCalled());
+  });
+
+  it('does not gate on a free event', () => {
+    mockUseFlag.mockReturnValue(true);
+    renderCard({ status: RsvpServerStatus.Maybe });
+    fireEvent.click(screen.getByRole('button', { name: /^i'm going$/i }));
+    expect(updateMutate).toHaveBeenCalledOnce();
+  });
+
+  it('does not gate when the flag is off', () => {
+    mockUseFlag.mockReturnValue(false);
+    renderCard({ status: RsvpServerStatus.Maybe, event: paidEventOverrides });
+    fireEvent.click(screen.getByRole('button', { name: /^i'm going$/i }));
+    expect(updateMutate).toHaveBeenCalledOnce();
   });
 });

--- a/frontend/src/screens/events/PublicRsvpCard.tsx
+++ b/frontend/src/screens/events/PublicRsvpCard.tsx
@@ -2,8 +2,9 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { toast } from 'sonner';
 
-import { extractApiErrorOr, getApiStatus } from '@/api/apiErrors';
+import { extractApiErrorOr, getApiStatus, hasErrorCode } from '@/api/apiErrors';
 import { useCancelPublicMyRsvp, useUpdatePublicMyRsvp } from '@/api/publicRsvp';
+import { Code } from '@/api/validationCodes.gen';
 import { Button } from '@/components/ui/Button';
 import { RsvpStatusPicker } from '@/components/ui/RsvpStatusPicker';
 import { type Event, eventPath, type RsvpInputStatus, RsvpServerStatus } from '@/models/event';
@@ -24,6 +25,9 @@ const STATUS_LABELS: Record<string, string> = {
 };
 
 function errorMessage(err: unknown): string {
+  if (hasErrorCode(err, Code.Event.PaymentConfirmationRequired)) {
+    return 'confirm you paid before rsvping';
+  }
   const status = getApiStatus(err);
   if (status === 429) return "you're going too fast — try again in a few minutes";
   if (status === 404) return "this rsvp isn't available anymore — refresh";

--- a/frontend/src/screens/events/PublicRsvpCard.tsx
+++ b/frontend/src/screens/events/PublicRsvpCard.tsx
@@ -10,7 +10,9 @@ import { type Event, eventPath, type RsvpInputStatus, RsvpServerStatus } from '@
 import { formatEventDateTime } from '@/utils/datetime';
 import { buildEventLinks } from '@/utils/eventLinks';
 
+import { PaymentConfirmStep } from './PaymentConfirmStep';
 import { RsvpCommentField } from './RsvpCommentField';
+import { usePaymentGate } from './usePaymentGate';
 
 const UPDATED_TOAST = 'rsvp updated — check your email for an updated link';
 
@@ -40,10 +42,12 @@ export function PublicRsvpCard({ token, event, status }: Props) {
   const cancel = useCancelPublicMyRsvp(token);
   const [error, setError] = useState<string | null>(null);
   const [comment, setComment] = useState('');
+  const [pendingStatus, setPendingStatus] = useState<RsvpInputStatus | null>(null);
   const links = buildEventLinks(event);
   const busy = update.isPending || cancel.isPending;
+  const needsPaymentFor = usePaymentGate(event);
 
-  async function applyRsvp(next: RsvpInputStatus, rsvpComment?: string) {
+  async function applyRsvp(next: RsvpInputStatus, rsvpComment?: string, paidConfirmed?: boolean) {
     setError(null);
     try {
       await update.mutateAsync({
@@ -51,6 +55,7 @@ export function PublicRsvpCard({ token, event, status }: Props) {
         status: next,
         hasPlusOne: false,
         ...(rsvpComment !== undefined ? { comment: rsvpComment } : {}),
+        ...(paidConfirmed ? { paidConfirmed: true } : {}),
       });
       toast.success(UPDATED_TOAST);
     } catch (err) {
@@ -60,6 +65,10 @@ export function PublicRsvpCard({ token, event, status }: Props) {
 
   function changeStatus(next: RsvpInputStatus) {
     if (next === status) return;
+    if (needsPaymentFor(next)) {
+      setPendingStatus(next);
+      return;
+    }
     void applyRsvp(next);
   }
 
@@ -114,16 +123,33 @@ export function PublicRsvpCard({ token, event, status }: Props) {
         {STATUS_LABELS[status] ?? 'your rsvp'}
       </p>
       <div className="flex flex-col gap-3">
-        <RsvpStatusPicker value={status} onSelect={changeStatus} disabled={busy} />
+        {pendingStatus ? (
+          <PaymentConfirmStep
+            event={event}
+            busy={busy}
+            onConfirm={() => {
+              const next = pendingStatus;
+              setPendingStatus(null);
+              void applyRsvp(next, undefined, true);
+            }}
+            onBack={() => {
+              setPendingStatus(null);
+            }}
+          />
+        ) : (
+          <>
+            <RsvpStatusPicker value={status} onSelect={changeStatus} disabled={busy} />
 
-        <RsvpCommentField value={comment} onChange={setComment} disabled={busy} />
-        <Button variant="ghost" onClick={saveComment} disabled={busy || !comment.trim()}>
-          save comment
-        </Button>
+            <RsvpCommentField value={comment} onChange={setComment} disabled={busy} />
+            <Button variant="ghost" onClick={saveComment} disabled={busy || !comment.trim()}>
+              save comment
+            </Button>
 
-        <Button variant="ghost" onClick={() => void cancelRsvp()} disabled={busy}>
-          cancel rsvp
-        </Button>
+            <Button variant="ghost" onClick={() => void cancelRsvp()} disabled={busy}>
+              cancel rsvp
+            </Button>
+          </>
+        )}
 
         {error ? (
           <p role="alert" className="text-destructive text-sm">

--- a/frontend/src/screens/events/PublicRsvpForm.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.test.tsx
@@ -12,6 +12,9 @@ vi.mock('@/api/publicRsvp', () => ({
   useCheckPublicRsvpPhone: () => ({ mutateAsync: checkPhoneMutate, isPending: false }),
 }));
 
+const mockUseFlag = vi.hoisted(() => vi.fn(() => true));
+vi.mock('@/api/featureFlags', () => ({ useFlag: mockUseFlag }));
+
 const navigateMock = vi.fn();
 vi.mock('react-router-dom', async (importOriginal) => {
   const actual = await importOriginal<typeof ReactRouterDom>();
@@ -51,6 +54,8 @@ describe('PublicRsvpForm', () => {
     });
     checkPhoneMutate.mockReset();
     navigateMock.mockReset();
+    mockUseFlag.mockReset();
+    mockUseFlag.mockReturnValue(true);
   });
 
   it('submits the correct payload shape', async () => {
@@ -414,5 +419,83 @@ describe('PublicRsvpForm', () => {
     fireEvent.click(screen.getByRole('button', { name: 'rsvp' }));
     await screen.findByText('invalid phone number');
     expect(submitMutate).not.toHaveBeenCalled();
+  });
+});
+
+describe('PublicRsvpForm payment confirmation gate', () => {
+  const paidEvent = makeEvent({ price: '$10', venmoLink: 'https://venmo.com/u/host' });
+
+  beforeEach(() => {
+    submitMutate.mockReset();
+    submitMutate.mockResolvedValue({
+      event: { id: 'ev1' },
+      rsvp: { status: 'attending', has_plus_one: false },
+    });
+    checkPhoneMutate.mockReset();
+    navigateMock.mockReset();
+    mockUseFlag.mockReset();
+    mockUseFlag.mockReturnValue(true);
+  });
+
+  it('shows the payment step instead of submitting on a paid event', async () => {
+    const onSuccess = vi.fn();
+    renderForm(paidEvent, onSuccess);
+    await fillRequired();
+    fireEvent.click(screen.getByRole('button', { name: 'rsvp' }));
+    expect(await screen.findByRole('button', { name: /yes, i paid/i })).toBeInTheDocument();
+    expect(submitMutate).not.toHaveBeenCalled();
+  });
+
+  it('submits with paid_confirmed after the payment step', async () => {
+    const onSuccess = vi.fn();
+    renderForm(paidEvent, onSuccess);
+    await fillRequired();
+    fireEvent.click(screen.getByRole('button', { name: 'rsvp' }));
+    fireEvent.click(await screen.findByRole('button', { name: /yes, i paid/i }));
+    await waitFor(() => expect(submitMutate).toHaveBeenCalled());
+    expect(submitMutate).toHaveBeenCalledWith({
+      eventId: 'ev1',
+      payload: expect.objectContaining({ status: 'attending', paid_confirmed: true }),
+    });
+    await waitFor(() => expect(onSuccess).toHaveBeenCalled());
+  });
+
+  it('returns to the form from the payment step', async () => {
+    renderForm(paidEvent);
+    await fillRequired();
+    fireEvent.click(screen.getByRole('button', { name: 'rsvp' }));
+    fireEvent.click(await screen.findByRole('button', { name: /back/i }));
+    expect(screen.getByRole('button', { name: 'rsvp' })).toBeInTheDocument();
+    expect(submitMutate).not.toHaveBeenCalled();
+  });
+
+  it('skips the payment step for maybe', async () => {
+    checkPhoneMutate.mockResolvedValue({ status: 'new' });
+    renderForm(paidEvent);
+    fireEvent.click(screen.getByRole('button', { name: 'maybe' }));
+    fireEvent.change(screen.getByLabelText(/phone number/i), {
+      target: { value: '4155550123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'continue' }));
+    await waitFor(() => expect(screen.getByLabelText('first name')).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText('first name'), { target: { value: 'Ada' } });
+    fireEvent.change(screen.getByLabelText('email'), { target: { value: 'ada@example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: 'rsvp' }));
+    await waitFor(() => expect(submitMutate).toHaveBeenCalled());
+  });
+
+  it('skips the payment step on a free event', async () => {
+    renderForm(makeEvent());
+    await fillRequired();
+    fireEvent.click(screen.getByRole('button', { name: 'rsvp' }));
+    await waitFor(() => expect(submitMutate).toHaveBeenCalled());
+  });
+
+  it('skips the payment step when the flag is off', async () => {
+    mockUseFlag.mockReturnValue(false);
+    renderForm(paidEvent);
+    await fillRequired();
+    fireEvent.click(screen.getByRole('button', { name: 'rsvp' }));
+    await waitFor(() => expect(submitMutate).toHaveBeenCalled());
   });
 });

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -39,6 +39,9 @@ interface SubmitError {
 }
 
 function messageForStatus(status: number | null, err: unknown): SubmitError {
+  if (hasErrorCode(err, Code.Event.PaymentConfirmationRequired)) {
+    return { text: 'confirm you paid before rsvping', showSignIn: false };
+  }
   if (hasErrorCode(err, Code.Event.RsvpCouldNotBeCreated)) {
     return {
       text: "we couldn't set up your rsvp with those details — reach out and we'll help",

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -20,8 +20,10 @@ import {
 } from '@/models/event';
 import { optionalEmail, optionalPersonName, personName } from '@/utils/validators';
 
+import { PaymentConfirmStep } from './PaymentConfirmStep';
 import { PublicRsvpPhoneStep } from './PublicRsvpPhoneStep';
 import { RsvpCommentField } from './RsvpCommentField';
+import { usePaymentGate } from './usePaymentGate';
 
 const MAX_NAME = 100;
 const PUBLIC_RSVP_STATUSES: RsvpInputStatus[] = [RsvpStatus.Attending, RsvpStatus.Maybe];
@@ -81,7 +83,9 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
   const [website, setWebsite] = useState('');
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [submitError, setSubmitError] = useState<SubmitError | null>(null);
+  const [showPayment, setShowPayment] = useState(false);
   const submitErrorRef = useRef<HTMLDivElement | null>(null);
+  const needsPaymentFor = usePaymentGate(event);
 
   useEffect(() => {
     if (!submitError) return;
@@ -104,7 +108,7 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
     return Object.keys(next).length === 0;
   }
 
-  async function onSubmit() {
+  async function onSubmit(paidConfirmed: boolean) {
     setSubmitError(null);
     if (!status || !validate()) return;
     try {
@@ -119,13 +123,22 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
           has_plus_one: false,
           comment: comment.trim() || null,
           website,
-          paid_confirmed: false,
+          paid_confirmed: paidConfirmed,
         },
       });
       onSuccess(result);
     } catch (err) {
       setSubmitError(messageForStatus(getApiStatus(err), err));
     }
+  }
+
+  function handleSubmitClick() {
+    if (!status || !validate()) return;
+    if (needsPaymentFor(status)) {
+      setShowPayment(true);
+      return;
+    }
+    void onSubmit(false);
   }
 
   function renderStep() {
@@ -179,11 +192,25 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
         />
       );
     }
+    if (showPayment) {
+      return (
+        <PaymentConfirmStep
+          event={event}
+          busy={submit.isPending}
+          onConfirm={() => {
+            void onSubmit(true);
+          }}
+          onBack={() => {
+            setShowPayment(false);
+          }}
+        />
+      );
+    }
     return (
       <form
         onSubmit={(e) => {
           e.preventDefault();
-          void onSubmit();
+          handleSubmitClick();
         }}
         className="flex flex-col gap-4"
         noValidate
@@ -244,7 +271,7 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
           value={comment}
           onChange={setComment}
           disabled={submit.isPending}
-          onSubmitShortcut={() => void onSubmit()}
+          onSubmitShortcut={handleSubmitClick}
         />
 
         <Button type="submit" disabled={submit.isPending} fullWidth>

--- a/frontend/src/screens/events/PublicRsvpSection.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpSection.test.tsx
@@ -15,6 +15,8 @@ vi.mock('react-router-dom', async (importActual) => {
 
 const mockSubmit = vi.fn();
 const mockCheckPhone = vi.fn();
+vi.mock('@/api/featureFlags', () => ({ useFlag: () => false }));
+
 vi.mock('@/api/publicRsvp', () => ({
   useSubmitPublicRsvp: () => ({ mutateAsync: mockSubmit, isPending: false }),
   useCheckPublicRsvpPhone: () => ({ mutateAsync: mockCheckPhone, isPending: false }),

--- a/frontend/src/screens/events/PublicRsvpsScreen.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpsScreen.test.tsx
@@ -30,6 +30,8 @@ vi.mock('@/api/publicRsvp', () => ({
   useResendPublicRsvpManageLink: () => useResendPublicRsvpManageLink() as unknown,
 }));
 
+vi.mock('@/api/featureFlags', () => ({ useFlag: () => false }));
+
 // jsdom's default Storage isn't wired up for get/set round-trips — stub a real one.
 const storageMock = (() => {
   let store: Record<string, string> = {};

--- a/frontend/src/screens/events/RsvpBox.test.tsx
+++ b/frontend/src/screens/events/RsvpBox.test.tsx
@@ -1,9 +1,25 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
+import type { Event } from '@/models/event';
 import { RsvpStatus } from '@/models/event';
 
 import { RsvpBox } from './RsvpBox';
+
+const mockUseFlag = vi.hoisted(() => vi.fn(() => true));
+vi.mock('@/api/featureFlags', () => ({ useFlag: mockUseFlag }));
+
+function freeEvent(overrides: Partial<Event> = {}): Event {
+  return {
+    price: '',
+    venmoLink: '',
+    cashappLink: '',
+    zelleInfo: '',
+    myPaidConfirmed: false,
+    ...overrides,
+  } as Event;
+}
 
 const base = {
   open: true,
@@ -11,6 +27,7 @@ const base = {
   initialHasPlusOne: false,
   allowPlusOnes: true,
   onClose: () => {},
+  event: freeEvent(),
 };
 
 describe('RsvpBox', () => {
@@ -150,5 +167,78 @@ describe('RsvpBox', () => {
     expect(onConfirm).toHaveBeenCalledWith(
       expect.objectContaining({ status: RsvpStatus.Attending }),
     );
+  });
+});
+
+describe('RsvpBox payment confirmation gate', () => {
+  const paidEvent = freeEvent({ price: '$10', venmoLink: 'https://venmo.com/u/host' });
+
+  it('shows the payment step before confirming attending on a paid event', async () => {
+    const onConfirm = vi.fn();
+    render(<RsvpBox {...base} event={paidEvent} mode="create" onConfirm={onConfirm} />);
+    await userEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: /yes, i paid/i })).toBeInTheDocument();
+  });
+
+  it('submits with paidConfirmed after the payment step', async () => {
+    const onConfirm = vi.fn();
+    render(<RsvpBox {...base} event={paidEvent} mode="create" onConfirm={onConfirm} />);
+    await userEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
+    await userEvent.click(screen.getByRole('button', { name: /yes, i paid/i }));
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ status: RsvpStatus.Attending, paidConfirmed: true }),
+    );
+  });
+
+  it('skips the payment step for maybe', async () => {
+    const onConfirm = vi.fn();
+    render(
+      <RsvpBox
+        {...base}
+        event={paidEvent}
+        mode="create"
+        initialStatus={RsvpStatus.Maybe}
+        onConfirm={onConfirm}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it('skips the payment step on a free event', async () => {
+    const onConfirm = vi.fn();
+    render(<RsvpBox {...base} mode="create" onConfirm={onConfirm} />);
+    await userEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it('skips the payment step when the flag is off', async () => {
+    mockUseFlag.mockReturnValueOnce(false);
+    const onConfirm = vi.fn();
+    render(<RsvpBox {...base} event={paidEvent} mode="create" onConfirm={onConfirm} />);
+    await userEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it('skips the payment step when the viewer already confirmed', async () => {
+    const onConfirm = vi.fn();
+    render(
+      <RsvpBox
+        {...base}
+        event={freeEvent({ ...paidEvent, myPaidConfirmed: true })}
+        mode="edit"
+        onConfirm={onConfirm}
+      />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it('returns to the picker from the payment step', async () => {
+    render(<RsvpBox {...base} event={paidEvent} mode="create" onConfirm={vi.fn()} />);
+    await userEvent.click(screen.getByRole('button', { name: /^confirm$/i }));
+    await userEvent.click(screen.getByRole('button', { name: /back/i }));
+    expect(screen.getByRole('button', { name: /^confirm$/i })).toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/events/RsvpBox.tsx
+++ b/frontend/src/screens/events/RsvpBox.tsx
@@ -3,19 +3,23 @@ import { useState } from 'react';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import { RsvpStatusPicker } from '@/components/ui/RsvpStatusPicker';
-import { type RsvpInputStatus, RsvpStatus } from '@/models/event';
+import { type Event, type RsvpInputStatus, RsvpStatus } from '@/models/event';
 
+import { PaymentConfirmStep } from './PaymentConfirmStep';
 import { RsvpCommentField } from './RsvpCommentField';
+import { usePaymentGate } from './usePaymentGate';
 
 interface ConfirmArgs {
   status: RsvpInputStatus;
   comment?: string;
   hasPlusOne: boolean;
+  paidConfirmed?: boolean;
 }
 
 interface Props {
   open: boolean;
   mode: 'create' | 'edit';
+  event: Event;
   initialStatus: RsvpInputStatus;
   initialHasPlusOne: boolean;
   allowPlusOnes: boolean;
@@ -30,6 +34,7 @@ interface Props {
 export function RsvpBox({
   open,
   mode,
+  event,
   initialStatus,
   initialHasPlusOne,
   allowPlusOnes,
@@ -43,65 +48,89 @@ export function RsvpBox({
   const [status, setStatus] = useState<RsvpInputStatus>(initialStatus);
   const [comment, setComment] = useState('');
   const [hasPlusOne, setHasPlusOne] = useState(initialHasPlusOne);
+  const [showPayment, setShowPayment] = useState(false);
+  const needsPaymentFor = usePaymentGate(event);
 
   const showComment = allowComment ?? mode === 'create';
   const showPlusOne = allowPlusOnes;
   const joiningWaitlist = status === RsvpStatus.Attending && atCapacity;
 
-  function confirm() {
+  function submit(paidConfirmed: boolean) {
     const trimmed = comment.trim();
     const args: ConfirmArgs = { status, hasPlusOne };
     if (showComment && trimmed) args.comment = trimmed;
+    if (paidConfirmed) args.paidConfirmed = true;
     onConfirm(args);
+  }
+
+  function confirm() {
+    if (needsPaymentFor(status)) {
+      setShowPayment(true);
+      return;
+    }
+    submit(false);
   }
 
   return (
     <Dialog open={open} onClose={onClose} title="rsvp">
-      <div className="flex flex-col gap-4">
-        <RsvpStatusPicker
-          value={status}
-          onSelect={setStatus}
-          disabled={busy}
-          labelFor={(s, defaultLabel) =>
-            s === RsvpStatus.Attending && atCapacity ? 'join the waitlist' : defaultLabel
-          }
+      {showPayment ? (
+        <PaymentConfirmStep
+          event={event}
+          busy={busy}
+          onConfirm={() => {
+            submit(true);
+          }}
+          onBack={() => {
+            setShowPayment(false);
+          }}
         />
+      ) : (
+        <div className="flex flex-col gap-4">
+          <RsvpStatusPicker
+            value={status}
+            onSelect={setStatus}
+            disabled={busy}
+            labelFor={(s, defaultLabel) =>
+              s === RsvpStatus.Attending && atCapacity ? 'join the waitlist' : defaultLabel
+            }
+          />
 
-        {showPlusOne ? (
-          <div className="flex justify-center">
-            <Button
-              type="button"
-              variant={hasPlusOne ? 'primary' : 'secondary'}
-              onClick={() => {
-                setHasPlusOne(!hasPlusOne);
-              }}
-              disabled={busy}
-            >
-              {hasPlusOne ? 'remove +1' : 'add +1'}
-            </Button>
-          </div>
-        ) : null}
+          {showPlusOne ? (
+            <div className="flex justify-center">
+              <Button
+                type="button"
+                variant={hasPlusOne ? 'primary' : 'secondary'}
+                onClick={() => {
+                  setHasPlusOne(!hasPlusOne);
+                }}
+                disabled={busy}
+              >
+                {hasPlusOne ? 'remove +1' : 'add +1'}
+              </Button>
+            </div>
+          ) : null}
 
-        {showComment ? <RsvpCommentField value={comment} onChange={setComment} /> : null}
+          {showComment ? <RsvpCommentField value={comment} onChange={setComment} /> : null}
 
-        <div className="flex items-center justify-between gap-2">
-          {mode === 'edit' && onRemove ? (
-            <Button type="button" variant="secondary" onClick={onRemove} disabled={busy}>
-              remove rsvp
-            </Button>
-          ) : (
-            <span />
-          )}
-          <div className="flex justify-end gap-2">
-            <Button type="button" variant="secondary" onClick={onClose} disabled={busy}>
-              cancel
-            </Button>
-            <Button type="button" onClick={confirm} disabled={busy}>
-              {confirmLabel(mode, joiningWaitlist)}
-            </Button>
+          <div className="flex items-center justify-between gap-2">
+            {mode === 'edit' && onRemove ? (
+              <Button type="button" variant="secondary" onClick={onRemove} disabled={busy}>
+                remove rsvp
+              </Button>
+            ) : (
+              <span />
+            )}
+            <div className="flex justify-end gap-2">
+              <Button type="button" variant="secondary" onClick={onClose} disabled={busy}>
+                cancel
+              </Button>
+              <Button type="button" onClick={confirm} disabled={busy}>
+                {confirmLabel(mode, joiningWaitlist)}
+              </Button>
+            </div>
           </div>
         </div>
-      </div>
+      )}
     </Dialog>
   );
 }

--- a/frontend/src/screens/events/RsvpGuestList.tsx
+++ b/frontend/src/screens/events/RsvpGuestList.tsx
@@ -162,6 +162,7 @@ export function InvitedList({ event }: { event: Event }) {
               hasPlusOne: false,
               attendance: AttendanceStatus.Unknown,
               isMember: true,
+              paidConfirmed: false,
             }}
           />
         );

--- a/frontend/src/screens/events/usePaymentGate.test.ts
+++ b/frontend/src/screens/events/usePaymentGate.test.ts
@@ -1,0 +1,63 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Event } from '@/models/event';
+import { RsvpStatus } from '@/models/event';
+
+import { usePaymentGate } from './usePaymentGate';
+
+const mockUseFlag = vi.hoisted(() => vi.fn());
+vi.mock('@/api/featureFlags', () => ({ useFlag: mockUseFlag }));
+
+function makeEvent(overrides: Partial<Event> = {}): Event {
+  return {
+    price: '$10',
+    venmoLink: 'https://venmo.com/u/host',
+    cashappLink: '',
+    zelleInfo: '',
+    myPaidConfirmed: false,
+    ...overrides,
+  } as Event;
+}
+
+describe('usePaymentGate', () => {
+  beforeEach(() => {
+    mockUseFlag.mockReset();
+  });
+
+  it('gates attending on a paid event when the flag is on', () => {
+    mockUseFlag.mockReturnValue(true);
+    const { result } = renderHook(() => usePaymentGate(makeEvent()));
+    expect(result.current(RsvpStatus.Attending)).toBe(true);
+  });
+
+  it('does not gate when the flag is off', () => {
+    mockUseFlag.mockReturnValue(false);
+    const { result } = renderHook(() => usePaymentGate(makeEvent()));
+    expect(result.current(RsvpStatus.Attending)).toBe(false);
+  });
+
+  it('does not gate maybe', () => {
+    mockUseFlag.mockReturnValue(true);
+    const { result } = renderHook(() => usePaymentGate(makeEvent()));
+    expect(result.current(RsvpStatus.Maybe)).toBe(false);
+  });
+
+  it('does not gate cant go', () => {
+    mockUseFlag.mockReturnValue(true);
+    const { result } = renderHook(() => usePaymentGate(makeEvent()));
+    expect(result.current(RsvpStatus.CantGo)).toBe(false);
+  });
+
+  it('does not gate a free event', () => {
+    mockUseFlag.mockReturnValue(true);
+    const { result } = renderHook(() => usePaymentGate(makeEvent({ price: '', venmoLink: '' })));
+    expect(result.current(RsvpStatus.Attending)).toBe(false);
+  });
+
+  it('does not gate a viewer who has already confirmed payment', () => {
+    mockUseFlag.mockReturnValue(true);
+    const { result } = renderHook(() => usePaymentGate(makeEvent({ myPaidConfirmed: true })));
+    expect(result.current(RsvpStatus.Attending)).toBe(false);
+  });
+});

--- a/frontend/src/screens/events/usePaymentGate.ts
+++ b/frontend/src/screens/events/usePaymentGate.ts
@@ -1,0 +1,13 @@
+import { useFlag } from '@/api/featureFlags';
+import { type Event, type RsvpInputStatus, RsvpStatus } from '@/models/event';
+import { Feature } from '@/models/featureFlags';
+import { eventRequiresPaymentConfirmation } from '@/utils/eventCost';
+
+export function usePaymentGate(event: Event) {
+  const flagOn = useFlag(Feature.EventPaymentConfirmation);
+  return (status: RsvpInputStatus) =>
+    flagOn &&
+    status === RsvpStatus.Attending &&
+    !event.myPaidConfirmed &&
+    eventRequiresPaymentConfirmation(event);
+}

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -25,6 +25,7 @@ export function makeGuest(overrides: Partial<EventGuest> = {}): EventGuest {
     hasPlusOne: false,
     attendance: AttendanceStatus.Unknown,
     isMember: true,
+    paidConfirmed: false,
     ...overrides,
   };
 }
@@ -72,6 +73,7 @@ export function makeEvent(overrides: Partial<Event> = {}): Event {
         hasPlusOne: false,
         attendance: AttendanceStatus.Unknown,
         isMember: true,
+        paidConfirmed: false,
       },
       {
         userId: 'b',
@@ -82,9 +84,11 @@ export function makeEvent(overrides: Partial<Event> = {}): Event {
         hasPlusOne: false,
         isMember: true,
         attendance: AttendanceStatus.Unknown,
+        paidConfirmed: false,
       },
     ],
     myRsvp: null,
+    myPaidConfirmed: false,
     viewerUserId: null,
     surveySlugs: [],
     invitedUserIds: [],

--- a/frontend/src/utils/eventCost.test.ts
+++ b/frontend/src/utils/eventCost.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import type { Event } from '@/models/event';
+
+import { eventRequiresPaymentConfirmation, formatPrice } from './eventCost';
+
+function makeEvent(overrides: Partial<Event> = {}): Event {
+  return {
+    price: '$10',
+    venmoLink: 'https://venmo.com/u/host',
+    cashappLink: '',
+    zelleInfo: '',
+    ...overrides,
+  } as Event;
+}
+
+describe('eventRequiresPaymentConfirmation', () => {
+  it('requires confirmation with a price and venmo', () => {
+    expect(eventRequiresPaymentConfirmation(makeEvent())).toBe(true);
+  });
+
+  it('requires confirmation with a price and cashapp', () => {
+    const event = makeEvent({ venmoLink: '', cashappLink: 'https://cash.app/$host' });
+    expect(eventRequiresPaymentConfirmation(event)).toBe(true);
+  });
+
+  it('requires confirmation with a price and zelle', () => {
+    const event = makeEvent({ venmoLink: '', zelleInfo: 'host@example.com' });
+    expect(eventRequiresPaymentConfirmation(event)).toBe(true);
+  });
+
+  it('does not require confirmation with a price but no payment method', () => {
+    expect(eventRequiresPaymentConfirmation(makeEvent({ venmoLink: '' }))).toBe(false);
+  });
+
+  it('does not require confirmation with a payment method but no price', () => {
+    expect(eventRequiresPaymentConfirmation(makeEvent({ price: '' }))).toBe(false);
+  });
+
+  it('treats a whitespace-only price as no price', () => {
+    expect(eventRequiresPaymentConfirmation(makeEvent({ price: '   ' }))).toBe(false);
+  });
+
+  it('treats a whitespace-only payment method as absent', () => {
+    expect(eventRequiresPaymentConfirmation(makeEvent({ venmoLink: '  ' }))).toBe(false);
+  });
+});
+
+describe('formatPrice', () => {
+  it('prefixes a bare number with a dollar sign', () => {
+    expect(formatPrice('10')).toBe('$10');
+  });
+
+  it('leaves an existing dollar sign alone', () => {
+    expect(formatPrice('$10')).toBe('$10');
+  });
+
+  it('passes non-numeric text through as written', () => {
+    expect(formatPrice('sliding scale')).toBe('sliding scale');
+  });
+
+  it('returns empty for blank input', () => {
+    expect(formatPrice('   ')).toBe('');
+  });
+});

--- a/frontend/src/utils/eventCost.ts
+++ b/frontend/src/utils/eventCost.ts
@@ -1,0 +1,19 @@
+import type { Event } from '@/models/event';
+
+export function eventRequiresPaymentConfirmation(event: Event): boolean {
+  const hasPrice = event.price.trim().length > 0;
+  const hasPaymentMethod = [event.venmoLink, event.cashappLink, event.zelleInfo].some(
+    (value) => value.trim().length > 0,
+  );
+  return hasPrice && hasPaymentMethod;
+}
+
+// A bare number gets a "$" prefix unless the user already typed one.
+// Anything else (e.g. "sliding scale") passes through as-written.
+export function formatPrice(price: string): string {
+  const trimmed = price.trim();
+  if (!trimmed) return trimmed;
+  if (/^\$/.test(trimmed)) return trimmed;
+  if (/^\d/.test(trimmed)) return `$${trimmed}`;
+  return trimmed;
+}


### PR DESCRIPTION
## Overview

Frontend half of the payment-confirmation gate for Issue 1045 — the last piece of the backend stack (#1213, #1227, #1228, #1232) merged to `main`, so this branches directly off it.

**Ships dark alongside the backend.** `EVENT_PAYMENT_CONFIRMATION` defaults `False`; every gate here checks it via `useFlag(Feature.EventPaymentConfirmation)` before showing the payment step, so merging changes nothing until the flag is toggled.

### What's here

- **Model + mapper** — `Event.myPaidConfirmed`, `EventGuest.paidConfirmed` mapped from the backend's `my_paid_confirmed`/`paid_confirmed`. The hand-maintained `WireEvent`/`WireGuest` types in `eventMapper.ts` needed the fields added by hand (they aren't OpenAPI-generated).
- **`eventCost.ts`** — `eventRequiresPaymentConfirmation()` (price + at least one payment method), and `formatPrice()` moved here from `EventMemberSection.tsx` so both the cost card and the new payment step share it.
- **`usePaymentGate(event)`** — one hook, reused by all three surfaces: flag on AND status is attending AND event costs money AND the viewer hasn't already confirmed.
- **`PaymentConfirmStep`** — shared UI: price, normalized venmo/cashapp links (via the existing `toVenmoUrl`/`toCashAppUrl` handle normalizers — a bare `@handle` needs converting, plain `ensureHttps` isn't enough), zelle as text, confirm/back.
- **Three gate wirings**, matching the four-surface bypass map from the original exploration:
  - `RsvpBox` — member + token-holder create/edit dialog
  - `PublicRsvpForm` — brand-new person's step machine
  - `PublicRsvpCard` — token holder's quick-edit, which fires its mutation immediately with **no dialog at all** today. This was the one the original issue text didn't mention and would've stayed a silent bypass.
- **Error copy** for `event.payment_confirmation_required` on all three surfaces, for the stale-client case.

### Notes for review

- `RsvpBox` and `PublicRsvpCard` both had a hardcoded `paid_confirmed: false` / `paid_confirmed: false` already in their mutation call — leftover stubs from earlier work on this stack that would have silently defeated confirmation on those paths. Fixed as part of threading the real value through.
- Rebuilt this branch's history once: it was originally stacked on the backend branch pre-merge, and rebasing onto `origin/main` post-squash-merge produced bogus conflicts in backend files I never touched (the same content reapplying against itself). Reset to `origin/main` and cherry-picked the 10 real frontend commits instead — diff is frontend-only, verified via `git diff origin/main --stat`.
- Running the full test suite (not just changed files) surfaced 4 test files that render `PublicRsvpCard`/`PublicRsvpForm` without a `QueryClientProvider` and without mocking `@/api/featureFlags` — `usePaymentGate`'s `useFlag` call threw `No QueryClient set`. Fixed by mocking the flag off in those files, consistent with how every other test in this PR mocks it.

Part of Issue 1045.

## Test plan

- [x] New coverage: `eventMapper`, `eventCost`, `usePaymentGate`, `PaymentConfirmStep`, plus gate-specific describe blocks in `RsvpBox`, `PublicRsvpForm`, `PublicRsvpCard` — free event / paid event / flag-off / already-confirmed / non-attending-status all covered per surface
- [x] Full frontend suite: **138 files, 1128 tests passing**, 1 pre-existing skip
- [x] `pnpm tsc -b --noEmit` clean (project-references-aware; the bare `tsc --noEmit` silently skips `src/test/**` and `*.test.tsx` and would have missed several of the wire-type fixes below)
- [x] `make agent-frontend-lint`, `make agent-frontend-format-check` clean
- [x] Verified `git diff origin/main --stat` touches only `frontend/` — no backend files carried over from the rebuild
