### PR TITLE
refactor: collapse audit_log target/details into AuditTarget

### DIFF
--- a/backend/community/_dev_tools.py
+++ b/backend/community/_dev_tools.py
@@ -2,7 +2,7 @@ import logging
 import os
 from datetime import timedelta
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.ratelimit import rate_limit
 from django.utils import timezone
@@ -157,7 +157,6 @@ def create_dev_test_event(request, payload: DevTestEventIn):
         logging.INFO,
         "dev_test_event_created",
         request,
-        target_type=AuditTargetType.EVENT,
-        target_id=str(event.id),
+        target=AuditTarget(type=AuditTargetType.EVENT, id=str(event.id)),
     )
     return Status(201, _event_out(event, request.auth))

--- a/backend/community/_docs.py
+++ b/backend/community/_docs.py
@@ -8,7 +8,7 @@ helpers stay here so they're imported from a single place.
 import logging
 from datetime import datetime
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
@@ -145,11 +145,13 @@ def list_folders(request):
             logging.WARNING,
             "permission_denied",
             request,
-            details={
-                "endpoint": "list_folders",
-                "required_permission": PermissionKey.MANAGE_DOCUMENTS,
-            },
             persist=False,
+            target=AuditTarget(
+                details={
+                    "endpoint": "list_folders",
+                    "required_permission": PermissionKey.MANAGE_DOCUMENTS,
+                }
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_documents")
     top_level = DocFolder.objects.filter(parent__isnull=True).prefetch_related(
@@ -169,11 +171,13 @@ def create_folder(request, payload: FolderIn):
             logging.WARNING,
             "permission_denied",
             request,
-            details={
-                "endpoint": "create_folder",
-                "required_permission": PermissionKey.MANAGE_DOCUMENTS,
-            },
             persist=False,
+            target=AuditTarget(
+                details={
+                    "endpoint": "create_folder",
+                    "required_permission": PermissionKey.MANAGE_DOCUMENTS,
+                }
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_documents")
 
@@ -189,9 +193,11 @@ def create_folder(request, payload: FolderIn):
         logging.INFO,
         "doc_folder_created",
         request,
-        target_type=AuditTargetType.DOC_FOLDER,
-        target_id=str(folder.id),
-        details={"name": folder.name, "parent_id": str(parent.id) if parent else None},
+        target=AuditTarget(
+            type=AuditTargetType.DOC_FOLDER,
+            id=str(folder.id),
+            details={"name": folder.name, "parent_id": str(parent.id) if parent else None},
+        ),
     )
     return Status(201, _folder_to_out(folder))
 
@@ -207,11 +213,13 @@ def reorder_folders(request, payload: ReorderIn):
             logging.WARNING,
             "permission_denied",
             request,
-            details={
-                "endpoint": "reorder_folders",
-                "required_permission": PermissionKey.MANAGE_DOCUMENTS,
-            },
             persist=False,
+            target=AuditTarget(
+                details={
+                    "endpoint": "reorder_folders",
+                    "required_permission": PermissionKey.MANAGE_DOCUMENTS,
+                }
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_documents")
 
@@ -232,13 +240,15 @@ def update_folder(request, folder_id: str, payload: FolderPatchIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.DOC_FOLDER,
-            target_id=folder_id,
-            details={
-                "endpoint": "update_folder",
-                "required_permission": PermissionKey.MANAGE_DOCUMENTS,
-            },
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.DOC_FOLDER,
+                id=folder_id,
+                details={
+                    "endpoint": "update_folder",
+                    "required_permission": PermissionKey.MANAGE_DOCUMENTS,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_documents")
 
@@ -267,9 +277,11 @@ def update_folder(request, folder_id: str, payload: FolderPatchIn):
         logging.INFO,
         "doc_folder_updated",
         request,
-        target_type=AuditTargetType.DOC_FOLDER,
-        target_id=folder_id,
-        details={"fields_changed": list(updates.keys())},
+        target=AuditTarget(
+            type=AuditTargetType.DOC_FOLDER,
+            id=folder_id,
+            details={"fields_changed": list(updates.keys())},
+        ),
     )
     return Status(200, _folder_to_out(folder))
 
@@ -285,13 +297,15 @@ def delete_folder(request, folder_id: str):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.DOC_FOLDER,
-            target_id=folder_id,
-            details={
-                "endpoint": "delete_folder",
-                "required_permission": PermissionKey.MANAGE_DOCUMENTS,
-            },
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.DOC_FOLDER,
+                id=folder_id,
+                details={
+                    "endpoint": "delete_folder",
+                    "required_permission": PermissionKey.MANAGE_DOCUMENTS,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_documents")
 
@@ -306,8 +320,8 @@ def delete_folder(request, folder_id: str):
         logging.INFO,
         "doc_folder_deleted",
         request,
-        target_type=AuditTargetType.DOC_FOLDER,
-        target_id=folder_id,
-        details={"name": folder_name},
+        target=AuditTarget(
+            type=AuditTargetType.DOC_FOLDER, id=folder_id, details={"name": folder_name}
+        ),
     )
     return Status(200, {"detail": "Folder deleted."})

--- a/backend/community/_docs_documents.py
+++ b/backend/community/_docs_documents.py
@@ -7,7 +7,7 @@ from there — single source of truth.
 
 import logging
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
@@ -43,11 +43,13 @@ def create_document(request, payload: DocumentIn):
             logging.WARNING,
             "permission_denied",
             request,
-            details={
-                "endpoint": "create_document",
-                "required_permission": PermissionKey.MANAGE_DOCUMENTS,
-            },
             persist=False,
+            target=AuditTarget(
+                details={
+                    "endpoint": "create_document",
+                    "required_permission": PermissionKey.MANAGE_DOCUMENTS,
+                }
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_documents")
 
@@ -69,9 +71,11 @@ def create_document(request, payload: DocumentIn):
         logging.INFO,
         "document_created",
         request,
-        target_type=AuditTargetType.DOCUMENT,
-        target_id=str(doc.id),
-        details={"title": doc.title, "folder_id": str(folder.id)},
+        target=AuditTarget(
+            type=AuditTargetType.DOCUMENT,
+            id=str(doc.id),
+            details={"title": doc.title, "folder_id": str(folder.id)},
+        ),
     )
     return Status(201, _doc_to_out(doc))
 
@@ -87,11 +91,13 @@ def reorder_documents(request, payload: ReorderIn):
             logging.WARNING,
             "permission_denied",
             request,
-            details={
-                "endpoint": "reorder_documents",
-                "required_permission": PermissionKey.MANAGE_DOCUMENTS,
-            },
             persist=False,
+            target=AuditTarget(
+                details={
+                    "endpoint": "reorder_documents",
+                    "required_permission": PermissionKey.MANAGE_DOCUMENTS,
+                }
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_documents")
 
@@ -112,11 +118,13 @@ def get_document(request, doc_id: str):
             logging.WARNING,
             "permission_denied",
             request,
-            details={
-                "endpoint": "get_document",
-                "required_permission": PermissionKey.MANAGE_DOCUMENTS,
-            },
             persist=False,
+            target=AuditTarget(
+                details={
+                    "endpoint": "get_document",
+                    "required_permission": PermissionKey.MANAGE_DOCUMENTS,
+                }
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_documents")
     try:
@@ -138,13 +146,15 @@ def update_document(request, doc_id: str, payload: DocumentPatchIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.DOCUMENT,
-            target_id=doc_id,
-            details={
-                "endpoint": "update_document",
-                "required_permission": PermissionKey.MANAGE_DOCUMENTS,
-            },
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.DOCUMENT,
+                id=doc_id,
+                details={
+                    "endpoint": "update_document",
+                    "required_permission": PermissionKey.MANAGE_DOCUMENTS,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_documents")
 
@@ -175,9 +185,11 @@ def update_document(request, doc_id: str, payload: DocumentPatchIn):
         logging.INFO,
         "document_updated",
         request,
-        target_type=AuditTargetType.DOCUMENT,
-        target_id=doc_id,
-        details={"fields_changed": list(updates.keys())},
+        target=AuditTarget(
+            type=AuditTargetType.DOCUMENT,
+            id=doc_id,
+            details={"fields_changed": list(updates.keys())},
+        ),
     )
     return Status(200, _doc_to_out(doc))
 
@@ -193,13 +205,15 @@ def delete_document(request, doc_id: str):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.DOCUMENT,
-            target_id=doc_id,
-            details={
-                "endpoint": "delete_document",
-                "required_permission": PermissionKey.MANAGE_DOCUMENTS,
-            },
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.DOCUMENT,
+                id=doc_id,
+                details={
+                    "endpoint": "delete_document",
+                    "required_permission": PermissionKey.MANAGE_DOCUMENTS,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_documents")
 
@@ -214,8 +228,6 @@ def delete_document(request, doc_id: str):
         logging.INFO,
         "document_deleted",
         request,
-        target_type=AuditTargetType.DOCUMENT,
-        target_id=doc_id,
-        details={"title": title},
+        target=AuditTarget(type=AuditTargetType.DOCUMENT, id=doc_id, details={"title": title}),
     )
     return Status(200, {"detail": "Document deleted."})

--- a/backend/community/_event_actions.py
+++ b/backend/community/_event_actions.py
@@ -2,7 +2,7 @@ import logging
 import time
 from uuid import UUID
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.ratelimit import rate_limit
 from django.utils import timezone
@@ -56,10 +56,12 @@ def upload_event_photo(request, event_id: UUID, photo: UploadedFile = File(...))
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.EVENT,
-            target_id=str(event_id),
-            details={"endpoint": "upload_event_photo"},
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.EVENT,
+                id=str(event_id),
+                details={"endpoint": "upload_event_photo"},
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="upload_event_photo")
     if event.is_cancelled:
@@ -76,7 +78,6 @@ def upload_event_photo(request, event_id: UUID, photo: UploadedFile = File(...))
         logging.INFO,
         "event_photo_uploaded",
         request,
-        target_type=AuditTargetType.EVENT,
-        target_id=str(event_id),
+        target=AuditTarget(type=AuditTargetType.EVENT, id=str(event_id)),
     )
     return Status(200, _event_out(event, request.auth))

--- a/backend/community/_event_blasts.py
+++ b/backend/community/_event_blasts.py
@@ -1,7 +1,7 @@
 import logging
 from uuid import UUID
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.ratelimit import rate_limit
 from ninja import Router, Schema
@@ -110,10 +110,12 @@ def send_email_blast(request, event_id: UUID, payload: EmailBlastIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.EVENT,
-            target_id=str(event_id),
-            details={"endpoint": "send_email_blast"},
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.EVENT,
+                id=str(event_id),
+                details={"endpoint": "send_email_blast"},
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="send_email_blast")
 
@@ -143,14 +145,16 @@ def send_email_blast(request, event_id: UUID, payload: EmailBlastIn):
         logging.INFO,
         "event_email_blast_sent",
         request,
-        target_type=AuditTargetType.EVENT,
-        target_id=str(event_id),
-        details={
-            "sent_count": sent_count,
-            "skipped_no_email_count": skipped_no_email,
-            "failed_count": failed_count,
-            "audience": statuses,
-        },
+        target=AuditTarget(
+            type=AuditTargetType.EVENT,
+            id=str(event_id),
+            details={
+                "sent_count": sent_count,
+                "skipped_no_email_count": skipped_no_email,
+                "failed_count": failed_count,
+                "audience": statuses,
+            },
+        ),
     )
     return Status(
         200,

--- a/backend/community/_event_host_actions.py
+++ b/backend/community/_event_host_actions.py
@@ -2,7 +2,7 @@ import logging
 from datetime import timedelta
 from uuid import UUID
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.ratelimit import rate_limit
 from django.db import transaction
@@ -165,9 +165,11 @@ def set_attendance(request, event_id: UUID, user_id: UUID, payload: AttendanceIn
         logging.INFO,
         "attendance_marked",
         request,
-        target_type=AuditTargetType.EVENT,
-        target_id=str(event_id),
-        details={"user_id": str(user_id), "attendance": payload.attendance},
+        target=AuditTarget(
+            type=AuditTargetType.EVENT,
+            id=str(event_id),
+            details={"user_id": str(user_id), "attendance": payload.attendance},
+        ),
     )
 
     event = load_event_with_stats_prefetch(event_id)

--- a/backend/community/_event_host_rsvps.py
+++ b/backend/community/_event_host_rsvps.py
@@ -1,7 +1,7 @@
 import logging
 from uuid import UUID
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.ratelimit import rate_limit
 from django.db import transaction
@@ -118,13 +118,15 @@ def set_guest_rsvp(request, event_id: UUID, user_id: UUID, payload: HostRSVPIn):
         logging.INFO,
         "guest_rsvp_changed",
         request,
-        target_type=AuditTargetType.EVENT,
-        target_id=str(event_id),
-        details={
-            "user_id": str(user_id),
-            "status": final_status,
-            **payment_audit_details(event_id, user_id),
-        },
+        target=AuditTarget(
+            type=AuditTargetType.EVENT,
+            id=str(event_id),
+            details={
+                "user_id": str(user_id),
+                "status": final_status,
+                **payment_audit_details(event_id, user_id),
+            },
+        ),
     )
     event = load_event_with_stats_prefetch(event_id)
     if event is None:
@@ -179,13 +181,15 @@ def set_guest_payment(request, event_id: UUID, user_id: UUID, payload: HostRSVPP
         logging.INFO,
         "guest_payment_revoked" if is_revoke else "guest_payment_changed",
         request,
-        target_type=AuditTargetType.EVENT,
-        target_id=str(event_id),
-        details={
-            "user_id": str(user_id),
-            "was_paid": was_paid,
-            **payment_audit_details(event_id, user_id),
-        },
+        target=AuditTarget(
+            type=AuditTargetType.EVENT,
+            id=str(event_id),
+            details={
+                "user_id": str(user_id),
+                "was_paid": was_paid,
+                **payment_audit_details(event_id, user_id),
+            },
+        ),
     )
     if is_revoke:
         create_payment_revoked_notification(event, str(user_id))
@@ -226,9 +230,9 @@ def remove_guest_rsvp(request, event_id: UUID, user_id: UUID):
         logging.INFO,
         "guest_rsvp_removed",
         request,
-        target_type=AuditTargetType.EVENT,
-        target_id=str(event_id),
-        details={"user_id": str(user_id)},
+        target=AuditTarget(
+            type=AuditTargetType.EVENT, id=str(event_id), details={"user_id": str(user_id)}
+        ),
     )
     event = load_event_with_stats_prefetch(event_id)
     if event is None:

--- a/backend/community/_event_invitations.py
+++ b/backend/community/_event_invitations.py
@@ -12,7 +12,7 @@ Co-host invites are a different flow — see _event_cohost_invites.py.
 import logging
 from uuid import UUID
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from django.shortcuts import get_object_or_404
 from ninja import Router
@@ -67,10 +67,12 @@ def invite_to_event(request, event_id: UUID, payload: InviteIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.EVENT,
-            target_id=str(event_id),
-            details={"endpoint": "invite_to_event"},
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.EVENT,
+                id=str(event_id),
+                details={"endpoint": "invite_to_event"},
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="invite_to_event")
 
@@ -95,12 +97,14 @@ def invite_to_event(request, event_id: UUID, payload: InviteIn):
         logging.INFO,
         "event_invitations_added",
         request,
-        target_type=AuditTargetType.EVENT,
-        target_id=str(event_id),
-        details={
-            "requested_count": len(requested_ids),
-            "newly_invited_count": len(new_ids),
-        },
+        target=AuditTarget(
+            type=AuditTargetType.EVENT,
+            id=str(event_id),
+            details={
+                "requested_count": len(requested_ids),
+                "newly_invited_count": len(new_ids),
+            },
+        ),
     )
     event.refresh_from_db()
     return Status(200, _event_out(event, request.auth))

--- a/backend/community/_event_invite_email.py
+++ b/backend/community/_event_invite_email.py
@@ -1,6 +1,6 @@
 import logging
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from django.conf import settings
 from django.utils import timezone
 from notifications._email_helpers import EventInviteEmailDetails, send_event_invite_email
@@ -54,7 +54,9 @@ def email_invited_members(request, event: Event, new_user_ids: list[str], invite
                 logging.WARNING,
                 "event_invite_email_failed",
                 request,
-                target_type=AuditTargetType.EVENT,
-                target_id=str(event.id),
-                details={"user_id": str(user.pk), "error": str(exc)},
+                target=AuditTarget(
+                    type=AuditTargetType.EVENT,
+                    id=str(event.id),
+                    details={"user_id": str(user.pk), "error": str(exc)},
+                ),
             )

--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime
 from uuid import UUID
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.ratelimit import rate_limit
 from django.db import transaction
@@ -254,12 +254,14 @@ def upsert_rsvp(request, event_id: UUID, payload: RSVPIn):
         logging.INFO,
         "rsvp_changed",
         request,
-        target_type=AuditTargetType.EVENT,
-        target_id=str(event_id),
-        details={
-            "status": final_status,
-            **payment_audit_details(event_id, request.auth.pk),
-        },
+        target=AuditTarget(
+            type=AuditTargetType.EVENT,
+            id=str(event_id),
+            details={
+                "status": final_status,
+                **payment_audit_details(event_id, request.auth.pk),
+            },
+        ),
     )
     event = load_event_with_stats_prefetch(event_id)
     if event is None:
@@ -291,8 +293,7 @@ def delete_rsvp(request, event_id: UUID):
         logging.INFO,
         "rsvp_deleted",
         request,
-        target_type=AuditTargetType.EVENT,
-        target_id=str(event_id),
+        target=AuditTarget(type=AuditTargetType.EVENT, id=str(event_id)),
     )
     _email_promoted_non_members(request, event, promoted_user_ids)
     return Status(204, None)

