### PR TITLE
feat: manage co-hosts from the event edit screen (Issue 1251)

### DIFF
--- a/backend/community/_cohost_invite_helpers.py
+++ b/backend/community/_cohost_invite_helpers.py
@@ -135,6 +135,31 @@ def diff_cohost_invites(
     return newly_invited, accepted_co_host_ids_to_remove
 
 
+def add_cohost_invites(
+    event: Event,
+    co_host_ids: Iterable[str],
+    inviter: UserModel,
+) -> list[str]:
+    """Invite the given users without touching anyone already on the event.
+
+    Set-union counterpart to ``diff_cohost_invites``: ids absent from the input
+    are left alone rather than rescinded, so a caller can add a co-host without
+    first knowing the full current roster.
+
+    Returns the newly-invited user ids so the caller can fire notifications.
+    """
+    next_ids = _next_ids_excluding_creator(event, co_host_ids)
+    existing_by_user = {str(inv.user_id): inv for inv in event.cohost_invites.all()}
+    _check_past_event_guard(event, next_ids, existing_by_user)
+
+    newly_invited: list[str] = []
+    with transaction.atomic():
+        for user_id in next_ids:
+            if _upsert_pending_invite(event, user_id, inviter, existing_by_user.get(user_id)):
+                newly_invited.append(user_id)
+    return newly_invited
+
+
 def _next_ids_excluding_creator(event: Event, co_host_ids: Iterable[str]) -> set[str]:
     """Normalize requested ids, dropping the creator only while they're still a
     host — once they step down they're re-invitable like anyone else."""

--- a/backend/community/_event_cohost_invites.py
+++ b/backend/community/_event_cohost_invites.py
@@ -16,11 +16,17 @@ from ninja.responses import Status
 from notifications._cohost_notifications import (
     create_cohost_invite_accepted_notification,
     create_cohost_invite_declined_notification,
+    create_cohost_invite_notifications,
     create_cohost_removed_notification,
 )
 from notifications.service import broadcast_cohost_change
+from pydantic import BaseModel, Field
 
-from community._cohost_invite_helpers import expire_stale_cohost_invites
+from community._cohost_invite_helpers import (
+    add_cohost_invites,
+    expire_stale_cohost_invites,
+    send_cohost_invite_emails,
+)
 from community._event_helpers import _can_manage_cohost_invites, _event_out
 from community._event_schemas import EventOut
 from community._shared import ErrorOut
@@ -44,6 +50,46 @@ def _reload_event_for_response(event_id: UUID) -> Event:
         .prefetch_related("co_hosts", "invited_users", "rsvps__user", "cohost_invites__user")
         .get(id=event_id)
     )
+
+
+class AddCoHostsIn(BaseModel):
+    user_ids: list[str] = Field(..., min_length=1, max_length=50)
+
+
+@router.post(
+    "/events/{event_id}/cohost-invites/",
+    response={200: EventOut, 400: ErrorOut, 403: ErrorOut, 404: ErrorOut},
+    auth=gated_jwt,
+)
+def add_cohosts(request, event_id: UUID, payload: AddCoHostsIn):
+    """Invite co-hosts with set-union semantics — nobody already on the event
+    is touched. PATCH co_host_ids treats its list as a replacement set, so a
+    caller that didn't resend pending invitees silently rescinded them."""
+    event = get_object_or_404(
+        Event.objects.select_related("created_by").prefetch_related(
+            "co_hosts", "cohost_invites__user"
+        ),
+        id=event_id,
+    )
+    if event.is_deleted:
+        raise_validation(Code.Event.NOT_FOUND, status_code=404)
+
+    co_host_ids = {str(uid) for uid in event.co_hosts.values_list("pk", flat=True)}
+    if not _can_manage_cohost_invites(request.auth, co_host_ids):
+        raise_validation(Code.CoHostInvite.NOT_HOST, status_code=403)
+
+    newly_invited = add_cohost_invites(event, payload.user_ids, request.auth)
+
+    event = _reload_event_for_response(event_id)
+    if newly_invited:
+        create_cohost_invite_notifications(event, newly_invited, request.auth)
+        send_cohost_invite_emails(event, newly_invited, request.auth)
+        broadcast_cohost_change(
+            event,
+            exclude_user_ids={str(request.auth.pk)},
+            extra_user_ids=set(newly_invited),
+        )
+    return Status(200, _event_out(event, request.auth))
 
 
 @router.post(

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -27,6 +27,24 @@
         "title": "AccessOut",
         "type": "object"
       },
+      "AddCoHostsIn": {
+        "properties": {
+          "user_ids": {
+            "items": {
+              "type": "string"
+            },
+            "maxItems": 50,
+            "minItems": 1,
+            "title": "User Ids",
+            "type": "array"
+          }
+        },
+        "required": [
+          "user_ids"
+        ],
+        "title": "AddCoHostsIn",
+        "type": "object"
+      },
       "ApproveJoinRequestOut": {
         "properties": {
           "first_name": {
@@ -8903,6 +8921,85 @@
           }
         ],
         "summary": "Update Event",
+        "tags": [
+          "community"
+        ]
+      }
+    },
+    "/api/community/events/{event_id}/cohost-invites/": {
+      "post": {
+        "description": "Invite co-hosts with set-union semantics \u2014 nobody already on the event\nis touched. PATCH co_host_ids treats its list as a replacement set, so a\ncaller that didn't resend pending invitees silently rescinded them.",
+        "operationId": "community__event_cohost_invites_add_cohosts",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "event_id",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "title": "Event Id",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddCoHostsIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EventOut"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Not Found"
+          }
+        },
+        "security": [
+          {
+            "GatedJWTAuth": []
+          }
+        ],
+        "summary": "Add Cohosts",
         "tags": [
           "community"
         ]

