### PR TITLE
feat: add Railway cron config for attendance reminders

### DIFF
--- a/railway/cron-attendance-reminders.toml
+++ b/railway/cron-attendance-reminders.toml
@@ -1,0 +1,9 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+startCommand = "cd backend && uv run python manage.py send_attendance_reminders"
+cronSchedule = "0 4 * * *"
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 10


### PR DESCRIPTION
## Summary

Adds a Railway cron service config for the existing `send_attendance_reminders` management command (Issue 1236), which sends 10/11/11.5/12-month milestone attendance-reminder emails but currently has nothing invoking it on a schedule.

- `railway/cron-attendance-reminders.toml` — new Railway service (config-as-code) with `startCommand = "cd backend && uv run python manage.py send_attendance_reminders"`, `cronSchedule = "0 4 * * *"` (daily, offset from the `0 3 * * *` / `*/15 * * * *` schedules used by the other cron services in this repo)

Follows the pattern established in the (still-unmerged) `cron-checkin-nudges.toml` from PR #1237: a single management-command cron gets a direct `startCommand` in its own TOML, no wrapper shell script needed (the shell-script wrapper pattern in `cron-daily.toml` is only for services chaining multiple commands).

This TOML is added independently of PR #1237 and does not depend on it merging first — Railway will need this new service registered/pointed at the TOML once deployed.

## Follow-up / manual verification needed

- Confirming a scheduled run actually sends milestone emails as expected requires a live Railway cron run and is out of scope for this sandboxed change — needs manual verification after deploy (or a dry-run/log check), per the issue's acceptance criteria.
- The new service needs the same env vars (`DATABASE_URL`, etc.) as the web service — this is a Railway dashboard/project setup step, not something expressible in this file alone.

## Test plan

- [ ] N/A — config-only change, no Python logic touched (no lint/typecheck run per task scope)
- [ ] Manually verify Railway cron service is created from this TOML and env vars are shared with the web service
- [ ] Manually confirm a scheduled run sends the expected milestone emails