--- a/backend/community/_event_tags.py
+++ b/backend/community/_event_tags.py
@@ -9,7 +9,7 @@ Django admin.
 import logging
 from uuid import UUID
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.ratelimit import rate_limit
 from django.db import IntegrityError, transaction
@@ -33,13 +33,15 @@ def _require_manage_tags(request, endpoint: str, target_id: str = "") -> None:
         logging.WARNING,
         "permission_denied",
         request,
-        target_type=AuditTargetType.EVENT_TAG,
-        target_id=target_id,
-        details={
-            "endpoint": endpoint,
-            "required_permission": PermissionKey.MANAGE_EVENTS,
-        },
         persist=False,
+        target=AuditTarget(
+            type=AuditTargetType.EVENT_TAG,
+            id=target_id,
+            details={
+                "endpoint": endpoint,
+                "required_permission": PermissionKey.MANAGE_EVENTS,
+            },
+        ),
     )
     raise_validation(Code.Perm.DENIED, status_code=403, action="manage_events")
 
@@ -76,9 +78,11 @@ def create_event_tag(request, payload: TagIn):
         logging.INFO,
         "event_tag_created",
         request,
-        target_type=AuditTargetType.EVENT_TAG,
-        target_id=str(tag.id),
-        details={"name": tag.name, "slug": tag.slug},
+        target=AuditTarget(
+            type=AuditTargetType.EVENT_TAG,
+            id=str(tag.id),
+            details={"name": tag.name, "slug": tag.slug},
+        ),
     )
     return Status(201, _tag_out(tag))
 
@@ -100,8 +104,6 @@ def delete_event_tag(request, tag_id: UUID):
         logging.WARNING,
         "event_tag_deleted",
         request,
-        target_type=AuditTargetType.EVENT_TAG,
-        target_id=str(tag_id),
-        details={"name": name},
+        target=AuditTarget(type=AuditTargetType.EVENT_TAG, id=str(tag_id), details={"name": name}),
     )
     return Status(204, None)

--- a/backend/community/_event_transitions.py
+++ b/backend/community/_event_transitions.py
@@ -2,7 +2,7 @@
 
 import logging
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from django.db import transaction
 from django.utils import timezone
 from ninja.responses import Status
@@ -34,9 +34,11 @@ def _cancel_event(request, event: Event, notify: bool) -> None:
         logging.INFO,
         "event_cancelled",
         request,
-        target_type=AuditTargetType.EVENT,
-        target_id=str(event.id),
-        details={"title": event.title, "notify_attendees": notify},
+        target=AuditTarget(
+            type=AuditTargetType.EVENT,
+            id=str(event.id),
+            details={"title": event.title, "notify_attendees": notify},
+        ),
     )
 
 
@@ -51,9 +53,9 @@ def _delete_event(request, event: Event) -> None:
         logging.INFO,
         "event_deleted",
         request,
-        target_type=AuditTargetType.EVENT,
-        target_id=str(event.id),
-        details={"title": event.title},
+        target=AuditTarget(
+            type=AuditTargetType.EVENT, id=str(event.id), details={"title": event.title}
+        ),
     )
 
 
@@ -66,9 +68,9 @@ def _uncancel_event(request, event: Event) -> None:
         logging.INFO,
         "event_uncancelled",
         request,
-        target_type=AuditTargetType.EVENT,
-        target_id=str(event.id),
-        details={"title": event.title},
+        target=AuditTarget(
+            type=AuditTargetType.EVENT, id=str(event.id), details={"title": event.title}
+        ),
     )
 
 
@@ -112,9 +114,9 @@ def _publish_draft(request, event: Event) -> None:
         logging.INFO,
         "event_published",
         request,
-        target_type=AuditTargetType.EVENT,
-        target_id=str(event.id),
-        details={"title": event.title},
+        target=AuditTarget(
+            type=AuditTargetType.EVENT, id=str(event.id), details={"title": event.title}
+        ),
     )
 
 

--- a/backend/community/_events.py
+++ b/backend/community/_events.py
@@ -3,7 +3,7 @@
 import logging
 from uuid import UUID
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.media_proxy import media_path
 from config.ratelimit import rate_limit
@@ -89,13 +89,17 @@ def _enforce_type_tag_permission(request, event_type: str, endpoint: str, event_
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.EVENT,
-            target_id=str(event_id),
-            details=details,
             persist=False,
+            target=AuditTarget(type=AuditTargetType.EVENT, id=str(event_id), details=details),
         )
     else:
-        audit_log(logging.WARNING, "permission_denied", request, details=details, persist=False)
+        audit_log(
+            logging.WARNING,
+            "permission_denied",
+            request,
+            persist=False,
+            target=AuditTarget(details=details),
+        )
     raise_validation(Code.Perm.DENIED, status_code=403, action=required)
 
 
@@ -372,14 +376,16 @@ def create_event(request, payload: EventIn):
         logging.INFO,
         "event_created_draft" if event.is_draft else "event_created",
         request,
-        target_type=AuditTargetType.EVENT,
-        target_id=str(event.id),
-        details={
-            "title": event.title,
-            "event_type": event.event_type,
-            "visibility": event.visibility,
-            "status": event.status,
-        },
+        target=AuditTarget(
+            type=AuditTargetType.EVENT,
+            id=str(event.id),
+            details={
+                "title": event.title,
+                "event_type": event.event_type,
+                "visibility": event.visibility,
+                "status": event.status,
+            },
+        ),
     )
     return Status(201, _event_out(event, request.auth))
 
@@ -407,9 +413,9 @@ def _apply_field_updates(request, event: Event, event_id: UUID, updates: dict) -
         logging.INFO,
         "event_updated",
         request,
-        target_type=AuditTargetType.EVENT,
-        target_id=str(event_id),
-        details={"fields_changed": changed_fields},
+        target=AuditTarget(
+            type=AuditTargetType.EVENT, id=str(event_id), details={"fields_changed": changed_fields}
+        ),
     )
 
 
@@ -436,10 +442,10 @@ def update_event(request, event_id: UUID, payload: EventPatchIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.EVENT,
-            target_id=str(event_id),
-            details={"endpoint": "update_event"},
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.EVENT, id=str(event_id), details={"endpoint": "update_event"}
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="update_event")
 

