### PR TITLE
test: move all imports above vi.mock in frontend tests

### DIFF
--- a/frontend/src/api/calendar.test.ts
+++ b/frontend/src/api/calendar.test.ts
@@ -4,15 +4,15 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { apiClient } from '@/api/client';
+
+import { useCalendarToken, useRegenerateCalendarToken } from './calendar';
+
 vi.mock('@/api/client', () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
   authClient: { post: vi.fn() },
   setAuthBridge: vi.fn(),
 }));
-
-import { apiClient } from '@/api/client';
-
-import { useCalendarToken, useRegenerateCalendarToken } from './calendar';
 
 const mockedGet = vi.mocked(apiClient.get);
 const mockedPost = vi.mocked(apiClient.post);

--- a/frontend/src/api/content.test.ts
+++ b/frontend/src/api/content.test.ts
@@ -4,6 +4,10 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { apiClient } from '@/api/client';
+
+import { useGuidelines, useHome, useUpdateGuidelines, useUpdateHome } from './content';
+
 vi.mock('@/api/client', () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
 }));
@@ -14,10 +18,6 @@ vi.mock('@/auth/store', () => ({
     selector({ status: 'authed' }),
   ),
 }));
-
-import { apiClient } from '@/api/client';
-
-import { useGuidelines, useHome, useUpdateGuidelines, useUpdateHome } from './content';
 
 const mockedGet = vi.mocked(apiClient.get);
 const mockedPatch = vi.mocked(apiClient.patch);

--- a/frontend/src/api/docs.mutations.test.ts
+++ b/frontend/src/api/docs.mutations.test.ts
@@ -4,12 +4,6 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('@/api/client', () => ({
-  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn(), put: vi.fn() },
-  authClient: { post: vi.fn() },
-  setAuthBridge: vi.fn(),
-}));
-
 import { apiClient } from '@/api/client';
 
 import {
@@ -20,6 +14,12 @@ import {
   useReorderDocFolders,
   useReorderDocuments,
 } from './docs';
+
+vi.mock('@/api/client', () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn(), put: vi.fn() },
+  authClient: { post: vi.fn() },
+  setAuthBridge: vi.fn(),
+}));
 
 const mockedPost = vi.mocked(apiClient.post);
 const mockedDelete = vi.mocked(apiClient.delete);

--- a/frontend/src/api/eventComments.test.ts
+++ b/frontend/src/api/eventComments.test.ts
@@ -4,6 +4,14 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { apiClient } from '@/api/client';
+
+import { type WireCommentList } from './eventCommentMapper';
+import { mapCommentList } from './eventCommentMapper';
+import { eventCommentKeys, useEventComments } from './eventComments';
+import { useDeleteComment } from './eventComments';
+import { useToggleReaction } from './eventComments';
+
 vi.mock('@/api/client', () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
 }));
@@ -22,11 +30,6 @@ vi.mock('@/auth/store', () => {
   useAuthStore.getState = () => state;
   return { useAuthStore };
 });
-
-import { apiClient } from '@/api/client';
-
-import { type WireCommentList } from './eventCommentMapper';
-import { eventCommentKeys, useEventComments } from './eventComments';
 
 const mockedGet = vi.mocked(apiClient.get);
 const mockedPost = vi.mocked(apiClient.post);