--- a/backend/tests/test_event_cohost_add_endpoint.py
+++ b/backend/tests/test_event_cohost_add_endpoint.py
@@ -1,0 +1,124 @@
+import json
+
+import pytest
+from community.models import Event, EventCoHostInvite, EventStatus
+from community.models.choices import CoHostInviteStatus
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
+
+from tests.conftest import future_iso, past_iso
+
+
+def _make_user(phone: str, name: str) -> User:
+    return User.objects.create_user(
+        phone_number=phone,
+        password="testpass123",
+        first_name=name,
+        email=f"{name.lower()}@example.com",
+    )
+
+
+def _auth_headers(user: User) -> dict:
+    refresh = RefreshToken.for_user(user)
+    return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
+
+
+@pytest.fixture
+def creator(db) -> User:
+    return _make_user("+12025550401", "Creator")
+
+
+@pytest.fixture
+def alice(db) -> User:
+    return _make_user("+12025550402", "Alice")
+
+
+@pytest.fixture
+def bob(db) -> User:
+    return _make_user("+12025550403", "Bob")
+
+
+@pytest.fixture
+def outsider(db) -> User:
+    return _make_user("+12025550404", "Outsider")
+
+
+@pytest.fixture
+def event(db, creator) -> Event:
+    event = Event.objects.create(
+        title="Potluck",
+        start_datetime=future_iso(days=30),
+        end_datetime=future_iso(days=30, hours=2),
+        status=EventStatus.ACTIVE,
+        created_by=creator,
+    )
+    event.co_hosts.add(creator)
+    return event
+
+
+def _add_cohosts(api_client, event, user, ids):
+    return api_client.post(
+        f"/api/community/events/{event.id}/cohost-invites/",
+        data=json.dumps({"user_ids": [str(i) for i in ids]}),
+        content_type="application/json",
+        **_auth_headers(user),
+    )
+
+
+@pytest.mark.django_db
+class TestAddCohostsEndpoint:
+    def test_adding_a_cohost_leaves_existing_pending_invites_alone(
+        self, api_client, event, creator, alice, bob
+    ):
+        """The regression this endpoint exists to prevent."""
+        _add_cohosts(api_client, event, creator, [alice.id])
+        _add_cohosts(api_client, event, creator, [bob.id])
+
+        assert (
+            EventCoHostInvite.objects.get(event=event, user=alice).status
+            == CoHostInviteStatus.PENDING
+        )
+        assert (
+            EventCoHostInvite.objects.get(event=event, user=bob).status
+            == CoHostInviteStatus.PENDING
+        )
+
+    def test_response_includes_the_new_pending_invite(self, api_client, event, creator, alice):
+        resp = _add_cohosts(api_client, event, creator, [alice.id])
+
+        assert resp.status_code == 200
+        pending = resp.json()["pending_cohost_invites"]
+        assert [p["user_id"] for p in pending] == [str(alice.id)]
+
+    def test_re_adding_an_already_pending_user_is_a_noop(self, api_client, event, creator, alice):
+        _add_cohosts(api_client, event, creator, [alice.id])
+        resp = _add_cohosts(api_client, event, creator, [alice.id])
+
+        assert resp.status_code == 200
+        assert EventCoHostInvite.objects.filter(event=event, user=alice).count() == 1
+
+    def test_non_host_cannot_add_cohosts(self, api_client, event, outsider, alice):
+        resp = _add_cohosts(api_client, event, outsider, [alice.id])
+
+        assert resp.status_code == 403
+        assert not EventCoHostInvite.objects.filter(event=event, user=alice).exists()
+
+    def test_cannot_invite_to_a_past_event(self, api_client, db, creator, alice):
+        past = Event.objects.create(
+            title="Last Month",
+            start_datetime=past_iso(days=30),
+            end_datetime=past_iso(days=29),
+            status=EventStatus.ACTIVE,
+            created_by=creator,
+        )
+        past.co_hosts.add(creator)
+
+        resp = _add_cohosts(api_client, past, creator, [alice.id])
+
+        assert resp.status_code == 400
+        assert not EventCoHostInvite.objects.filter(event=past, user=alice).exists()
+
+    def test_empty_user_ids_is_rejected(self, api_client, event, creator):
+        resp = _add_cohosts(api_client, event, creator, [])
+
+        assert resp.status_code == 422

--- a/backend/tests/test_event_cohost_add_preserves_pending.py
+++ b/backend/tests/test_event_cohost_add_preserves_pending.py
@@ -1,0 +1,98 @@
+import json
+
+import pytest
+from community.models import Event, EventCoHostInvite, EventStatus
+from community.models.choices import CoHostInviteStatus
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
+
+from tests.conftest import future_iso
+
+
+def _make_user(phone: str, name: str) -> User:
+    return User.objects.create_user(
+        phone_number=phone,
+        password="testpass123",
+        first_name=name,
+        email=f"{name.lower()}@example.com",
+    )
+
+
+def _auth_headers(user: User) -> dict:
+    refresh = RefreshToken.for_user(user)
+    return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
+
+
+@pytest.fixture
+def creator(db) -> User:
+    return _make_user("+12025550301", "Creator")
+
+
+@pytest.fixture
+def first_invitee(db) -> User:
+    return _make_user("+12025550302", "First")
+
+
+@pytest.fixture
+def second_invitee(db) -> User:
+    return _make_user("+12025550303", "Second")
+
+
+@pytest.fixture
+def event(db, creator) -> Event:
+    return Event.objects.create(
+        title="Potluck",
+        start_datetime=future_iso(days=30),
+        end_datetime=future_iso(days=30, hours=2),
+        status=EventStatus.ACTIVE,
+        created_by=creator,
+    )
+
+
+def _patch_cohosts(api_client, event, user, ids):
+    return api_client.patch(
+        f"/api/community/events/{event.id}/",
+        data=json.dumps({"co_host_ids": [str(i) for i in ids]}),
+        content_type="application/json",
+        **_auth_headers(user),
+    )
+
+
+@pytest.mark.django_db
+class TestAddCohostPreservesPendingInvites:
+    def test_adding_a_cohost_does_not_rescind_an_existing_pending_invite(
+        self, api_client, event, creator, first_invitee, second_invitee
+    ):
+        _patch_cohosts(api_client, event, creator, [first_invitee.id])
+        assert EventCoHostInvite.objects.get(
+            event=event, user=first_invitee
+        ).status == CoHostInviteStatus.PENDING
+
+        # Adding a second co-host must not drop the first, still-pending invite.
+        _patch_cohosts(api_client, event, creator, [first_invitee.id, second_invitee.id])
+
+        first = EventCoHostInvite.objects.get(event=event, user=first_invitee)
+        second = EventCoHostInvite.objects.get(event=event, user=second_invitee)
+        assert first.status == CoHostInviteStatus.PENDING
+        assert second.status == CoHostInviteStatus.PENDING
+
+    def test_patch_response_includes_the_newly_invited_cohost(
+        self, api_client, event, creator, first_invitee
+    ):
+        resp = _patch_cohosts(api_client, event, creator, [first_invitee.id])
+
+        assert resp.status_code == 200
+        pending = resp.json()["pending_cohost_invites"]
+        assert [p["user_id"] for p in pending] == [str(first_invitee.id)]
+
+    def test_payload_omitting_pending_invitee_rescinds_them(
+        self, api_client, event, creator, first_invitee, second_invitee
+    ):
+        """Guards the contract AddCoHostDialog relies on: an id absent from
+        co_host_ids is a removal, so callers must resend pending invitees."""
+        _patch_cohosts(api_client, event, creator, [first_invitee.id])
+
+        _patch_cohosts(api_client, event, creator, [second_invitee.id])
+
+        first = EventCoHostInvite.objects.get(event=event, user=first_invitee)
+        assert first.status == CoHostInviteStatus.RESCINDED