--- a/backend/community/_feature_flags.py
+++ b/backend/community/_feature_flags.py
@@ -1,6 +1,6 @@
 import logging
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
@@ -38,11 +38,13 @@ def update_feature_flag(request, key: str, payload: FeatureFlagPatchIn):
             logging.WARNING,
             "permission_denied",
             request,
-            details={
-                "endpoint": "update_feature_flag",
-                "required_permission": PermissionKey.MANAGE_FEATURE_FLAGS,
-            },
             persist=False,
+            target=AuditTarget(
+                details={
+                    "endpoint": "update_feature_flag",
+                    "required_permission": PermissionKey.MANAGE_FEATURE_FLAGS,
+                }
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_feature_flags")
     if key not in FeatureFlag.values:
@@ -54,8 +56,8 @@ def update_feature_flag(request, key: str, payload: FeatureFlagPatchIn):
         logging.INFO,
         "feature_flag_updated",
         request,
-        target_type=AuditTargetType.FEATURE_FLAG,
-        target_id=key,
-        details={"enabled": payload.enabled},
+        target=AuditTarget(
+            type=AuditTargetType.FEATURE_FLAG, id=key, details={"enabled": payload.enabled}
+        ),
     )
     return Status(200, FeatureFlagsOut(flags=resolve_flags()))

--- a/backend/community/_guidelines.py
+++ b/backend/community/_guidelines.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import datetime
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
@@ -62,11 +62,13 @@ def update_guidelines(request, payload: GuidelinesPatchIn):
             logging.WARNING,
             "permission_denied",
             request,
-            details={
-                "endpoint": "update_guidelines",
-                "required_permission": PermissionKey.EDIT_GUIDELINES,
-            },
             persist=False,
+            target=AuditTarget(
+                details={
+                    "endpoint": "update_guidelines",
+                    "required_permission": PermissionKey.EDIT_GUIDELINES,
+                }
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_guidelines")
     g = CommunityGuidelines.get()
@@ -75,8 +77,7 @@ def update_guidelines(request, payload: GuidelinesPatchIn):
         logging.INFO,
         "guidelines_updated",
         request,
-        target_type=AuditTargetType.GUIDELINES,
-        details={"format": "prosemirror"},
+        target=AuditTarget(type=AuditTargetType.GUIDELINES, details={"format": "prosemirror"}),
     )
     return Status(200, _singleton_out(g))
 
@@ -93,8 +94,10 @@ def update_faq(request, payload: GuidelinesPatchIn):
             logging.WARNING,
             "permission_denied",
             request,
-            details={"endpoint": "update_faq", "required_permission": PermissionKey.EDIT_FAQ},
             persist=False,
+            target=AuditTarget(
+                details={"endpoint": "update_faq", "required_permission": PermissionKey.EDIT_FAQ}
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_guidelines")
     f = FAQ.get()
@@ -103,7 +106,6 @@ def update_faq(request, payload: GuidelinesPatchIn):
         logging.INFO,
         "faq_updated",
         request,
-        target_type=AuditTargetType.FAQ,
-        details={"format": "prosemirror"},
+        target=AuditTarget(type=AuditTargetType.FAQ, details={"format": "prosemirror"}),
     )
     return Status(200, _singleton_out(f))

--- a/backend/community/_home.py
+++ b/backend/community/_home.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import datetime
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
@@ -67,8 +67,13 @@ def update_home(request, payload: HomePagePatchIn):
             logging.WARNING,
             "permission_denied",
             request,
-            details={"endpoint": "update_home", "required_permission": PermissionKey.EDIT_HOMEPAGE},
             persist=False,
+            target=AuditTarget(
+                details={
+                    "endpoint": "update_home",
+                    "required_permission": PermissionKey.EDIT_HOMEPAGE,
+                }
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="update_home")
     h = HomePage.get()
@@ -80,7 +85,6 @@ def update_home(request, payload: HomePagePatchIn):
         logging.INFO,
         "homepage_updated",
         request,
-        target_type=AuditTargetType.HOMEPAGE,
-        details={"fields_changed": changed},
+        target=AuditTarget(type=AuditTargetType.HOMEPAGE, details={"fields_changed": changed}),
     )
     return Status(200, _home_out(h))

--- a/backend/community/_join_form.py
+++ b/backend/community/_join_form.py
@@ -3,7 +3,7 @@
 import logging
 from uuid import UUID
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
@@ -66,11 +66,13 @@ def create_join_form_question(request, payload: JoinFormQuestionIn):
             logging.WARNING,
             "permission_denied",
             request,
-            details={
-                "endpoint": "create_join_form_question",
-                "required_permission": PermissionKey.EDIT_JOIN_QUESTIONS,
-            },
             persist=False,
+            target=AuditTarget(
+                details={
+                    "endpoint": "create_join_form_question",
+                    "required_permission": PermissionKey.EDIT_JOIN_QUESTIONS,
+                }
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_join_form")
     max_order = JoinFormQuestion.objects.count()
@@ -85,9 +87,9 @@ def create_join_form_question(request, payload: JoinFormQuestionIn):
         logging.INFO,
         "join_form_question_created",
         request,
-        target_type=AuditTargetType.JOIN_FORM_QUESTION,
-        target_id=str(q.id),
-        details={"label": q.label},
+        target=AuditTarget(
+            type=AuditTargetType.JOIN_FORM_QUESTION, id=str(q.id), details={"label": q.label}
+        ),
     )
     return Status(201, _question_out(q))
 
@@ -103,11 +105,13 @@ def reorder_join_form_questions(request, payload: JoinFormQuestionOrderIn):
             logging.WARNING,
             "permission_denied",
             request,
-            details={
-                "endpoint": "reorder_join_form_questions",
-                "required_permission": PermissionKey.EDIT_JOIN_QUESTIONS,
-            },
             persist=False,
+            target=AuditTarget(
+                details={
+                    "endpoint": "reorder_join_form_questions",
+                    "required_permission": PermissionKey.EDIT_JOIN_QUESTIONS,
+                }
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_join_form")
     for idx, qid in enumerate(payload.question_ids):
@@ -128,13 +132,15 @@ def update_join_form_question(request, question_id: UUID, payload: JoinFormQuest
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.JOIN_FORM_QUESTION,
-            target_id=str(question_id),
-            details={
-                "endpoint": "update_join_form_question",
-                "required_permission": PermissionKey.EDIT_JOIN_QUESTIONS,
-            },
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.JOIN_FORM_QUESTION,
+                id=str(question_id),
+                details={
+                    "endpoint": "update_join_form_question",
+                    "required_permission": PermissionKey.EDIT_JOIN_QUESTIONS,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_join_form")
     try:
@@ -150,9 +156,9 @@ def update_join_form_question(request, question_id: UUID, payload: JoinFormQuest
         logging.INFO,
         "join_form_question_updated",
         request,
-        target_type=AuditTargetType.JOIN_FORM_QUESTION,
-        target_id=str(question_id),
-        details={"label": q.label},
+        target=AuditTarget(
+            type=AuditTargetType.JOIN_FORM_QUESTION, id=str(question_id), details={"label": q.label}
+        ),
     )
     return Status(200, _question_out(q))
 
@@ -168,13 +174,15 @@ def delete_join_form_question(request, question_id: UUID):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.JOIN_FORM_QUESTION,
-            target_id=str(question_id),
-            details={
-                "endpoint": "delete_join_form_question",
-                "required_permission": PermissionKey.EDIT_JOIN_QUESTIONS,
-            },
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.JOIN_FORM_QUESTION,
+                id=str(question_id),
+                details={
+                    "endpoint": "delete_join_form_question",
+                    "required_permission": PermissionKey.EDIT_JOIN_QUESTIONS,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_join_form")
     try:
@@ -187,8 +195,8 @@ def delete_join_form_question(request, question_id: UUID):
         logging.INFO,
         "join_form_question_deleted",
         request,
-        target_type=AuditTargetType.JOIN_FORM_QUESTION,
-        target_id=str(question_id),
-        details={"label": label},
+        target=AuditTarget(
+            type=AuditTargetType.JOIN_FORM_QUESTION, id=str(question_id), details={"label": label}
+        ),
     )
     return Status(204, None)

--- a/backend/community/_join_request_resend.py
+++ b/backend/community/_join_request_resend.py
@@ -6,7 +6,7 @@ Split from ``_join_requests.py`` to keep that file under the 500-line cap.
 import logging
 from uuid import UUID
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.ratelimit import rate_limit
 from django.db import transaction
@@ -42,13 +42,15 @@ def resend_magic_link(request, id: UUID):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.JOIN_REQUEST,
-            target_id=str(id),
-            details={
-                "endpoint": "resend_magic_link",
-                "required_permission": PermissionKey.APPROVE_JOIN_REQUESTS,
-            },
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.JOIN_REQUEST,
+                id=str(id),
+                details={
+                    "endpoint": "resend_magic_link",
+                    "required_permission": PermissionKey.APPROVE_JOIN_REQUESTS,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="resend_magic_link")
 
@@ -79,15 +81,17 @@ def resend_magic_link(request, id: UUID):
         logging.INFO,
         "join_request_magic_link_resent",
         request,
-        target_type=AuditTargetType.JOIN_REQUEST,
-        target_id=str(join_request.id),
-        details={
-            "full_name": join_request.full_name,
-            "first_name": join_request.first_name,
-            "last_name": join_request.last_name,
-            "user_id": str(user.id),
-            "invalidated_token_count": invalidated,
-        },
+        target=AuditTarget(
+            type=AuditTargetType.JOIN_REQUEST,
+            id=str(join_request.id),
+            details={
+                "full_name": join_request.full_name,
+                "first_name": join_request.first_name,
+                "last_name": join_request.last_name,
+                "user_id": str(user.id),
+                "invalidated_token_count": invalidated,
+            },
+        ),
     )
     return Status(
         200,

--- a/backend/community/_join_request_submit.py
+++ b/backend/community/_join_request_submit.py
@@ -3,7 +3,7 @@
 import logging
 from enum import StrEnum
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.ratelimit import client_ip, rate_limit
 from django.conf import settings
 from django.core.mail import send_mail
@@ -210,8 +210,8 @@ def submit_join_request(request, payload: JoinRequestIn):
             logging.WARNING,
             "join_request_honeypot_tripped",
             request,
-            details={"full_name": full_name},
             persist=False,
+            target=AuditTarget(details={"full_name": full_name}),
         )
         return Status(201, _honeypot_decoy_response(first_name, full_name, payload.phone_number))
 
@@ -259,9 +259,11 @@ def submit_join_request(request, payload: JoinRequestIn):
         logging.INFO,
         "join_request_submitted",
         request,
-        target_type=AuditTargetType.JOIN_REQUEST,
-        target_id=str(join_request.id),
-        details={"full_name": full_name},
+        target=AuditTarget(
+            type=AuditTargetType.JOIN_REQUEST,
+            id=str(join_request.id),
+            details={"full_name": full_name},
+        ),
     )
     _send_join_request_email(full_name, validated_phone, custom_answers)
     try:

--- a/backend/community/_join_requests.py
+++ b/backend/community/_join_requests.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 from typing import NamedTuple
 from uuid import UUID
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from django.db import transaction
 from django.db.models import Prefetch
@@ -245,11 +245,13 @@ def list_join_requests(request):
             logging.WARNING,
             "permission_denied",
             request,
-            details={
-                "endpoint": "list_join_requests",
-                "required_permission": PermissionKey.APPROVE_JOIN_REQUESTS,
-            },
             persist=False,
+            target=AuditTarget(
+                details={
+                    "endpoint": "list_join_requests",
+                    "required_permission": PermissionKey.APPROVE_JOIN_REQUESTS,
+                }
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="list_join_requests")
 
@@ -342,13 +344,15 @@ def update_join_request_status(request, id: UUID, payload: JoinRequestStatusIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.JOIN_REQUEST,
-            target_id=str(id),
-            details={
-                "endpoint": "update_join_request_status",
-                "required_permission": PermissionKey.APPROVE_JOIN_REQUESTS,
-            },
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.JOIN_REQUEST,
+                id=str(id),
+                details={
+                    "endpoint": "update_join_request_status",
+                    "required_permission": PermissionKey.APPROVE_JOIN_REQUESTS,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="update_join_request_status")
 
@@ -382,9 +386,11 @@ def update_join_request_status(request, id: UUID, payload: JoinRequestStatusIn):
         logging.INFO,
         action,
         request,
-        target_type=AuditTargetType.JOIN_REQUEST,
-        target_id=str(join_request.id),
-        details={"full_name": join_request.full_name, "user_created": user_created},
+        target=AuditTarget(
+            type=AuditTargetType.JOIN_REQUEST,
+            id=str(join_request.id),
+            details={"full_name": join_request.full_name, "user_created": user_created},
+        ),
     )
 
     # A promoted non-member is the linked User itself (which may have been
@@ -419,13 +425,15 @@ def unreject_join_request(request, id: UUID):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.JOIN_REQUEST,
-            target_id=str(id),
-            details={
-                "endpoint": "unreject_join_request",
-                "required_permission": PermissionKey.APPROVE_JOIN_REQUESTS,
-            },
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.JOIN_REQUEST,
+                id=str(id),
+                details={
+                    "endpoint": "unreject_join_request",
+                    "required_permission": PermissionKey.APPROVE_JOIN_REQUESTS,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="unreject_join_request")
 
@@ -444,9 +452,11 @@ def unreject_join_request(request, id: UUID):
         logging.INFO,
         "join_request_unrejected",
         request,
-        target_type=AuditTargetType.JOIN_REQUEST,
-        target_id=str(join_request.id),
-        details={"full_name": join_request.full_name},
+        target=AuditTarget(
+            type=AuditTargetType.JOIN_REQUEST,
+            id=str(join_request.id),
+            details={"full_name": join_request.full_name},
+        ),
     )
 
     return Status(200, _join_request_out(join_request))

