### PR TITLE
fix: 1242 - going list not updating after own rsvp

### DIFF
--- a/frontend/src/api/rsvp.test.ts
+++ b/frontend/src/api/rsvp.test.ts
@@ -1,0 +1,86 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { createElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { apiClient } from '@/api/client';
+import { eventKeys } from '@/api/events';
+import { RsvpStatus } from '@/models/event';
+import { makeEvent } from '@/test/fixtures';
+
+import { useRemoveRsvp, useSetRsvp } from './rsvp';
+
+vi.mock('@/api/client', () => ({
+  apiClient: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+
+vi.mock('@/auth/store', () => {
+  const state = { status: 'authed', user: { id: 'u-me' } };
+  const useAuthStore = vi.fn((selector?: (s: typeof state) => unknown) =>
+    selector ? selector(state) : state,
+  );
+  return { useAuthStore };
+});
+
+const EVENT_ID = '11111111-1111-1111-1111-111111111111';
+const EVENT_SLUG = 'summer-potluck';
+
+function buildWrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const Wrapper = ({ children }: { children: ReactNode }) =>
+    createElement(QueryClientProvider, { client: qc }, children);
+  return { qc, Wrapper };
+}
+
+describe('useSetRsvp cache patching (issue 1242)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('patches a detail query cached under the event slug, not just the uuid', async () => {
+    const { qc, Wrapper } = buildWrapper();
+    // Simulate EventDetailScreen having loaded via the slug URL — the query
+    // cache entry backing the visible screen is keyed by slug, not uuid.
+    qc.setQueryData(
+      eventKeys.detail(EVENT_SLUG, true),
+      makeEvent({ id: EVENT_ID, slug: EVENT_SLUG, myRsvp: null }),
+    );
+    vi.mocked(apiClient.post).mockResolvedValue({
+      data: { id: EVENT_ID, slug: EVENT_SLUG, title: 'potluck', my_rsvp: RsvpStatus.Attending },
+    });
+
+    const { result } = renderHook(() => useSetRsvp(), { wrapper: Wrapper });
+    result.current.mutate({ eventId: EVENT_ID, status: RsvpStatus.Attending });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(qc.getQueryData(eventKeys.detail(EVENT_SLUG, true))).toMatchObject({
+      myRsvp: RsvpStatus.Attending,
+    });
+  });
+});
+
+describe('useRemoveRsvp cache invalidation (issue 1242)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('invalidates a detail query cached under the event slug, not just the uuid', async () => {
+    const { qc, Wrapper } = buildWrapper();
+    qc.setQueryData(
+      eventKeys.detail(EVENT_SLUG, true),
+      makeEvent({ id: EVENT_ID, slug: EVENT_SLUG, myRsvp: RsvpStatus.Attending }),
+    );
+    vi.mocked(apiClient.delete).mockResolvedValue({ data: undefined });
+    const invalidateSpy = vi.spyOn(qc, 'invalidateQueries');
+
+    const { result } = renderHook(() => useRemoveRsvp(), { wrapper: Wrapper });
+    result.current.mutate(EVENT_ID);
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(qc.getQueryState(eventKeys.detail(EVENT_SLUG, true))?.isInvalidated).toBe(true);
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: eventKeys.list(true) });
+  });
+});

--- a/frontend/src/api/rsvp.ts
+++ b/frontend/src/api/rsvp.ts
@@ -22,12 +22,20 @@ interface SetRsvpArgs {
   paidConfirmed?: boolean;
 }
 