@@ -109,9 +112,6 @@ describe('useEventComments', () => {
 // useDeleteComment — optimistic update + rollback
 // ---------------------------------------------------------------------------
 
-import { mapCommentList } from './eventCommentMapper';
-import { useDeleteComment } from './eventComments';
-
 const wireWithComment: WireCommentList = {
   can_post: true,
   cannot_post_reason: null,
@@ -188,8 +188,6 @@ describe('useDeleteComment', () => {
 // ---------------------------------------------------------------------------
 // useToggleReaction — optimistic update + rollback
 // ---------------------------------------------------------------------------
-
-import { useToggleReaction } from './eventComments';
 
 const wireWithReaction: WireCommentList = {
   can_post: true,

--- a/frontend/src/api/eventPolls.test.ts
+++ b/frontend/src/api/eventPolls.test.ts
@@ -5,6 +5,12 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { apiClient } from '@/api/client';
+import { VoteChoice } from '@/models/eventPoll';
+
+import { mapEventPoll, type WireEventPoll } from './eventPollMapper';
+import { eventPollKeys, useEventPoll, useVotePoll } from './eventPolls';
+
 vi.mock('@/api/client', () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
 }));
@@ -23,12 +29,6 @@ vi.mock('@/auth/store', () => {
   useAuthStore.getState = () => state;
   return { useAuthStore };
 });
-
-import { apiClient } from '@/api/client';
-import { VoteChoice } from '@/models/eventPoll';
-
-import { mapEventPoll, type WireEventPoll } from './eventPollMapper';
-import { eventPollKeys, useEventPoll, useVotePoll } from './eventPolls';
 
 const mockedGet = vi.mocked(apiClient.get);
 const mockedPost = vi.mocked(apiClient.post);

--- a/frontend/src/api/eventWrites.test.ts
+++ b/frontend/src/api/eventWrites.test.ts
@@ -4,8 +4,17 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { apiClient } from '@/api/client';
 import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
 import { makeEvent } from '@/test/fixtures';
+
+import {
+  eventToFormValues,
+  toPartialWireBody,
+  useInviteToEvent,
+  useUploadEventPhoto,
+} from './eventWrites';
+import { textRecipientsKeys } from './textRecipients';
 
 vi.mock('@/api/client', () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
@@ -18,16 +27,6 @@ vi.mock('@/auth/store', () => {
   );
   return { useAuthStore };
 });
-
-import { apiClient } from '@/api/client';
-
-import {
-  eventToFormValues,
-  toPartialWireBody,
-  useInviteToEvent,
-  useUploadEventPhoto,
-} from './eventWrites';
-import { textRecipientsKeys } from './textRecipients';
 
 describe('eventToFormValues enum validation', () => {
   it('passes through known enum values', () => {

--- a/frontend/src/api/featureFlags.test.ts
+++ b/frontend/src/api/featureFlags.test.ts
@@ -4,14 +4,14 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('@/api/client', () => ({
-  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
-}));
-
 import { apiClient } from '@/api/client';
 import { Feature } from '@/models/featureFlags';
 
 import { useFeatureFlags, useFlag, useSetFeatureFlag } from './featureFlags';
+
+vi.mock('@/api/client', () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
 
 const mockedGet = vi.mocked(apiClient.get);
 const mockedPatch = vi.mocked(apiClient.patch);

--- a/frontend/src/api/feedback.test.ts
+++ b/frontend/src/api/feedback.test.ts
@@ -4,13 +4,13 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('@/api/client', () => ({
-  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
-}));
-
 import { apiClient } from '@/api/client';
 
 import { useSubmitFeedback } from './feedback';
+
+vi.mock('@/api/client', () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
 
 const mockedPost = vi.mocked(apiClient.post);
 

--- a/frontend/src/api/join.test.ts
+++ b/frontend/src/api/join.test.ts
@@ -4,13 +4,13 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('@/api/client', () => ({
-  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
-}));
-
 import { apiClient } from '@/api/client';
 
 import { AlreadyInvitedError, useJoinRequests, useSubmitJoinRequest } from './join';
+
+vi.mock('@/api/client', () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
 
 const mockedGet = vi.mocked(apiClient.get);
 const mockedPost = vi.mocked(apiClient.post);

--- a/frontend/src/api/notifications.test.ts
+++ b/frontend/src/api/notifications.test.ts
@@ -4,6 +4,16 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { apiClient } from '@/api/client';
+
+import {
+  notificationKeys,
+  useMarkAllNotificationsRead,
+  useNotificationHistory,
+  useNotifications,
+  useUnreadCount,
+} from './notifications';
+
 vi.mock('@/api/client', () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
 }));
@@ -16,16 +26,6 @@ vi.mock('@/auth/store', () => ({
     selector({ status: mockAuthStatus }),
   ),
 }));
-
-import { apiClient } from '@/api/client';
-
-import {
-  notificationKeys,
-  useMarkAllNotificationsRead,
-  useNotificationHistory,
-  useNotifications,
-  useUnreadCount,
-} from './notifications';
 
 const mockedGet = vi.mocked(apiClient.get);
 const mockedPost = vi.mocked(apiClient.post);

--- a/frontend/src/api/roles.test.ts
+++ b/frontend/src/api/roles.test.ts
@@ -4,15 +4,15 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { apiClient } from '@/api/client';
+
+import { useCreateRole, useDeleteRole, useRoles, useUpdateRole } from './roles';
+
 vi.mock('@/api/client', () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
   authClient: { post: vi.fn() },
   setAuthBridge: vi.fn(),
 }));
-
-import { apiClient } from '@/api/client';
-
-import { useCreateRole, useDeleteRole, useRoles, useUpdateRole } from './roles';
 
 const mockedGet = vi.mocked(apiClient.get);
 const mockedPost = vi.mocked(apiClient.post);

--- a/frontend/src/api/surveyAdmin.tallies.test.ts
+++ b/frontend/src/api/surveyAdmin.tallies.test.ts
@@ -4,15 +4,15 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { apiClient } from '@/api/client';
+
+import { useFinalizeSurveyPoll, useSurveyPollTallies } from './surveyAdmin';
+
 vi.mock('@/api/client', () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
   authClient: { post: vi.fn() },
   setAuthBridge: vi.fn(),
 }));
-
-import { apiClient } from '@/api/client';
-
-import { useFinalizeSurveyPoll, useSurveyPollTallies } from './surveyAdmin';
 
 const mockedGet = vi.mocked(apiClient.get);
 const mockedPost = vi.mocked(apiClient.post);

--- a/frontend/src/api/users.test.ts
+++ b/frontend/src/api/users.test.ts
@@ -4,12 +4,6 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('@/api/client', () => ({
-  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
-  authClient: { post: vi.fn() },
-  setAuthBridge: vi.fn(),
-}));
-
 import { apiClient } from '@/api/client';
 
 import {
@@ -21,6 +15,12 @@ import {
   useUpdateUser,
   useUsers,
 } from './users';
+
+vi.mock('@/api/client', () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+  authClient: { post: vi.fn() },
+  setAuthBridge: vi.fn(),
+}));
 
 const mockedGet = vi.mocked(apiClient.get);
 const mockedPost = vi.mocked(apiClient.post);

--- a/frontend/src/api/version.test.ts
+++ b/frontend/src/api/version.test.ts
@@ -4,13 +4,13 @@ import type { ReactNode } from 'react';
 import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-vi.mock('@/api/client', () => ({
-  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
-}));
-
 import { apiClient } from '@/api/client';
 
 import { useVersion } from './version';
+
+vi.mock('@/api/client', () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
 
 const mockedGet = vi.mocked(apiClient.get);
 

--- a/frontend/src/auth/store.test.ts
+++ b/frontend/src/auth/store.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import * as authApi from '@/api/auth';
 import type { User } from '@/models/user';
 
 import { useAuthStore } from './store';
@@ -25,8 +26,6 @@ vi.mock('@/api/client', () => ({
   authClient: { post: vi.fn(), get: vi.fn() },
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
 }));
-
-import * as authApi from '@/api/auth';
 
 const mockUser: User = {
   id: 'user-1',

--- a/frontend/src/components/DevTestEventsButton.test.tsx
+++ b/frontend/src/components/DevTestEventsButton.test.tsx
@@ -4,6 +4,12 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useCreateDevTestEvents } from '@/api/devTools';
+import { useVersion } from '@/api/version';
+import { useAuthStore } from '@/auth/store';
+
+import { DevTestEventsButton } from './DevTestEventsButton';
+
 vi.mock('@/api/devTools', () => ({
   useCreateDevTestEvents: vi.fn(),
 }));
@@ -15,12 +21,6 @@ vi.mock('@/api/version', () => ({
 vi.mock('@/auth/store', () => ({
   useAuthStore: vi.fn(),
 }));
-
-import { useCreateDevTestEvents } from '@/api/devTools';
-import { useVersion } from '@/api/version';
-import { useAuthStore } from '@/auth/store';
-
-import { DevTestEventsButton } from './DevTestEventsButton';
 
 const mockUseVersion = vi.mocked(useVersion);
 const mockUseAuthStore = vi.mocked(useAuthStore);

--- a/frontend/src/components/FeedbackButton.a11y.test.tsx
+++ b/frontend/src/components/FeedbackButton.a11y.test.tsx
@@ -9,6 +9,8 @@ import { useAuthStore } from '@/auth/store';
 import type { User } from '@/models/user';
 import { makeUser as makeSharedUser } from '@/test/fixtures';
 
+import { FeedbackButton } from './FeedbackButton';
+
 const submitFeedbackMock = vi.fn();
 const useSubmitFeedbackMock =
   vi.fn<() => { mutateAsync: typeof submitFeedbackMock; isPending: boolean }>();
@@ -26,8 +28,6 @@ vi.mock('@/api/client', () => ({
 vi.mock('sonner', () => ({
   toast: { success: vi.fn(), error: vi.fn() },
 }));
-
-import { FeedbackButton } from './FeedbackButton';
 
 function makeUser(overrides: Partial<User> = {}): User {
   return makeSharedUser({

--- a/frontend/src/components/FeedbackButton.test.tsx
+++ b/frontend/src/components/FeedbackButton.test.tsx
@@ -3,10 +3,13 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useSubmitFeedback } from '@/api/feedback';
 import { clearStoredRsvpToken, setStoredRsvpToken } from '@/api/rsvpTokenStorage';
 import { useAuthStore } from '@/auth/store';
 import type { User } from '@/models/user';
 import { makeUser as makeSharedUser } from '@/test/fixtures';
+
+import { FeedbackButton } from './FeedbackButton';
 
 const submitFeedbackMock = vi.fn();
 
@@ -14,8 +17,8 @@ vi.mock('@/api/feedback', () => ({
   useSubmitFeedback: vi.fn(),
 }));
 
-const toastSuccessMock = vi.fn();
-const toastErrorMock = vi.fn();
+const toastSuccessMock = vi.hoisted(() => vi.fn());
+const toastErrorMock = vi.hoisted(() => vi.fn());
 vi.mock('sonner', () => ({
   toast: {
     success: (msg: string, opts?: unknown) => {
@@ -26,10 +29,6 @@ vi.mock('sonner', () => ({
     },
   },
 }));
-
-import { useSubmitFeedback } from '@/api/feedback';
-
-import { FeedbackButton } from './FeedbackButton';
 
 const mockedUseSubmitFeedback = vi.mocked(useSubmitFeedback);
 

--- a/frontend/src/components/ImageCropDialog.a11y.test.tsx
+++ b/frontend/src/components/ImageCropDialog.a11y.test.tsx
@@ -3,6 +3,8 @@ import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
 
+import { ImageCropDialog } from './ImageCropDialog';
+
 vi.mock('react-image-crop', () => ({
   default: ({ circularCrop, children }: { circularCrop?: boolean; children?: ReactNode }) => (
     <div data-testid="cropper" data-circular={String(Boolean(circularCrop))}>
@@ -16,8 +18,6 @@ vi.mock('react-image-crop', () => ({
 vi.mock('@/utils/cropImage', () => ({
   cropImage: vi.fn().mockResolvedValue(new Blob(['img'], { type: 'image/png' })),
 }));
-
-import { ImageCropDialog } from './ImageCropDialog';
 
 beforeEach(() => {
   vi.stubGlobal('URL', {

--- a/frontend/src/components/ImageCropDialog.test.tsx
+++ b/frontend/src/components/ImageCropDialog.test.tsx
@@ -5,6 +5,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { cropImage } from '@/utils/cropImage';
 
+import { ImageCropDialog } from './ImageCropDialog';
+
 // react-image-crop uses pointer events + ResizeObserver that jsdom doesn't
 // fully support. Stub it so it renders a simple sentinel element that
 // still exposes the props we care about (circularCrop, aspect).
@@ -44,8 +46,6 @@ vi.mock('react-image-crop', () => ({
 vi.mock('@/utils/cropImage', () => ({
   cropImage: vi.fn().mockResolvedValue(new Blob(['img'], { type: 'image/png' })),
 }));
-
-import { ImageCropDialog } from './ImageCropDialog';
 
 // jsdom doesn't implement createObjectURL/revokeObjectURL
 beforeEach(() => {

--- a/frontend/src/layout/AppShell.test.tsx
+++ b/frontend/src/layout/AppShell.test.tsx
@@ -6,6 +6,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAuthStore } from '@/auth/store';
 
+import { AppShell } from './AppShell';
+
 // Stub modules that reach out to the network or browser APIs the AppShell
 // pulls in transitively.
 vi.mock('@/api/notifications', () => ({
@@ -24,8 +26,6 @@ vi.mock('@/auth/useAuth', () => ({
   useHasAnyAdminPermission: vi.fn().mockReturnValue(false),
   useHasPermission: vi.fn().mockReturnValue(false),
 }));
-
-import { AppShell } from './AppShell';
 
 function makeQc() {
   return new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/frontend/src/layout/NotificationBell.test.tsx
+++ b/frontend/src/layout/NotificationBell.test.tsx
@@ -4,8 +4,16 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import {
+  useMarkAllNotificationsRead,
+  useMarkNotificationRead,
+  useNotifications,
+  useUnreadCount,
+} from '@/api/notifications';
 import { useAuthStore } from '@/auth/store';
 import { NotificationType } from '@/models/notification';
+
+import { NotificationBell } from './NotificationBell';
 
 // Mock the notifications API hooks (but NOT the stores)
 vi.mock('@/api/notifications', () => ({
@@ -31,15 +39,6 @@ vi.mock('@/hooks/useEventSource', () => ({
 vi.mock('@/utils/errorReporter', () => ({
   reportError: vi.fn().mockResolvedValue(undefined),
 }));
-
-import {
-  useMarkAllNotificationsRead,
-  useMarkNotificationRead,
-  useNotifications,
-  useUnreadCount,
-} from '@/api/notifications';
-
-import { NotificationBell } from './NotificationBell';
 
 const mockUseUnreadCount = vi.mocked(useUnreadCount);
 const mockUseNotifications = vi.mocked(useNotifications);

--- a/frontend/src/screens/admin/AttendanceReportScreen.test.tsx
+++ b/frontend/src/screens/admin/AttendanceReportScreen.test.tsx
@@ -4,6 +4,13 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useAttendanceReport } from '@/api/attendanceReport';
+import { useFlag } from '@/api/featureFlags';
+import { Feature } from '@/models/featureFlags';
+import { makeRow } from '@/test/fixtures';
+
+import AttendanceReportScreen from './AttendanceReportScreen';
+
 vi.mock('@/api/attendanceReport', () => ({
   useAttendanceReport: vi.fn(),
 }));
@@ -14,13 +21,6 @@ vi.mock('@/api/featureFlags', () => ({
 vi.mock('./MemberAttendanceTab', () => ({
   MemberAttendanceTab: () => <div>members tab content</div>,
 }));
-
-import { useAttendanceReport } from '@/api/attendanceReport';
-import { useFlag } from '@/api/featureFlags';
-import { Feature } from '@/models/featureFlags';
-import { makeRow } from '@/test/fixtures';
-
-import AttendanceReportScreen from './AttendanceReportScreen';
 
 const mockUseReport = vi.mocked(useAttendanceReport);
 const mockUseFlag = vi.mocked(useFlag);

--- a/frontend/src/screens/admin/FeatureFlagsScreen.test.tsx
+++ b/frontend/src/screens/admin/FeatureFlagsScreen.test.tsx
@@ -4,6 +4,11 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useFeatureFlags, useSetFeatureFlag } from '@/api/featureFlags';
+import { useVersion } from '@/api/version';
+
+import FeatureFlagsScreen from './FeatureFlagsScreen';
+
 vi.mock('@/api/featureFlags', () => ({
   useFeatureFlags: vi.fn(),
   useSetFeatureFlag: vi.fn(),
@@ -12,11 +17,6 @@ vi.mock('@/api/featureFlags', () => ({
 vi.mock('@/api/version', () => ({
   useVersion: vi.fn(),
 }));
-
-import { useFeatureFlags, useSetFeatureFlag } from '@/api/featureFlags';
-import { useVersion } from '@/api/version';
-
-import FeatureFlagsScreen from './FeatureFlagsScreen';
 
 const mockUseFlags = vi.mocked(useFeatureFlags);
 const mockUseSetFlag = vi.mocked(useSetFeatureFlag);

--- a/frontend/src/screens/admin/JoinRequestsScreen.test.tsx
+++ b/frontend/src/screens/admin/JoinRequestsScreen.test.tsx
@@ -6,7 +6,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type * as JoinApi from '@/api/join';
 import { JoinRequestStatus, type JoinRequestSummary } from '@/api/join';
+import { useDecideJoinRequest, useJoinRequests } from '@/api/join';
 import { makeRequest } from '@/test/fixtures';
+
+import JoinRequestsScreen from './JoinRequestsScreen';
 
 vi.mock('@/api/join', async (importOriginal) => {
   const actual = await importOriginal<typeof JoinApi>();
@@ -25,10 +28,6 @@ vi.mock('@/api/content', () => ({
   useMemberPromotionMessage: () => ({ data: undefined, isPending: false, isError: false }),
   useWhatsAppLink: () => ({ data: undefined, isPending: false, isError: false }),
 }));
-
-import { useDecideJoinRequest, useJoinRequests } from '@/api/join';
-
-import JoinRequestsScreen from './JoinRequestsScreen';
 
 const mockUseJoinRequests = vi.mocked(useJoinRequests);
 

--- a/frontend/src/screens/admin/MembersScreen.test.tsx
+++ b/frontend/src/screens/admin/MembersScreen.test.tsx
@@ -4,10 +4,13 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useUsers } from '@/api/users';
 import { useAuthStore } from '@/auth/store';
 import { Permission } from '@/models/permissions';
 import type { User } from '@/models/user';
 import { makeMember } from '@/test/fixtures';
+
+import MembersScreen from './MembersScreen';
 
 // Mock the users API module so we can drive loading / error / data states
 // without hitting the network. useCreateUser is only pulled in transitively
@@ -20,10 +23,6 @@ vi.mock('@/api/users', () => ({
     reset: vi.fn(),
   })),
 }));
-
-import { useUsers } from '@/api/users';
-
-import MembersScreen from './MembersScreen';
 
 const mockUseUsers = vi.mocked(useUsers);
 

--- a/frontend/src/screens/auth/LoginScreen.a11y.test.tsx
+++ b/frontend/src/screens/auth/LoginScreen.a11y.test.tsx
@@ -5,6 +5,10 @@ import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
 
+import { useAuthStore } from '@/auth/store';
+
+import LoginScreen from './LoginScreen';
+
 vi.mock('@/api/join', () => ({
   checkPhone: vi.fn(),
 }));
@@ -14,10 +18,6 @@ vi.mock('@/api/client', () => ({
   authClient: { post: vi.fn() },
   setAuthBridge: vi.fn(),
 }));
-
-import { useAuthStore } from '@/auth/store';
-
-import LoginScreen from './LoginScreen';
 
 function renderWith(component: ReactElement) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/frontend/src/screens/auth/LoginScreen.test.tsx
+++ b/frontend/src/screens/auth/LoginScreen.test.tsx
@@ -3,6 +3,10 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useAuthStore } from '@/auth/store';
+
+import LoginScreen from './LoginScreen';
+
 vi.mock('@/api/join', () => ({
   checkPhone: vi.fn(),
 }));
@@ -12,10 +16,6 @@ vi.mock('@/api/client', () => ({
   authClient: { post: vi.fn() },
   setAuthBridge: vi.fn(),
 }));
-
-import { useAuthStore } from '@/auth/store';
-
-import LoginScreen from './LoginScreen';
 
 function renderAt(entry: { pathname: string; state?: unknown }) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/frontend/src/screens/calendar/CalendarScreen.test.tsx
+++ b/frontend/src/screens/calendar/CalendarScreen.test.tsx
@@ -6,7 +6,10 @@ import { useEffect } from 'react';
 import { MemoryRouter, useLocation } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useEvents } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
+
+import CalendarScreen from './CalendarScreen';
 
 // react-big-calendar is a heavy component that requires CSS imports and relies
 // on browser layout. Stub it so tests focus on CalendarScreen logic.
@@ -26,10 +29,6 @@ vi.mock('@/api/events', () => ({
   useEvents: vi.fn(),
   eventKeys: { all: ['events'], list: vi.fn(), detail: vi.fn() },
 }));
-
-import { useEvents } from '@/api/events';
-
-import CalendarScreen from './CalendarScreen';
 
 const mockUseEvents = vi.mocked(useEvents);
 

--- a/frontend/src/screens/events/AddCoHostDialog.test.tsx
+++ b/frontend/src/screens/events/AddCoHostDialog.test.tsx
@@ -4,7 +4,9 @@ import { describe, expect, it, vi } from 'vitest';
 import type { Event } from '@/models/event';
 import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
 
-const updateMutateAsync = vi.fn();
+import { AddCoHostDialog } from './AddCoHostDialog';
+
+const updateMutateAsync = vi.hoisted(() => vi.fn());
 
 vi.mock('@/api/eventWrites', () => ({
   useUpdateEvent: () => ({ mutateAsync: updateMutateAsync, isPending: false }),
@@ -19,8 +21,6 @@ vi.mock('@/api/userSearch', () => ({
     ],
   }),
 }));
-
-import { AddCoHostDialog } from './AddCoHostDialog';
 
 const BASE_EVENT: Event = {
   id: 'ev1',

--- a/frontend/src/screens/events/CohostInviteBanner.test.tsx
+++ b/frontend/src/screens/events/CohostInviteBanner.test.tsx
@@ -5,16 +5,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Event } from '@/models/event';
 import { makeEvent } from '@/test/fixtures';
 
-const acceptMutate = vi.fn();
-const declineMutate = vi.fn();
+import { CohostInviteBanner } from './CohostInviteBanner';
+
+const acceptMutate = vi.hoisted(() => vi.fn());
+const declineMutate = vi.hoisted(() => vi.fn());
 
 vi.mock('@/api/cohostInvites', () => ({
   useAcceptCohostInvite: () => ({ mutate: acceptMutate, isPending: false }),
   useDeclineCohostInvite: () => ({ mutate: declineMutate, isPending: false }),
   useRescindCohostInvite: () => ({ mutate: vi.fn(), isPending: false }),
 }));
-
-import { CohostInviteBanner } from './CohostInviteBanner';
 
 const BASE_EVENT = makeEvent({
   slug: 'spring-potluck',

--- a/frontend/src/screens/events/EmailBlastButton.test.tsx
+++ b/frontend/src/screens/events/EmailBlastButton.test.tsx
@@ -5,12 +5,12 @@ import { describe, expect, it, vi } from 'vitest';
 import { EventStatus } from '@/models/event';
 import { makeEvent } from '@/test/fixtures';
 
+import { EmailBlastButton } from './EmailBlastButton';
+
 vi.mock('./EmailBlastDialog', () => ({
   EmailBlastDialog: ({ open }: { open: boolean }) =>
     open ? <div data-testid="email-blast-dialog" /> : null,
 }));
-
-import { EmailBlastButton } from './EmailBlastButton';
 
 describe('EmailBlastButton', () => {
   it('renders the email-blast button when the event has guests', () => {

--- a/frontend/src/screens/events/EmailBlastDialog.test.tsx
+++ b/frontend/src/screens/events/EmailBlastDialog.test.tsx
@@ -6,9 +6,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Event, EventGuest } from '@/models/event';
 import { makeEvent as makeEventFixture } from '@/test/fixtures';
 
-const mutateAsyncMock = vi.fn();
-const toastSuccessMock = vi.fn();
-const toastErrorMock = vi.fn();
+import { EmailBlastDialog } from './EmailBlastDialog';
+
+const mutateAsyncMock = vi.hoisted(() => vi.fn());
+const toastSuccessMock = vi.hoisted(() => vi.fn());
+const toastErrorMock = vi.hoisted(() => vi.fn());
 
 vi.mock('@/api/eventBlast', () => ({
   useEmailBlast: () => ({ mutateAsync: mutateAsyncMock, isPending: false }),
@@ -24,8 +26,6 @@ vi.mock('sonner', () => ({
     },
   },
 }));
-
-import { EmailBlastDialog } from './EmailBlastDialog';
 
 function guest(status: string, i: number): EventGuest {
   return {

--- a/frontend/src/screens/events/EventAdminActions.test.tsx
+++ b/frontend/src/screens/events/EventAdminActions.test.tsx
@@ -9,6 +9,8 @@ import { EventStatus, InvitePermission } from '@/models/event';
 import type { User } from '@/models/user';
 import { makeEvent, makeUser as makeBaseUser } from '@/test/fixtures';
 
+import { EventAdminActions } from './EventAdminActions';
+
 // Mock network-touching dependencies
 vi.mock('@/api/eventWrites', () => ({
   useUpdateEvent: vi.fn().mockReturnValue({ mutateAsync: vi.fn(), isPending: false }),
@@ -17,8 +19,6 @@ vi.mock('@/api/eventWrites', () => ({
 }));
 
 vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
-
-import { EventAdminActions } from './EventAdminActions';
 
 const CREATOR_ID = 'creator-user';
 const COHOST_ID = 'cohost-user';

--- a/frontend/src/screens/events/EventAttendancePanel.test.tsx
+++ b/frontend/src/screens/events/EventAttendancePanel.test.tsx
@@ -2,12 +2,15 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useEventStats } from '@/api/eventStats';
 import type { Event, EventStats } from '@/models/event';
 import { AttendanceStatus, RsvpServerStatus } from '@/models/event';
 import { makeEvent, makeGuest } from '@/test/fixtures';
 
-const setAttendanceMutate = vi.fn();
-const toastError = vi.fn();
+import { EventAttendancePanel } from './EventAttendancePanel';
+
+const setAttendanceMutate = vi.hoisted(() => vi.fn());
+const toastError = vi.hoisted(() => vi.fn());
 
 vi.mock('sonner', () => ({
   toast: {
@@ -21,10 +24,6 @@ vi.mock('@/api/eventStats', () => ({
   useEventStats: vi.fn(),
   useSetAttendance: () => ({ mutate: setAttendanceMutate, isPending: false }),
 }));
-
-import { useEventStats } from '@/api/eventStats';
-
-import { EventAttendancePanel } from './EventAttendancePanel';
 
 const BASE_EVENT = makeEvent({
   invitedCount: 2,

--- a/frontend/src/screens/events/EventAttendanceScreen.test.tsx
+++ b/frontend/src/screens/events/EventAttendanceScreen.test.tsx
@@ -3,8 +3,11 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useEvent } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
 import { makeEvent, makeUser } from '@/test/fixtures';
+
+import EventAttendanceScreen from './EventAttendanceScreen';
 
 vi.mock('@/api/events', () => ({
   useEvent: vi.fn(),
@@ -15,10 +18,6 @@ vi.mock('@/api/eventStats', () => ({
   useEventStats: vi.fn().mockReturnValue({ data: undefined, isLoading: true, isError: false }),
   useSetAttendance: () => ({ mutate: vi.fn(), isPending: false }),
 }));
-
-import { useEvent } from '@/api/events';
-
-import EventAttendanceScreen from './EventAttendanceScreen';
 
 const BASE_EVENT = makeEvent({
   title: 'Spring Potluck',

--- a/frontend/src/screens/events/EventCheckInReportScreen.test.tsx
+++ b/frontend/src/screens/events/EventCheckInReportScreen.test.tsx
@@ -3,8 +3,11 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useEvent } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
 import { makeEvent, makeUser } from '@/test/fixtures';
+
+import EventCheckInReportScreen from './EventCheckInReportScreen';
 
 vi.mock('@/api/events', () => ({
   useEvent: vi.fn(),
@@ -19,10 +22,6 @@ vi.mock('@/api/eventCheckInReport', () => ({
     { key: 'attendance', label: 'attendance' },
   ],
 }));
-
-import { useEvent } from '@/api/events';
-
-import EventCheckInReportScreen from './EventCheckInReportScreen';
 
 const BASE_EVENT = makeEvent({
   title: 'Spring Potluck',

--- a/frontend/src/screens/events/EventDetailKebabMenu.test.tsx
+++ b/frontend/src/screens/events/EventDetailKebabMenu.test.tsx
@@ -3,6 +3,13 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 
+import { useFlag } from '@/api/featureFlags';
+import type { Event } from '@/models/event';
+import { EventStatus } from '@/models/event';
+import { makeEvent } from '@/test/fixtures';
+
+import { EventDetailKebabMenu } from './EventDetailKebabMenu';
+
 vi.mock('@/api/featureFlags', () => ({
   useFlag: vi.fn(),
 }));
@@ -14,13 +21,6 @@ vi.mock('./GroupTextDialog', () => ({
   GroupTextDialog: ({ open }: { open: boolean }) =>
     open ? <div data-testid="group-text-dialog" /> : null,
 }));
-
-import { useFlag } from '@/api/featureFlags';
-import type { Event } from '@/models/event';
-import { EventStatus } from '@/models/event';
-import { makeEvent } from '@/test/fixtures';
-
-import { EventDetailKebabMenu } from './EventDetailKebabMenu';
 
 function renderMenu(
   overrides: {

--- a/frontend/src/screens/events/EventDetailScreen.test.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.test.tsx
@@ -4,10 +4,13 @@ import { AxiosError, type AxiosResponse } from 'axios';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useEvent } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
 import { EventType, InvitePermission } from '@/models/event';
 import type { User } from '@/models/user';
 import { makeEvent } from '@/test/fixtures';
+
+import EventDetailScreen from './EventDetailScreen';
 
 vi.mock('@/api/events', () => ({
   useEvent: vi.fn(),
@@ -30,10 +33,6 @@ vi.mock('./InviteDialog', () => ({
 vi.mock('@/utils/datetime', () => ({
   formatEventDateTime: vi.fn().mockReturnValue('Saturday, Jan 1 · 6:00 PM'),
 }));
-
-import { useEvent } from '@/api/events';
-
-import EventDetailScreen from './EventDetailScreen';
 
 const mockUseEvent = vi.mocked(useEvent);
 

--- a/frontend/src/screens/events/EventManageRsvpsPanel.test.tsx
+++ b/frontend/src/screens/events/EventManageRsvpsPanel.test.tsx
@@ -6,8 +6,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RsvpServerStatus } from '@/models/event';
 import { makeEvent, makeGuest } from '@/test/fixtures';
 
-const setGuestRsvpMutate = vi.fn();
-const removeGuestRsvpMutate = vi.fn();
+import { EventManageRsvpsPanel } from './EventManageRsvpsPanel';
+
+const setGuestRsvpMutate = vi.hoisted(() => vi.fn());
+const removeGuestRsvpMutate = vi.hoisted(() => vi.fn());
 vi.mock('@/api/eventStats', () => ({
   useSetGuestRsvp: () => ({ mutate: setGuestRsvpMutate, isPending: false }),
   useRemoveGuestRsvp: () => ({ mutate: removeGuestRsvpMutate, isPending: false }),
@@ -18,8 +20,6 @@ vi.mock('@/api/userSearch', () => ({
     data: [{ id: 'new-1', fullName: 'New Member', phoneNumber: '+15551234567' }],
   }),
 }));
-
-import { EventManageRsvpsPanel } from './EventManageRsvpsPanel';
 
 function renderPanel(event = makeEvent({})) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/frontend/src/screens/events/EventManageRsvpsScreen.test.tsx
+++ b/frontend/src/screens/events/EventManageRsvpsScreen.test.tsx
@@ -3,17 +3,16 @@ import { render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useEvent } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
 import { makeEvent, makeUser } from '@/test/fixtures';
+
+import EventManageRsvpsScreen from './EventManageRsvpsScreen';
 
 vi.mock('@/api/events', () => ({
   useEvent: vi.fn(),
   eventKeys: { all: ['events'], list: vi.fn(), detail: vi.fn() },
 }));
-
-import { useEvent } from '@/api/events';
-
-import EventManageRsvpsScreen from './EventManageRsvpsScreen';
 
 const BASE_EVENT = makeEvent({
   title: 'Spring Potluck',

--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -10,10 +10,12 @@ import { Permission } from '@/models/permissions';
 import type { User } from '@/models/user';
 import { makeEvent, makeGuest } from '@/test/fixtures';
 
-const rescindMutate = vi.fn();
-const removeCohostMutate = vi.fn();
-const updatePublicRsvpMutate = vi.fn();
-const cancelPublicRsvpMutate = vi.fn();
+import { EventMemberSection } from './EventMemberSection';
+
+const rescindMutate = vi.hoisted(() => vi.fn());
+const removeCohostMutate = vi.hoisted(() => vi.fn());
+const updatePublicRsvpMutate = vi.hoisted(() => vi.fn());
+const cancelPublicRsvpMutate = vi.hoisted(() => vi.fn());
 
 vi.mock('@/api/cohostInvites', () => ({
   useAcceptCohostInvite: () => ({ mutate: vi.fn(), isPending: false }),
@@ -39,8 +41,6 @@ vi.mock('./AddCoHostDialog', () => ({ AddCoHostDialog: () => null }));
 vi.mock('./comments/EventCommentsCard', () => ({
   EventCommentsCard: () => <div data-testid="comments-card" />,
 }));
-
-import { EventMemberSection } from './EventMemberSection';
 
 const BASE_EVENT = makeEvent({
   slug: 'spring-potluck',

--- a/frontend/src/screens/events/GroupTextButton.test.tsx
+++ b/frontend/src/screens/events/GroupTextButton.test.tsx
@@ -3,12 +3,12 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { makeEvent } from '@/test/fixtures';
 
+import { GroupTextButton } from './GroupTextButton';
+
 vi.mock('./GroupTextDialog', () => ({
   GroupTextDialog: ({ open }: { open: boolean }) =>
     open ? <div role="dialog" aria-label="group text" /> : null,
 }));
-
-import { GroupTextButton } from './GroupTextButton';
 
 describe('GroupTextButton', () => {
   it('renders a trigger and opens the picker dialog on click', () => {

--- a/frontend/src/screens/events/GroupTextDialog.test.tsx
+++ b/frontend/src/screens/events/GroupTextDialog.test.tsx
@@ -3,8 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { TextRecipients } from '@/api/textRecipients';
 
-const toastSuccess = vi.fn();
-const toastError = vi.fn();
+import { GroupTextDialog } from './GroupTextDialog';
+
+const toastSuccess = vi.hoisted(() => vi.fn());
+const toastError = vi.hoisted(() => vi.fn());
 vi.mock('sonner', () => ({
   toast: {
     success: (m: string) => {
@@ -25,8 +27,6 @@ const useTextRecipients = vi.fn<() => RecipientsQueryResult>();
 vi.mock('@/api/textRecipients', () => ({
   useTextRecipients: () => useTextRecipients(),
 }));
-
-import { GroupTextDialog } from './GroupTextDialog';
 
 function recipients(overrides: Partial<TextRecipients> = {}): TextRecipients {
   return {

--- a/frontend/src/screens/events/MyRsvpSection.test.tsx
+++ b/frontend/src/screens/events/MyRsvpSection.test.tsx
@@ -7,15 +7,17 @@ import { useAuthStore } from '@/auth/store';
 import { type Event, RsvpServerStatus } from '@/models/event';
 import { makeEvent as makeBaseEvent, makeGuest, makeUser } from '@/test/fixtures';
 
-const setRsvpMutate = vi.fn();
-const removeRsvpMutate = vi.fn();
+import { MyRsvpSection } from './MyRsvpSection';
+
+const setRsvpMutate = vi.hoisted(() => vi.fn());
+const removeRsvpMutate = vi.hoisted(() => vi.fn());
 vi.mock('@/api/rsvp', () => ({
   useSetRsvp: () => ({ mutateAsync: setRsvpMutate, isPending: false }),
   useRemoveRsvp: () => ({ mutateAsync: removeRsvpMutate, isPending: false }),
 }));
 
-const updatePublicRsvpMutate = vi.fn();
-const cancelPublicRsvpMutate = vi.fn();
+const updatePublicRsvpMutate = vi.hoisted(() => vi.fn());
+const cancelPublicRsvpMutate = vi.hoisted(() => vi.fn());
 vi.mock('@/api/publicRsvp', () => ({
   useUpdatePublicMyRsvp: () => ({ mutateAsync: updatePublicRsvpMutate, isPending: false }),
   useCancelPublicMyRsvp: () => ({ mutateAsync: cancelPublicRsvpMutate, isPending: false }),
@@ -32,8 +34,6 @@ vi.mock('./RsvpCommentField', () => ({
     />
   ),
 }));
-
-import { MyRsvpSection } from './MyRsvpSection';
 
 const ME = makeUser({ id: 'user-me', firstName: 'Me', lastName: '', fullName: 'Me' });
 

--- a/frontend/src/screens/events/PublicRsvp.a11y.test.tsx
+++ b/frontend/src/screens/events/PublicRsvp.a11y.test.tsx
@@ -6,13 +6,13 @@ import { axe } from 'vitest-axe';
 import type { Event } from '@/models/event';
 import { makeEvent } from '@/test/fixtures';
 
-const checkPhoneMutate = vi.fn();
+import { PublicRsvpForm } from './PublicRsvpForm';
+
+const checkPhoneMutate = vi.hoisted(() => vi.fn());
 vi.mock('@/api/publicRsvp', () => ({
   useSubmitPublicRsvp: () => ({ mutateAsync: vi.fn(), isPending: false }),
   useCheckPublicRsvpPhone: () => ({ mutateAsync: checkPhoneMutate, isPending: false }),
 }));
-
-import { PublicRsvpForm } from './PublicRsvpForm';
 
 function renderForm(event: Event) {
   return render(

--- a/frontend/src/screens/events/PublicRsvpCard.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpCard.test.tsx
@@ -6,14 +6,14 @@ import { describe, expect, it, vi } from 'vitest';
 import { type Event, RsvpServerStatus } from '@/models/event';
 import { makeEvent } from '@/test/fixtures';
 
-const updateMutate = vi.fn();
-const cancelMutate = vi.fn();
+import { PublicRsvpCard } from './PublicRsvpCard';
+
+const updateMutate = vi.hoisted(() => vi.fn());
+const cancelMutate = vi.hoisted(() => vi.fn());
 vi.mock('@/api/publicRsvp', () => ({
   useUpdatePublicMyRsvp: () => ({ mutateAsync: updateMutate, isPending: false }),
   useCancelPublicMyRsvp: () => ({ mutateAsync: cancelMutate, isPending: false }),
 }));
-
-import { PublicRsvpCard } from './PublicRsvpCard';
 
 function renderCard(props: { status: string; event?: Partial<Event> }) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/frontend/src/screens/events/PublicRsvpForm.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.test.tsx
@@ -5,20 +5,20 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { makeEvent } from '@/test/fixtures';
 
-const submitMutate = vi.fn();
-const checkPhoneMutate = vi.fn();
+import { PublicRsvpForm } from './PublicRsvpForm';
+
+const submitMutate = vi.hoisted(() => vi.fn());
+const checkPhoneMutate = vi.hoisted(() => vi.fn());
 vi.mock('@/api/publicRsvp', () => ({
   useSubmitPublicRsvp: () => ({ mutateAsync: submitMutate, isPending: false }),
   useCheckPublicRsvpPhone: () => ({ mutateAsync: checkPhoneMutate, isPending: false }),
 }));
 
-const navigateMock = vi.fn();
+const navigateMock = vi.hoisted(() => vi.fn());
 vi.mock('react-router-dom', async (importOriginal) => {
   const actual = await importOriginal<typeof ReactRouterDom>();
   return { ...actual, useNavigate: () => navigateMock };
 });
-
-import { PublicRsvpForm } from './PublicRsvpForm';
 
 function renderForm(event = makeEvent(), onSuccess = vi.fn()) {
   return render(

--- a/frontend/src/screens/events/PublicRsvpSection.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpSection.test.tsx
@@ -7,20 +7,20 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { canPublicRsvp, EventStatus, EventType, EventVisibility } from '@/models/event';
 import { makeEvent } from '@/test/fixtures';
 
-const mockNavigate = vi.fn();
+import { PublicRsvpSection } from './PublicRsvpSection';
+
+const mockNavigate = vi.hoisted(() => vi.fn());
 vi.mock('react-router-dom', async (importActual) => {
   const actual = await importActual<typeof RouterDom>();
   return { ...actual, useNavigate: () => mockNavigate };
 });
 
-const mockSubmit = vi.fn();
-const mockCheckPhone = vi.fn();
+const mockSubmit = vi.hoisted(() => vi.fn());
+const mockCheckPhone = vi.hoisted(() => vi.fn());
 vi.mock('@/api/publicRsvp', () => ({
   useSubmitPublicRsvp: () => ({ mutateAsync: mockSubmit, isPending: false }),
   useCheckPublicRsvpPhone: () => ({ mutateAsync: mockCheckPhone, isPending: false }),
 }));
-
-import { PublicRsvpSection } from './PublicRsvpSection';
 
 function officialEvent(overrides: Partial<Parameters<typeof makeEvent>[0]> = {}) {
   return makeEvent({

--- a/frontend/src/screens/events/PublicRsvpsScreen.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpsScreen.test.tsx
@@ -7,7 +7,9 @@ import type { ManageRsvps } from '@/api/publicRsvp';
 import { RsvpServerStatus, RsvpStatus } from '@/models/event';
 import { makeEvent } from '@/test/fixtures';
 
-const toastSuccess = vi.fn();
+import PublicRsvpsScreen from './PublicRsvpsScreen';
+
+const toastSuccess = vi.hoisted(() => vi.fn());
 vi.mock('sonner', () => ({
   toast: {
     success: (m: string) => {
@@ -17,11 +19,11 @@ vi.mock('sonner', () => ({
   },
 }));
 
-const updateAsync = vi.fn();
-const cancelAsync = vi.fn();
-const resendAsync = vi.fn();
-const usePublicMyRsvps = vi.fn();
-const useResendPublicRsvpManageLink = vi.fn();
+const updateAsync = vi.hoisted(() => vi.fn());
+const cancelAsync = vi.hoisted(() => vi.fn());
+const resendAsync = vi.hoisted(() => vi.fn());
+const usePublicMyRsvps = vi.hoisted(() => vi.fn());
+const useResendPublicRsvpManageLink = vi.hoisted(() => vi.fn());
 
 vi.mock('@/api/publicRsvp', () => ({
   usePublicMyRsvps: (token: string) => usePublicMyRsvps(token) as unknown,
@@ -51,8 +53,6 @@ const storageMock = (() => {
   };
 })();
 Object.defineProperty(window, 'localStorage', { value: storageMock, writable: true });
-
-import PublicRsvpsScreen from './PublicRsvpsScreen';
 
 function renderAt(token: string | null) {
   const path = token === null ? '/my-rsvps' : `/my-rsvps?token=${token}`;

--- a/frontend/src/screens/events/comments/CommentItem.test.tsx
+++ b/frontend/src/screens/events/comments/CommentItem.test.tsx
@@ -4,6 +4,10 @@ import userEvent from '@testing-library/user-event';
 import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
+import type { EventComment } from '@/models/eventComment';
+
+import { CommentItem } from './CommentItem';
+
 const { mockPost } = vi.hoisted(() => ({ mockPost: vi.fn().mockResolvedValue({ data: {} }) }));
 
 vi.mock('@/api/client', () => ({
@@ -17,10 +21,6 @@ vi.mock('@/api/client', () => ({
 vi.mock('@/auth/store', () => ({
   useAuthStore: (selector: (s: { status: string }) => unknown) => selector({ status: 'authed' }),
 }));
-
-import type { EventComment } from '@/models/eventComment';
-
-import { CommentItem } from './CommentItem';
 
 function wrap(ui: ReactNode) {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });

--- a/frontend/src/screens/events/comments/EventCommentsCard.test.tsx
+++ b/frontend/src/screens/events/comments/EventCommentsCard.test.tsx
@@ -2,6 +2,10 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { apiClient } from '@/api/client';
+
+import { EventCommentsCard } from './EventCommentsCard';
+
 vi.mock('@/api/client', () => ({
   apiClient: {
     get: vi.fn(),
@@ -26,9 +30,6 @@ vi.mock('@/auth/store', () => {
 });
 
 // Import after mocks
-import { apiClient } from '@/api/client';
-
-import { EventCommentsCard } from './EventCommentsCard';
 
 const eventId = '11111111-1111-1111-1111-111111111111';
 

--- a/frontend/src/screens/events/comments/ReactionBar.test.tsx
+++ b/frontend/src/screens/events/comments/ReactionBar.test.tsx
@@ -1,16 +1,16 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
+import type { CommentReactionSummary, CommentReactor } from '@/models/eventComment';
+import { ReactionEmoji } from '@/models/eventComment';
+
+import { ReactionBar } from './ReactionBar';
+
 // the voter popover links reactors only when authed; the bar's own behaviour
 // is auth-independent, so pin it signed-out to keep these tests router-free
 vi.mock('@/auth/store', () => ({
   useAuthStore: (selector: (s: { status: string }) => unknown) => selector({ status: 'unauthed' }),
 }));
-
-import type { CommentReactionSummary, CommentReactor } from '@/models/eventComment';
-import { ReactionEmoji } from '@/models/eventComment';
-
-import { ReactionBar } from './ReactionBar';
 
 const summary = (
   emoji: string,

--- a/frontend/src/screens/events/comments/ReactionVoterPopover.test.tsx
+++ b/frontend/src/screens/events/comments/ReactionVoterPopover.test.tsx
@@ -3,17 +3,17 @@ import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 
+import type { CommentReactionSummary } from '@/models/eventComment';
+import { ReactionEmoji } from '@/models/eventComment';
+
+import { ReactionVoterPopover } from './ReactionVoterPopover';
+
 const { authStatus } = vi.hoisted(() => ({ authStatus: { value: 'authed' } }));
 
 vi.mock('@/auth/store', () => ({
   useAuthStore: (selector: (s: { status: string }) => unknown) =>
     selector({ status: authStatus.value }),
 }));
-
-import type { CommentReactionSummary } from '@/models/eventComment';
-import { ReactionEmoji } from '@/models/eventComment';
-
-import { ReactionVoterPopover } from './ReactionVoterPopover';
 
 const reaction: CommentReactionSummary = {
   emoji: ReactionEmoji.Heart,

--- a/frontend/src/screens/events/form/EventFormPhoto.test.tsx
+++ b/frontend/src/screens/events/form/EventFormPhoto.test.tsx
@@ -2,6 +2,8 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
+import { EventFormPhoto } from './EventFormPhoto';
+
 vi.mock('@/components/ImageCropDialog', () => ({
   ImageCropDialog: ({ file, onCrop }: { file: File; onCrop: (blob: Blob) => Promise<void> }) => (
     <div data-testid="crop-dialog" data-filename={file.name}>
@@ -41,8 +43,6 @@ vi.mock('@/components/PhotoLibraryDialog', () => ({
     </div>
   ),
 }));
-
-import { EventFormPhoto } from './EventFormPhoto';
 
 describe('EventFormPhoto', () => {
   it('opens the tabbed picker from the change-photo button', async () => {

--- a/frontend/src/screens/notifications/NotificationsScreen.test.tsx
+++ b/frontend/src/screens/notifications/NotificationsScreen.test.tsx
@@ -3,6 +3,11 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useMarkNotificationRead, useNotificationHistory } from '@/api/notifications';
+import { makeNotification } from '@/test/fixtures';
+
+import NotificationsScreen from './NotificationsScreen';
+
 vi.mock('@/api/notifications', () => ({
   useNotificationHistory: vi.fn(),
   useMarkNotificationRead: vi.fn(),
@@ -11,11 +16,6 @@ vi.mock('@/api/notifications', () => ({
 vi.mock('@/utils/errorReporter', () => ({
   reportError: vi.fn().mockResolvedValue(undefined),
 }));
-
-import { useMarkNotificationRead, useNotificationHistory } from '@/api/notifications';
-import { makeNotification } from '@/test/fixtures';
-
-import NotificationsScreen from './NotificationsScreen';
 
 const mockUseHistory = vi.mocked(useNotificationHistory);
 const mockUseMarkRead = vi.mocked(useMarkNotificationRead);

--- a/frontend/src/screens/public/FaqScreen.test.tsx
+++ b/frontend/src/screens/public/FaqScreen.test.tsx
@@ -4,8 +4,11 @@ import type { ReactElement } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useFaq } from '@/api/content';
 import { useAuthStore } from '@/auth/store';
 import type { User } from '@/models/user';
+
+import FaqScreen from './FaqScreen';
 
 vi.mock('@/api/content', () => ({
   useFaq: vi.fn(),
@@ -15,10 +18,6 @@ vi.mock('@/api/content', () => ({
 vi.mock('@/components/RichEditor/RichEditor', () => ({
   RichEditor: () => <div data-testid="rich-editor" />,
 }));
-
-import { useFaq } from '@/api/content';
-
-import FaqScreen from './FaqScreen';
 
 const mockUseFaq = vi.mocked(useFaq);
 

--- a/frontend/src/screens/public/GuidelinesScreen.test.tsx
+++ b/frontend/src/screens/public/GuidelinesScreen.test.tsx
@@ -4,8 +4,11 @@ import type { ReactElement } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useGuidelines } from '@/api/content';
 import { useAuthStore } from '@/auth/store';
 import type { User } from '@/models/user';
+
+import GuidelinesScreen from './GuidelinesScreen';
 
 vi.mock('@/api/content', () => ({
   useGuidelines: vi.fn(),
@@ -15,10 +18,6 @@ vi.mock('@/api/content', () => ({
 vi.mock('@/components/RichEditor/RichEditor', () => ({
   RichEditor: () => <div data-testid="rich-editor" />,
 }));
-
-import { useGuidelines } from '@/api/content';
-
-import GuidelinesScreen from './GuidelinesScreen';
 
 const mockUseGuidelines = vi.mocked(useGuidelines);
 

--- a/frontend/src/screens/public/HomeScreen.test.tsx
+++ b/frontend/src/screens/public/HomeScreen.test.tsx
@@ -4,8 +4,11 @@ import type { ReactElement } from 'react';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useHome } from '@/api/content';
 import { useAuthStore } from '@/auth/store';
 import type { User } from '@/models/user';
+
+import HomeScreen from './HomeScreen';
 
 // Mock API before importing the screen
 vi.mock('@/api/content', () => ({
@@ -17,10 +20,6 @@ vi.mock('@/api/content', () => ({
 vi.mock('@/components/RichEditor/RichEditor', () => ({
   RichEditor: () => <div data-testid="rich-editor" />,
 }));
-
-import { useHome } from '@/api/content';
-
-import HomeScreen from './HomeScreen';
 
 const mockUseHome = vi.mocked(useHome);
 

--- a/frontend/src/screens/public/JoinScreen.a11y.test.tsx
+++ b/frontend/src/screens/public/JoinScreen.a11y.test.tsx
@@ -5,6 +5,10 @@ import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { axe } from 'vitest-axe';
 
+import { useJoinQuestions, useSubmitJoinRequest } from '@/api/join';
+
+import JoinScreen from './JoinScreen';
+
 vi.mock('@/api/join', () => ({
   useJoinQuestions: vi.fn(),
   useSubmitJoinRequest: vi.fn(),
@@ -15,10 +19,6 @@ vi.mock('@/api/join', () => ({
     }
   },
 }));
-
-import { useJoinQuestions, useSubmitJoinRequest } from '@/api/join';
-
-import JoinScreen from './JoinScreen';
 
 const mockUseJoinQuestions = vi.mocked(useJoinQuestions);
 const mockUseSubmitJoinRequest = vi.mocked(useSubmitJoinRequest);

--- a/frontend/src/screens/public/JoinScreen.test.tsx
+++ b/frontend/src/screens/public/JoinScreen.test.tsx
@@ -5,6 +5,11 @@ import type { ReactElement } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useJoinQuestions, useSubmitJoinRequest } from '@/api/join';
+
+import JoinScreen from './JoinScreen';
+import JoinSuccessScreen from './JoinSuccessScreen';
+
 vi.mock('@/api/join', () => ({
   useJoinQuestions: vi.fn(),
   useSubmitJoinRequest: vi.fn(),
@@ -15,11 +20,6 @@ vi.mock('@/api/join', () => ({
     }
   },
 }));
-
-import { useJoinQuestions, useSubmitJoinRequest } from '@/api/join';
-
-import JoinScreen from './JoinScreen';
-import JoinSuccessScreen from './JoinSuccessScreen';
 
 const mockUseJoinQuestions = vi.mocked(useJoinQuestions);
 const mockUseSubmitJoinRequest = vi.mocked(useSubmitJoinRequest);

--- a/frontend/src/screens/settings/SettingsScreen.test.tsx
+++ b/frontend/src/screens/settings/SettingsScreen.test.tsx
@@ -29,8 +29,11 @@ import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAccessibilityStore } from '@/accessibility/store';
+import * as authApi from '@/api/auth';
 import { useAuthStore } from '@/auth/store';
 import type { User } from '@/models/user';
+
+import SettingsScreen from './SettingsScreen';
 
 // Stub heavy sub-components that have their own API/DOM dependencies
 vi.mock('./AvatarUpload', () => ({
@@ -63,10 +66,6 @@ vi.mock('@/api/auth', () => ({
   uploadProfilePhoto: vi.fn(),
   deleteProfilePhoto: vi.fn(),
 }));
-
-import * as authApi from '@/api/auth';
-
-import SettingsScreen from './SettingsScreen';
 
 const TEST_USER: User = {
   id: 'u1',

--- a/frontend/src/utils/errorReporter.test.ts
+++ b/frontend/src/utils/errorReporter.test.ts
@@ -1,15 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { apiClient } from '@/api/client';
+import { useAuthStore } from '@/auth/store';
+
+import { reportError } from './errorReporter';
+
 vi.mock('@/api/client', () => ({
   apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
   authClient: { post: vi.fn() },
   setAuthBridge: vi.fn(),
 }));
-
-import { apiClient } from '@/api/client';
-import { useAuthStore } from '@/auth/store';
-
-import { reportError } from './errorReporter';
 
 const mockedPost = vi.mocked(apiClient.post);
 


### PR DESCRIPTION
## Overview

63 frontend test files split their imports — the module under test was imported *below* the `vi.mock` block rather than at the top with everything else:

```ts
import { makeEvent } from '@/test/fixtures';

vi.mock('@/api/publicRsvp', () => ({ ... }));

import { PublicRsvpCard } from './PublicRsvpCard';   // ← down here
```

Vitest hoists `vi.mock` above the module body regardless of where it's written, so the split buys nothing. It just reads as though import order is load-bearing, which invites cargo-culting into new tests. `RsvpBox.test.tsx` already imported at the top and passed — that's the proof the split was never required.

## Changes

- All imports moved to the top of the file, in the existing `simple-import-sort` grouping.
- A `const` that a mock factory closes over becomes `vi.hoisted(() => vi.fn())` — with the import above, the hoisted factory would otherwise read it before initialization. 39 such conversions.
- A `const` no factory references stays a plain `vi.fn()`.

## Verification

Baseline captured on this branch point *before* any edit, then re-run after:

| | Test files | Tests |
|---|---|---|
| Before | 135 passed | 1080 passed, 1 skipped |
| After | 135 passed | 1080 passed, 1 skipped |

Identical — no behaviour change. `tsc --noEmit` and `eslint --max-warnings 0` both clean.

Verified invariant across every test file in the repo: no `import` (including multiline blocks) now appears below a `vi.mock`.

## Notes

Split out of #1241, where the pattern was spotted in the RSVP tests. That PR fixes its own 6 files; this one covers the remaining 57 so the cleanup reviews independently of the payment-confirmation work.

Mechanical and script-assisted, but the `vi.fn` → `vi.hoisted` decision was made per-const based on whether a factory actually references it — worth a skim of that specific transform rather than assuming it's uniform.
