### PR TITLE
fix: show event price to public rsvp visitors

### DIFF
--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -303,7 +303,7 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
   }
 
   return (
-    <section aria-label="rsvp" className="border-border bg-surface mt-8 rounded-lg border p-6">
+    <section aria-label="rsvp" className="border-border bg-surface rounded-lg border p-6">
       <h2 className="mb-4 text-base font-medium">rsvp</h2>
       <p className="text-foreground-tertiary mb-4 text-sm">
         rsvp to see the location and more details

--- a/frontend/src/screens/events/PublicRsvpSection.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpSection.test.tsx
@@ -69,6 +69,24 @@ describe('PublicRsvpSection', () => {
     expect(screen.getByRole('heading', { name: 'rsvp' })).toBeInTheDocument();
   });
 
+  it('shows the price to a public visitor before they rsvp', () => {
+    render(
+      <MemoryRouter>
+        <PublicRsvpSection event={officialEvent({ price: '$10' })} />
+      </MemoryRouter>,
+    );
+    expect(screen.getByText('$10')).toBeInTheDocument();
+  });
+
+  it('shows no cost section when the event has no price or payment links', () => {
+    render(
+      <MemoryRouter>
+        <PublicRsvpSection event={officialEvent({ price: '' })} />
+      </MemoryRouter>,
+    );
+    expect(screen.queryByText('cost')).not.toBeInTheDocument();
+  });
+
   it('persists the rsvp token and refreshes without putting it in the url', async () => {
     mockCheckPhone.mockResolvedValue({ status: 'new' });
     mockSubmit.mockResolvedValue({

--- a/frontend/src/screens/events/PublicRsvpSection.tsx
+++ b/frontend/src/screens/events/PublicRsvpSection.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { setStoredRsvpToken } from '@/api/rsvpTokenStorage';
 import type { Event } from '@/models/event';
 
+import { CostSection } from './EventMemberSection';
 import { PublicRsvpForm } from './PublicRsvpForm';
 
 interface Props {
@@ -19,11 +20,14 @@ export function PublicRsvpSection({ event }: Props) {
   }
 
   return (
-    <PublicRsvpForm
-      event={event}
-      onSuccess={(result) => {
-        unlockWithToken(result.rsvp_token);
-      }}
-    />
+    <div className="mt-8 flex flex-col gap-6">
+      <CostSection event={event} />
+      <PublicRsvpForm
+        event={event}
+        onSuccess={(result) => {
+          unlockWithToken(result.rsvp_token);
+        }}
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## root cause

price only ever rendered via `PaymentConfirmStep`, which only mounts when `eventRequiresPaymentConfirmation(event)` is true (requires **both** a price and a venmo/cashapp/zelle link) **and** the visitor already picked "attending." an event with just a price and no payment link set — or a visitor who hasn't RSVP'd "attending" yet — never saw cost anywhere in the public/anonymous RSVP flow.

logged-in members go through `EventMemberSection`'s `CostSection`, which unconditionally shows price/venmo/cashapp/zelle whenever any are set — that's the working reference implementation this PR reuses.

backend schemas already include `price` correctly for all viewers; this was a frontend rendering gap only.

## fix

- `PublicRsvpSection.tsx` — render the existing `CostSection` (exported from `EventMemberSection.tsx`) above the RSVP form so price shows up front for anonymous public-eligible visitors, same as members already see.
- `PublicRsvpForm.tsx` — dropped a now-redundant top margin since the new wrapper provides spacing.
- added tests: price renders for a public visitor before RSVPing; no cost card renders when the event has no price/payment info.

## verification

- `make agent-frontend-lint` — clean
- `make agent-frontend-typecheck` — clean
- targeted vitest run (`PublicRsvpSection`, `PublicRsvpForm`, `EventMemberSection`, `EventMemberSection.overflow`) — 94/94 passed

(Issue 1259)