+// EventDetailScreen's :id route param can be the event's UUID or its slug
+// (old links, or navigating in via a slug URL) — eventKeys.detail() keys the
+// query cache on whichever one was used, and it can also carry a non-member
+// rsvp token, so a plain setQueryData(eventKeys.detail(event.id, ...)) can
+// miss the entry actually backing the visible screen. Match by data instead.
+function isDetailQueryForEvent(queryKey: readonly unknown[], event: Pick<Event, 'id' | 'slug'>) {
+  return queryKey[1] === 'detail' && (queryKey[2] === event.id || queryKey[2] === event.slug);
+}
+
 function updateCaches(qc: ReturnType<typeof useQueryClient>, event: Event, isAuthed: boolean) {
   qc.setQueryData(eventKeys.detail(event.id, isAuthed), event);
-  // EventDetailScreen canonicalizes the URL to slug, so also patch detail queries keyed by slug.
   qc.setQueriesData<Event | undefined>(
-    { queryKey: eventKeys.all, predicate: (query) => query.queryKey[1] === 'detail' },
-    (prev) => (prev && (prev.id === event.id || prev.slug === event.slug) ? event : prev),
+    { queryKey: eventKeys.all, predicate: (query) => isDetailQueryForEvent(query.queryKey, event) },
+    () => event,
   );
   // Also patch the list cache if we've got it. The list endpoint returns
   // fewer fields than detail, so we merge conservatively.
@@ -77,12 +85,13 @@ export function useRemoveRsvp() {
     },
     onSuccess: (eventId) => {
       // DELETE returns 204, so we can't patch from the response — invalidate instead.
-      void qc.invalidateQueries({ queryKey: eventKeys.detail(eventId, isAuthed) });
-      // Also matches detail queries keyed by slug (EventDetailScreen canonicalizes to slug).
+      // eventId is always the UUID here, but the visible screen may be keyed by
+      // slug (see isDetailQueryForEvent), so also match by the cached event's id.
       void qc.invalidateQueries({
         queryKey: eventKeys.all,
         predicate: (query) =>
-          query.queryKey[1] === 'detail' && (query.state.data as Event | undefined)?.id === eventId,
+          query.queryKey[1] === 'detail' &&
+          (query.queryKey[2] === eventId || (query.state.data as Event | undefined)?.id === eventId),
       });
       void qc.invalidateQueries({ queryKey: eventKeys.list(isAuthed) });
       void qc.invalidateQueries({ queryKey: eventStatsKeys.detail(eventId) });

--- a/frontend/src/api/rsvp.ts
+++ b/frontend/src/api/rsvp.ts
@@ -85,7 +85,8 @@ export function useRemoveRsvp() {
         queryKey: eventKeys.all,
         predicate: (query) =>
           query.queryKey[1] === 'detail' &&
-          (query.queryKey[2] === eventId || (query.state.data as Event | undefined)?.id === eventId),
+          (query.queryKey[2] === eventId ||
+            (query.state.data as Event | undefined)?.id === eventId),
       });
       void qc.invalidateQueries({ queryKey: eventKeys.list(isAuthed) });
       void qc.invalidateQueries({ queryKey: eventStatsKeys.detail(eventId) });

--- a/frontend/src/api/rsvp.ts
+++ b/frontend/src/api/rsvp.ts
@@ -24,6 +24,14 @@ interface SetRsvpArgs {
 
 function updateCaches(qc: ReturnType<typeof useQueryClient>, event: Event, isAuthed: boolean) {
   qc.setQueryData(eventKeys.detail(event.id, isAuthed), event);
+  // The live route may have queried by slug rather than event.id (EventDetailScreen
+  // canonicalizes the URL to the slug), so the write above can miss the cache entry
+  // actually backing the screen. Patch every detail query for this event regardless
+  // of which id shape keyed it.
+  qc.setQueriesData<Event | undefined>(
+    { queryKey: eventKeys.all, predicate: (query) => query.queryKey[1] === 'detail' },
+    (prev) => (prev && (prev.id === event.id || prev.slug === event.slug) ? event : prev),
+  );
   // Also patch the list cache if we've got it. The list endpoint returns
   // fewer fields than detail, so we merge conservatively.
   qc.setQueryData<Event[] | undefined>(eventKeys.list(isAuthed), (prev) => {
@@ -72,8 +80,15 @@ export function useRemoveRsvp() {
     },
     onSuccess: (eventId) => {
       // DELETE returns 204, so we can't patch from the response. Just
-      // invalidate — cheaper than a second round-trip.
+      // invalidate — cheaper than a second round-trip. The live route may have
+      // queried by slug rather than eventId (EventDetailScreen canonicalizes the
+      // URL to the slug), so match on cached data id too, not just the key.
       void qc.invalidateQueries({ queryKey: eventKeys.detail(eventId, isAuthed) });
+      void qc.invalidateQueries({
+        queryKey: eventKeys.all,
+        predicate: (query) =>
+          query.queryKey[1] === 'detail' && (query.state.data as Event | undefined)?.id === eventId,
+      });
       void qc.invalidateQueries({ queryKey: eventKeys.list(isAuthed) });
       void qc.invalidateQueries({ queryKey: eventStatsKeys.detail(eventId) });
       // can_post on the comments list depends on RSVP existence — refresh it.

--- a/frontend/src/api/rsvp.ts
+++ b/frontend/src/api/rsvp.ts
@@ -22,11 +22,7 @@ interface SetRsvpArgs {
   paidConfirmed?: boolean;
 }
 
-// EventDetailScreen's :id route param can be the event's UUID or its slug
-// (old links, or navigating in via a slug URL) — eventKeys.detail() keys the
-// query cache on whichever one was used, and it can also carry a non-member
-// rsvp token, so a plain setQueryData(eventKeys.detail(event.id, ...)) can
-// miss the entry actually backing the visible screen. Match by data instead.
+// EventDetailScreen's :id route param can be the event's uuid or slug, so the cache key varies.
 function isDetailQueryForEvent(queryKey: readonly unknown[], event: Pick<Event, 'id' | 'slug'>) {
   return queryKey[1] === 'detail' && (queryKey[2] === event.id || queryKey[2] === event.slug);
 }
@@ -85,8 +81,6 @@ export function useRemoveRsvp() {
     },
     onSuccess: (eventId) => {
       // DELETE returns 204, so we can't patch from the response — invalidate instead.
-      // eventId is always the UUID here, but the visible screen may be keyed by
-      // slug (see isDetailQueryForEvent), so also match by the cached event's id.
       void qc.invalidateQueries({
         queryKey: eventKeys.all,
         predicate: (query) =>

--- a/frontend/src/api/rsvp.ts
+++ b/frontend/src/api/rsvp.ts
@@ -24,10 +24,7 @@ interface SetRsvpArgs {
 
 function updateCaches(qc: ReturnType<typeof useQueryClient>, event: Event, isAuthed: boolean) {
   qc.setQueryData(eventKeys.detail(event.id, isAuthed), event);
-  // The live route may have queried by slug rather than event.id (EventDetailScreen
-  // canonicalizes the URL to the slug), so the write above can miss the cache entry
-  // actually backing the screen. Patch every detail query for this event regardless
-  // of which id shape keyed it.
+  // EventDetailScreen canonicalizes the URL to slug, so also patch detail queries keyed by slug.
   qc.setQueriesData<Event | undefined>(
     { queryKey: eventKeys.all, predicate: (query) => query.queryKey[1] === 'detail' },
     (prev) => (prev && (prev.id === event.id || prev.slug === event.slug) ? event : prev),
@@ -79,11 +76,9 @@ export function useRemoveRsvp() {
       return eventId;
     },
     onSuccess: (eventId) => {
-      // DELETE returns 204, so we can't patch from the response. Just
-      // invalidate — cheaper than a second round-trip. The live route may have
-      // queried by slug rather than eventId (EventDetailScreen canonicalizes the
-      // URL to the slug), so match on cached data id too, not just the key.
+      // DELETE returns 204, so we can't patch from the response — invalidate instead.
       void qc.invalidateQueries({ queryKey: eventKeys.detail(eventId, isAuthed) });
+      // Also matches detail queries keyed by slug (EventDetailScreen canonicalizes to slug).
       void qc.invalidateQueries({
         queryKey: eventKeys.all,
         predicate: (query) =>


### PR DESCRIPTION
## Summary

Fixes Issue 1242 — event rsvp lists (going/maybe/waitlist) didn't update on screen right after adding your own rsvp, only after a manual refresh.

## Root cause

`EventDetailScreen` fetches the event via `useEvent(id, ...)`, where `id` is the route's `:id` param. That param is frequently the event **slug**, not the UUID — the screen even canonicalizes the URL to the slug once the event loads (`EventDetailScreen.tsx` lines 47-51). The query cache key is `eventKeys.detail(id, isAuthed, token)`, so once on the slug URL, the live query is cached under the **slug**.

`useSetRsvp`'s `onSuccess` (`frontend/src/api/rsvp.ts`) patched the cache with `qc.setQueryData(eventKeys.detail(event.id, isAuthed), event)`, where `event.id` is the **UUID** from the RSVP response. `useRemoveRsvp` invalidated the same UUID-keyed entry. Neither touched the slug-keyed cache entry actually backing the visible screen, so the going list stayed stale until something else (window refocus, manual refresh, or a subsequent SSE-driven `broadcast_capacity_change` ping to *other* stakeholders) forced a refetch.

This is a frontend cache-key mismatch, not a missing `broadcast_event_update()` call — the backend RSVP endpoint (`backend/community/_event_rsvps.py`) already calls `broadcast_capacity_change()` (which wraps `broadcast_event_update()`) after a successful RSVP, correctly notifying *other* open tabs/attendees. The bug was specific to the mutating user's own view.

## Fix

In `frontend/src/api/rsvp.ts`:
- `useSetRsvp`: in addition to the existing UUID-keyed `setQueryData`, added a `setQueriesData` call with a predicate matching any `events/detail` query for this event by `id` or `slug`, so it patches the cache entry regardless of which id shape keyed it.
- `useRemoveRsvp`: alongside the existing UUID-keyed `invalidateQueries`, added a predicate-based `invalidateQueries` matching cached detail data by `id`.

No polling added, no new SSE channel — the existing `event_updates`/`broadcast_event_update()` mechanism for other viewers is untouched.

## Test plan

- [x] `make agent-frontend-typecheck` — clean
- [x] `make agent-frontend-lint` — clean (includes prettier check)
- [x] `npx vitest run src/screens/events/MyRsvpSection.test.tsx src/screens/events/RsvpGuestList.test.tsx` — 33 passed