--- a/backend/community/_login_link.py
+++ b/backend/community/_login_link.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import timedelta
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.ratelimit import client_ip, rate_limit
 from django.conf import settings
 from django.utils import timezone
@@ -119,9 +119,8 @@ def request_login_link(request, payload: RequestLoginLinkIn):
             logging.INFO,
             "magic_link_request_skipped_recent_token",
             request,
-            target_type=AuditTargetType.USER,
-            target_id=str(user.pk),
             persist=False,
+            target=AuditTarget(type=AuditTargetType.USER, id=str(user.pk)),
         )
         retry_after = max(1, round((recent_token.created_at + _COOLDOWN - now).total_seconds()))
         return Status(
@@ -163,8 +162,7 @@ def request_login_link(request, payload: RequestLoginLinkIn):
         logging.INFO,
         "magic_link_requested",
         request,
-        target_type=AuditTargetType.USER,
-        target_id=str(user.pk),
+        target=AuditTarget(type=AuditTargetType.USER, id=str(user.pk)),
     )
 
     return Status(200, RequestLoginLinkOut(detail=_ADMIN_RESPONSE, delivery=_DELIVERY_ADMIN))
@@ -192,18 +190,20 @@ def _try_email_delivery(*, request, user, magic_token) -> bool:
                 logging.INFO,
                 "magic_link_email_sent",
                 request,
-                target_type=AuditTargetType.USER,
-                target_id=str(user.pk),
-                details={"provider_message_id": send_result.provider_message_id},
+                target=AuditTarget(
+                    type=AuditTargetType.USER,
+                    id=str(user.pk),
+                    details={"provider_message_id": send_result.provider_message_id},
+                ),
             )
             return True
         audit_log(
             logging.WARNING,
             "magic_link_email_failed",
             request,
-            target_type=AuditTargetType.USER,
-            target_id=str(user.pk),
-            details={"error": send_result.error},
+            target=AuditTarget(
+                type=AuditTargetType.USER, id=str(user.pk), details={"error": send_result.error}
+            ),
         )
         return False
     except Exception:

--- a/backend/community/_member_promotion_message.py
+++ b/backend/community/_member_promotion_message.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
@@ -49,11 +49,13 @@ def update_member_promotion_message(request, payload: MemberPromotionMessagePatc
             logging.WARNING,
             "permission_denied",
             request,
-            details={
-                "endpoint": "update_member_promotion_message",
-                "required_permission": PermissionKey.APPROVE_JOIN_REQUESTS,
-            },
             persist=False,
+            target=AuditTarget(
+                details={
+                    "endpoint": "update_member_promotion_message",
+                    "required_permission": PermissionKey.APPROVE_JOIN_REQUESTS,
+                }
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="edit_member_promotion_message")
 
@@ -71,6 +73,6 @@ def update_member_promotion_message(request, payload: MemberPromotionMessagePatc
         logging.INFO,
         "member_promotion_message_updated",
         request,
-        target_type=AuditTargetType.MEMBER_PROMOTION_MESSAGE,
+        target=AuditTarget(type=AuditTargetType.MEMBER_PROMOTION_MESSAGE),
     )
     return Status(200, _out(template))

--- a/backend/community/_pages.py
+++ b/backend/community/_pages.py
@@ -3,7 +3,7 @@
 import logging
 from datetime import datetime
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from django.contrib.auth.models import AnonymousUser
 from ninja import Router
@@ -68,13 +68,15 @@ def update_page(request, slug: str, payload: EditablePagePatchIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.EDITABLE_PAGE,
-            target_id=slug,
-            details={
-                "endpoint": "update_page",
-                "required_permission": PermissionKey.EDIT_GUIDELINES,
-            },
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.EDITABLE_PAGE,
+                id=slug,
+                details={
+                    "endpoint": "update_page",
+                    "required_permission": PermissionKey.EDIT_GUIDELINES,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="update_page")
 
@@ -104,8 +106,10 @@ def update_page(request, slug: str, payload: EditablePagePatchIn):
         logging.INFO,
         "page_updated",
         request,
-        target_type=AuditTargetType.EDITABLE_PAGE,
-        target_id=slug,
-        details={"slug": slug, "fields_changed": changed},
+        target=AuditTarget(
+            type=AuditTargetType.EDITABLE_PAGE,
+            id=slug,
+            details={"slug": slug, "fields_changed": changed},
+        ),
     )
     return Status(200, _page_out(page))

--- a/backend/community/_poll_options.py
+++ b/backend/community/_poll_options.py
@@ -3,7 +3,7 @@
 import logging
 from uuid import UUID
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.ratelimit import rate_limit
 from ninja import Router
@@ -62,9 +62,9 @@ def add_poll_option(request, event_id: UUID, payload: PollOptionIn):
         logging.INFO,
         "poll_option_added",
         request,
-        target_type=AuditTargetType.EVENT_POLL,
-        target_id=str(poll.id),
-        details={"event_id": str(event_id)},
+        target=AuditTarget(
+            type=AuditTargetType.EVENT_POLL, id=str(poll.id), details={"event_id": str(event_id)}
+        ),
     )
     poll_fresh = (
         EventPoll.objects.select_related("winning_option")
@@ -94,9 +94,11 @@ def update_poll_option(request, event_id: UUID, payload: PollOptionIn, option_id
         logging.INFO,
         "poll_option_updated",
         request,
-        target_type=AuditTargetType.EVENT_POLL,
-        target_id=str(poll.id),
-        details={"event_id": str(event_id), "option_id": str(option_id)},
+        target=AuditTarget(
+            type=AuditTargetType.EVENT_POLL,
+            id=str(poll.id),
+            details={"event_id": str(event_id), "option_id": str(option_id)},
+        ),
     )
     poll_fresh = (
         EventPoll.objects.select_related("winning_option")
@@ -125,9 +127,11 @@ def delete_poll_option(request, event_id: UUID, option_id: UUID):
         logging.INFO,
         "poll_option_deleted",
         request,
-        target_type=AuditTargetType.EVENT_POLL,
-        target_id=str(poll.id),
-        details={"event_id": str(event_id), "option_id": str(option_id)},
+        target=AuditTarget(
+            type=AuditTargetType.EVENT_POLL,
+            id=str(poll.id),
+            details={"event_id": str(event_id), "option_id": str(option_id)},
+        ),
     )
     poll_fresh = (
         EventPoll.objects.select_related("winning_option")

--- a/backend/community/_polls.py
+++ b/backend/community/_polls.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta
 from uuid import UUID
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.media_proxy import media_path
 from config.ratelimit import rate_limit
@@ -167,10 +167,12 @@ def create_event_poll(request, event_id: UUID, payload: EventPollIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.EVENT,
-            target_id=str(event_id),
-            details={"endpoint": "create_event_poll"},
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.EVENT,
+                id=str(event_id),
+                details={"endpoint": "create_event_poll"},
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="create_event_poll")
     if event.status == EventStatus.CANCELLED:
@@ -194,9 +196,11 @@ def create_event_poll(request, event_id: UUID, payload: EventPollIn):
         logging.INFO,
         "poll_created",
         request,
-        target_type=AuditTargetType.EVENT_POLL,
-        target_id=str(poll.id),
-        details={"event_id": str(event_id), "option_count": len(payload.options)},
+        target=AuditTarget(
+            type=AuditTargetType.EVENT_POLL,
+            id=str(poll.id),
+            details={"event_id": str(event_id), "option_count": len(payload.options)},
+        ),
     )
     return Status(201, _poll_out(poll, request.auth))
 
@@ -267,9 +271,9 @@ def vote_on_event_poll(request, event_id: UUID, payload: EventPollVoteIn):
         logging.INFO,
         "poll_vote",
         request,
-        target_type=AuditTargetType.EVENT_POLL,
-        target_id=str(poll.id),
-        details={"event_id": str(event_id)},
+        target=AuditTarget(
+            type=AuditTargetType.EVENT_POLL, id=str(poll.id), details={"event_id": str(event_id)}
+        ),
     )
     poll.refresh_from_db()
     poll_fresh = (
@@ -296,10 +300,12 @@ def finalize_event_poll(request, event_id: UUID, payload: EventPollFinalizeIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.EVENT,
-            target_id=str(event_id),
-            details={"endpoint": "finalize_event_poll"},
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.EVENT,
+                id=str(event_id),
+                details={"endpoint": "finalize_event_poll"},
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="finalize_event_poll")
     if event.status == EventStatus.CANCELLED:
@@ -329,12 +335,14 @@ def finalize_event_poll(request, event_id: UUID, payload: EventPollFinalizeIn):
         logging.INFO,
         "poll_finalized",
         request,
-        target_type=AuditTargetType.EVENT_POLL,
-        target_id=str(poll.id),
-        details={
-            "event_id": str(event_id),
-            "winning_datetime": winning_option.datetime.isoformat(),
-        },
+        target=AuditTarget(
+            type=AuditTargetType.EVENT_POLL,
+            id=str(poll.id),
+            details={
+                "event_id": str(event_id),
+                "winning_datetime": winning_option.datetime.isoformat(),
+            },
+        ),
     )
     poll_fresh = (
         EventPoll.objects.select_related("winning_option")
@@ -360,10 +368,12 @@ def delete_event_poll(request, event_id: UUID):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.EVENT,
-            target_id=str(event_id),
-            details={"endpoint": "delete_event_poll"},
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.EVENT,
+                id=str(event_id),
+                details={"endpoint": "delete_event_poll"},
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="delete_event_poll")
     try:
@@ -376,9 +386,9 @@ def delete_event_poll(request, event_id: UUID):
         logging.INFO,
         "poll_deleted",
         request,
-        target_type=AuditTargetType.EVENT_POLL,
-        target_id=poll_id,
-        details={"event_id": str(event_id)},
+        target=AuditTarget(
+            type=AuditTargetType.EVENT_POLL, id=poll_id, details={"event_id": str(event_id)}
+        ),
     )
     return Status(204, None)
 

--- a/backend/community/_public_rsvp_manage.py
+++ b/backend/community/_public_rsvp_manage.py
@@ -1,6 +1,6 @@
 import logging
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.ratelimit import client_ip, rate_limit
 from django.db import transaction
 from django.db.models import Count, Q