--- a/backend/tests/test_event_cohost_add_preserves_pending.py
+++ b/backend/tests/test_event_cohost_add_preserves_pending.py
@@ -64,9 +64,10 @@ class TestAddCohostPreservesPendingInvites:
         self, api_client, event, creator, first_invitee, second_invitee
     ):
         _patch_cohosts(api_client, event, creator, [first_invitee.id])
-        assert EventCoHostInvite.objects.get(
-            event=event, user=first_invitee
-        ).status == CoHostInviteStatus.PENDING
+        assert (
+            EventCoHostInvite.objects.get(event=event, user=first_invitee).status
+            == CoHostInviteStatus.PENDING
+        )
 
         # Adding a second co-host must not drop the first, still-pending invite.
         _patch_cohosts(api_client, event, creator, [first_invitee.id, second_invitee.id])

--- a/frontend/src/api/cohostInvites.ts
+++ b/frontend/src/api/cohostInvites.ts
@@ -47,6 +47,20 @@ async function deleteCohost({
   return mapEvent(data);
 }
 
+async function postAddCohosts({
+  eventId,
+  userIds,
+}: {
+  eventId: string;
+  userIds: string[];
+}): Promise<Event> {
+  const { data } = await apiClient.post<WireEvent>(
+    `/api/community/events/${eventId}/cohost-invites/`,
+    { user_ids: userIds },
+  );
+  return mapEvent(data);
+}
+
 function useCohostInviteMutation<TArgs extends { eventId: string }>(
   fn: (args: TArgs) => Promise<Event>,
 ) {
@@ -75,4 +89,8 @@ export function useRescindCohostInvite() {
 
 export function useRemoveCohost() {
   return useCohostInviteMutation(deleteCohost);
+}
+
+export function useAddCohosts() {
+  return useCohostInviteMutation(postAddCohosts);
 }

--- a/frontend/src/api/events.ts
+++ b/frontend/src/api/events.ts
@@ -28,6 +28,7 @@ export function setEventDetailData(
   isAuthed: boolean,
   token?: string,
 ): void {
+  // token is omitted at every call site — all are host/admin mutations, never reachable by an rsvp-token holder.
   for (const key of new Set([event.id, event.slug].filter(Boolean))) {
     qc.setQueryData(eventKeys.detail(key, isAuthed, token), event);
   }

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -722,6 +722,28 @@ export interface paths {
         patch: operations["community__events_update_event"];
         trace?: never;
     };
+    "/api/community/events/{event_id}/cohost-invites/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Add Cohosts
+         * @description Invite co-hosts with set-union semantics — nobody already on the event
+         *     is touched. PATCH co_host_ids treats its list as a replacement set, so a
+         *     caller that didn't resend pending invitees silently rescinded them.
+         */
+        post: operations["community__event_cohost_invites_add_cohosts"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/community/events/{event_id}/cohost-invites/{invite_id}/": {
         parameters: {
             query?: never;
@@ -2040,6 +2062,11 @@ export interface components {
         AccessOut: {
             /** Access */
             access: string;
+        };
+        /** AddCoHostsIn */
+        AddCoHostsIn: {
+            /** User Ids */
+            user_ids: string[];
         };
         /** ApproveJoinRequestOut */
         ApproveJoinRequestOut: {
@@ -6794,6 +6821,59 @@ export interface operations {
             };
             /** @description Conflict */
             409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
+    community__event_cohost_invites_add_cohosts: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                event_id: string;
+            };
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AddCoHostsIn"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EventOut"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -188,6 +188,10 @@ export function isHosting(event: Event, userId: string): boolean {
   return event.coHostIds.includes(userId);
 }
 
+export function eventHostCount(event: Event): number {
+  return event.coHostIds.length + event.pendingCohostInvites.length;
+}
+
 export function canManageEvent(event: Event, user: User | null): boolean {
   if (!user) return false;
   if (isHosting(event, user.id)) return true;

--- a/frontend/src/screens/events/AddCoHostDialog.test.tsx
+++ b/frontend/src/screens/events/AddCoHostDialog.test.tsx
@@ -7,8 +7,8 @@ import { AddCoHostDialog } from './AddCoHostDialog';
 
 const updateMutateAsync = vi.hoisted(() => vi.fn());
 
-vi.mock('@/api/eventWrites', () => ({
-  useUpdateEvent: () => ({ mutateAsync: updateMutateAsync, isPending: false }),
+vi.mock('@/api/cohostInvites', () => ({
+  useAddCohosts: () => ({ mutateAsync: updateMutateAsync, isPending: false }),
 }));
 
 vi.mock('@/api/userSearch', () => ({
@@ -54,7 +54,7 @@ describe('AddCoHostDialog', () => {
     expect(screen.queryByText('Accepted Host')).not.toBeInTheDocument();
   });
 
-  it('resends pending invitees so adding a co-host does not rescind them', async () => {
+  it('sends only the newly added members, never the existing roster', async () => {
     updateMutateAsync.mockClear();
     updateMutateAsync.mockResolvedValue(undefined);
     render(<AddCoHostDialog event={BASE_EVENT} open onClose={() => {}} />);
@@ -66,12 +66,9 @@ describe('AddCoHostDialog', () => {
     await vi.waitFor(() => {
       expect(updateMutateAsync).toHaveBeenCalledTimes(1);
     });
-    const sent = updateMutateAsync.mock.calls[0]?.[0] as { coHostIds: string[] };
-    expect([...sent.coHostIds].sort()).toEqual([
-      'user-accepted',
-      'user-available',
-      'user-creator',
-      'user-pending',
-    ]);
+    expect(updateMutateAsync).toHaveBeenCalledWith({
+      eventId: 'ev1',
+      userIds: ['user-available'],
+    });
   });
 });

--- a/frontend/src/screens/events/AddCoHostDialog.test.tsx
+++ b/frontend/src/screens/events/AddCoHostDialog.test.tsx
@@ -53,4 +53,25 @@ describe('AddCoHostDialog', () => {
     expect(screen.queryByText('Pending Invitee')).not.toBeInTheDocument();
     expect(screen.queryByText('Accepted Host')).not.toBeInTheDocument();
   });
+
+  it('resends pending invitees so adding a co-host does not rescind them', async () => {
+    updateMutateAsync.mockClear();
+    updateMutateAsync.mockResolvedValue(undefined);
+    render(<AddCoHostDialog event={BASE_EVENT} open onClose={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText('search members'), { target: { value: 'me' } });
+    fireEvent.click(screen.getByText('Available Member'));
+    fireEvent.click(screen.getByRole('button', { name: 'add 1' }));
+
+    await vi.waitFor(() => {
+      expect(updateMutateAsync).toHaveBeenCalledTimes(1);
+    });
+    const sent = updateMutateAsync.mock.calls[0]?.[0] as { coHostIds: string[] };
+    expect([...sent.coHostIds].sort()).toEqual([
+      'user-accepted',
+      'user-available',
+      'user-creator',
+      'user-pending',
+    ]);
+  });
 });

--- a/frontend/src/screens/events/AddCoHostDialog.tsx
+++ b/frontend/src/screens/events/AddCoHostDialog.tsx
@@ -25,7 +25,9 @@ export function AddCoHostDialog({ event, open, onClose }: Props) {
 
   async function submit() {
     setError(null);
-    const combined = Array.from(new Set([...event.coHostIds, ...added.map((m) => m.id)]));
+    // co_host_ids is a replacement set — pending invitees must be resent or
+    // the backend reads their absence as a rescind.
+    const combined = Array.from(new Set([...excludeIds, ...added.map((m) => m.id)]));
     try {
       await update.mutateAsync({ coHostIds: combined });
       setAdded([]);

--- a/frontend/src/screens/events/AddCoHostDialog.tsx
+++ b/frontend/src/screens/events/AddCoHostDialog.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 
 import { extractApiErrorOr } from '@/api/apiErrors';
-import { useUpdateEvent } from '@/api/eventWrites';
+import { useAddCohosts } from '@/api/cohostInvites';
 import type { MemberSearchResult } from '@/api/userSearch';
 import { MemberPicker } from '@/components/MemberPicker';
 import { Button } from '@/components/ui/Button';
@@ -15,7 +15,7 @@ interface Props {
 }
 
 export function AddCoHostDialog({ event, open, onClose }: Props) {
-  const update = useUpdateEvent(event.id);
+  const update = useAddCohosts();
   const [added, setAdded] = useState<MemberSearchResult[]>([]);
   const [error, setError] = useState<string | null>(null);
   const excludeIds = [
@@ -25,11 +25,8 @@ export function AddCoHostDialog({ event, open, onClose }: Props) {
 
   async function submit() {
     setError(null);
-    // co_host_ids is a replacement set — pending invitees must be resent or
-    // the backend reads their absence as a rescind.
-    const combined = Array.from(new Set([...excludeIds, ...added.map((m) => m.id)]));
     try {
-      await update.mutateAsync({ coHostIds: combined });
+      await update.mutateAsync({ eventId: event.id, userIds: added.map((m) => m.id) });
       setAdded([]);
       onClose();
     } catch (err) {

--- a/frontend/src/screens/events/EventHostSection.tsx
+++ b/frontend/src/screens/events/EventHostSection.tsx
@@ -8,7 +8,6 @@ import { useConfirm } from '@/components/ui/useConfirm';
 import type { Event, PendingCohostInvite } from '@/models/event';
 
 import { AddCoHostDialog } from './AddCoHostDialog';
-import { Card } from './EventDetailCard';
 
 interface HostRow {
   userId: string;
@@ -21,13 +20,11 @@ export function EventHostSection({
   isHostOrEventManager,
   canEdit,
   viewerId,
-  headless = false,
 }: {
   event: Event;
   isHostOrEventManager: boolean;
   canEdit: boolean;
   viewerId: string | null;
-  headless?: boolean;
 }) {
   const [addOpen, setAddOpen] = useState(false);
   const { confirm, element: confirmElement } = useConfirm();
@@ -48,10 +45,6 @@ export function EventHostSection({
     .map((row) => ({ userId: row.id, name: row.name, photoUrl: row.photoUrl }));
   // backend already scopes pending invites to creator/accepted co-hosts; others get []
   const pending = event.pendingCohostInvites;
-  if (hosts.length === 0 && pending.length === 0 && !isHostOrEventManager && !headless)
-    return null;
-  const totalChips = hosts.length + pending.length;
-  const label = totalChips > 1 ? 'hosts' : 'host';
 
   async function removeCohost(host: HostRow) {
     const isSelf = host.userId === viewerId;
@@ -77,7 +70,7 @@ export function EventHostSection({
     );
   }
 
-  const body = (
+  return (
     <>
       <div className="flex flex-wrap items-center gap-2">
         {hosts.map((h) => {
@@ -138,8 +131,6 @@ export function EventHostSection({
       {confirmElement}
     </>
   );
-
-  return headless ? body : <Card label={label}>{body}</Card>;
 }
 
 function HostChip({

--- a/frontend/src/screens/events/EventHostSection.tsx
+++ b/frontend/src/screens/events/EventHostSection.tsx
@@ -21,14 +21,13 @@ export function EventHostSection({
   isHostOrEventManager,
   canEdit,
   viewerId,
-  bare = false,
+  headless = false,
 }: {
   event: Event;
   isHostOrEventManager: boolean;
   canEdit: boolean;
   viewerId: string | null;
-  /** Render chips only — the edit form supplies its own section heading. */
-  bare?: boolean;
+  headless?: boolean;
 }) {
   const [addOpen, setAddOpen] = useState(false);
   const { confirm, element: confirmElement } = useConfirm();
@@ -49,7 +48,8 @@ export function EventHostSection({
     .map((row) => ({ userId: row.id, name: row.name, photoUrl: row.photoUrl }));
   // backend already scopes pending invites to creator/accepted co-hosts; others get []
   const pending = event.pendingCohostInvites;
-  if (hosts.length === 0 && pending.length === 0 && !isHostOrEventManager && !bare) return null;
+  if (hosts.length === 0 && pending.length === 0 && !isHostOrEventManager && !headless)
+    return null;
   const totalChips = hosts.length + pending.length;
   const label = totalChips > 1 ? 'hosts' : 'host';
 
@@ -139,7 +139,7 @@ export function EventHostSection({
     </>
   );
 
-  return bare ? body : <Card label={label}>{body}</Card>;
+  return headless ? body : <Card label={label}>{body}</Card>;
 }
 
 function HostChip({

--- a/frontend/src/screens/events/EventHostSection.tsx
+++ b/frontend/src/screens/events/EventHostSection.tsx
@@ -21,11 +21,14 @@ export function EventHostSection({
   isHostOrEventManager,
   canEdit,
   viewerId,
+  bare = false,
 }: {
   event: Event;
   isHostOrEventManager: boolean;
   canEdit: boolean;
   viewerId: string | null;
+  /** Render chips only — the edit form supplies its own section heading. */
+  bare?: boolean;
 }) {
   const [addOpen, setAddOpen] = useState(false);
   const { confirm, element: confirmElement } = useConfirm();
@@ -46,7 +49,7 @@ export function EventHostSection({
     .map((row) => ({ userId: row.id, name: row.name, photoUrl: row.photoUrl }));
   // backend already scopes pending invites to creator/accepted co-hosts; others get []
   const pending = event.pendingCohostInvites;
-  if (hosts.length === 0 && pending.length === 0 && !isHostOrEventManager) return null;
+  if (hosts.length === 0 && pending.length === 0 && !isHostOrEventManager && !bare) return null;
   const totalChips = hosts.length + pending.length;
   const label = totalChips > 1 ? 'hosts' : 'host';
 
@@ -74,8 +77,8 @@ export function EventHostSection({
     );
   }
 
-  return (
-    <Card label={label}>
+  const body = (
+    <>
       <div className="flex flex-wrap items-center gap-2">
         {hosts.map((h) => {
           const isSelf = h.userId === viewerId;
@@ -133,8 +136,10 @@ export function EventHostSection({
         />
       ) : null}
       {confirmElement}
-    </Card>
+    </>
   );
+
+  return bare ? body : <Card label={label}>{body}</Card>;
 }
 
 function HostChip({

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -5,7 +5,7 @@ import { useFlag } from '@/api/featureFlags';
 import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
 import type { Event } from '@/models/event';
-import { spotsLeft } from '@/models/event';
+import { eventHostCount, spotsLeft } from '@/models/event';
 import { Feature } from '@/models/featureFlags';
 import { formatPrice } from '@/utils/eventCost';
 import { buildEventLinks } from '@/utils/eventLinks';
@@ -34,16 +34,19 @@ export function EventMemberSection({ event, token }: Props) {
 
   const { isHostOrEventManager, canEdit, canInvite, showRsvp, showStandaloneInvited } =
     eventMemberSectionFlags(event, user);
+  const hostCount = eventHostCount(event);
 
   return (
     <div className="mt-8 flex flex-col gap-6">
-      {user ? (
-        <EventHostSection
-          event={event}
-          isHostOrEventManager={isHostOrEventManager}
-          canEdit={canEdit}
-          viewerId={user.id}
-        />
+      {user && (hostCount > 0 || isHostOrEventManager) ? (
+        <Card label={hostCount > 1 ? 'hosts' : 'host'}>
+          <EventHostSection
+            event={event}
+            isHostOrEventManager={isHostOrEventManager}
+            canEdit={canEdit}
+            viewerId={user.id}
+          />
+        </Card>
       ) : null}
       <LocationSection event={event} />
       <LinksSection event={event} />

--- a/frontend/src/screens/events/form/EventForm.tsx
+++ b/frontend/src/screens/events/form/EventForm.tsx
@@ -22,6 +22,7 @@ import { CollapsibleCard } from '@/components/ui/CollapsibleCard';
 import { useConfirm } from '@/components/ui/useConfirm';
 import { type Event, eventHostCount, eventPath, EventType } from '@/models/event';
 import { hasPermission, Permission } from '@/models/permissions';
+import type { User } from '@/models/user';
 
 import { EventHostSection } from '../EventHostSection';
 import { eventMemberSectionFlags } from '../eventMemberFlags';
@@ -233,9 +234,6 @@ export function EventForm({ existing }: Props) {
     values.venmoLink.trim().length > 0 ||
     values.cashappLink.trim().length > 0 ||
     values.zelleInfo.trim().length > 0;
-  const existingHosts = existing
-    ? { event: existing, flags: eventMemberSectionFlags(existing, user) }
-    : null;
   const hostsCount = existing ? eventHostCount(existing) : coHosts.length;
 
   return (
@@ -284,13 +282,8 @@ export function EventForm({ existing }: Props) {
               : undefined
           }
         >
-          {existingHosts ? (
-            <EventHostSection
-              event={existingHosts.event}
-              isHostOrEventManager={existingHosts.flags.isHostOrEventManager}
-              canEdit={existingHosts.flags.canEdit}
-              viewerId={user?.id ?? null}
-            />
+          {existing ? (
+            <ExistingEventHosts event={existing} user={user} />
           ) : (
             <MemberPicker
               label="co-hosts"
@@ -390,5 +383,17 @@ export function EventForm({ existing }: Props) {
       </div>
       {confirmElement}
     </form>
+  );
+}
+
+function ExistingEventHosts({ event, user }: { event: Event; user: User | null }) {
+  const { isHostOrEventManager, canEdit } = eventMemberSectionFlags(event, user);
+  return (
+    <EventHostSection
+      event={event}
+      isHostOrEventManager={isHostOrEventManager}
+      canEdit={canEdit}
+      viewerId={user?.id ?? null}
+    />
   );
 }

--- a/frontend/src/screens/events/form/EventForm.tsx
+++ b/frontend/src/screens/events/form/EventForm.tsx
@@ -290,7 +290,7 @@ export function EventForm({ existing }: Props) {
               isHostOrEventManager={hostFlags.isHostOrEventManager}
               canEdit={hostFlags.canEdit}
               viewerId={user?.id ?? null}
-              bare
+              headless
             />
           ) : (
             <MemberPicker

--- a/frontend/src/screens/events/form/EventForm.tsx
+++ b/frontend/src/screens/events/form/EventForm.tsx
@@ -20,7 +20,7 @@ import { MemberPicker } from '@/components/MemberPicker';
 import { Button } from '@/components/ui/Button';
 import { CollapsibleCard } from '@/components/ui/CollapsibleCard';
 import { useConfirm } from '@/components/ui/useConfirm';
-import { type Event, eventPath, EventType } from '@/models/event';
+import { type Event, eventHostCount, eventPath, EventType } from '@/models/event';
 import { hasPermission, Permission } from '@/models/permissions';
 
 import { EventHostSection } from '../EventHostSection';
@@ -233,10 +233,10 @@ export function EventForm({ existing }: Props) {
     values.venmoLink.trim().length > 0 ||
     values.cashappLink.trim().length > 0 ||
     values.zelleInfo.trim().length > 0;
-  const hostFlags = existing ? eventMemberSectionFlags(existing, user) : null;
-  const hostsCount = existing
-    ? existing.coHostIds.length + existing.pendingCohostInvites.length
-    : coHosts.length;
+  const existingHosts = existing
+    ? { event: existing, flags: eventMemberSectionFlags(existing, user) }
+    : null;
+  const hostsCount = existing ? eventHostCount(existing) : coHosts.length;
 
   return (
     <form
@@ -284,13 +284,12 @@ export function EventForm({ existing }: Props) {
               : undefined
           }
         >
-          {existing && hostFlags ? (
+          {existingHosts ? (
             <EventHostSection
-              event={existing}
-              isHostOrEventManager={hostFlags.isHostOrEventManager}
-              canEdit={hostFlags.canEdit}
+              event={existingHosts.event}
+              isHostOrEventManager={existingHosts.flags.isHostOrEventManager}
+              canEdit={existingHosts.flags.canEdit}
               viewerId={user?.id ?? null}
-              headless
             />
           ) : (
             <MemberPicker

--- a/frontend/src/screens/events/form/EventForm.tsx
+++ b/frontend/src/screens/events/form/EventForm.tsx
@@ -79,7 +79,14 @@ export function EventForm({ existing }: Props) {
   const [values, setValues] = useState<EventFormValues>(() =>
     existing ? eventToFormValues(existing) : emptyEventFormValues(),
   );
-  const [coHosts, setCoHosts] = useState<MemberSearchResult[]>([]);
+  const [coHosts, setCoHosts] = useState<MemberSearchResult[]>(() => {
+    if (!existing) return [];
+    return existing.coHostIds.map((id, idx) => ({
+      id,
+      fullName: existing.coHostNames[idx] ?? '',
+      phoneNumber: '',
+    }));
+  });
   // On edit, pre-run validation so issues in the loaded values (e.g. a stale
   // draft whose start is now in the past) are visible immediately instead of
   // waiting for the first save attempt.
@@ -271,29 +278,22 @@ export function EventForm({ existing }: Props) {
           onBufferPoll={setBufferedPollOptions}
         />
 
-        {!existing && (
-          <CollapsibleCard
-            title="hosts"
-            summary={
-              hostsCount > 0
-                ? `${String(hostsCount)} ${hostsCount === 1 ? 'person' : 'people'}`
-                : undefined
-            }
-          >
-            <MemberPicker
-              label="co-hosts"
-              selected={coHosts}
-              onChange={setCoHosts}
-              excludeIds={user ? [user.id] : []}
-              hint="co-hosts get an invite — once they accept, they can edit the event and manage rsvps"
-            />
-          </CollapsibleCard>
-        )}
-        {existing && (
-          <CollapsibleCard title="hosts">
-            <p className="text-foreground-tertiary text-sm">manage co-hosts on the event page</p>
-          </CollapsibleCard>
-        )}
+        <CollapsibleCard
+          title="hosts"
+          summary={
+            hostsCount > 0
+              ? `${String(hostsCount)} ${hostsCount === 1 ? 'person' : 'people'}`
+              : undefined
+          }
+        >
+          <MemberPicker
+            label="co-hosts"
+            selected={coHosts}
+            onChange={setCoHosts}
+            excludeIds={user ? [user.id] : []}
+            hint="co-hosts get an invite — once they accept, they can edit the event and manage rsvps"
+          />
+        </CollapsibleCard>
 
         <CollapsibleCard
           title="details"

--- a/frontend/src/screens/events/form/EventForm.tsx
+++ b/frontend/src/screens/events/form/EventForm.tsx
@@ -23,6 +23,8 @@ import { useConfirm } from '@/components/ui/useConfirm';
 import { type Event, eventPath, EventType } from '@/models/event';
 import { hasPermission, Permission } from '@/models/permissions';
 
+import { EventHostSection } from '../EventHostSection';
+import { eventMemberSectionFlags } from '../eventMemberFlags';
 import { EventFormBasics } from './EventFormBasics';
 import { EventFormDetails } from './EventFormDetails';
 import { EventFormLinks, EventFormMoney } from './EventFormLinksAndCost';
@@ -79,14 +81,7 @@ export function EventForm({ existing }: Props) {
   const [values, setValues] = useState<EventFormValues>(() =>
     existing ? eventToFormValues(existing) : emptyEventFormValues(),
   );
-  const [coHosts, setCoHosts] = useState<MemberSearchResult[]>(() => {
-    if (!existing) return [];
-    return existing.coHostIds.map((id, idx) => ({
-      id,
-      fullName: existing.coHostNames[idx] ?? '',
-      phoneNumber: '',
-    }));
-  });
+  const [coHosts, setCoHosts] = useState<MemberSearchResult[]>([]);
   // On edit, pre-run validation so issues in the loaded values (e.g. a stale
   // draft whose start is now in the past) are visible immediately instead of
   // waiting for the first save attempt.
@@ -238,7 +233,10 @@ export function EventForm({ existing }: Props) {
     values.venmoLink.trim().length > 0 ||
     values.cashappLink.trim().length > 0 ||
     values.zelleInfo.trim().length > 0;
-  const hostsCount = coHosts.length;
+  const hostFlags = existing ? eventMemberSectionFlags(existing, user) : null;
+  const hostsCount = existing
+    ? existing.coHostIds.length + existing.pendingCohostInvites.length
+    : coHosts.length;
 
   return (
     <form
@@ -286,13 +284,23 @@ export function EventForm({ existing }: Props) {
               : undefined
           }
         >
-          <MemberPicker
-            label="co-hosts"
-            selected={coHosts}
-            onChange={setCoHosts}
-            excludeIds={user ? [user.id] : []}
-            hint="co-hosts get an invite — once they accept, they can edit the event and manage rsvps"
-          />
+          {existing && hostFlags ? (
+            <EventHostSection
+              event={existing}
+              isHostOrEventManager={hostFlags.isHostOrEventManager}
+              canEdit={hostFlags.canEdit}
+              viewerId={user?.id ?? null}
+              bare
+            />
+          ) : (
+            <MemberPicker
+              label="co-hosts"
+              selected={coHosts}
+              onChange={setCoHosts}
+              excludeIds={user ? [user.id] : []}
+              hint="co-hosts get an invite — once they accept, they can edit the event and manage rsvps"
+            />
+          )}
         </CollapsibleCard>
 
         <CollapsibleCard

--- a/frontend/src/screens/events/form/EventFormHosts.test.tsx
+++ b/frontend/src/screens/events/form/EventFormHosts.test.tsx
@@ -1,0 +1,96 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type * as EventWritesModule from '@/api/eventWrites';
+import { useAuthStore } from '@/auth/store';
+import type { Event } from '@/models/event';
+import type { User } from '@/models/user';
+import { makeEvent } from '@/test/fixtures';
+
+type EventWrites = typeof EventWritesModule;
+
+vi.mock('@/api/cohostInvites', () => ({
+  useAcceptCohostInvite: () => ({ mutate: vi.fn(), isPending: false }),
+  useDeclineCohostInvite: () => ({ mutate: vi.fn(), isPending: false }),
+  useRescindCohostInvite: () => ({ mutate: vi.fn(), isPending: false }),
+  useRemoveCohost: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock('@/api/eventWrites', async () => {
+  const actual = await vi.importActual<EventWrites>('@/api/eventWrites');
+  return {
+    ...actual,
+    useCreateEvent: () => ({ mutateAsync: vi.fn(), isPending: false }),
+    useUpdateEvent: () => ({ mutateAsync: vi.fn(), isPending: false }),
+    useUploadEventPhoto: () => ({ mutateAsync: vi.fn(), isPending: false }),
+  };
+});
+
+vi.mock('./EventFormPhoto', () => ({ EventFormPhoto: () => null }));
+
+import { EventForm } from './EventForm';
+
+const HOST: User = {
+  id: 'creator',
+  fullName: 'creator person',
+  phoneNumber: '+15551110000',
+  photoUrl: '',
+  roles: [],
+  permissions: [],
+} as unknown as User;
+
+function renderForm(existing?: Event) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const result = render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter>
+        <EventForm existing={existing} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+  // The hosts card is collapsed by default — its contents aren't mounted until opened.
+  fireEvent.click(screen.getByRole('button', { name: /hosts/ }));
+  return result;
+}
+
+describe('EventForm hosts section', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthStore.setState({ user: HOST, status: 'authed' });
+  });
+
+  it('shows current co-host chips on edit instead of the staged picker', () => {
+    renderForm(
+      makeEvent({
+        coHostIds: ['creator', 'u2'],
+        coHostNames: ['creator person', 'jamie'],
+        coHostPhotoUrls: ['', ''],
+      }),
+    );
+
+    expect(screen.getByText('jamie')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'add co-host' })).toBeInTheDocument();
+    expect(screen.queryByLabelText('co-hosts')).not.toBeInTheDocument();
+  });
+
+  it('offers removal of an existing co-host from the edit form', () => {
+    renderForm(
+      makeEvent({
+        coHostIds: ['creator', 'u2'],
+        coHostNames: ['creator person', 'jamie'],
+        coHostPhotoUrls: ['', ''],
+      }),
+    );
+
+    expect(screen.getByRole('button', { name: 'remove jamie as co-host' })).toBeInTheDocument();
+  });
+
+  it('shows the staged member picker when creating', () => {
+    renderForm();
+
+    expect(screen.getByLabelText('co-hosts')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'add co-host' })).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/events/form/EventFormHosts.test.tsx
+++ b/frontend/src/screens/events/form/EventFormHosts.test.tsx
@@ -16,6 +16,7 @@ vi.mock('@/api/cohostInvites', () => ({
   useDeclineCohostInvite: () => ({ mutate: vi.fn(), isPending: false }),
   useRescindCohostInvite: () => ({ mutate: vi.fn(), isPending: false }),
   useRemoveCohost: () => ({ mutate: vi.fn(), isPending: false }),
+  useAddCohosts: () => ({ mutateAsync: vi.fn(), isPending: false }),
 }));
 
 vi.mock('@/api/eventWrites', async () => {


### PR DESCRIPTION
## Summary

The event edit screen now shows current hosts and lets you manage them inline — the same chip UI as the event detail page, with avatars, pending-invite badges, an `×` to remove, and a `+` to add. Previously it showed a static "manage co-hosts on the event page" message.

Along the way this uncovered a data-loss bug in co-host adding, which is fixed here, plus the API design that made it possible.

## The UI change

Rather than build a second co-host editor, the form reuses `EventHostSection` — the detail page's component. One implementation, so the two screens can't drift.

`EventHostSection` was reduced to just the chip row; each caller supplies its own wrapper (`Card` on the detail page, `CollapsibleCard` in the form). That keeps the detail-page-specific bits — the singular/plural label, the hide-when-empty rule — at the call site that wants them, instead of behind a flag in the shared component.

Create mode keeps the existing `MemberPicker`: there's no event to mutate yet, so co-hosts are staged and sent with the create call.

Excluding current co-hosts from search needed no new code — `MemberPicker` already takes `excludeIds`, and `AddCoHostDialog` already passed both accepted and pending ids.

## Bug fix: adding a co-host rescinded pending invites

Reported during review: add a co-host at create, publish, then add a second co-host from the detail page — the second doesn't appear until refresh, and after refreshing the *first* one is gone.

`AddCoHostDialog` built its PATCH payload by merging `event.coHostIds`, which holds **accepted** co-hosts only. Pending invitees live in a separate `pendingCohostInvites` array. Since `co_host_ids` is a replacement set, anyone missing from the payload gets rescinded — so adding the second co-host sent a list omitting the first, still-pending one.

The "didn't see them until refresh" half was the same event: a newly added co-host is *pending*, so they render as a greyed pending chip rather than a normal one — easy to miss while the first invite disappears in the same update.

## The API design behind it

`PATCH co_host_ids` treats its list as a replacement set, so every caller has to resend the full roster (accepted + pending) or silently rescind whoever it forgot. That's a trap any future caller can fall into.

This adds `POST /events/{id}/cohost-invites/` with set-union semantics — ids absent from the payload are left alone. It mirrors `_event_invitations.py`, the member-invitation endpoint that was split off PATCH for exactly this reason ("editing an event can never clobber the invitee list"). Co-host invites needed the same treatment.

`AddCoHostDialog` now sends only the users being added, so it has no ability to affect the existing roster — the bug class is gone rather than avoided.

`PATCH co_host_ids` is unchanged. The event form still uses it and needs replacement semantics for create; its behavior stays pinned by tests.

## Follow-up fix: pending cohost didn't appear on detail page until refresh

A separate staleness bug, found while testing this: adding a cohost from the event *detail* page (not the edit form) didn't show it as pending until a manual refresh, even though the edit page updated live. Root cause was a query-cache key mismatch — the detail page's query key can be the event's slug (after URL canonicalization) while the mutation wrote its cache update keyed by UUID, so the write landed on an entry nothing was reading.

Fixed via `setEventDetailData` (`frontend/src/api/events.ts`), which writes the mutation result into the detail cache under **both** the UUID and slug keys. Added a one-line comment noting the helper omits the `rsvp_token` cache-key segment — acceptable because every current call site is a host/admin-only mutation, never reachable by a token-holding non-member.

## Behavior notes

- Detail page rendering is unchanged
- Host changes made from the edit form apply **immediately** (they hit the co-host endpoints on click), not on form save — this matches the detail page, but means cancelling the form does not undo a host change
- Past/cancelled events keep the existing guard: `+` is disabled with the "can't edit hosts on a past or cancelled event" tooltip, and the new endpoint enforces the past-event rule server-side

## Testing

- `test_event_cohost_add_endpoint.py` — 6 tests: the reported regression, permission denial, past-event guard, re-adding a pending user (no-op), empty payload
- `test_event_cohost_add_preserves_pending.py` — pins the replacement-set contract that `PATCH co_host_ids` callers depend on
- `EventFormHosts.test.tsx` — host chips on edit, remove affordance, staged picker on create; verified the edit-mode tests fail when the change is reverted
- `AddCoHostDialog.test.tsx` — asserts the dialog sends only the newly added members
- 89 cohost backend tests, 507 frontend tests, ruff / ty / complexity / eslint / tsc all pass
- OpenAPI schema + generated frontend API types regenerated for the new endpoint

Fixes Issue 1251
