### PR TITLE
feat: 1045 - payment confirmation frontend foundation (1/2)

### DIFF
--- a/frontend/src/api/eventMapper.test.ts
+++ b/frontend/src/api/eventMapper.test.ts
@@ -37,8 +37,8 @@ describe('mapEvent', () => {
         ],
       }),
     );
-    expect(result.guests[0].paidConfirmed).toBe(true);
-    expect(result.guests[1].paidConfirmed).toBe(false);
+    expect(result.guests[0]!.paidConfirmed).toBe(true);
+    expect(result.guests[1]!.paidConfirmed).toBe(false);
   });
 
   it('converts ISO start_datetime to Date', () => {

--- a/frontend/src/api/eventMapper.test.ts
+++ b/frontend/src/api/eventMapper.test.ts
@@ -20,6 +20,27 @@ describe('mapEvent', () => {
     expect(result.startDatetime!.getUTCHours()).toBe(18);
   });
 
+  it('maps my_paid_confirmed', () => {
+    expect(mapEvent(wireEvent({ my_paid_confirmed: true })).myPaidConfirmed).toBe(true);
+  });
+
+  it('defaults myPaidConfirmed to false when absent', () => {
+    expect(mapEvent(wireEvent()).myPaidConfirmed).toBe(false);
+  });
+
+  it('maps paid_confirmed on guests', () => {
+    const result = mapEvent(
+      wireEvent({
+        guests: [
+          { user_id: 'u1', name: 'Paid Guest', status: 'attending', paid_confirmed: true },
+          { user_id: 'u2', name: 'Unpaid Guest', status: 'attending' },
+        ],
+      }),
+    );
+    expect(result.guests[0].paidConfirmed).toBe(true);
+    expect(result.guests[1].paidConfirmed).toBe(false);
+  });
+
   it('converts ISO start_datetime to Date', () => {
     const result = mapEvent(wireEvent({ start_datetime: '2026-01-05T09:05:03Z' }));
     expect(result.startDatetime!.getUTCFullYear()).toBe(2026);

--- a/frontend/src/api/eventMapper.ts
+++ b/frontend/src/api/eventMapper.ts
@@ -109,6 +109,7 @@ function mapGuest(g: WireGuest): EventGuest {
     hasPlusOne: g.has_plus_one ?? false,
     attendance: mapAttendance(g.attendance),
     isMember: g.is_member ?? true,
+    paidConfirmed: g.paid_confirmed ?? false,
   };
 }
 
@@ -167,6 +168,7 @@ export function mapEvent(e: WireEvent): Event {
 
     guests: (e.guests ?? []).map(mapGuest),
     myRsvp: e.my_rsvp ?? null,
+    myPaidConfirmed: e.my_paid_confirmed ?? false,
     viewerUserId: e.viewer_user_id ?? null,
     surveySlugs: e.survey_slugs ?? [],
     invitedUserIds: e.invited_user_ids ?? [],

--- a/frontend/src/api/eventMapper.ts
+++ b/frontend/src/api/eventMapper.ts
@@ -16,6 +16,7 @@ interface WireGuest {
   has_plus_one?: boolean;
   attendance?: string;
   is_member?: boolean;
+  paid_confirmed?: boolean;
 }
 
 export interface WireEvent {
@@ -58,6 +59,7 @@ export interface WireEvent {
 
   guests?: WireGuest[];
   my_rsvp?: string | null;
+  my_paid_confirmed?: boolean;
   viewer_user_id?: string | null;
   survey_slugs?: string[];
   invited_user_ids?: string[];

--- a/frontend/src/api/publicRsvp.ts
+++ b/frontend/src/api/publicRsvp.ts
@@ -108,6 +108,7 @@ interface UpdateArgs {
   status: RsvpInputStatus;
   hasPlusOne: boolean;
   comment?: string;
+  paidConfirmed?: boolean;
 }
 
 function useManageInvalidate(token: string) {
@@ -125,12 +126,12 @@ function useManageInvalidate(token: string) {
 export function useUpdatePublicMyRsvp(token: string) {
   const invalidate = useManageInvalidate(token);
   return useMutation({
-    mutationFn: async ({ eventId, status, hasPlusOne, comment }: UpdateArgs) => {
+    mutationFn: async ({ eventId, status, hasPlusOne, comment, paidConfirmed }: UpdateArgs) => {
       const body: PublicRsvpManageIn = {
         status,
         has_plus_one: hasPlusOne,
         comment: comment ?? null,
-        paid_confirmed: false,
+        paid_confirmed: paidConfirmed ?? false,
       };
       const { data } = await apiClient.post<PublicRsvpOut>(`${MANAGE_BASE}${eventId}/`, body, {
         params: { token },

--- a/frontend/src/api/rsvp.ts
+++ b/frontend/src/api/rsvp.ts
@@ -19,6 +19,7 @@ interface SetRsvpArgs {
   // Not persisted server-side — a non-empty comment is posted once, as a
   // public EventComment or a host-only decline notification.
   comment?: string;
+  paidConfirmed?: boolean;
 }
 
 function updateCaches(qc: ReturnType<typeof useQueryClient>, event: Event, isAuthed: boolean) {
@@ -35,11 +36,18 @@ export function useSetRsvp() {
   const qc = useQueryClient();
   const isAuthed = useAuthStore((s) => s.status === 'authed');
   return useMutation({
-    mutationFn: async ({ eventId, status, hasPlusOne = false, comment }: SetRsvpArgs) => {
+    mutationFn: async ({
+      eventId,
+      status,
+      hasPlusOne = false,
+      comment,
+      paidConfirmed,
+    }: SetRsvpArgs) => {
       const { data } = await apiClient.post<WireEvent>(`/api/community/events/${eventId}/rsvp/`, {
         status,
         has_plus_one: hasPlusOne,
         ...(comment === undefined ? {} : { comment }),
+        ...(paidConfirmed ? { paid_confirmed: true } : {}),
       });
       return mapEvent(data);
     },

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -84,6 +84,7 @@ export interface EventGuest {
   hasPlusOne: boolean;
   attendance: AttendanceStatusValue;
   isMember: boolean;
+  paidConfirmed: boolean;
 }
 
 export interface EventCancellation {
@@ -150,9 +151,7 @@ export interface Event {
 
   guests: EventGuest[];
   myRsvp: string | null;
-  // The resolved viewer's own user id — carried from the backend so a
-  // token-holding (logged-out) viewer can find their own entry in `guests`,
-  // since useAuthStore has no user for them.
+  myPaidConfirmed: boolean;
   viewerUserId: string | null;
   surveySlugs: string[];
   invitedUserIds: string[];

--- a/frontend/src/screens/events/AddCoHostDialog.test.tsx
+++ b/frontend/src/screens/events/AddCoHostDialog.test.tsx
@@ -1,8 +1,7 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import type { Event } from '@/models/event';
-import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
+import { makeEvent } from '@/test/fixtures';
 
 const updateMutateAsync = vi.fn();
 
@@ -22,46 +21,17 @@ vi.mock('@/api/userSearch', () => ({
 
 import { AddCoHostDialog } from './AddCoHostDialog';
 
-const BASE_EVENT: Event = {
+const BASE_EVENT = makeEvent({
   id: 'ev1',
   slug: 'spring-potluck',
   title: 'Spring Potluck',
-  description: '',
   startDatetime: new Date('2099-06-01T18:00:00Z'),
-  endDatetime: null,
-  location: '',
-  latitude: null,
-  longitude: null,
-  whatsappLink: '',
-  partifulLink: '',
-  otherLink: '',
-  venmoLink: '',
-  cashappLink: '',
-  zelleInfo: '',
-  price: '',
   rsvpEnabled: false,
-  allowPlusOnes: false,
-  maxAttendees: null,
   attendingCount: 0,
-  waitlistedCount: 0,
-  invitedCount: 0,
-  datetimeTbd: false,
-  hasPoll: false,
-  datetimePollSlug: null,
   createdById: 'user-creator',
   createdByName: 'Alice',
-  createdByPhotoUrl: '',
   coHostIds: ['user-creator', 'user-accepted'],
-  coHostNames: [],
-  coHostPhotoUrls: [],
   guests: [],
-  myRsvp: null,
-  viewerUserId: null,
-  surveySlugs: [],
-  invitedUserIds: [],
-  invitedUserNames: [],
-  invitedUserPhotoUrls: [],
-  invitePermission: InvitePermission.AllMembers,
   pendingCohostInvites: [
     {
       id: 'inv1',
@@ -71,15 +41,7 @@ const BASE_EVENT: Event = {
       invitedAt: new Date(),
     },
   ],
-  myPendingCohostInviteId: null,
-  eventType: EventType.Community,
-  visibility: EventVisibility.Public,
-  photoUrl: '',
-  photoUpdatedAt: null,
-  tags: [],
-  isPast: false,
-  status: EventStatus.Active,
-};
+});
 
 describe('AddCoHostDialog', () => {
   it('excludes members with a pending cohost invite from search results', () => {

--- a/frontend/src/screens/events/EmailBlastDialog.test.tsx
+++ b/frontend/src/screens/events/EmailBlastDialog.test.tsx
@@ -4,7 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { Event, EventGuest } from '@/models/event';
-import { makeEvent as makeEventFixture } from '@/test/fixtures';
+import { makeEvent as makeEventFixture, makeGuest } from '@/test/fixtures';
 
 const mutateAsyncMock = vi.fn();
 const toastSuccessMock = vi.fn();
@@ -28,16 +28,7 @@ vi.mock('sonner', () => ({
 import { EmailBlastDialog } from './EmailBlastDialog';
 
 function guest(status: string, i: number): EventGuest {
-  return {
-    userId: `u${String(i)}`,
-    name: `Guest ${String(i)}`,
-    status,
-    phone: null,
-    photoUrl: '',
-    hasPlusOne: false,
-    attendance: 'unknown',
-    isMember: true,
-  };
+  return makeGuest({ userId: `u${String(i)}`, name: `Guest ${String(i)}`, status });
 }
 
 function makeEvent(guests: EventGuest[]): Event {

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -5,6 +5,7 @@ import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import type { Event } from '@/models/event';
 import { spotsLeft } from '@/models/event';
+import { formatPrice } from '@/utils/eventCost';
 import { buildEventLinks } from '@/utils/eventLinks';
 import { ensureHttps } from '@/utils/url';
 
@@ -190,17 +191,6 @@ export function CostSection({ event }: { event: Event }) {
       </ul>
     </Card>
   );
-}
-
-// "free" stays bare. Anything that starts with a digit gets "$" prepended
-// unless the user already typed one. Anything else (e.g. "sliding scale")
-// passes through as-written.
-function formatPrice(price: string): string {
-  const trimmed = price.trim();
-  if (!trimmed) return trimmed;
-  if (/^\$/.test(trimmed)) return trimmed;
-  if (/^\d/.test(trimmed)) return `$${trimmed}`;
-  return trimmed;
 }
 
 function InviteSection({ event }: { event: Event }) {

--- a/frontend/src/screens/events/PaymentConfirmStep.test.tsx
+++ b/frontend/src/screens/events/PaymentConfirmStep.test.tsx
@@ -2,19 +2,9 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
-import { makeEvent } from '@/test/fixtures';
+import { makePaidEvent } from '@/test/fixtures';
 
 import { PaymentConfirmStep } from './PaymentConfirmStep';
-
-function makePaidEvent(overrides: Parameters<typeof makeEvent>[0] = {}) {
-  return makeEvent({
-    price: '$10',
-    venmoLink: 'https://venmo.com/u/host',
-    cashappLink: '',
-    zelleInfo: '',
-    ...overrides,
-  });
-}
 
 describe('PaymentConfirmStep', () => {
   it('shows the price', () => {

--- a/frontend/src/screens/events/PaymentConfirmStep.test.tsx
+++ b/frontend/src/screens/events/PaymentConfirmStep.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { makeEvent } from '@/test/fixtures';
+
+import { PaymentConfirmStep } from './PaymentConfirmStep';
+
+function makePaidEvent(overrides: Parameters<typeof makeEvent>[0] = {}) {
+  return makeEvent({
+    price: '$10',
+    venmoLink: 'https://venmo.com/u/host',
+    cashappLink: '',
+    zelleInfo: '',
+    ...overrides,
+  });
+}
+
+describe('PaymentConfirmStep', () => {
+  it('shows the price', () => {
+    render(<PaymentConfirmStep event={makePaidEvent()} onConfirm={vi.fn()} onBack={vi.fn()} />);
+    expect(screen.getByText(/\$10/)).toBeInTheDocument();
+  });
+
+  it('renders a venmo link', () => {
+    render(<PaymentConfirmStep event={makePaidEvent()} onConfirm={vi.fn()} onBack={vi.fn()} />);
+    expect(screen.getByRole('link', { name: /venmo/i })).toHaveAttribute(
+      'href',
+      'https://venmo.com/u/host',
+    );
+  });
+
+  it('normalizes a bare venmo handle into a url', () => {
+    render(
+      <PaymentConfirmStep
+        event={makePaidEvent({ venmoLink: '@host' })}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('link', { name: /venmo/i })).toHaveAttribute(
+      'href',
+      'https://venmo.com/u/host',
+    );
+  });
+
+  it('normalizes a bare cashapp handle into a url', () => {
+    render(
+      <PaymentConfirmStep
+        event={makePaidEvent({ venmoLink: '', cashappLink: '$host' })}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('link', { name: /cashapp/i })).toHaveAttribute(
+      'href',
+      'https://cash.app/$host',
+    );
+  });
+
+  it('renders zelle info as text, not a link', () => {
+    render(
+      <PaymentConfirmStep
+        event={makePaidEvent({ venmoLink: '', zelleInfo: 'host@example.com' })}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/host@example\.com/)).toBeInTheDocument();
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+  });
+
+  it('calls onConfirm when the confirm button is clicked', async () => {
+    const onConfirm = vi.fn();
+    render(<PaymentConfirmStep event={makePaidEvent()} onConfirm={onConfirm} onBack={vi.fn()} />);
+    await userEvent.click(screen.getByRole('button', { name: /yes, i paid/i }));
+    expect(onConfirm).toHaveBeenCalledOnce();
+  });
+
+  it('calls onBack when the back button is clicked', async () => {
+    const onBack = vi.fn();
+    render(<PaymentConfirmStep event={makePaidEvent()} onConfirm={vi.fn()} onBack={onBack} />);
+    await userEvent.click(screen.getByRole('button', { name: /back/i }));
+    expect(onBack).toHaveBeenCalledOnce();
+  });
+
+  it('disables both buttons while busy', () => {
+    render(
+      <PaymentConfirmStep event={makePaidEvent()} busy onConfirm={vi.fn()} onBack={vi.fn()} />,
+    );
+    expect(screen.getByRole('button', { name: /yes, i paid/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /back/i })).toBeDisabled();
+  });
+});

--- a/frontend/src/screens/events/PaymentConfirmStep.tsx
+++ b/frontend/src/screens/events/PaymentConfirmStep.tsx
@@ -1,0 +1,57 @@
+import { Button } from '@/components/ui/Button';
+import type { Event } from '@/models/event';
+import { formatPrice } from '@/utils/eventCost';
+import { toCashAppUrl, toVenmoUrl } from '@/utils/paymentHandle';
+
+interface Props {
+  event: Event;
+  busy?: boolean;
+  onConfirm: () => void;
+  onBack: () => void;
+}
+
+export function PaymentConfirmStep({ event, busy = false, onConfirm, onBack }: Props) {
+  const links: { label: string; url?: string }[] = [];
+  if (event.venmoLink) links.push({ label: 'venmo', url: toVenmoUrl(event.venmoLink) });
+  if (event.cashappLink) links.push({ label: 'cashapp', url: toCashAppUrl(event.cashappLink) });
+  if (event.zelleInfo) links.push({ label: `zelle: ${event.zelleInfo}` });
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <p className="text-foreground text-sm font-medium">{formatPrice(event.price)}</p>
+        <p className="text-foreground-secondary mt-1 text-sm">
+          pay the host before you rsvp — then confirm below
+        </p>
+      </div>
+
+      <ul className="flex flex-col gap-2 text-sm">
+        {links.map((link) => (
+          <li key={link.label}>
+            {link.url ? (
+              <a
+                href={link.url}
+                target="_blank"
+                rel="noreferrer"
+                className="text-info hover:underline"
+              >
+                {link.label}
+              </a>
+            ) : (
+              <span className="text-foreground-secondary">{link.label}</span>
+            )}
+          </li>
+        ))}
+      </ul>
+
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="secondary" onClick={onBack} disabled={busy}>
+          back
+        </Button>
+        <Button type="button" onClick={onConfirm} disabled={busy}>
+          yes, i paid
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/screens/events/RsvpGuestList.tsx
+++ b/frontend/src/screens/events/RsvpGuestList.tsx
@@ -162,6 +162,7 @@ export function InvitedList({ event }: { event: Event }) {
               hasPlusOne: false,
               attendance: AttendanceStatus.Unknown,
               isMember: true,
+              paidConfirmed: false,
             }}
           />
         );

--- a/frontend/src/screens/events/usePaymentGate.test.ts
+++ b/frontend/src/screens/events/usePaymentGate.test.ts
@@ -1,0 +1,65 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RsvpStatus } from '@/models/event';
+import { makeEvent } from '@/test/fixtures';
+
+import { usePaymentGate } from './usePaymentGate';
+
+const mockUseFlag = vi.hoisted(() => vi.fn());
+vi.mock('@/api/featureFlags', () => ({ useFlag: mockUseFlag }));
+
+function makePaidEvent(overrides: Parameters<typeof makeEvent>[0] = {}) {
+  return makeEvent({
+    price: '$10',
+    venmoLink: 'https://venmo.com/u/host',
+    cashappLink: '',
+    zelleInfo: '',
+    myPaidConfirmed: false,
+    ...overrides,
+  });
+}
+
+describe('usePaymentGate', () => {
+  beforeEach(() => {
+    mockUseFlag.mockReset();
+  });
+
+  it('gates attending on a paid event when the flag is on', () => {
+    mockUseFlag.mockReturnValue(true);
+    const { result } = renderHook(() => usePaymentGate(makePaidEvent()));
+    expect(result.current(RsvpStatus.Attending)).toBe(true);
+  });
+
+  it('does not gate when the flag is off', () => {
+    mockUseFlag.mockReturnValue(false);
+    const { result } = renderHook(() => usePaymentGate(makePaidEvent()));
+    expect(result.current(RsvpStatus.Attending)).toBe(false);
+  });
+
+  it('does not gate maybe', () => {
+    mockUseFlag.mockReturnValue(true);
+    const { result } = renderHook(() => usePaymentGate(makePaidEvent()));
+    expect(result.current(RsvpStatus.Maybe)).toBe(false);
+  });
+
+  it('does not gate cant go', () => {
+    mockUseFlag.mockReturnValue(true);
+    const { result } = renderHook(() => usePaymentGate(makePaidEvent()));
+    expect(result.current(RsvpStatus.CantGo)).toBe(false);
+  });
+
+  it('does not gate a free event', () => {
+    mockUseFlag.mockReturnValue(true);
+    const { result } = renderHook(() =>
+      usePaymentGate(makePaidEvent({ price: '', venmoLink: '' })),
+    );
+    expect(result.current(RsvpStatus.Attending)).toBe(false);
+  });
+
+  it('does not gate a viewer who has already confirmed payment', () => {
+    mockUseFlag.mockReturnValue(true);
+    const { result } = renderHook(() => usePaymentGate(makePaidEvent({ myPaidConfirmed: true })));
+    expect(result.current(RsvpStatus.Attending)).toBe(false);
+  });
+});

--- a/frontend/src/screens/events/usePaymentGate.test.ts
+++ b/frontend/src/screens/events/usePaymentGate.test.ts
@@ -2,23 +2,12 @@ import { renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { RsvpStatus } from '@/models/event';
-import { makeEvent } from '@/test/fixtures';
+import { makePaidEvent } from '@/test/fixtures';
 
 import { usePaymentGate } from './usePaymentGate';
 
 const mockUseFlag = vi.hoisted(() => vi.fn());
 vi.mock('@/api/featureFlags', () => ({ useFlag: mockUseFlag }));
-
-function makePaidEvent(overrides: Parameters<typeof makeEvent>[0] = {}) {
-  return makeEvent({
-    price: '$10',
-    venmoLink: 'https://venmo.com/u/host',
-    cashappLink: '',
-    zelleInfo: '',
-    myPaidConfirmed: false,
-    ...overrides,
-  });
-}
 
 describe('usePaymentGate', () => {
   beforeEach(() => {

--- a/frontend/src/screens/events/usePaymentGate.ts
+++ b/frontend/src/screens/events/usePaymentGate.ts
@@ -1,0 +1,13 @@
+import { useFlag } from '@/api/featureFlags';
+import { type Event, type RsvpInputStatus, RsvpStatus } from '@/models/event';
+import { Feature } from '@/models/featureFlags';
+import { eventRequiresPaymentConfirmation } from '@/utils/eventCost';
+
+export function usePaymentGate(event: Event) {
+  const flagOn = useFlag(Feature.EventPaymentConfirmation);
+  return (status: RsvpInputStatus) =>
+    eventRequiresPaymentConfirmation(event) &&
+    flagOn &&
+    status === RsvpStatus.Attending &&
+    !event.myPaidConfirmed;
+}

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -25,6 +25,7 @@ export function makeGuest(overrides: Partial<EventGuest> = {}): EventGuest {
     hasPlusOne: false,
     attendance: AttendanceStatus.Unknown,
     isMember: true,
+    paidConfirmed: false,
     ...overrides,
   };
 }
@@ -63,28 +64,16 @@ export function makeEvent(overrides: Partial<Event> = {}): Event {
     coHostNames: [],
     coHostPhotoUrls: [],
     guests: [
-      {
-        userId: 'a',
-        name: 'alice',
-        status: RsvpServerStatus.Attending,
-        phone: '+15551112222',
-        photoUrl: '',
-        hasPlusOne: false,
-        attendance: AttendanceStatus.Unknown,
-        isMember: true,
-      },
-      {
+      makeGuest({ userId: 'a', name: 'alice', phone: '+15551112222' }),
+      makeGuest({
         userId: 'b',
         name: 'bob',
         status: RsvpServerStatus.CantGo,
         phone: '+15553334444',
-        photoUrl: '',
-        hasPlusOne: false,
-        isMember: true,
-        attendance: AttendanceStatus.Unknown,
-      },
+      }),
     ],
     myRsvp: null,
+    myPaidConfirmed: false,
     viewerUserId: null,
     surveySlugs: [],
     invitedUserIds: [],
@@ -102,6 +91,16 @@ export function makeEvent(overrides: Partial<Event> = {}): Event {
     status: EventStatus.Active,
     ...overrides,
   };
+}
+
+export function makePaidEvent(overrides: Partial<Event> = {}): Event {
+  return makeEvent({
+    price: '$10',
+    venmoLink: 'https://venmo.com/u/host',
+    cashappLink: '',
+    zelleInfo: '',
+    ...overrides,
+  });
 }
 
 export function makeUser(overrides: Partial<User> = {}): User {

--- a/frontend/src/utils/eventCost.test.ts
+++ b/frontend/src/utils/eventCost.test.ts
@@ -1,18 +1,8 @@
 import { describe, expect, it } from 'vitest';
 
-import { makeEvent } from '@/test/fixtures';
+import { makePaidEvent } from '@/test/fixtures';
 
 import { eventRequiresPaymentConfirmation, formatPrice } from './eventCost';
-
-function makePaidEvent(overrides: Parameters<typeof makeEvent>[0] = {}) {
-  return makeEvent({
-    price: '$10',
-    venmoLink: 'https://venmo.com/u/host',
-    cashappLink: '',
-    zelleInfo: '',
-    ...overrides,
-  });
-}
 
 describe('eventRequiresPaymentConfirmation', () => {
   it('requires confirmation with a price and venmo', () => {

--- a/frontend/src/utils/eventCost.test.ts
+++ b/frontend/src/utils/eventCost.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+
+import { makeEvent } from '@/test/fixtures';
+
+import { eventRequiresPaymentConfirmation, formatPrice } from './eventCost';
+
+function makePaidEvent(overrides: Parameters<typeof makeEvent>[0] = {}) {
+  return makeEvent({
+    price: '$10',
+    venmoLink: 'https://venmo.com/u/host',
+    cashappLink: '',
+    zelleInfo: '',
+    ...overrides,
+  });
+}
+
+describe('eventRequiresPaymentConfirmation', () => {
+  it('requires confirmation with a price and venmo', () => {
+    expect(eventRequiresPaymentConfirmation(makePaidEvent())).toBe(true);
+  });
+
+  it('requires confirmation with a price and cashapp', () => {
+    const event = makePaidEvent({ venmoLink: '', cashappLink: 'https://cash.app/$host' });
+    expect(eventRequiresPaymentConfirmation(event)).toBe(true);
+  });
+
+  it('requires confirmation with a price and zelle', () => {
+    const event = makePaidEvent({ venmoLink: '', zelleInfo: 'host@example.com' });
+    expect(eventRequiresPaymentConfirmation(event)).toBe(true);
+  });
+
+  it('does not require confirmation with a price but no payment method', () => {
+    expect(eventRequiresPaymentConfirmation(makePaidEvent({ venmoLink: '' }))).toBe(false);
+  });
+
+  it('does not require confirmation with a payment method but no price', () => {
+    expect(eventRequiresPaymentConfirmation(makePaidEvent({ price: '' }))).toBe(false);
+  });
+
+  it('treats a whitespace-only price as no price', () => {
+    expect(eventRequiresPaymentConfirmation(makePaidEvent({ price: '   ' }))).toBe(false);
+  });
+
+  it('treats a whitespace-only payment method as absent', () => {
+    expect(eventRequiresPaymentConfirmation(makePaidEvent({ venmoLink: '  ' }))).toBe(false);
+  });
+});
+
+describe('formatPrice', () => {
+  it('prefixes a bare number with a dollar sign', () => {
+    expect(formatPrice('10')).toBe('$10');
+  });
+
+  it('leaves an existing dollar sign alone', () => {
+    expect(formatPrice('$10')).toBe('$10');
+  });
+
+  it('passes non-numeric text through as written', () => {
+    expect(formatPrice('sliding scale')).toBe('sliding scale');
+  });
+
+  it('returns empty for blank input', () => {
+    expect(formatPrice('   ')).toBe('');
+  });
+});

--- a/frontend/src/utils/eventCost.ts
+++ b/frontend/src/utils/eventCost.ts
@@ -1,0 +1,19 @@
+import type { Event } from '@/models/event';
+
+export function eventRequiresPaymentConfirmation(event: Event): boolean {
+  const hasPrice = event.price.trim().length > 0;
+  const hasPaymentMethod = [event.venmoLink, event.cashappLink, event.zelleInfo].some(
+    (value) => value.trim().length > 0,
+  );
+  return hasPrice && hasPaymentMethod;
+}
+
+// A bare number gets a "$" prefix unless the user already typed one.
+// Anything else (e.g. "sliding scale") passes through as-written.
+export function formatPrice(price: string): string {
+  const trimmed = price.trim();
+  if (!trimmed) return trimmed;
+  if (/^\$/.test(trimmed)) return trimmed;
+  if (/^\d/.test(trimmed)) return `$${trimmed}`;
+  return trimmed;
+}


### PR DESCRIPTION
## Overview

**1 of 2** in the split of the payment-confirmation gate frontend (previously #1239, closed for being over the 400-line PR limit — 849 lines). This PR is the foundation: model/mapper plumbing, the shared cost helper, the gate hook, and the shared `PaymentConfirmStep` component. **No gate is wired into any RSVP surface yet** — that's PR 2/2, stacked on this branch.

Branches directly off `main` now that the backend stack (#1213, #1227, #1228, #1232) is merged.

### What's here

- **Model + mapper** — `Event.myPaidConfirmed`, `EventGuest.paidConfirmed` mapped from the backend's `my_paid_confirmed`/`paid_confirmed`. The hand-maintained `WireEvent`/`WireGuest` types in `eventMapper.ts` needed the fields added by hand (they aren't OpenAPI-generated) — along with every other hand-built `EventGuest`/`Event` fixture across the test suite that the new required fields broke.
- **`eventCost.ts`** — `eventRequiresPaymentConfirmation()` (price + at least one payment method), and `formatPrice()` moved here from `EventMemberSection.tsx` so both the cost card and the new payment step share it.
- **`usePaymentGate(event)`** — one hook: flag on AND status is attending AND event costs money AND the viewer hasn't already confirmed. Not called from anywhere yet in this PR.
- **`PaymentConfirmStep`** — shared UI: price, normalized venmo/cashapp links (via the existing `toVenmoUrl`/`toCashAppUrl` handle normalizers — a bare `@handle` needs converting, plain `ensureHttps` isn't enough), zelle as text, confirm/back. Not rendered from anywhere yet.
- **`paidConfirmed` threaded through `useSetRsvp`/`useUpdatePublicMyRsvp`** so the next PR's callers have somewhere to put the flag. `useUpdatePublicMyRsvp` had a hardcoded `paid_confirmed: false` stub already in its mutation body — a leftover from earlier work on this stack that would have silently defeated confirmation on that path. Fixed here.
- **Test fixture hygiene** — `frontend/src/test/fixtures.ts` already had a shared `makeGuest()`, but `makeEvent()` built its own two guests inline instead of using it, and `EmailBlastDialog.test.tsx` had a fully duplicated local `guest()` builder. Both now call the shared `makeGuest`. `AddCoHostDialog.test.tsx` also hand-rolled a full ~40-field `Event` literal instead of using the shared `makeEvent` — converted it, which is why this PR is net smaller in that file despite adding a field everywhere.

### Why this split

This PR compiles, typechecks, and tests green with **zero behavior change** — nothing calls `usePaymentGate` or renders `PaymentConfirmStep` yet, so it's safe to merge on its own regardless of the `EVENT_PAYMENT_CONFIRMATION` flag state. PR 2/2 wires the three RSVP surfaces on top of this.

Closes #1045

## Test plan

- [x] New coverage: `eventMapper`, `eventCost`, `usePaymentGate`, `PaymentConfirmStep` — free event / paid event / flag-off / already-confirmed all covered
- [x] Full frontend suite: **138 files, 1108 tests passing**, 1 pre-existing skip
- [x] `pnpm tsc -b --noEmit` clean (project-references-aware; the bare `tsc --noEmit` silently skips `src/test/**` and `*.test.tsx` and would have missed the wire-type/fixture fixes)
- [x] `make agent-frontend-lint`, `make agent-frontend-format-check` clean
- [x] **449 lines changed vs `origin/main` — over the 400-line PR limit.** Discussed with the user; kept in this PR rather than split further, since the excess is test-fixture deduplication (shared `makeGuest`, `AddCoHostDialog` converted to the shared `makeEvent`) directly triggered by this PR's model change, not unrelated scope.

