### PR TITLE
feat: prefill cashapp amount on event pay link (Issue 1214)

### DIFF
--- a/frontend/src/screens/events/EventMemberSection.overflow.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.overflow.test.tsx
@@ -1,3 +1,4 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
@@ -9,7 +10,12 @@ import { CostSection, LinksSection, LocationSection } from './EventMemberSection
 const LONG_TOKEN = 'x'.repeat(200);
 
 function renderIn(node: React.ReactElement) {
-  return render(<MemoryRouter>{node}</MemoryRouter>);
+  const queryClient = new QueryClient();
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>{node}</MemoryRouter>
+    </QueryClientProvider>,
+  );
 }
 
 describe('event detail — long user content wraps (issue 1131)', () => {

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -1,12 +1,15 @@
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
+import { useFlag } from '@/api/featureFlags';
 import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import type { Event } from '@/models/event';
 import { spotsLeft } from '@/models/event';
+import { Feature } from '@/models/featureFlags';
 import { formatPrice } from '@/utils/eventCost';
 import { buildEventLinks } from '@/utils/eventLinks';
+import { toCashAppPayUrl } from '@/utils/paymentHandle';
 import { ensureHttps } from '@/utils/url';
 
 import { EventCommentsCard } from './comments/EventCommentsCard';
@@ -161,10 +164,16 @@ export function LinksSection({ event }: { event: Event }) {
 }
 
 export function CostSection({ event }: { event: Event }) {
+  const paymentPrefillOn = useFlag(Feature.EventPaymentConfirmation);
   const items: { label: string; url?: string }[] = [];
   if (event.price) items.push({ label: formatPrice(event.price) });
   if (event.venmoLink) items.push({ label: 'venmo', url: ensureHttps(event.venmoLink) });
-  if (event.cashappLink) items.push({ label: 'cashapp', url: ensureHttps(event.cashappLink) });
+  if (event.cashappLink) {
+    const url = paymentPrefillOn
+      ? toCashAppPayUrl(event.cashappLink, { price: event.price })
+      : ensureHttps(event.cashappLink);
+    items.push({ label: 'cashapp', url });
+  }
   if (event.zelleInfo) items.push({ label: `zelle: ${event.zelleInfo}` });
   if (items.length === 0) return null;
   return (

--- a/frontend/src/utils/paymentHandle.test.ts
+++ b/frontend/src/utils/paymentHandle.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+
+import { toCashAppPayUrl } from './paymentHandle';
+
+describe('toCashAppPayUrl', () => {
+  it('appends a clean numeric price as the amount segment', () => {
+    expect(toCashAppPayUrl('$handle', { price: '20' })).toBe('https://cash.app/$handle/20');
+  });
+
+  it('strips a leading dollar sign from the price', () => {
+    expect(toCashAppPayUrl('$handle', { price: '$20.50' })).toBe('https://cash.app/$handle/20.50');
+  });
+
+  it('falls back to the plain profile link for a non-numeric price', () => {
+    expect(toCashAppPayUrl('$handle', { price: 'sliding scale' })).toBe('https://cash.app/$handle');
+  });
+
+  it('falls back to the plain profile link for an empty price', () => {
+    expect(toCashAppPayUrl('$handle', { price: '' })).toBe('https://cash.app/$handle');
+  });
+});

--- a/frontend/src/utils/paymentHandle.ts
+++ b/frontend/src/utils/paymentHandle.ts
@@ -27,3 +27,19 @@ export function fromCashAppUrl(url: string): string {
   if (!handle) return url;
   return `$${handle}`;
 }
+
+// Cash App's public web links support an amount path segment (cash.app/$tag/20)
+// but have no documented/supported query param for a note — amount-only.
+export function toCashAppPayUrl(cashappLink: string, opts: { price?: string }): string {
+  const base = toCashAppUrl(cashappLink);
+  if (!base) return base;
+  const amount = parseCashAppAmount(opts.price);
+  if (amount === null) return base;
+  return `${base}/${amount}`;
+}
+
+function parseCashAppAmount(price: string | undefined): string | null {
+  const trimmed = (price ?? '').trim().replace(/^\$/, '');
+  if (!/^\d+(\.\d{1,2})?$/.test(trimmed)) return null;
+  return trimmed;
+}


### PR DESCRIPTION
## Summary

- Closes the attendee-facing "cashapp integration" ask in Issue 1214: prefill price (and note, if feasible) when an attendee taps the cashapp link on an event.
- Gated behind the existing `event_payment_confirmation` feature flag (`Feature.EventPaymentConfirmation`).
- Added `toCashAppPayUrl` in `frontend/src/utils/paymentHandle.ts`: when the event's `price` is a clean numeric value (optionally with a leading `$` and up to 2 decimal places), the cashapp link becomes `https://cash.app/$handle/<amount>`. Non-numeric prices (e.g. "sliding scale", "free") or an empty price fall back to the plain profile link, unchanged from current behavior.
- `EventMemberSection.tsx` (`CostSection`) now calls `toCashAppPayUrl` only when the flag is on; with the flag off, behavior is byte-for-byte the same as before (plain `ensureHttps(event.cashappLink)` link).

## Note/memo prefill — not implemented

Researched Cash App's public `cash.app/$cashtag` web link format. It supports an amount as a path segment (`/20`), but there is **no documented or supported query parameter for a note/memo** on the plain web link. This matches an open, unresolved feature request on the Square/Cash App developer forum asking for exactly this (`?note=`) — it isn't a shipped capability, so I didn't invent a parameter that Cash App doesn't actually honor. This lines up with the issue's own "iff possible" phrasing anticipating this might not be feasible. If Cash App ships this later, `toCashAppPayUrl` is the single place to add it.

## Test plan

- [x] `cd frontend && npx vitest run src/utils/paymentHandle.test.ts` — 4/4 passing (numeric price → amount in URL, `$`-prefixed price, non-numeric price → plain link, empty price → plain link)
- [x] `make agent-frontend-typecheck`
- [x] `make agent-frontend-lint`
- [x] `npx prettier --check` on changed files