### PR TITLE
fix: prefill cashapp amount on rsvp payment confirm step

### DIFF
--- a/frontend/src/screens/events/PaymentConfirmStep.test.tsx
+++ b/frontend/src/screens/events/PaymentConfirmStep.test.tsx
@@ -34,10 +34,24 @@ describe('PaymentConfirmStep', () => {
     );
   });
 
-  it('normalizes a bare cashapp handle into a url', () => {
+  it('normalizes a bare cashapp handle into a url with the price prefilled', () => {
     render(
       <PaymentConfirmStep
         event={makePaidEvent({ venmoLink: '', cashappLink: '$host' })}
+        onConfirm={vi.fn()}
+        onBack={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole('link', { name: /cashapp/i })).toHaveAttribute(
+      'href',
+      'https://cash.app/$host/10',
+    );
+  });
+
+  it('falls back to a bare cashapp url when the price is non-numeric', () => {
+    render(
+      <PaymentConfirmStep
+        event={makePaidEvent({ venmoLink: '', cashappLink: '$host', price: 'sliding scale' })}
         onConfirm={vi.fn()}
         onBack={vi.fn()}
       />,

--- a/frontend/src/screens/events/PaymentConfirmStep.tsx
+++ b/frontend/src/screens/events/PaymentConfirmStep.tsx
@@ -1,7 +1,7 @@
 import { Button } from '@/components/ui/Button';
 import type { Event } from '@/models/event';
 import { formatPrice } from '@/utils/eventCost';
-import { toCashAppUrl, toVenmoUrl } from '@/utils/paymentHandle';
+import { toCashAppPayUrl, toVenmoUrl } from '@/utils/paymentHandle';
 
 interface Props {
   event: Event;
@@ -13,7 +13,12 @@ interface Props {
 export function PaymentConfirmStep({ event, busy = false, onConfirm, onBack }: Props) {
   const links: { label: string; url?: string }[] = [];
   if (event.venmoLink) links.push({ label: 'venmo', url: toVenmoUrl(event.venmoLink) });
-  if (event.cashappLink) links.push({ label: 'cashapp', url: toCashAppUrl(event.cashappLink) });
+  if (event.cashappLink) {
+    links.push({
+      label: 'cashapp',
+      url: toCashAppPayUrl(event.cashappLink, { price: event.price }),
+    });
+  }
   if (event.zelleInfo) links.push({ label: `zelle: ${event.zelleInfo}` });
 
   return (


### PR DESCRIPTION
## Summary

- The rsvp payment confirm step (`PaymentConfirmStep.tsx` — used by `RsvpBox`, `PublicRsvpForm`, `PublicRsvpCard`, i.e. the event confirmation modal flow) still built its cashapp link with the bare `toCashAppUrl`, producing a plain `cash.app/$handle` profile link with no amount.
- `EventMemberSection`'s `CostSection` already builds a prefilled link via `toCashAppPayUrl` (added in #1256 / Issue 1214) — `PaymentConfirmStep` was the one remaining call site still on the old bare-link path.
- Switched `PaymentConfirmStep` to `toCashAppPayUrl(event.cashappLink, { price: event.price })`, so attendees now land on `https://cash.app/$handle/<amount>` with the event price prefilled, same as the member event section.

## Fallback behavior

`event.price` is free text (Issue 1244), so `toCashAppPayUrl` only appends an amount when the price parses cleanly as a number (optionally `$`-prefixed, up to 2 decimals). For non-numeric prices like `"sliding scale"` or `"free"`, it falls back to the bare `https://cash.app/$handle` link — no broken deep link is ever constructed.

## Scope

- Venmo and Zelle prefill behavior is untouched (separate issue, out of scope here).
- The event-form save/load round trip (`eventWrites.ts`, using `toCashAppUrl`/`fromCashAppUrl` for the stored handle-only link) is untouched — no amount is baked into the persisted link.

## Test plan

- [x] `make agent-frontend-typecheck` — clean
- [x] `make agent-frontend-lint` — clean
- [x] `npx vitest run src/screens/events/PaymentConfirmStep.test.tsx src/utils/paymentHandle.test.ts src/screens/events/EventMemberSection.test.tsx` — 59 passed
- [x] Added/updated tests: cashapp link now asserts the `/10` amount suffix; added a fallback test for a non-numeric price