### PR TITLE
fix: 1264 - stop scroll silently rewriting event capacity

### DIFF
--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 from uuid import UUID
 
+from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.media_proxy import media_path
 from django.db import transaction
 from notifications._cohost_notifications import create_cohost_invite_notifications
@@ -36,11 +38,14 @@ from community._rsvp_counts import (
 )
 from community._rsvp_payment import can_see_payment_details, payment_enforced_for_event
 from community._shared import _authenticated_user, _gated
+from community._validation import Code, raise_validation
 from community.models import (
     Event,
     EventRSVP,
     EventTag,
+    EventType,
     FeatureFlag,
+    PageVisibility,
     RSVPStatus,
     SurveyQuestionType,
     flag_enabled,
@@ -424,3 +429,50 @@ def _update_invited_users(
     new_ids = {str(uid) for uid in id_list} - {str(uid) for uid in old_ids}
     if new_ids:
         create_event_invite_notifications(event, new_ids, inviter)
+
+
+def _can_edit_event(user, event: Event) -> bool:
+    """Check if user can edit/delete this event (host or manager)."""
+    if user.has_permission(PermissionKey.MANAGE_EVENTS):
+        return True
+    return event.co_hosts.filter(pk=user.pk).exists()
+
+
+_PUBLIC_ONLY_TYPES = frozenset({EventType.OFFICIAL, EventType.CLUB})
+
+# Event types that require an explicit permission to tag. Community events need
+# none. Maps type → the permission that gates it.
+_TYPE_TAG_PERMISSIONS = {
+    EventType.OFFICIAL: PermissionKey.TAG_OFFICIAL_EVENT,
+    EventType.CLUB: PermissionKey.TAG_CLUB_EVENT,
+}
+
+
+def _is_invalid_typed_visibility(event_type: str, visibility: str) -> bool:
+    """Public-only event types (official, club) must have public visibility."""
+    return event_type in _PUBLIC_ONLY_TYPES and visibility != PageVisibility.PUBLIC
+
+
+def _enforce_type_tag_permission(request, event_type: str, endpoint: str, event_id=None) -> None:
+    """Raise 403 if the event type requires a tag permission the user lacks."""
+    required = _TYPE_TAG_PERMISSIONS.get(event_type)
+    if required is None or request.auth.has_permission(required):
+        return
+    details = {"endpoint": endpoint, "required_permission": required}
+    if event_id is not None:
+        audit_log(
+            logging.WARNING,
+            "permission_denied",
+            request,
+            persist=False,
+            target=AuditTarget(type=AuditTargetType.EVENT, id=str(event_id), details=details),
+        )
+    else:
+        audit_log(
+            logging.WARNING,
+            "permission_denied",
+            request,
+            persist=False,
+            target=AuditTarget(details=details),
+        )
+    raise_validation(Code.Perm.DENIED, status_code=403, action=required)

--- a/backend/community/_event_update.py
+++ b/backend/community/_event_update.py
@@ -1,0 +1,121 @@
+import logging
+from uuid import UUID
+
+from config.audit import AuditTarget, AuditTargetType, audit_log
+from django.utils import timezone
+
+from community._event_helpers import (
+    _can_edit_event,
+    _enforce_type_tag_permission,
+    _is_invalid_typed_visibility,
+    _set_event_tags,
+    _update_co_hosts,
+    promote_from_waitlist,
+)
+from community._validation import Code, raise_validation
+from community.models import Event
+
+
+def _validate_event_datetimes(start, end, datetime_tbd: bool, *, check_past: bool = True) -> None:
+    """Raise ValidationException if datetime fields are invalid."""
+    if start is None:
+        if not datetime_tbd:
+            raise_validation(Code.Event.START_DATETIME_REQUIRED_UNLESS_TBD, field="start_datetime")
+        return
+    if end is not None and end <= start:
+        raise_validation(Code.Event.END_BEFORE_START, field="end_datetime")
+    if check_past and not datetime_tbd and start < timezone.now():
+        raise_validation(Code.Event.START_DATETIME_MUST_BE_FUTURE, field="start_datetime")
+
+
+def _validate_update_payload(request, event: Event, event_id, updates: dict) -> None:
+    """Validate PATCH payload fields. Raises ValidationException on failure."""
+    if "event_type" in updates:
+        _enforce_type_tag_permission(request, updates["event_type"], "update_event", event_id)
+    effective_type = updates.get("event_type", event.event_type)
+    effective_visibility = updates.get("visibility", event.visibility)
+    if _is_invalid_typed_visibility(effective_type, effective_visibility):
+        raise_validation(Code.Event.OFFICIAL_MUST_BE_PUBLIC, status_code=400)
+    # While a poll is active, the poll is the source of truth for when. Block
+    # direct edits to start/end so the event time can't drift from the poll.
+    # Host must finalize (or delete) the poll before setting a time.
+    time_fields_edited = any(
+        f in updates for f in ("start_datetime", "end_datetime", "datetime_tbd")
+    )
+    if time_fields_edited and hasattr(event, "poll") and event.poll.is_active:
+        raise_validation(Code.Event.DATE_LOCKED_BY_POLL, status_code=400)
+    effective_start = updates.get("start_datetime", event.start_datetime)
+    effective_end = updates.get("end_datetime", event.end_datetime)
+    effective_tbd = updates.get("datetime_tbd", event.datetime_tbd)
+    # Drafts can legitimately have no start yet (see #357) — don't enforce
+    # "start required" or past-check when a draft stays dateless. But if the
+    # draft has a start (existing or being set), it must be a future date.
+    if event.is_draft and effective_start is None:
+        return
+    # Past-check applies when start_datetime is being touched, or on any
+    # edit to a draft that already has a start (stale-draft guard). Non-
+    # draft past events keep being tweakable for non-date fields within
+    # the 6-hour grace window (enforced client-side).
+    check_past = "start_datetime" in updates or event.is_draft
+    _validate_event_datetimes(effective_start, effective_end, effective_tbd, check_past=check_past)
+
+
+def _promote_if_capacity_increased(
+    event: Event, updates: dict, old_max_attendees: int | None
+) -> list[str]:
+    """Promote waitlisted users if `max_attendees` grew. Must run inside the locked transaction."""
+    capacity_increased = (
+        "max_attendees" in updates
+        and event.max_attendees is not None
+        and (old_max_attendees is None or event.max_attendees > old_max_attendees)
+    )
+    if not capacity_increased:
+        return []
+    return promote_from_waitlist(event)
+
+
+def _guard_can_edit_event(request, event: Event, event_id: UUID) -> None:
+    if _can_edit_event(request.auth, event):
+        return
+    audit_log(
+        logging.WARNING,
+        "permission_denied",
+        request,
+        persist=False,
+        target=AuditTarget(
+            type=AuditTargetType.EVENT, id=str(event_id), details={"endpoint": "update_event"}
+        ),
+    )
+    raise_validation(Code.Perm.DENIED, status_code=403, action="update_event")
+
+
+def _apply_field_updates(request, event: Event, event_id: UUID, updates: dict) -> None:
+    """Apply non-status field edits to an event. Raises ValidationException on failure."""
+    if not updates:
+        return
+    if "max_attendees" in updates:
+        # Lock the row so a concurrent capacity-based promotion can't race this edit.
+        Event.objects.select_for_update().get(id=event_id)
+    _validate_update_payload(request, event, event_id, updates)
+    co_host_ids = updates.pop("co_host_ids", None)
+    tag_ids = updates.pop("tag_ids", None)
+    changed_fields = list(updates.keys())
+    if co_host_ids is not None:
+        changed_fields.append("co_host_ids")
+    if tag_ids is not None:
+        changed_fields.append("tag_ids")
+    for field, value in updates.items():
+        setattr(event, field, value)
+    if co_host_ids is not None:
+        _update_co_hosts(event, co_host_ids, request.auth)
+    if tag_ids is not None:
+        _set_event_tags(event, tag_ids)
+    event.save()
+    audit_log(
+        logging.INFO,
+        "event_updated",
+        request,
+        target=AuditTarget(
+            type=AuditTargetType.EVENT, id=str(event_id), details={"fields_changed": changed_fields}
+        ),
+    )

--- a/backend/community/_events.py
+++ b/backend/community/_events.py
@@ -14,17 +14,19 @@ from ninja import Router
 from ninja.responses import Status
 from notifications.service import broadcast_event_created
 from users._helpers import visible_display_name
-from users.permissions import PermissionKey
 
 from community._cohost_invite_helpers import has_pending_cohost_invite
 from community._event_helpers import (
+    _can_edit_event,
     _can_see_invite_only,
+    _enforce_type_tag_permission,
     _event_out,
     _get_creator_name,
+    _is_invalid_typed_visibility,
     _my_rsvp_fields,
     _set_event_tags,
     _tags_out,
-    _update_co_hosts,
+    broadcast_capacity_change,
 )
 from community._event_nonmember_removal import (
     email_removed_non_members,
@@ -36,11 +38,14 @@ from community._event_schemas import (
     EventOut,
     EventPatchIn,
 )
-from community._event_transitions import (
-    _handle_status_update,
-    _set_event_participants,
+from community._event_transitions import _handle_status_update, _set_event_participants
+from community._event_update import (
+    _apply_field_updates,
+    _guard_can_edit_event,
+    _promote_if_capacity_increased,
 )
 from community._event_viewer import resolve_event_viewer
+from community._public_rsvp_shared import _email_promoted_non_members
 from community._rsvp_counts import _attending_headcount, _waitlisted_count
 from community._rsvp_payment import can_see_payment_details
 from community._shared import ErrorOut, _authenticated_user, _gated, _optional_jwt
@@ -48,59 +53,11 @@ from community._validation import Code, raise_validation
 from community.models import (
     Event,
     EventStatus,
-    EventType,
     PageVisibility,
     parse_event_ref,
 )
 
 router = Router()
-
-
-def _can_edit_event(user, event: Event) -> bool:
-    """Check if user can edit/delete this event (host or manager)."""
-    if user.has_permission(PermissionKey.MANAGE_EVENTS):
-        return True
-    return event.co_hosts.filter(pk=user.pk).exists()
-
-
-_PUBLIC_ONLY_TYPES = frozenset({EventType.OFFICIAL, EventType.CLUB})
-
-# Event types that require an explicit permission to tag. Community events need
-# none. Maps type → the permission that gates it.
-_TYPE_TAG_PERMISSIONS = {
-    EventType.OFFICIAL: PermissionKey.TAG_OFFICIAL_EVENT,
-    EventType.CLUB: PermissionKey.TAG_CLUB_EVENT,
-}
-
-
-def _is_invalid_typed_visibility(event_type: str, visibility: str) -> bool:
-    """Public-only event types (official, club) must have public visibility."""
-    return event_type in _PUBLIC_ONLY_TYPES and visibility != PageVisibility.PUBLIC
-
-
-def _enforce_type_tag_permission(request, event_type: str, endpoint: str, event_id=None) -> None:
-    """Raise 403 if the event type requires a tag permission the user lacks."""
-    required = _TYPE_TAG_PERMISSIONS.get(event_type)
-    if required is None or request.auth.has_permission(required):
-        return
-    details = {"endpoint": endpoint, "required_permission": required}
-    if event_id is not None:
-        audit_log(
-            logging.WARNING,
-            "permission_denied",
-            request,
-            persist=False,
-            target=AuditTarget(type=AuditTargetType.EVENT, id=str(event_id), details=details),
-        )
-    else:
-        audit_log(
-            logging.WARNING,
-            "permission_denied",
-            request,
-            persist=False,
-            target=AuditTarget(details=details),
-        )
-    raise_validation(Code.Perm.DENIED, status_code=403, action=required)
 
 
 def _validate_event_datetimes(start, end, datetime_tbd: bool, *, check_past: bool = True) -> None:
@@ -113,38 +70,6 @@ def _validate_event_datetimes(start, end, datetime_tbd: bool, *, check_past: boo
         raise_validation(Code.Event.END_BEFORE_START, field="end_datetime")
     if check_past and not datetime_tbd and start < timezone.now():
         raise_validation(Code.Event.START_DATETIME_MUST_BE_FUTURE, field="start_datetime")
-
-
-def _validate_update_payload(request, event: Event, event_id, updates: dict) -> None:
-    """Validate PATCH payload fields. Raises ValidationException on failure."""
-    if "event_type" in updates:
-        _enforce_type_tag_permission(request, updates["event_type"], "update_event", event_id)
-    effective_type = updates.get("event_type", event.event_type)
-    effective_visibility = updates.get("visibility", event.visibility)
-    if _is_invalid_typed_visibility(effective_type, effective_visibility):
-        raise_validation(Code.Event.OFFICIAL_MUST_BE_PUBLIC, status_code=400)
-    # While a poll is active, the poll is the source of truth for when. Block
-    # direct edits to start/end so the event time can't drift from the poll.
-    # Host must finalize (or delete) the poll before setting a time.
-    time_fields_edited = any(
-        f in updates for f in ("start_datetime", "end_datetime", "datetime_tbd")
-    )
-    if time_fields_edited and hasattr(event, "poll") and event.poll.is_active:
-        raise_validation(Code.Event.DATE_LOCKED_BY_POLL, status_code=400)
-    effective_start = updates.get("start_datetime", event.start_datetime)
-    effective_end = updates.get("end_datetime", event.end_datetime)
-    effective_tbd = updates.get("datetime_tbd", event.datetime_tbd)
-    # Drafts can legitimately have no start yet (see #357) — don't enforce
-    # "start required" or past-check when a draft stays dateless. But if the
-    # draft has a start (existing or being set), it must be a future date.
-    if event.is_draft and effective_start is None:
-        return
-    # Past-check applies when start_datetime is being touched, or on any
-    # edit to a draft that already has a start (stale-draft guard). Non-
-    # draft past events keep being tweakable for non-date fields within
-    # the 6-hour grace window (enforced client-side).
-    check_past = "start_datetime" in updates or event.is_draft
-    _validate_event_datetimes(effective_start, effective_end, effective_tbd, check_past=check_past)
 
 
 def _build_events_queryset(status: str, auth_user, is_authed):
@@ -390,35 +315,6 @@ def create_event(request, payload: EventIn):
     return Status(201, _event_out(event, request.auth))
 
 
-def _apply_field_updates(request, event: Event, event_id: UUID, updates: dict) -> None:
-    """Apply non-status field edits to an event. Raises ValidationException on failure."""
-    if not updates:
-        return
-    _validate_update_payload(request, event, event_id, updates)
-    co_host_ids = updates.pop("co_host_ids", None)
-    tag_ids = updates.pop("tag_ids", None)
-    changed_fields = list(updates.keys())
-    if co_host_ids is not None:
-        changed_fields.append("co_host_ids")
-    if tag_ids is not None:
-        changed_fields.append("tag_ids")
-    for field, value in updates.items():
-        setattr(event, field, value)
-    if co_host_ids is not None:
-        _update_co_hosts(event, co_host_ids, request.auth)
-    if tag_ids is not None:
-        _set_event_tags(event, tag_ids)
-    event.save()
-    audit_log(
-        logging.INFO,
-        "event_updated",
-        request,
-        target=AuditTarget(
-            type=AuditTargetType.EVENT, id=str(event_id), details={"fields_changed": changed_fields}
-        ),
-    )
-
-
 @router.patch(
     "/events/{event_id}/",
     response={200: EventOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut, 409: ErrorOut},
@@ -437,17 +333,7 @@ def update_event(request, event_id: UUID, payload: EventPatchIn):
     if event.is_deleted:
         raise_validation(Code.Event.NOT_FOUND, status_code=404)
 
-    if not _can_edit_event(request.auth, event):
-        audit_log(
-            logging.WARNING,
-            "permission_denied",
-            request,
-            persist=False,
-            target=AuditTarget(
-                type=AuditTargetType.EVENT, id=str(event_id), details={"endpoint": "update_event"}
-            ),
-        )
-        raise_validation(Code.Perm.DENIED, status_code=403, action="update_event")
+    _guard_can_edit_event(request, event, event_id)
 
     updates = payload.model_dump(exclude_unset=True)
     new_status = updates.pop("status", None)
@@ -455,7 +341,9 @@ def update_event(request, event_id: UUID, payload: EventPatchIn):
     force = updates.pop("force", False) or False
     # Checked before status transitions, which have their own attendee notifications.
     was_eligible = event.is_public_rsvp_eligible
+    old_max_attendees = event.max_attendees
     removed_user_ids: list[str] = []
+    promoted_user_ids: list[str] = []
 
     # Field edits before the transition so publish validates the corrected date.
     with transaction.atomic():
@@ -469,7 +357,12 @@ def update_event(request, event_id: UUID, payload: EventPatchIn):
             if early is not None:
                 return early
 
+        promoted_user_ids = _promote_if_capacity_increased(event, updates, old_max_attendees)
+
     email_removed_non_members(request, event, removed_user_ids)
+    if promoted_user_ids:
+        broadcast_capacity_change(event_id, exclude_user_ids={str(request.auth.pk)})
+        _email_promoted_non_members(request, event, promoted_user_ids)
 
     # Re-fetch to pick up any M2M changes
     event.refresh_from_db()

--- a/backend/tests/test_event_waitlist_promotion.py
+++ b/backend/tests/test_event_waitlist_promotion.py
@@ -273,3 +273,50 @@ class TestWaitlistPromotionNotification:
         assert not Notification.objects.filter(
             notification_type=NotificationType.WAITLIST_PROMOTED,
         ).exists()
+
+
+# ---------------------------------------------------------------------------
+# TestPromoteOnCapacityIncrease
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.django_db
+class TestPromoteOnCapacityIncrease:
+    def test_promote_on_max_attendees_increase(  # noqa: PLR0913
+        self, api_client, capped_event, test_user, user3, headers1, headers2, headers3
+    ):
+        _rsvp(api_client, capped_event, headers1)
+        _rsvp(api_client, capped_event, headers2)
+        _rsvp(api_client, capped_event, headers3)  # waitlisted, cap=2
+
+        host_headers = _jwt_headers(test_user)
+        response = api_client.patch(
+            f"/api/community/events/{capped_event.id}/",
+            {"max_attendees": 3},
+            content_type="application/json",
+            **host_headers,
+        )
+        assert response.status_code == 200
+        assert response.json()["attending_count"] == 3
+
+        rsvp3 = EventRSVP.objects.get(event=capped_event, user=user3)
+        assert rsvp3.status == RSVPStatus.ATTENDING
+
+    def test_no_promotion_on_max_attendees_decrease(  # noqa: PLR0913
+        self, api_client, capped_event, test_user, user3, headers1, headers2, headers3
+    ):
+        _rsvp(api_client, capped_event, headers1)
+        _rsvp(api_client, capped_event, headers2)
+        _rsvp(api_client, capped_event, headers3)  # waitlisted, cap=2
+
+        host_headers = _jwt_headers(test_user)
+        response = api_client.patch(
+            f"/api/community/events/{capped_event.id}/",
+            {"max_attendees": 1},
+            content_type="application/json",
+            **host_headers,
+        )
+        assert response.status_code == 200
+
+        rsvp3 = EventRSVP.objects.get(event=capped_event, user=user3)
+        assert rsvp3.status == RSVPStatus.WAITLISTED

--- a/frontend/src/api/cohostInvites.ts
+++ b/frontend/src/api/cohostInvites.ts
@@ -6,7 +6,7 @@ import type { Event } from '@/models/event';
 import { apiClient } from './client';
 import type { WireEvent } from './eventMapper';
 import { mapEvent } from './eventMapper';
-import { eventKeys } from './events';
+import { eventKeys, setEventDetailData } from './events';
 
 interface CohostInviteArgs {
   eventId: string;
@@ -54,8 +54,8 @@ function useCohostInviteMutation<TArgs extends { eventId: string }>(
   const isAuthed = useAuthStore((s) => s.status === 'authed');
   return useMutation({
     mutationFn: fn,
-    onSuccess: (event, vars) => {
-      qc.setQueryData(eventKeys.detail(vars.eventId, isAuthed), event);
+    onSuccess: (event) => {
+      setEventDetailData(qc, event, isAuthed);
       void qc.invalidateQueries({ queryKey: eventKeys.list(isAuthed) });
     },
   });

--- a/frontend/src/api/eventPolls.ts
+++ b/frontend/src/api/eventPolls.ts
@@ -6,7 +6,7 @@ import { type EventPoll, VoteChoice } from '@/models/eventPoll';
 import { extractApiErrorOr, getApiStatus } from './apiErrors';
 import { apiClient } from './client';
 import { mapEventPoll, type WireEventPoll } from './eventPollMapper';
-import { eventKeys } from './events';
+import { eventKeys, invalidateEventDetail } from './events';
 
 export const eventPollKeys = {
   all: ['event-poll'] as const,
@@ -51,7 +51,7 @@ function invalidateEventAndPoll(
   if (poll) qc.setQueryData(eventPollKeys.detail(eventId, isAuthed), poll);
   else qc.removeQueries({ queryKey: eventPollKeys.detail(eventId, isAuthed) });
   // Finalize + create + delete all change event.hasPoll / event.startDatetime.
-  void qc.invalidateQueries({ queryKey: eventKeys.detail(eventId, isAuthed) });
+  invalidateEventDetail(qc, eventId);
   void qc.invalidateQueries({ queryKey: eventKeys.list(isAuthed) });
 }
 

--- a/frontend/src/api/eventStats.ts
+++ b/frontend/src/api/eventStats.ts
@@ -10,7 +10,7 @@ import type {
 import { attendanceReportKey } from './attendanceReport';
 import { apiClient } from './client';
 import { mapEvent, type WireEvent } from './eventMapper';
-import { eventKeys } from './events';
+import { invalidateEventDetail, setEventDetailData } from './events';
 import { USERS_KEY } from './users';
 
 interface WireCancellation {
@@ -83,7 +83,7 @@ export function useSetAttendance(eventId: string) {
       return mapEvent(data);
     },
     onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: eventKeys.detail(eventId, true) });
+      invalidateEventDetail(qc, eventId);
       void qc.invalidateQueries({ queryKey: eventStatsKeys.detail(eventId) });
       // attendance marks feed the admin report + members-list last_attended.
       void qc.invalidateQueries({ queryKey: attendanceReportKey });
@@ -103,7 +103,7 @@ export function useSetGuestRsvp(eventId: string) {
       return mapEvent(data);
     },
     onSuccess: (event) => {
-      qc.setQueryData(eventKeys.detail(event.id, true), event);
+      setEventDetailData(qc, event, true);
       void qc.invalidateQueries({ queryKey: eventStatsKeys.detail(eventId) });
     },
   });
@@ -120,7 +120,7 @@ export function useSetGuestPayment(eventId: string) {
       return mapEvent(data);
     },
     onSuccess: (event) => {
-      qc.setQueryData(eventKeys.detail(event.id, true), event);
+      setEventDetailData(qc, event, true);
     },
   });
 }
@@ -132,7 +132,7 @@ export function useRemoveGuestRsvp(eventId: string) {
       await apiClient.delete(`/api/community/events/${eventId}/rsvps/${args.userId}/rsvp/`);
     },
     onSuccess: () => {
-      void qc.invalidateQueries({ queryKey: eventKeys.detail(eventId, true) });
+      invalidateEventDetail(qc, eventId);
       void qc.invalidateQueries({ queryKey: eventStatsKeys.detail(eventId) });
     },
   });

--- a/frontend/src/api/eventWrites.test.ts
+++ b/frontend/src/api/eventWrites.test.ts
@@ -5,6 +5,7 @@ import { createElement } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { apiClient } from '@/api/client';
+import { eventKeys } from '@/api/events';
 import { EventStatus, EventType, EventVisibility, InvitePermission } from '@/models/event';
 import { makeEvent } from '@/test/fixtures';
 
@@ -12,6 +13,7 @@ import {
   eventToFormValues,
   toPartialWireBody,
   useInviteToEvent,
+  useUpdateEvent,
   useUploadEventPhoto,
 } from './eventWrites';
 import { textRecipientsKeys } from './textRecipients';
@@ -181,5 +183,40 @@ describe('useUploadEventPhoto', () => {
       expect.any(FormData),
       expect.objectContaining({ headers: { 'Content-Type': 'multipart/form-data' } }),
     );
+  });
+});
+
+describe('useUpdateEvent cache patching', () => {
+  const EVENT_ID = '33333333-3333-3333-3333-333333333333';
+  const EVENT_SLUG = 'blue-mountain-hike';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Routes link by slug (eventPath), so a uuid-only cache write leaves the open
+  // page showing the pre-save value until a hard refresh.
+  it('writes the updated event to the slug key the detail route reads from', async () => {
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const Wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: qc }, children);
+
+    qc.setQueryData(
+      eventKeys.detail(EVENT_SLUG, true),
+      makeEvent({ id: EVENT_ID, slug: EVENT_SLUG, maxAttendees: 8 }),
+    );
+    vi.mocked(apiClient.patch).mockResolvedValue({
+      data: { ...makeEvent({ id: EVENT_ID, slug: EVENT_SLUG }), max_attendees: 12 },
+    });
+
+    const { result } = renderHook(() => useUpdateEvent(EVENT_ID), { wrapper: Wrapper });
+    result.current.mutate({ maxAttendees: 12 });
+
+    await waitFor(() => {
+      expect(qc.getQueryData(eventKeys.detail(EVENT_SLUG, true))).toMatchObject({
+        maxAttendees: 12,
+      });
+    });
+    expect(qc.getQueryData(eventKeys.detail(EVENT_ID, true))).toMatchObject({ maxAttendees: 12 });
   });
 });