@@ -167,13 +167,15 @@ def update_my_rsvp(request, event_id, payload: PublicRsvpManageIn, token: str = 
         logging.INFO,
         "public_rsvp_updated",
         request,
-        target_type=AuditTargetType.EVENT,
-        target_id=str(event.id),
-        details={
-            "user_id": str(user.pk),
-            "status": final_status,
-            **payment_audit_details(event.id, user.pk),
-        },
+        target=AuditTarget(
+            type=AuditTargetType.EVENT,
+            id=str(event.id),
+            details={
+                "user_id": str(user.pk),
+                "status": final_status,
+                **payment_audit_details(event.id, user.pk),
+            },
+        ),
     )
     sent_decline_note = _post_rsvp_comment(event.id, user, final_status, payload.comment)
     email_error = _send_manage_rsvp_email(
@@ -225,9 +227,9 @@ def delete_my_rsvp(request, event_id, token: str = ""):
         logging.INFO,
         "public_rsvp_deleted",
         request,
-        target_type=AuditTargetType.EVENT,
-        target_id=str(event_id),
-        details={"user_id": str(user.pk)},
+        target=AuditTarget(
+            type=AuditTargetType.EVENT, id=str(event_id), details={"user_id": str(user.pk)}
+        ),
     )
     _email_promoted_non_members(request, event, promoted_user_ids)
     broadcast_capacity_change(event.id)

--- a/backend/community/_public_rsvp_resend.py
+++ b/backend/community/_public_rsvp_resend.py
@@ -1,6 +1,6 @@
 import logging
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.ratelimit import client_ip, rate_limit
 from django.conf import settings
 from ninja import Router
@@ -65,9 +65,9 @@ def _send_manage_link(request, user: User) -> None:
             logging.WARNING,
             "public_rsvp_resend_email_failed",
             request,
-            target_type=AuditTargetType.USER,
-            target_id=str(user.pk),
-            details={"error": str(exc)},
+            target=AuditTarget(
+                type=AuditTargetType.USER, id=str(user.pk), details={"error": str(exc)}
+            ),
         )
 
 
@@ -108,7 +108,6 @@ def resend_manage_link(request, payload: ResendManageLinkIn):
             logging.INFO,
             "public_rsvp_resend_sent",
             request,
-            target_type=AuditTargetType.USER,
-            target_id=str(user.pk),
+            target=AuditTarget(type=AuditTargetType.USER, id=str(user.pk)),
         )
     return _neutral()

--- a/backend/community/_public_rsvp_shared.py
+++ b/backend/community/_public_rsvp_shared.py
@@ -1,6 +1,6 @@
 import logging
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from django.conf import settings
 from django.utils import timezone
 from notifications._email_helpers import (
@@ -77,9 +77,11 @@ def _log_email_failure(request, event: Event, user: User, exc: Exception) -> Non
         logging.WARNING,
         "public_rsvp_email_failed",
         request,
-        target_type=AuditTargetType.EVENT,
-        target_id=str(event.id),
-        details={"user_id": str(user.pk), "error": str(exc)},
+        target=AuditTarget(
+            type=AuditTargetType.EVENT,
+            id=str(event.id),
+            details={"user_id": str(user.pk), "error": str(exc)},
+        ),
     )
 
 

--- a/backend/community/_public_rsvp_submit.py
+++ b/backend/community/_public_rsvp_submit.py
@@ -2,7 +2,7 @@ import logging
 from enum import StrEnum
 from typing import NoReturn
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.ratelimit import client_ip, rate_limit
 from django.conf import settings
 from django.core.cache import cache
@@ -79,7 +79,7 @@ def _reject_email_collision(request, email: str) -> NoReturn:
         logging.WARNING,
         "public_rsvp_email_collision",
         request,
-        details={"email": email},
+        target=AuditTarget(details={"email": email}),
     )
     raise_validation(Code.Event.RSVP_COULD_NOT_BE_CREATED, status_code=409)
 
@@ -173,9 +173,9 @@ def _send_recognized_login_link(request, user: User) -> None:
             logging.WARNING,
             "public_rsvp_recognized_email_failed",
             request,
-            target_type=AuditTargetType.USER,
-            target_id=str(user.pk),
-            details={"error": str(exc)},
+            target=AuditTarget(
+                type=AuditTargetType.USER, id=str(user.pk), details={"error": str(exc)}
+            ),
         )
 
 
@@ -218,9 +218,8 @@ def submit_public_rsvp(request, event_id, payload: PublicRsvpIn):
             logging.WARNING,
             "public_rsvp_honeypot_tripped",
             request,
-            target_type=AuditTargetType.EVENT,
-            target_id=str(event_id),
             persist=False,
+            target=AuditTarget(type=AuditTargetType.EVENT, id=str(event_id)),
         )
         return Status(200, _public_rsvp_decoy(event, payload.status, False))
 
@@ -250,13 +249,15 @@ def submit_public_rsvp(request, event_id, payload: PublicRsvpIn):
         logging.INFO,
         "public_rsvp_created",
         request,
-        target_type=AuditTargetType.EVENT,
-        target_id=str(event.id),
-        details={
-            "user_id": str(user.pk),
-            "status": final_status,
-            **payment_audit_details(event.id, user.pk),
-        },
+        target=AuditTarget(
+            type=AuditTargetType.EVENT,
+            id=str(event.id),
+            details={
+                "user_id": str(user.pk),
+                "status": final_status,
+                **payment_audit_details(event.id, user.pk),
+            },
+        ),
     )
 
     _post_rsvp_comment(event.id, user, final_status, payload.comment)

--- a/backend/community/_surveys.py
+++ b/backend/community/_surveys.py
@@ -3,7 +3,7 @@
 import logging
 from uuid import UUID
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
@@ -50,11 +50,13 @@ def list_surveys_admin(request):
             logging.WARNING,
             "permission_denied",
             request,
-            details={
-                "endpoint": "list_surveys_admin",
-                "required_permission": PermissionKey.MANAGE_SURVEYS,
-            },
             persist=False,
