### PR TITLE
feat: add edit to event detail kebab menu

### DIFF
--- a/frontend/src/screens/events/EventAdminActions.tsx
+++ b/frontend/src/screens/events/EventAdminActions.tsx
@@ -10,6 +10,8 @@ import type { Event } from '@/models/event';
 import { EventStatus } from '@/models/event';
 import { hasPermission, Permission } from '@/models/permissions';
 
+import { canEditEventWindow } from './eventEditGate';
+
 interface Props {
   event: Event;
 }
@@ -52,9 +54,7 @@ function AdminActionRow({
   const hasNoAttendees = event.attendingCount === 0;
   const canDelete = (isHost || canManage) && (isDraft || isCancelled || hasNoAttendees);
   const showCancel = !isCancelled && !isDraft && !hasNoAttendees && !event.isPast;
-  // Drafts are always editable — the edit-window cutoff protects the
-  // historical record of published events, which drafts don't have.
-  const canEditEvent = isDraft || isEditWindowOpen(event);
+  const canEditEvent = canEditEventWindow(event);
 
   async function onCancel() {
     setCancelError(null);
@@ -214,17 +214,6 @@ function AdminActionRow({
       </Dialog>
     </div>
   );
-}
-
-// Editing stays open until 6 hours after the event's end (or start, if no end
-// set) — gives hosts room to fix typos, post follow-ups, or tweak details
-// during and right after the event without hitting a stale-data wall.
-const EDIT_GRACE_MS = 6 * 60 * 60 * 1000;
-
-function isEditWindowOpen(event: Event): boolean {
-  const reference = event.endDatetime ?? event.startDatetime;
-  if (!reference) return true;
-  return Date.now() <= reference.getTime() + EDIT_GRACE_MS;
 }
 
 function extractMutationError(err: unknown): string {

--- a/frontend/src/screens/events/EventAdminActions.tsx
+++ b/frontend/src/screens/events/EventAdminActions.tsx
@@ -54,7 +54,7 @@ function AdminActionRow({
   const hasNoAttendees = event.attendingCount === 0;
   const canDelete = (isHost || canManage) && (isDraft || isCancelled || hasNoAttendees);
   const showCancel = !isCancelled && !isDraft && !hasNoAttendees && !event.isPast;
-  const canEditEvent = isEventEditable(event);
+  const eventIsEditable = isEventEditable(event);
 
   async function onCancel() {
     setCancelError(null);
@@ -88,7 +88,7 @@ function AdminActionRow({
   return (
     <div className="flex flex-col gap-2">
       <div className="flex flex-wrap justify-center gap-2">
-        {canEditEvent ? (
+        {eventIsEditable ? (
           <Button variant="secondary" onClick={() => void navigate(`/events/${event.id}/edit`)}>
             edit
           </Button>
@@ -125,7 +125,7 @@ function AdminActionRow({
           </Button>
         ) : null}
       </div>
-      {!canEditEvent && !isCancelled ? (
+      {!eventIsEditable && !isCancelled ? (
         <p className="text-foreground-tertiary text-center text-xs">
           editing closes 6 hours after the event ends
         </p>

--- a/frontend/src/screens/events/EventAdminActions.tsx
+++ b/frontend/src/screens/events/EventAdminActions.tsx
@@ -10,7 +10,7 @@ import type { Event } from '@/models/event';
 import { EventStatus } from '@/models/event';
 import { hasPermission, Permission } from '@/models/permissions';
 
-import { canEditEventWindow } from './eventEditGate';
+import { isEventEditable } from './eventEditGate';
 
 interface Props {
   event: Event;
@@ -54,7 +54,7 @@ function AdminActionRow({
   const hasNoAttendees = event.attendingCount === 0;
   const canDelete = (isHost || canManage) && (isDraft || isCancelled || hasNoAttendees);
   const showCancel = !isCancelled && !isDraft && !hasNoAttendees && !event.isPast;
-  const canEditEvent = canEditEventWindow(event);
+  const canEditEvent = isEventEditable(event);
 
   async function onCancel() {
     setCancelError(null);

--- a/frontend/src/screens/events/EventDetailKebabMenu.test.tsx
+++ b/frontend/src/screens/events/EventDetailKebabMenu.test.tsx
@@ -1,14 +1,17 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useFlag } from '@/api/featureFlags';
+import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
 import { EventStatus } from '@/models/event';
-import { makeEvent } from '@/test/fixtures';
+import { makeEvent, makeUser } from '@/test/fixtures';
 
 import { EventDetailKebabMenu } from './EventDetailKebabMenu';
+
+const HOST_ID = 'host-user';
 
 vi.mock('@/api/featureFlags', () => ({
   useFlag: vi.fn(),
@@ -44,7 +47,58 @@ async function openMenu() {
   await userEvent.click(screen.getByRole('button', { name: /event settings/i }));
 }
 
+beforeEach(() => {
+  useAuthStore.setState({ status: 'unauthed', user: null, accessToken: null });
+});
+
 describe('EventDetailKebabMenu', () => {
+  it('shows an edit item for a co-host, linking to the edit route', async () => {
+    vi.mocked(useFlag).mockReturnValue(false);
+    useAuthStore.setState({
+      status: 'authed',
+      user: makeUser({ id: HOST_ID }),
+      accessToken: 'tok',
+    });
+    renderMenu({ event: { coHostIds: [HOST_ID] } });
+    await openMenu();
+
+    const edit = screen.getByRole('menuitem', { name: 'edit' });
+    expect(edit).toHaveAttribute('href', '/events/ev1/edit');
+  });
+
+  it('hides the edit item for a member who is not a host', async () => {
+    vi.mocked(useFlag).mockReturnValue(false);
+    useAuthStore.setState({
+      status: 'authed',
+      user: makeUser({ id: 'regular-user' }),
+      accessToken: 'tok',
+    });
+    renderMenu({ event: { coHostIds: [HOST_ID] } });
+    await openMenu();
+
+    expect(screen.queryByRole('menuitem', { name: 'edit' })).not.toBeInTheDocument();
+  });
+
+  it('hides the edit item once the edit window has closed', async () => {
+    vi.mocked(useFlag).mockReturnValue(false);
+    useAuthStore.setState({
+      status: 'authed',
+      user: makeUser({ id: HOST_ID }),
+      accessToken: 'tok',
+    });
+    renderMenu({
+      event: {
+        coHostIds: [HOST_ID],
+        status: EventStatus.Active,
+        startDatetime: new Date(Date.now() - 24 * 60 * 60 * 1000),
+        endDatetime: new Date(Date.now() - 24 * 60 * 60 * 1000),
+      },
+    });
+    await openMenu();
+
+    expect(screen.queryByRole('menuitem', { name: 'edit' })).not.toBeInTheDocument();
+  });
+
   it('shows a check-in item linking to the attendance route', async () => {
     vi.mocked(useFlag).mockReturnValue(false);
     renderMenu();

--- a/frontend/src/screens/events/EventDetailKebabMenu.tsx
+++ b/frontend/src/screens/events/EventDetailKebabMenu.tsx
@@ -2,11 +2,13 @@ import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { useFlag } from '@/api/featureFlags';
+import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
 import { EventStatus } from '@/models/event';
 import { Feature } from '@/models/featureFlags';
 
 import { EmailBlastDialog } from './EmailBlastDialog';
+import { canEditEvent } from './eventEditGate';
 import { GroupTextDialog } from './GroupTextDialog';
 
 interface Props {
@@ -22,9 +24,11 @@ export function EventDetailKebabMenu({ event, eventHasEnded, canManageRsvps }: P
   const [groupTextOpen, setGroupTextOpen] = useState(false);
   const rootRef = useRef<HTMLDivElement>(null);
   const reportFlagOn = useFlag(Feature.HostAttendanceReport);
+  const user = useAuthStore((s) => s.user);
   const showCheckInReport = eventHasEnded && reportFlagOn;
   const showManageRsvps = canManageRsvps && !eventHasEnded;
   const showEmailBlast = event.status !== EventStatus.Draft && event.guests.length > 0;
+  const showEdit = canEditEvent(event, user);
 
   useEffect(() => {
     if (!open) return;
@@ -63,6 +67,16 @@ export function EventDetailKebabMenu({ event, eventHasEnded, canManageRsvps }: P
           role="menu"
           className="border-border bg-surface absolute right-0 z-10 mt-1 w-44 overflow-hidden rounded-md border text-sm shadow-lg"
         >
+          {showEdit ? (
+            <MenuLink
+              to={`/events/${eventId}/edit`}
+              onSelect={() => {
+                setOpen(false);
+              }}
+            >
+              edit
+            </MenuLink>
+          ) : null}
           {showManageRsvps ? (
             <MenuLink
               to={`/events/${eventId}/manage-rsvps`}

--- a/frontend/src/screens/events/eventEditGate.ts
+++ b/frontend/src/screens/events/eventEditGate.ts
@@ -1,0 +1,24 @@
+import type { Event } from '@/models/event';
+import { canManageEvent, EventStatus } from '@/models/event';
+import type { User } from '@/models/user';
+
+// Editing stays open until 6 hours after the event's end (or start, if no end
+// set) — gives hosts room to fix typos, post follow-ups, or tweak details
+// during and right after the event without hitting a stale-data wall.
+const EDIT_GRACE_MS = 6 * 60 * 60 * 1000;
+
+function isEditWindowOpen(event: Event): boolean {
+  const reference = event.endDatetime ?? event.startDatetime;
+  if (!reference) return true;
+  return Date.now() <= reference.getTime() + EDIT_GRACE_MS;
+}
+
+// Drafts are always editable — the edit-window cutoff protects the
+// historical record of published events, which drafts don't have.
+export function canEditEventWindow(event: Event): boolean {
+  return event.status === EventStatus.Draft || isEditWindowOpen(event);
+}
+
+export function canEditEvent(event: Event, user: User | null): boolean {
+  return canManageEvent(event, user) && canEditEventWindow(event);
+}

--- a/frontend/src/screens/events/eventEditGate.ts
+++ b/frontend/src/screens/events/eventEditGate.ts
@@ -2,9 +2,7 @@ import type { Event } from '@/models/event';
 import { canManageEvent, EventStatus } from '@/models/event';
 import type { User } from '@/models/user';
 
-// Editing stays open until 6 hours after the event's end (or start, if no end
-// set) — gives hosts room to fix typos, post follow-ups, or tweak details
-// during and right after the event without hitting a stale-data wall.
+// grace period after an event ends so hosts can still fix typos or add follow-ups
 const EDIT_GRACE_MS = 6 * 60 * 60 * 1000;
 
 function isEditWindowOpen(event: Event): boolean {
@@ -13,8 +11,7 @@ function isEditWindowOpen(event: Event): boolean {
   return Date.now() <= reference.getTime() + EDIT_GRACE_MS;
 }
 
-// Drafts are always editable — the edit-window cutoff protects the
-// historical record of published events, which drafts don't have.
+// drafts have no published history to protect, so the edit-window cutoff doesn't apply
 export function canEditEventWindow(event: Event): boolean {
   return event.status === EventStatus.Draft || isEditWindowOpen(event);
 }

--- a/frontend/src/screens/events/eventEditGate.ts
+++ b/frontend/src/screens/events/eventEditGate.ts
@@ -12,10 +12,10 @@ function isEditWindowOpen(event: Event): boolean {
 }
 
 // drafts have no published history to protect, so the edit-window cutoff doesn't apply
-export function canEditEventWindow(event: Event): boolean {
+export function isEventEditable(event: Event): boolean {
   return event.status === EventStatus.Draft || isEditWindowOpen(event);
 }
 
 export function canEditEvent(event: Event, user: User | null): boolean {
-  return canManageEvent(event, user) && canEditEventWindow(event);
+  return canManageEvent(event, user) && isEventEditable(event);
 }


### PR DESCRIPTION
## Summary
- Adds an "edit" item to the top event-detail kebab menu (`EventDetailKebabMenu.tsx`), so hosts/managers can edit from the top in addition to the existing bottom edit button
- Extracts the edit permission + edit-window gate (`canEditEvent`, `canEditEventWindow`) from `EventAdminActions.tsx` into a shared `eventEditGate.ts` so both the top and bottom edit actions use identical logic — no duplicated permission checks
- Both edit entry points navigate to the same `/events/:id/edit` route

(Issue 1250)

## Test plan
- [x] `make agent-frontend-lint` — clean
- [x] `make agent-frontend-typecheck` — clean
- [x] `pnpm exec vitest run src/screens/events/EventDetailKebabMenu.test.tsx src/screens/events/EventAdminActions.test.tsx` — 27/27 passing, including new tests for showing edit to a co-host, hiding it for a non-host, and hiding it once the edit window has closed