--- a/frontend/src/api/eventWrites.ts
+++ b/frontend/src/api/eventWrites.ts
@@ -14,7 +14,7 @@ import { fromCashAppUrl, fromVenmoUrl, toCashAppUrl, toVenmoUrl } from '@/utils/
 import { extractApiErrorOr, getApiStatus } from './apiErrors';
 import { apiClient } from './client';
 import { mapEvent, type WireEvent } from './eventMapper';
-import { eventKeys } from './events';
+import { eventKeys, setEventDetailData } from './events';
 import { textRecipientsKeys } from './textRecipients';
 
 const ROUTE = '/events';
@@ -136,7 +136,7 @@ export function useCreateEvent() {
       return mapEvent(data);
     },
     onSuccess: (event) => {
-      qc.setQueryData(eventKeys.detail(event.id, isAuthed), event);
+      setEventDetailData(qc, event, isAuthed);
       void qc.invalidateQueries({ queryKey: eventKeys.list(isAuthed) });
     },
     onError: (err) => {
@@ -161,7 +161,7 @@ export function useInviteToEvent(eventId: string) {
       return mapEvent(data);
     },
     onSuccess: (event) => {
-      qc.setQueryData(eventKeys.detail(event.id, isAuthed), event);
+      setEventDetailData(qc, event, isAuthed);
       void qc.invalidateQueries({ queryKey: eventKeys.list(isAuthed) });
       void qc.invalidateQueries({ queryKey: textRecipientsKeys.detail(event.id) });
     },
@@ -185,7 +185,7 @@ export function useUpdateEvent(eventId: string) {
       return mapEvent(data);
     },
     onSuccess: (event) => {
-      qc.setQueryData(eventKeys.detail(event.id, isAuthed), event);
+      setEventDetailData(qc, event, isAuthed);
       void qc.invalidateQueries({ queryKey: eventKeys.list(isAuthed) });
     },
     onError: (err) => {
@@ -209,7 +209,7 @@ export function useCancelEvent(eventId: string) {
       return mapEvent(data);
     },
     onSuccess: (event) => {
-      qc.setQueryData(eventKeys.detail(event.id, isAuthed), event);
+      setEventDetailData(qc, event, isAuthed);
       void qc.invalidateQueries({ queryKey: eventKeys.list(isAuthed) });
     },
     onError: (err) => {
@@ -230,7 +230,7 @@ export function useDeleteEvent(eventId: string) {
       return mapEvent(data);
     },
     onSuccess: (event) => {
-      qc.setQueryData(eventKeys.detail(event.id, isAuthed), event);
+      setEventDetailData(qc, event, isAuthed);
       void qc.invalidateQueries({ queryKey: eventKeys.list(isAuthed) });
     },
     onError: (err) => {
@@ -258,7 +258,7 @@ export function useUploadEventPhoto() {
       return mapEvent(data);
     },
     onSuccess: (event) => {
-      qc.setQueryData(eventKeys.detail(event.id, isAuthed), event);
+      setEventDetailData(qc, event, isAuthed);
       void qc.invalidateQueries({ queryKey: eventKeys.list(isAuthed) });
     },
     onError: (err, { eventId }) => {

--- a/frontend/src/api/events.ts
+++ b/frontend/src/api/events.ts
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { type QueryClient, useQuery } from '@tanstack/react-query';
 
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
@@ -16,6 +16,39 @@ export const eventKeys = {
   detail: (id: string, isAuthed: boolean, token?: string) =>
     ['events', 'detail', id, { authed: isAuthed, token: token ?? '' }] as const,
 };
+
+/**
+ * Write an event into its detail cache under BOTH its uuid and its slug.
+ * Routes use `eventPath` (slug when present), so a uuid-only write lands on a
+ * key nothing is reading and the open page keeps showing stale data.
+ */
+export function setEventDetailData(
+  qc: QueryClient,
+  event: Event,
+  isAuthed: boolean,
+  token?: string,
+): void {
+  for (const key of new Set([event.id, event.slug].filter(Boolean))) {
+    qc.setQueryData(eventKeys.detail(key, isAuthed, token), event);
+  }
+}
+
+/**
+ * Invalidate an event's detail cache. Callers often hold only one of the two
+ * identifiers (a route param is a slug, a mutation arg is usually a uuid), so
+ * match on the cached event itself rather than reconstructing an exact key.
+ */
+export function invalidateEventDetail(qc: QueryClient, eventIdOrSlug: string): void {
+  void qc.invalidateQueries({
+    queryKey: eventKeys.all,
+    predicate: (query) => {
+      if (query.queryKey[1] !== 'detail') return false;
+      if (query.queryKey[2] === eventIdOrSlug) return true;
+      const cached = query.state.data as Event | undefined;
+      return cached?.id === eventIdOrSlug || cached?.slug === eventIdOrSlug;
+    },
+  });
+}
 
 export async function fetchEvents(status?: EventListStatus): Promise<Event[]> {
   const { data } = await apiClient.get<WireEvent[]>('/api/community/events/', {

--- a/frontend/src/components/DevTestEventOverrides.tsx
+++ b/frontend/src/components/DevTestEventOverrides.tsx
@@ -37,7 +37,6 @@ function NumberField({
         onChange(Number(e.target.value));
       }}
       disabled={disabled}
-      className="[-moz-appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
     />
   );
 }

--- a/frontend/src/components/DevTestEventOverrides.tsx
+++ b/frontend/src/components/DevTestEventOverrides.tsx
@@ -28,13 +28,12 @@ function NumberField({
   return (
     <TextField
       label={label}
-      type="number"
+      type="text"
       inputMode="numeric"
-      min={0}
-      max={50}
       value={String(value)}
       onChange={(e) => {
-        onChange(Number(e.target.value));
+        const digits = e.target.value.replace(/\D/g, '');
+        onChange(digits === '' ? 0 : Number(digits));
       }}
       disabled={disabled}
     />

--- a/frontend/src/screens/events/form/EventFormRsvp.test.tsx
+++ b/frontend/src/screens/events/form/EventFormRsvp.test.tsx
@@ -1,28 +1,73 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 import { emptyEventFormValues, type EventFormValues } from '@/api/eventWrites';
 
 import { EventFormRsvp } from './EventFormRsvp';
 
-function renderRsvp(overrides: Partial<EventFormValues> = {}) {
-  return render(
+function renderRsvp(overrides: Partial<EventFormValues> = {}, onChange = vi.fn()) {
+  render(
     <EventFormRsvp
       values={{ ...emptyEventFormValues(), rsvpEnabled: true, ...overrides }}
-      onChange={vi.fn()}
+      onChange={onChange}
       errors={{}}
     />,
+  );
+  return { onChange, input: screen.getByLabelText('max attendees (optional)') };
+}
+
+function Harness() {
+  const [values, setValues] = useState<EventFormValues>({
+    ...emptyEventFormValues(),
+    rsvpEnabled: true,
+    maxAttendees: 15,
+  });
+  return (
+    <EventFormRsvp
+      values={values}
+      onChange={(p) => {
+        setValues((v) => ({ ...v, ...p }));
+      }}
+      errors={{}}
+    />
   );
 }
 
 describe('max attendees field (issue 1264)', () => {
-  // Hiding the spinners doesn't disable stepping — the field still steps on
-  // wheel/arrow keys, so the value changed with no visible control to explain
-  // it. Keep the arrows visible rather than hiding a live affordance.
-  it('does not hide the number input spinners', () => {
-    renderRsvp({ maxAttendees: 15 });
-    const input = screen.getByLabelText('max attendees (optional)');
-    expect(input.className).not.toMatch(/spin-button/);
-    expect(input.className).not.toMatch(/moz-appearance/);
+  // A focused type="number" steps on wheel/arrow keys, so scrolling the page
+  // silently rewrote the typed capacity. Its spinners are also unstyleable.
+  it('is not a number input, so scrolling cannot step it', () => {
+    const { input } = renderRsvp({ maxAttendees: 15 });
+    expect(input).toHaveAttribute('type', 'text');
+    expect(input).toHaveAttribute('inputmode', 'numeric');
+  });
+
+  it('keeps the value when the page is scrolled over a focused field', () => {
+    render(<Harness />);
+    const input = screen.getByLabelText('max attendees (optional)') as HTMLInputElement;
+    input.focus();
+
+    fireEvent.wheel(input, { deltaY: 100 });
+
+    expect(input.value).toBe('15');
+  });
+
+  it('accepts digits', () => {
+    const { onChange, input } = renderRsvp({ maxAttendees: null });
+    fireEvent.change(input, { target: { value: '12' } });
+    expect(onChange).toHaveBeenCalledWith({ maxAttendees: 12 });
+  });
+
+  it('strips non-digits rather than storing NaN', () => {
+    const { onChange, input } = renderRsvp({ maxAttendees: null });
+    fireEvent.change(input, { target: { value: '1e5' } });
+    expect(onChange).toHaveBeenCalledWith({ maxAttendees: 15 });
+  });
+
+  it('clears to null (unlimited) when emptied', () => {
+    const { onChange, input } = renderRsvp({ maxAttendees: 10 });
+    fireEvent.change(input, { target: { value: '' } });
+    expect(onChange).toHaveBeenCalledWith({ maxAttendees: null });
   });
 });

--- a/frontend/src/screens/events/form/EventFormRsvp.test.tsx
+++ b/frontend/src/screens/events/form/EventFormRsvp.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { emptyEventFormValues, type EventFormValues } from '@/api/eventWrites';
+
+import { EventFormRsvp } from './EventFormRsvp';
+
+function renderRsvp(overrides: Partial<EventFormValues> = {}) {
+  return render(
+    <EventFormRsvp
+      values={{ ...emptyEventFormValues(), rsvpEnabled: true, ...overrides }}
+      onChange={vi.fn()}
+      errors={{}}
+    />,
+  );
+}
+
+describe('max attendees field (issue 1264)', () => {
+  // Hiding the spinners doesn't disable stepping — the field still steps on
+  // wheel/arrow keys, so the value changed with no visible control to explain
+  // it. Keep the arrows visible rather than hiding a live affordance.
+  it('does not hide the number input spinners', () => {
+    renderRsvp({ maxAttendees: 15 });
+    const input = screen.getByLabelText('max attendees (optional)');
+    expect(input.className).not.toMatch(/spin-button/);
+    expect(input.className).not.toMatch(/moz-appearance/);
+  });
+});

--- a/frontend/src/screens/events/form/EventFormRsvp.test.tsx
+++ b/frontend/src/screens/events/form/EventFormRsvp.test.tsx
@@ -35,8 +35,6 @@ function Harness() {
 }
 
 describe('max attendees field (issue 1264)', () => {
-  // A focused type="number" steps on wheel/arrow keys, so scrolling the page
-  // silently rewrote the typed capacity. Its spinners are also unstyleable.
   it('is not a number input, so scrolling cannot step it', () => {
     const { input } = renderRsvp({ maxAttendees: 15 });
     expect(input).toHaveAttribute('type', 'text');

--- a/frontend/src/screens/events/form/EventFormRsvp.tsx
+++ b/frontend/src/screens/events/form/EventFormRsvp.tsx
@@ -46,14 +46,15 @@ export function EventFormRsvp({ values, onChange, errors }: Props) {
           />
           <TextField
             label="max attendees (optional)"
-            type="number"
+            // Deliberately not type="number": its spinners can't be styled, and
+            // a focused number input steps on wheel/arrow keys, silently
+            // rewriting the typed capacity (issue 1264).
+            type="text"
             inputMode="numeric"
-            min={1}
-            max={200}
             value={values.maxAttendees === null ? '' : String(values.maxAttendees)}
             onChange={(e) => {
-              const v = e.target.value;
-              onChange({ maxAttendees: v === '' ? null : Number(v) });
+              const digits = e.target.value.replace(/\D/g, '');
+              onChange({ maxAttendees: digits === '' ? null : Number(digits) });
             }}
             error={errors.maxAttendees}
           />

--- a/frontend/src/screens/events/form/EventFormRsvp.tsx
+++ b/frontend/src/screens/events/form/EventFormRsvp.tsx
@@ -46,9 +46,7 @@ export function EventFormRsvp({ values, onChange, errors }: Props) {
           />
           <TextField
             label="max attendees (optional)"
-            // Deliberately not type="number": its spinners can't be styled, and
-            // a focused number input steps on wheel/arrow keys, silently
-            // rewriting the typed capacity (issue 1264).
+            // Not type="number": a focused one steps on wheel/arrow keys (issue 1264).
             type="text"
             inputMode="numeric"
             value={values.maxAttendees === null ? '' : String(values.maxAttendees)}

--- a/frontend/src/screens/events/form/EventFormRsvp.tsx
+++ b/frontend/src/screens/events/form/EventFormRsvp.tsx
@@ -56,7 +56,6 @@ export function EventFormRsvp({ values, onChange, errors }: Props) {
               onChange({ maxAttendees: v === '' ? null : Number(v) });
             }}
             error={errors.maxAttendees}
-            className="[-moz-appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
           />
         </>
       ) : null}


### PR DESCRIPTION
## Overview

Fixes Issue 1264 — a host would type a capacity, and the number would change on its own before saving. Two related event-capacity bugs turned up while tracking it down and are fixed here too.

## 1. Scrolling silently rewrote the capacity field — the actual Issue 1264

The max-attendees field was `type="number"` with its spinner arrows hidden by CSS:

```
[-moz-appearance:textfield]
[&::-webkit-inner-spin-button]:appearance-none
```

Hiding the arrows removes the affordance but **not the stepping behaviour behind it**. A focused number input still steps on wheel and arrow keys — so typing `15` and scrolling toward the save button decremented it to `14`, with no visible control to explain why. Every number in the original report was a decrement proportional to a scroll (`12→9`, `10→8`, `10→7`).

This is also why it was so hard to pin down: nothing appears in the JS, the network tab, or any test. The browser was doing exactly what a number input is specified to do.

**Fix:** `type="text"` + `inputMode="numeric"` — mobile keeps the numeric keypad, there are no spinners to style, and nothing for the wheel to step. Non-digits are stripped on input, so junk like `1e5` no longer coerces through `Number()` into `100000`. `validateEventForm` already owned the `>= 1` rule; the removed `max={200}` was a UI-only hint the backend never enforced.

`SurveyQuestionField` stays `type="number"` — it never hid its spinners (so it has no hidden-affordance bug) and passes its value through as a string, where digit-stripping would break decimals.

## 2. Waitlist not promoted when capacity increases (backend)

Raising `max_attendees` saved the new capacity but never re-ran waitlist promotion, unlike every other capacity-freeing path (RSVP cancel, plus-one drop, host removal). Newly-opened spots stayed empty until an unrelated RSVP change happened to trigger promotion.

**Fix:** lock the event row and call `promote_from_waitlist` in the same transaction when capacity increases. Promoted guests get the existing notification and capacity-change broadcast.

## 3. Cache written by uuid while the page reads by slug (frontend)

Routes link to events by slug (`eventPath` returns `event.slug` when set), so `useEvent` caches the detail query under the slug — but every mutation wrote its fresh event back under `event.id`, landing on a cache entry nothing was reading. Saving an edit left the open page showing pre-save values until a hard refresh.

**Fix:** `setEventDetailData` / `invalidateEventDetail` helpers covering both identifiers, with the event-write, event-stats, poll and cohost-invite mutations routed through them. `rsvp.ts` already worked around this with its own predicate and is left as-is.

## Refactor

Splits `_events.py`'s update helpers into `_event_update.py` and moves shared permission/visibility helpers into `_event_helpers.py` — the backend change in (2) pushed `_events.py` past the repo's 500-line limit.

## Follow-up

Issue 1288 — warn (not block) when a host reduces capacity below the current going count. Deliberately out of scope here.

## Test plan

- [x] `EventFormRsvp.test.tsx` — not a number input; scrolling a focused field leaves the value intact; digits accepted; `1e5` stripped to `15`; empty clears to unlimited
- [x] `eventWrites.test.ts` — updated event lands on the slug key; verified it **fails** against the old uuid-only write and passes with the fix
- [x] `test_event_waitlist_promotion.py::TestPromoteOnCapacityIncrease` — promotion fires on increase, not on decrease
- [x] Frontend suite: 1148 passed, 141 files
- [x] Backend suite: 1927 passed
- [x] `agent-typecheck`, `agent-lint`, `agent-complexity`, `agent-frontend-typecheck`, `agent-frontend-lint` all clean
- [ ] Manual verification in the running app

Fixes #1264