+            target=AuditTarget(
+                details={
+                    "endpoint": "list_surveys_admin",
+                    "required_permission": PermissionKey.MANAGE_SURVEYS,
+                }
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_surveys")
     surveys = Survey.objects.all()
@@ -87,11 +89,13 @@ def create_survey(request, payload: SurveyIn):
             logging.WARNING,
             "permission_denied",
             request,
-            details={
-                "endpoint": "create_survey",
-                "required_permission": PermissionKey.MANAGE_SURVEYS,
-            },
             persist=False,
+            target=AuditTarget(
+                details={
+                    "endpoint": "create_survey",
+                    "required_permission": PermissionKey.MANAGE_SURVEYS,
+                }
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_surveys")
     if Survey.objects.filter(slug=payload.slug).exists():
@@ -116,9 +120,11 @@ def create_survey(request, payload: SurveyIn):
         logging.INFO,
         "survey_created",
         request,
-        target_type=AuditTargetType.SURVEY,
-        target_id=str(survey.id),
-        details={"title": survey.title, "slug": survey.slug},
+        target=AuditTarget(
+            type=AuditTargetType.SURVEY,
+            id=str(survey.id),
+            details={"title": survey.title, "slug": survey.slug},
+        ),
     )
     return Status(201, _survey_out(survey, include_questions=True))
 
@@ -134,13 +140,15 @@ def get_survey_admin(request, survey_id: UUID):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.SURVEY,
-            target_id=str(survey_id),
-            details={
-                "endpoint": "get_survey_admin",
-                "required_permission": PermissionKey.MANAGE_SURVEYS,
-            },
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.SURVEY,
+                id=str(survey_id),
+                details={
+                    "endpoint": "get_survey_admin",
+                    "required_permission": PermissionKey.MANAGE_SURVEYS,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_surveys")
     try:
@@ -161,13 +169,15 @@ def update_survey(request, survey_id: UUID, payload: SurveyPatchIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.SURVEY,
-            target_id=str(survey_id),
-            details={
-                "endpoint": "update_survey",
-                "required_permission": PermissionKey.MANAGE_SURVEYS,
-            },
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.SURVEY,
+                id=str(survey_id),
+                details={
+                    "endpoint": "update_survey",
+                    "required_permission": PermissionKey.MANAGE_SURVEYS,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_surveys")
     try:
@@ -187,9 +197,11 @@ def update_survey(request, survey_id: UUID, payload: SurveyPatchIn):
         logging.INFO,
         "survey_updated",
         request,
-        target_type=AuditTargetType.SURVEY,
-        target_id=str(survey_id),
-        details={"fields_changed": list(updates.keys())},
+        target=AuditTarget(
+            type=AuditTargetType.SURVEY,
+            id=str(survey_id),
+            details={"fields_changed": list(updates.keys())},
+        ),
     )
     return Status(200, _survey_out(survey, include_questions=True))
 
@@ -205,13 +217,15 @@ def delete_survey(request, survey_id: UUID):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.SURVEY,
-            target_id=str(survey_id),
-            details={
-                "endpoint": "delete_survey",
-                "required_permission": PermissionKey.MANAGE_SURVEYS,
-            },
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.SURVEY,
+                id=str(survey_id),
+                details={
+                    "endpoint": "delete_survey",
+                    "required_permission": PermissionKey.MANAGE_SURVEYS,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_surveys")
     try:
@@ -224,9 +238,9 @@ def delete_survey(request, survey_id: UUID):
         logging.WARNING,
         "survey_deleted",
         request,
-        target_type=AuditTargetType.SURVEY,
-        target_id=str(survey_id),
-        details={"title": title},
+        target=AuditTarget(
+            type=AuditTargetType.SURVEY, id=str(survey_id), details={"title": title}
+        ),
     )
     return Status(204, None)
 
@@ -245,13 +259,15 @@ def create_survey_question(request, survey_id: UUID, payload: SurveyQuestionIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.SURVEY,
-            target_id=str(survey_id),
-            details={
-                "endpoint": "create_survey_question",
-                "required_permission": PermissionKey.MANAGE_SURVEYS,
-            },
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.SURVEY,
+                id=str(survey_id),
+                details={
+                    "endpoint": "create_survey_question",
+                    "required_permission": PermissionKey.MANAGE_SURVEYS,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_surveys")
     try:
@@ -271,9 +287,11 @@ def create_survey_question(request, survey_id: UUID, payload: SurveyQuestionIn):
         logging.INFO,
         "survey_question_created",
         request,
-        target_type=AuditTargetType.SURVEY_QUESTION,
-        target_id=str(q.id),
-        details={"survey_id": str(survey_id), "label": q.label},
+        target=AuditTarget(
+            type=AuditTargetType.SURVEY_QUESTION,
+            id=str(q.id),
+            details={"survey_id": str(survey_id), "label": q.label},
+        ),
     )
     return Status(201, _survey_question_out(q))
 
@@ -289,13 +307,15 @@ def update_survey_question(request, survey_id: UUID, question_id: UUID, payload:
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.SURVEY_QUESTION,
-            target_id=str(question_id),
-            details={
-                "endpoint": "update_survey_question",
-                "required_permission": PermissionKey.MANAGE_SURVEYS,
-            },
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.SURVEY_QUESTION,
+                id=str(question_id),
+                details={
+                    "endpoint": "update_survey_question",
+                    "required_permission": PermissionKey.MANAGE_SURVEYS,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_surveys")
     try:
@@ -311,9 +331,11 @@ def update_survey_question(request, survey_id: UUID, question_id: UUID, payload:
         logging.INFO,
         "survey_question_updated",
         request,
-        target_type=AuditTargetType.SURVEY_QUESTION,
-        target_id=str(question_id),
-        details={"survey_id": str(survey_id), "label": q.label},
+        target=AuditTarget(
+            type=AuditTargetType.SURVEY_QUESTION,
+            id=str(question_id),
+            details={"survey_id": str(survey_id), "label": q.label},
+        ),
     )
     return Status(200, _survey_question_out(q))
 
@@ -329,13 +351,15 @@ def delete_survey_question(request, survey_id: UUID, question_id: UUID):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.SURVEY_QUESTION,
-            target_id=str(question_id),
-            details={
-                "endpoint": "delete_survey_question",
-                "required_permission": PermissionKey.MANAGE_SURVEYS,
-            },
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.SURVEY_QUESTION,
+                id=str(question_id),
+                details={
+                    "endpoint": "delete_survey_question",
+                    "required_permission": PermissionKey.MANAGE_SURVEYS,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_surveys")
     try:
@@ -347,9 +371,11 @@ def delete_survey_question(request, survey_id: UUID, question_id: UUID):
         logging.INFO,
         "survey_question_deleted",
         request,
-        target_type=AuditTargetType.SURVEY_QUESTION,
-        target_id=str(question_id),
-        details={"survey_id": str(survey_id)},
+        target=AuditTarget(
+            type=AuditTargetType.SURVEY_QUESTION,
+            id=str(question_id),
+            details={"survey_id": str(survey_id)},
+        ),
     )
     return Status(204, None)
 
@@ -365,13 +391,15 @@ def reorder_survey_questions(request, survey_id: UUID, payload: SurveyQuestionOr
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.SURVEY,
-            target_id=str(survey_id),
-            details={
-                "endpoint": "reorder_survey_questions",
-                "required_permission": PermissionKey.MANAGE_SURVEYS,
-            },
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.SURVEY,
+                id=str(survey_id),
+                details={
+                    "endpoint": "reorder_survey_questions",
+                    "required_permission": PermissionKey.MANAGE_SURVEYS,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_surveys")
     try:
@@ -384,8 +412,7 @@ def reorder_survey_questions(request, survey_id: UUID, payload: SurveyQuestionOr
         logging.INFO,
         "survey_questions_reordered",
         request,
-        target_type=AuditTargetType.SURVEY,
-        target_id=str(survey_id),
+        target=AuditTarget(type=AuditTargetType.SURVEY, id=str(survey_id)),
     )
     questions = SurveyQuestion.objects.filter(survey_id=survey_id)
     return Status(200, [_survey_question_out(q) for q in questions])
@@ -405,13 +432,15 @@ def list_survey_responses(request, survey_id: UUID):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.SURVEY,
-            target_id=str(survey_id),
-            details={
-                "endpoint": "list_survey_responses",
-                "required_permission": PermissionKey.MANAGE_SURVEYS,
-            },
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.SURVEY,
+                id=str(survey_id),
+                details={
+                    "endpoint": "list_survey_responses",
+                    "required_permission": PermissionKey.MANAGE_SURVEYS,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="manage_surveys")
     try:

--- a/backend/community/_surveys_public.py
+++ b/backend/community/_surveys_public.py
@@ -3,7 +3,7 @@
 import logging
 from uuid import UUID
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.ratelimit import auth_or_ip_key, rate_limit
 from ninja import Router
@@ -86,9 +86,9 @@ def submit_survey_response(request, slug: str, payload: SurveyAnswersIn):
                 logging.INFO,
                 "survey_response_updated",
                 request,
-                target_type=AuditTargetType.SURVEY,
-                target_id=str(survey.id),
-                details={"slug": slug},
+                target=AuditTarget(
+                    type=AuditTargetType.SURVEY, id=str(survey.id), details={"slug": slug}
+                ),
             )
             return Status(200, _response_out(existing, user_name))
     response = SurveyResponse.objects.create(survey=survey, user=auth_user, answers=answers)
@@ -96,9 +96,7 @@ def submit_survey_response(request, slug: str, payload: SurveyAnswersIn):
         logging.INFO,
         "survey_response_submitted",
         request,
-        target_type=AuditTargetType.SURVEY,
-        target_id=str(survey.id),
-        details={"slug": slug},
+        target=AuditTarget(type=AuditTargetType.SURVEY, id=str(survey.id), details={"slug": slug}),
     )
     return Status(201, _response_out(response, user_name))
 
@@ -129,10 +127,12 @@ def get_survey_tallies(request, survey_id: UUID):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.SURVEY,
-            target_id=str(survey_id),
-            details={"endpoint": "get_survey_tallies"},
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.SURVEY,
+                id=str(survey_id),
+                details={"endpoint": "get_survey_tallies"},
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="get_survey_tallies")
 
@@ -165,10 +165,12 @@ def finalize_poll(request, survey_id: UUID, payload: FinalizePollIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.SURVEY,
-            target_id=str(survey_id),
-            details={"endpoint": "finalize_poll"},
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.SURVEY,
+                id=str(survey_id),
+                details={"endpoint": "finalize_poll"},
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="finalize_poll")
 
@@ -203,12 +205,14 @@ def finalize_poll(request, survey_id: UUID, payload: FinalizePollIn):
         logging.INFO,
         "survey_poll_finalized",
         request,
-        target_type=AuditTargetType.SURVEY,
-        target_id=str(survey_id),
-        details={
-            "winning_datetime": payload.winning_datetime.isoformat(),
-            "linked_event_id": str(event.id) if event else None,
-        },
+        target=AuditTarget(
+            type=AuditTargetType.SURVEY,
+            id=str(survey_id),
+            details={
+                "winning_datetime": payload.winning_datetime.isoformat(),
+                "linked_event_id": str(event.id) if event else None,
+            },
+        ),
     )
     survey.refresh_from_db()
     return Status(200, _survey_out(survey, include_questions=True, requesting_user=request.auth))

--- a/backend/community/_tentative_approval_message.py
+++ b/backend/community/_tentative_approval_message.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
@@ -49,11 +49,13 @@ def update_tentative_approval_message(request, payload: TentativeApprovalMessage
             logging.WARNING,
             "permission_denied",
             request,
-            details={
-                "endpoint": "update_tentative_approval_message",
-                "required_permission": PermissionKey.APPROVE_JOIN_REQUESTS,
-            },
             persist=False,
+            target=AuditTarget(
+                details={
+                    "endpoint": "update_tentative_approval_message",
+                    "required_permission": PermissionKey.APPROVE_JOIN_REQUESTS,
+                }
+            ),
         )
         raise_validation(
             Code.Perm.DENIED, status_code=403, action="edit_tentative_approval_message"
@@ -73,6 +75,6 @@ def update_tentative_approval_message(request, payload: TentativeApprovalMessage
         logging.INFO,
         "tentative_approval_message_updated",
         request,
-        target_type=AuditTargetType.TENTATIVE_APPROVAL_MESSAGE,
+        target=AuditTarget(type=AuditTargetType.TENTATIVE_APPROVAL_MESSAGE),
     )
     return Status(200, _out(template))

--- a/backend/community/_welcome_template.py
+++ b/backend/community/_welcome_template.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
@@ -48,11 +48,13 @@ def update_welcome_template(request, payload: WelcomeTemplatePatchIn):
             logging.WARNING,
             "permission_denied",
             request,
-            details={
-                "endpoint": "update_welcome_template",
-                "required_permission": PermissionKey.APPROVE_JOIN_REQUESTS,
-            },
             persist=False,
+            target=AuditTarget(
+                details={
+                    "endpoint": "update_welcome_template",
+                    "required_permission": PermissionKey.APPROVE_JOIN_REQUESTS,
+                }
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="edit_welcome_message")
 
@@ -70,6 +72,6 @@ def update_welcome_template(request, payload: WelcomeTemplatePatchIn):
         logging.INFO,
         "welcome_template_updated",
         request,
-        target_type=AuditTargetType.WELCOME_TEMPLATE,
+        target=AuditTarget(type=AuditTargetType.WELCOME_TEMPLATE),
     )
     return Status(200, _out(template))

--- a/backend/community/_whatsapp_link.py
+++ b/backend/community/_whatsapp_link.py
@@ -1,7 +1,7 @@
 import logging
 from datetime import datetime
 
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from ninja import Router
 from ninja.responses import Status
@@ -45,11 +45,13 @@ def update_whatsapp_link(request, payload: WhatsAppLinkPatchIn):
             logging.WARNING,
             "permission_denied",
             request,
-            details={
-                "endpoint": "update_whatsapp_link",
-                "required_permission": PermissionKey.APPROVE_JOIN_REQUESTS,
-            },
             persist=False,
+            target=AuditTarget(
+                details={
+                    "endpoint": "update_whatsapp_link",
+                    "required_permission": PermissionKey.APPROVE_JOIN_REQUESTS,
+                }
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="edit_whatsapp_link")
 
@@ -65,6 +67,6 @@ def update_whatsapp_link(request, payload: WhatsAppLinkPatchIn):
         logging.INFO,
         "whatsapp_link_updated",
         request,
-        target_type=AuditTargetType.WHATSAPP_LINK,
+        target=AuditTarget(type=AuditTargetType.WHATSAPP_LINK),
     )
     return Status(200, _out(config))

--- a/backend/config/audit.py
+++ b/backend/config/audit.py
@@ -2,13 +2,23 @@
 
 import ipaddress
 import logging
+from typing import NamedTuple
 
 from audit.models import AuditLogEntry, AuditTargetType
 from django.db import transaction
 
 from config.ratelimit import client_ip
 
-__all__ = ["AuditTargetType", "audit_log"]
+__all__ = ["AuditTarget", "AuditTargetType", "audit_log"]
+
+
+class AuditTarget(NamedTuple):
+    """The audited object and what happened to it: type, id, and context details."""
+
+    type: AuditTargetType | str = ""
+    id: str = ""
+    details: dict | None = None
+
 
 _audit_logger = logging.getLogger("pda.audit")
 
@@ -28,13 +38,11 @@ def _persist(**fields) -> None:
         _audit_logger.exception("audit_persist_failed", extra={"action": fields.get("action")})
 
 
-def audit_log(  # noqa: PLR0913
+def audit_log(
     level: int,
     action: str,
     request,
-    target_type: AuditTargetType | str = "",
-    target_id: str = "",
-    details: dict | None = None,
+    target: AuditTarget | None = None,
     *,
     persist: bool = True,
 ) -> None:
@@ -44,11 +52,10 @@ def audit_log(  # noqa: PLR0913
         level: logging.INFO or logging.WARNING
         action: verb describing the event (e.g. 'login_success', 'user_deleted')
         request: the Django/Ninja HttpRequest (used for actor and IP)
-        target_type: AuditTargetType member for the affected object
-        target_id: string ID of the affected object
-        details: optional context dict (avoid including raw phone numbers or tokens)
+        target: AuditTarget(type, id, details) for the affected object
         persist: write a row to the audit table; False for console-only noise
     """
+    target_type, target_id, details = target or AuditTarget()
     user = getattr(request, "auth", None)
     if user and hasattr(user, "pk"):
         actor_id = str(user.pk)

--- a/backend/tests/test_audit_persistence.py
+++ b/backend/tests/test_audit_persistence.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 import pytest
 from audit.models import AuditLogEntry, AuditTargetType
-from config.audit import audit_log
+from config.audit import AuditTarget, audit_log
 from django.db import transaction
 from django.test import RequestFactory
 
@@ -41,9 +41,7 @@ class TestAuditPersistence:
                 logging.INFO,
                 "role_created",
                 request_with_actor,
-                target_type=AuditTargetType.ROLE,
-                target_id="abc",
-                details={"name": "vettor"},
+                target=AuditTarget(type=AuditTargetType.ROLE, id="abc", details={"name": "vettor"}),
             )
         )
 
@@ -62,8 +60,8 @@ class TestAuditPersistence:
                 logging.WARNING,
                 "permission_denied",
                 request_with_actor,
-                target_type=AuditTargetType.ROLE,
                 persist=False,
+                target=AuditTarget(type=AuditTargetType.ROLE),
             )
         )
 
@@ -132,7 +130,9 @@ class TestAuditTargetTypeCoverage:
         for path in backend.rglob("*.py"):
             if "tests" in path.parts or "migrations" in path.parts:
                 continue
-            for match in re.finditer(r'target_type=(["\'])([^"\']*)\1', path.read_text()):
+            for match in re.finditer(
+                r'AuditTarget\([^)]*type=(["\'])([^"\']*)\1', path.read_text()
+            ):
                 literals.append((path.name, match.group(2)))
 
         assert literals == [], f"raw target_type literals found: {literals}"

--- a/backend/users/_auth.py
+++ b/backend/users/_auth.py
@@ -3,7 +3,7 @@
 import logging
 
 from community._validation import Code, raise_validation
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from config.ratelimit import client_ip, rate_limit
 from django.contrib.auth import authenticate
@@ -66,7 +66,10 @@ def login(request, payload: LoginIn, response: HttpResponse):
     if auth_user is None:
         logger.warning("Authentication failure: invalid credentials")
         audit_log(
-            logging.WARNING, "login_failed", request, details={"reason": "invalid_credentials"}
+            logging.WARNING,
+            "login_failed",
+            request,
+            target=AuditTarget(details={"reason": "invalid_credentials"}),
         )
         raise_validation(Code.Auth.INVALID_CREDENTIALS, status_code=401)
     user = User.objects.get(pk=auth_user.pk)
@@ -75,8 +78,7 @@ def login(request, payload: LoginIn, response: HttpResponse):
             logging.WARNING,
             "login_archived",
             request,
-            target_type=AuditTargetType.USER,
-            target_id=str(user.pk),
+            target=AuditTarget(type=AuditTargetType.USER, id=str(user.pk)),
         )
         raise_validation(Code.Auth.ACCOUNT_ARCHIVED, status_code=403)
     if user.is_paused:
@@ -84,8 +86,7 @@ def login(request, payload: LoginIn, response: HttpResponse):
             logging.WARNING,
             "login_paused",
             request,
-            target_type=AuditTargetType.USER,
-            target_id=str(user.pk),
+            target=AuditTarget(type=AuditTargetType.USER, id=str(user.pk)),
         )
         raise_validation(Code.Auth.ACCOUNT_PAUSED, status_code=403)
     refresh = RefreshToken.for_user(user)
@@ -95,8 +96,7 @@ def login(request, payload: LoginIn, response: HttpResponse):
         logging.INFO,
         "login_success",
         request,
-        target_type=AuditTargetType.USER,
-        target_id=str(user.pk),
+        target=AuditTarget(type=AuditTargetType.USER, id=str(user.pk)),
     )
     return Status(200, TokenOut(access=str(refresh.access_token)))  # type: ignore
 
@@ -193,9 +193,9 @@ def update_me(request, payload: MePatchIn):
             logging.INFO,
             "profile_updated",
             request,
-            target_type=AuditTargetType.USER,
-            target_id=str(user.pk),
-            details={"fields_changed": changed},
+            target=AuditTarget(
+                type=AuditTargetType.USER, id=str(user.pk), details={"fields_changed": changed}
+            ),
         )
     return Status(200, UserOut.from_user(user))
 
@@ -228,8 +228,7 @@ def upload_photo(request, photo: UploadedFile = File(...)):  # ty: ignore[call-n
         logging.INFO,
         "profile_photo_uploaded",
         request,
-        target_type=AuditTargetType.USER,
-        target_id=str(user.pk),
+        target=AuditTarget(type=AuditTargetType.USER, id=str(user.pk)),
     )
     return Status(200, UserOut.from_user(user))
 
@@ -246,8 +245,7 @@ def delete_photo(request):
         logging.INFO,
         "profile_photo_deleted",
         request,
-        target_type=AuditTargetType.USER,
-        target_id=str(user.pk),
+        target=AuditTarget(type=AuditTargetType.USER, id=str(user.pk)),
     )
     return Status(200, UserOut.from_user(user))
 
@@ -290,8 +288,7 @@ def complete_onboarding(request, payload: OnboardingIn):
         logging.INFO,
         "onboarding_completed",
         request,
-        target_type=AuditTargetType.USER,
-        target_id=str(user.pk),
+        target=AuditTarget(type=AuditTargetType.USER, id=str(user.pk)),
     )
     return Status(200, UserOut.from_user(user))
 
@@ -308,9 +305,11 @@ def accept_consents(request, payload: AcceptConsentsIn):
         logging.INFO,
         "consents_accepted",
         request,
-        target_type=AuditTargetType.USER,
-        target_id=str(user.pk),
-        details={"consent_types": [str(c) for c in payload.consent_types]},
+        target=AuditTarget(
+            type=AuditTargetType.USER,
+            id=str(user.pk),
+            details={"consent_types": [str(c) for c in payload.consent_types]},
+        ),
     )
     return Status(200, UserOut.from_user(user))
 
@@ -323,9 +322,11 @@ def change_password(request, payload: ChangePasswordIn):
             logging.WARNING,
             "password_change_failed",
             request,
-            target_type=AuditTargetType.USER,
-            target_id=str(user.pk),
-            details={"reason": "wrong_current_password"},
+            target=AuditTarget(
+                type=AuditTargetType.USER,
+                id=str(user.pk),
+                details={"reason": "wrong_current_password"},
+            ),
         )
         raise_validation(
             Code.Auth.CURRENT_PASSWORD_INCORRECT, field="current_password", status_code=400
@@ -347,7 +348,6 @@ def change_password(request, payload: ChangePasswordIn):
         logging.INFO,
         "password_changed",
         request,
-        target_type=AuditTargetType.USER,
-        target_id=str(user.pk),
+        target=AuditTarget(type=AuditTargetType.USER, id=str(user.pk)),
     )
     return Status(200, ErrorOut(detail="Password updated successfully."))

--- a/backend/users/_magic_links.py
+++ b/backend/users/_magic_links.py
@@ -4,7 +4,7 @@ import logging
 from datetime import timedelta
 
 from community._validation import Code, raise_validation
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from django.db import transaction
 from django.utils import timezone
@@ -32,13 +32,15 @@ def generate_magic_link(request, user_id: str):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.USER,
-            target_id=user_id,
-            details={
-                "endpoint": "generate_magic_link",
-                "required_permission": PermissionKey.MANAGE_USERS,
-            },
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.USER,
+                id=user_id,
+                details={
+                    "endpoint": "generate_magic_link",
+                    "required_permission": PermissionKey.MANAGE_USERS,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="generate_magic_link")
 
@@ -65,8 +67,7 @@ def generate_magic_link(request, user_id: str):
                 logging.INFO,
                 "magic_link_already_handled",
                 request,
-                target_type=AuditTargetType.USER,
-                target_id=user_id,
+                target=AuditTarget(type=AuditTargetType.USER, id=user_id),
             )
             return Status(
                 200,
@@ -104,16 +105,15 @@ def generate_magic_link(request, user_id: str):
             logging.INFO,
             "magic_link_notifications_cleared",
             request,
-            target_type=AuditTargetType.USER,
-            target_id=user_id,
-            details={"count": cleared_count},
+            target=AuditTarget(
+                type=AuditTargetType.USER, id=user_id, details={"count": cleared_count}
+            ),
         )
     audit_log(
         logging.INFO,
         "magic_link_generated",
         request,
-        target_type=AuditTargetType.USER,
-        target_id=user_id,
+        target=AuditTarget(type=AuditTargetType.USER, id=user_id),
     )
     return Status(
         200,

--- a/backend/users/_magic_login.py
+++ b/backend/users/_magic_login.py
@@ -3,7 +3,7 @@
 import logging
 
 from community._validation import Code, raise_validation
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.ratelimit import client_ip, rate_limit
 from django.db import transaction
 from django.http import HttpResponse
@@ -46,9 +46,11 @@ def _validate_magic_user(request, magic: MagicLoginToken) -> None:
             logging.WARNING,
             "magic_login_cross_user_blocked",
             request,
-            target_type=AuditTargetType.USER,
-            target_id=str(magic.user.pk),
-            details={"current_user_id": str(current_user.pk)},
+            target=AuditTarget(
+                type=AuditTargetType.USER,
+                id=str(magic.user.pk),
+                details={"current_user_id": str(current_user.pk)},
+            ),
         )
         raise_validation(Code.Auth.ALREADY_SIGNED_IN_AS_DIFFERENT_USER, status_code=403)
     if magic.user.archived_at is not None:
@@ -56,8 +58,7 @@ def _validate_magic_user(request, magic: MagicLoginToken) -> None:
             logging.WARNING,
             "magic_login_archived",
             request,
-            target_type=AuditTargetType.USER,
-            target_id=str(magic.user.pk),
+            target=AuditTarget(type=AuditTargetType.USER, id=str(magic.user.pk)),
         )
         raise_validation(Code.Auth.ACCOUNT_ARCHIVED, status_code=403)
     if magic.user.is_paused:
@@ -65,8 +66,7 @@ def _validate_magic_user(request, magic: MagicLoginToken) -> None:
             logging.WARNING,
             "magic_login_paused",
             request,
-            target_type=AuditTargetType.USER,
-            target_id=str(magic.user.pk),
+            target=AuditTarget(type=AuditTargetType.USER, id=str(magic.user.pk)),
         )
         raise_validation(Code.Auth.ACCOUNT_PAUSED, status_code=403)
 
@@ -84,7 +84,10 @@ def _consume_magic_token(request, token: str) -> MagicLoginToken:
             )
         except MagicLoginToken.DoesNotExist:
             audit_log(
-                logging.WARNING, "magic_login_failed", request, details={"reason": "invalid_token"}
+                logging.WARNING,
+                "magic_login_failed",
+                request,
+                target=AuditTarget(details={"reason": "invalid_token"}),
             )
             raise_validation(Code.Auth.MAGIC_LINK_INVALID_OR_EXPIRED, status_code=400)
         _validate_magic_user(request, magic)
@@ -93,9 +96,11 @@ def _consume_magic_token(request, token: str) -> MagicLoginToken:
                 logging.WARNING,
                 "magic_login_failed",
                 request,
-                target_type=AuditTargetType.USER,
-                target_id=str(magic.user.pk),
-                details={"reason": "used_or_expired"},
+                target=AuditTarget(
+                    type=AuditTargetType.USER,
+                    id=str(magic.user.pk),
+                    details={"reason": "used_or_expired"},
+                ),
             )
             raise_validation(Code.Auth.MAGIC_LINK_ALREADY_USED, status_code=400)
         magic.used = True
@@ -115,8 +120,7 @@ def _consume_magic_token(request, token: str) -> MagicLoginToken:
                 logging.INFO,
                 "magic_login_requires_password_reset",
                 request,
-                target_type=AuditTargetType.USER,
-                target_id=str(magic.user.pk),
+                target=AuditTarget(type=AuditTargetType.USER, id=str(magic.user.pk)),
             )
     return magic
 
@@ -136,7 +140,6 @@ def magic_login(request, token: str, response: HttpResponse):
         logging.INFO,
         "magic_login_success",
         request,
-        target_type=AuditTargetType.USER,
-        target_id=str(magic.user.pk),
+        target=AuditTarget(type=AuditTargetType.USER, id=str(magic.user.pk)),
     )
     return Status(200, TokenOut(access=str(refresh.access_token)))  # type: ignore

--- a/backend/users/_management.py
+++ b/backend/users/_management.py
@@ -7,7 +7,7 @@ from community._rsvp_counts import attendance_q, reportable_events_q
 from community._shared import validate_display_name
 from community._validation import Code, ValidationException, raise_validation
 from community.models import AttendanceStatus
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from django.db import models as dj_models
 from ninja import Router
@@ -54,8 +54,13 @@ def create_user(request, payload: UserCreateIn):
             logging.WARNING,
             "permission_denied",
             request,
-            details={"endpoint": "create_user", "required_permission": PermissionKey.CREATE_USER},
             persist=False,
+            target=AuditTarget(
+                details={
+                    "endpoint": "create_user",
+                    "required_permission": PermissionKey.CREATE_USER,
+                }
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="create_user")
 
@@ -78,12 +83,14 @@ def create_user(request, payload: UserCreateIn):
         logging.INFO,
         "user_created",
         request,
-        target_type=AuditTargetType.USER,
-        target_id=str(user.id),
-        details={
-            "full_name": user.full_name,
-            "role_id": str(payload.role_id) if payload.role_id else None,
-        },
+        target=AuditTarget(
+            type=AuditTargetType.USER,
+            id=str(user.id),
+            details={
+                "full_name": user.full_name,
+                "role_id": str(payload.role_id) if payload.role_id else None,
+            },
+        ),
     )
     return Status(
         201,
@@ -109,11 +116,13 @@ def bulk_create_users(request, payload: BulkUserCreateIn):
             logging.WARNING,
             "permission_denied",
             request,
-            details={
-                "endpoint": "bulk_create_users",
-                "required_permission": PermissionKey.MANAGE_USERS,
-            },
             persist=False,
+            target=AuditTarget(
+                details={
+                    "endpoint": "bulk_create_users",
+                    "required_permission": PermissionKey.MANAGE_USERS,
+                }
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="bulk_create_users")
 
@@ -172,7 +181,7 @@ def bulk_create_users(request, payload: BulkUserCreateIn):
         logging.INFO,
         "users_bulk_created",
         request,
-        details={"count_created": created, "count_failed": failed},
+        target=AuditTarget(details={"count_created": created, "count_failed": failed}),
     )
     return Status(
         200,
@@ -243,8 +252,13 @@ def list_users(request, include_non_members: bool = False):
             logging.WARNING,
             "permission_denied",
             request,
-            details={"endpoint": "list_users", "required_permission": PermissionKey.MANAGE_USERS},
             persist=False,
+            target=AuditTarget(
+                details={
+                    "endpoint": "list_users",
+                    "required_permission": PermissionKey.MANAGE_USERS,
+                }
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="list_users")
     # shares attendance_q + reportable_events_q with the report so the surfaces can't drift.
@@ -277,10 +291,15 @@ def update_user(request, user_id: str, payload: UserPatchIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.USER,
-            target_id=user_id,
-            details={"endpoint": "update_user", "required_permission": PermissionKey.MANAGE_USERS},
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.USER,
+                id=user_id,
+                details={
+                    "endpoint": "update_user",
+                    "required_permission": PermissionKey.MANAGE_USERS,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="update_user")
     try:
@@ -312,9 +331,7 @@ def _audit_user_update(
             logging.WARNING,
             action,
             request,
-            target_type=AuditTargetType.USER,
-            target_id=user_id,
-            details=details,
+            target=AuditTarget(type=AuditTargetType.USER, id=user_id, details=details),
         )
         return
 
@@ -328,9 +345,9 @@ def _audit_user_update(
             logging.INFO,
             "user_updated",
             request,
-            target_type=AuditTargetType.USER,
-            target_id=user_id,
-            details={"fields_changed": changed},
+            target=AuditTarget(
+                type=AuditTargetType.USER, id=user_id, details={"fields_changed": changed}
+            ),
         )
 
 
@@ -373,13 +390,15 @@ def update_user_roles(request, user_id: str, payload: UserRolesIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.USER,
-            target_id=user_id,
-            details={
-                "endpoint": "update_user_roles",
-                "required_permission": PermissionKey.MANAGE_USERS,
-            },
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.USER,
+                id=user_id,
+                details={
+                    "endpoint": "update_user_roles",
+                    "required_permission": PermissionKey.MANAGE_USERS,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="update_user_roles")
     try:
@@ -401,9 +420,11 @@ def update_user_roles(request, user_id: str, payload: UserRolesIn):
         logging.WARNING,
         "user_roles_changed",
         request,
-        target_type=AuditTargetType.USER,
-        target_id=user_id,
-        details={"old_role_ids": old_role_ids, "new_role_ids": new_role_ids},
+        target=AuditTarget(
+            type=AuditTargetType.USER,
+            id=user_id,
+            details={"old_role_ids": old_role_ids, "new_role_ids": new_role_ids},
+        ),
     )
     user = User.objects.members().prefetch_related("roles").get(pk=user.pk)
     return Status(200, UserOut.from_user(user))

--- a/backend/users/_roles.py
+++ b/backend/users/_roles.py
@@ -3,7 +3,7 @@
 import logging
 
 from community._validation import Code, raise_validation
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from django.db.models import Count, Q
 from ninja import Router
@@ -29,8 +29,13 @@ def list_roles(request):
             logging.WARNING,
             "permission_denied",
             request,
-            details={"endpoint": "list_roles", "required_permission": PermissionKey.MANAGE_ROLES},
             persist=False,
+            target=AuditTarget(
+                details={
+                    "endpoint": "list_roles",
+                    "required_permission": PermissionKey.MANAGE_ROLES,
+                }
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="list_roles")
     roles = Role.objects.annotate(
@@ -65,8 +70,13 @@ def create_role(request, payload: RoleIn):
             logging.WARNING,
             "permission_denied",
             request,
-            details={"endpoint": "create_role", "required_permission": PermissionKey.MANAGE_ROLES},
             persist=False,
+            target=AuditTarget(
+                details={
+                    "endpoint": "create_role",
+                    "required_permission": PermissionKey.MANAGE_ROLES,
+                }
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="create_role")
     if Role.objects.filter(name=payload.name).exists():
@@ -76,9 +86,11 @@ def create_role(request, payload: RoleIn):
         logging.INFO,
         "role_created",
         request,
-        target_type=AuditTargetType.ROLE,
-        target_id=str(role.id),
-        details={"name": role.name, "permissions": role.permissions},
+        target=AuditTarget(
+            type=AuditTargetType.ROLE,
+            id=str(role.id),
+            details={"name": role.name, "permissions": role.permissions},
+        ),
     )
     return Status(
         201,
@@ -102,10 +114,15 @@ def update_role(request, role_id: str, payload: RolePatchIn):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.ROLE,
-            target_id=role_id,
-            details={"endpoint": "update_role", "required_permission": PermissionKey.MANAGE_ROLES},
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.ROLE,
+                id=role_id,
+                details={
+                    "endpoint": "update_role",
+                    "required_permission": PermissionKey.MANAGE_ROLES,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="update_role")
     try:
@@ -136,14 +153,16 @@ def update_role(request, role_id: str, payload: RolePatchIn):
         logging.WARNING,
         "role_updated",
         request,
-        target_type=AuditTargetType.ROLE,
-        target_id=role_id,
-        details={
-            "old_name": old_name,
-            "new_name": role.name,
-            "old_permissions": old_permissions,
-            "new_permissions": role.permissions,
-        },
+        target=AuditTarget(
+            type=AuditTargetType.ROLE,
+            id=role_id,
+            details={
+                "old_name": old_name,
+                "new_name": role.name,
+                "old_permissions": old_permissions,
+                "new_permissions": role.permissions,
+            },
+        ),
     )
     return Status(
         200,
@@ -167,10 +186,15 @@ def delete_role(request, role_id: str):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.ROLE,
-            target_id=role_id,
-            details={"endpoint": "delete_role", "required_permission": PermissionKey.MANAGE_ROLES},
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.ROLE,
+                id=role_id,
+                details={
+                    "endpoint": "delete_role",
+                    "required_permission": PermissionKey.MANAGE_ROLES,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="delete_role")
     try:
@@ -186,8 +210,10 @@ def delete_role(request, role_id: str):
         logging.WARNING,
         "role_deleted",
         request,
-        target_type=AuditTargetType.ROLE,
-        target_id=role_id,
-        details={"name": role_name, "affected_user_count": affected_user_count},
+        target=AuditTarget(
+            type=AuditTargetType.ROLE,
+            id=role_id,
+            details={"name": role_name, "affected_user_count": affected_user_count},
+        ),
     )
     return Status(204, None)

--- a/backend/users/_user_deletion.py
+++ b/backend/users/_user_deletion.py
@@ -1,7 +1,7 @@
 import logging
 
 from community._validation import Code, raise_validation
-from config.audit import AuditTargetType, audit_log
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
 from django.utils import timezone
 from ninja.responses import Status
@@ -28,10 +28,15 @@ def delete_user(request, user_id: str):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.USER,
-            target_id=user_id,
-            details={"endpoint": "delete_user", "required_permission": PermissionKey.MANAGE_USERS},
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.USER,
+                id=user_id,
+                details={
+                    "endpoint": "delete_user",
+                    "required_permission": PermissionKey.MANAGE_USERS,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="delete_user")
     try:
@@ -51,9 +56,7 @@ def delete_user(request, user_id: str):
         logging.WARNING,
         "user_archived",
         request,
-        target_type=AuditTargetType.USER,
-        target_id=user_id,
-        details={"full_name": full_name},
+        target=AuditTarget(type=AuditTargetType.USER, id=user_id, details={"full_name": full_name}),
     )
     return Status(204, None)
 
@@ -75,13 +78,15 @@ def hard_delete_user(request, user_id: str):
             logging.WARNING,
             "permission_denied",
             request,
-            target_type=AuditTargetType.USER,
-            target_id=user_id,
-            details={
-                "endpoint": "hard_delete_user",
-                "required_permission": PermissionKey.MANAGE_USERS,
-            },
             persist=False,
+            target=AuditTarget(
+                type=AuditTargetType.USER,
+                id=user_id,
+                details={
+                    "endpoint": "hard_delete_user",
+                    "required_permission": PermissionKey.MANAGE_USERS,
+                },
+            ),
         )
         raise_validation(Code.Perm.DENIED, status_code=403, action="hard_delete_user")
     try:
@@ -99,9 +104,7 @@ def hard_delete_user(request, user_id: str):
         logging.WARNING,
         "user_hard_deleted",
         request,
-        target_type=AuditTargetType.USER,
-        target_id=user_id,
-        details={"full_name": full_name},
+        target=AuditTarget(type=AuditTargetType.USER, id=user_id, details={"full_name": full_name}),
     )
     # Safe because last_login is None: a never-logged-in user has authored no
     # EventComments (author is on_delete=PROTECT), so the cascade can't raise.


### PR DESCRIPTION
## Summary

Fixes Issue 1231.

`audit_log()` in `backend/config/audit.py` carried a `# noqa: PLR0913` suppressing ruff's too-many-arguments check. Before restructuring, I verified the actual configured threshold in `pyproject.toml`: `max-args = 5` (not ruff's default of 5 stated in the issue as an assumption, which happens to match, but I confirmed it directly rather than trusting the issue text). I also confirmed empirically that ruff's PLR0913 counts keyword-only parameters too, so making the optional tail keyword-only (one of the issue's options) would not have helped.

**Option chosen: group the target — extended.** The issue's "group target_type+target_id" option alone only drops the signature from 7 to 6 params, which still fails `max-args=5`. To actually get under the threshold without going to a full context-object rewrite (the issue's largest-diff option), I folded `details` into the same object as well:

```python
class AuditTarget(NamedTuple):
    """The audited object and what happened to it: type, id, and context details."""
    type: AuditTargetType | str = ""
    id: str = ""
    details: dict | None = None

def audit_log(
    level: int,
    action: str,
    request,
    target: AuditTarget | None = None,
    *,
    persist: bool = True,
) -> None:
```

5 total params (4 positional-or-keyword + 1 keyword-only), verified against the repo's ruff config directly (`ruff check --select PLR0913`) before and after.

Internally, `audit_log` unpacks `target_type, target_id, details = target or AuditTarget()` and proceeds exactly as before — log output shape and persisted `AuditLogEntry` fields are unchanged.

## Call sites

Updated all ~178 call sites across `backend/` (community/, users/, tests/) mechanically: `target_type=X, target_id=Y, details=Z` → `target=AuditTarget(type=X, id=Y, details=Z)`, with the appropriate kwargs omitted for calls that only used a subset. Also updated the `from config.audit import ...` line at each site to import `AuditTarget`.

`backend/tests/test_audit_persistence.py` has a guard test (`test_every_call_site_uses_a_valid_enum_member`) that regex-scans the codebase for raw string literals passed as target type instead of the `AuditTargetType` enum. Updated its regex to match the new `AuditTarget(type=...)` call shape (previously matched `target_type="..."`).

## Test plan

- [x] `make agent-lint` — passes, `# noqa: PLR0913` removed, ruff format applied
- [x] `make agent-typecheck` — passes with no errors
- [x] `cd backend && uv run pytest tests/test_audit_persistence.py -q` — 10/10 pass
- [x] Broader audit-adjacent test run (`-k audit`, plus payment/RSVP/email-blast/hard-delete/admin-extended/purge suites) — 121+28 pass, no regressions
- [x] Sanity run across heavily-touched files (auth, roles, management, user_deletion, magic_login) — 329 passed; 5 pre-existing SSE/pg_notify failures unrelated to this change (SQLite can't exercise `pg_notify`, documented pre-existing gap)