### PR TITLE
fix(events): restrict guest list visibility to RSVPs and hosts (Issue 1267)

### DIFF
--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -217,6 +217,22 @@ def _can_see_invited(
     return requesting_user.has_permission(PermissionKey.MANAGE_EVENTS)
 
 
+_INACTIVE_RSVP_STATUSES = {RSVPStatus.CANT_GO, RSVPStatus.REMOVED}
+
+
+def _can_see_guests(requesting_user, viewer_is_cohost: bool, my_rsvp_status: str | None) -> bool:
+    """Hosts, event managers, and active RSVPs can see the guest list.
+
+    A cancelled (CANT_GO) or host-removed (REMOVED) RSVP row still exists, so
+    my_rsvp_status is checked against active statuses rather than just None.
+    """
+    if requesting_user is None:
+        return False
+    if viewer_is_cohost or requesting_user.has_permission(PermissionKey.MANAGE_EVENTS):
+        return True
+    return my_rsvp_status is not None and my_rsvp_status not in _INACTIVE_RSVP_STATUSES
+
+
 def _can_manage_cohost_invites(
     requesting_user,
     co_host_ids: set[str],
@@ -318,7 +334,6 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
         FeatureFlag.EVENT_PAYMENT_CONFIRMATION
     )
     all_rsvps = list(event.rsvps.all()) if event.rsvp_enabled else []
-    rsvps = all_rsvps if is_authed else []
     all_invited = list(event.invited_users.all())
     invited = all_invited if _can_see_invited(auth_user, creator, co_host_ids) else []
 
@@ -327,7 +342,7 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
     my_pending_invite_id = str(my_pending_invite.id) if my_pending_invite else None
     comment_count = _resolve_comment_count(event)
     my_rsvp_status, my_paid_confirmed = _my_rsvp_fields(all_rsvps, auth_user)
-    can_see_guests = viewer_is_cohost or my_rsvp_status is not None
+    can_see_guests = _can_see_guests(auth_user, viewer_is_cohost, my_rsvp_status)
     return EventOut(
         id=str(event.id),
         slug=event.slug,
@@ -360,7 +375,7 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
         co_host_names=[visible_display_name(u, auth_user) for u in co_hosts],
         co_host_photo_urls=[media_path(u.profile_photo) for u in co_hosts],
         guests=_gated(
-            _build_guest_list(rsvps, viewer_is_cohost, auth_user, payment_status_visible),
+            _build_guest_list(all_rsvps, viewer_is_cohost, auth_user, payment_status_visible),
             [],
             can_see_guests,
         ),

--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -326,6 +326,7 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
     my_pending_invite_id = str(my_pending_invite.id) if my_pending_invite else None
     comment_count = _resolve_comment_count(event)
     my_rsvp_status, my_paid_confirmed = _my_rsvp_fields(rsvps, auth_user)
+    can_see_guests = is_authed and (viewer_is_cohost or my_rsvp_status is not None)
     return EventOut(
         id=str(event.id),
         slug=event.slug,
@@ -360,7 +361,7 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
         guests=_gated(
             _build_guest_list(rsvps, viewer_is_cohost, auth_user, payment_status_visible),
             [],
-            is_authed,
+            can_see_guests,
         ),
         my_rsvp=my_rsvp_status,
         my_paid_confirmed=my_paid_confirmed,

--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -317,7 +317,8 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
     payment_status_visible = viewer_is_cohost and flag_enabled(
         FeatureFlag.EVENT_PAYMENT_CONFIRMATION
     )
-    rsvps = list(event.rsvps.all()) if (event.rsvp_enabled and is_authed) else []
+    all_rsvps = list(event.rsvps.all()) if event.rsvp_enabled else []
+    rsvps = all_rsvps if is_authed else []
     all_invited = list(event.invited_users.all())
     invited = all_invited if _can_see_invited(auth_user, creator, co_host_ids) else []
 
@@ -325,8 +326,8 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
     my_pending_invite = get_my_pending_invite(event, auth_user)
     my_pending_invite_id = str(my_pending_invite.id) if my_pending_invite else None
     comment_count = _resolve_comment_count(event)
-    my_rsvp_status, my_paid_confirmed = _my_rsvp_fields(rsvps, auth_user)
-    can_see_guests = is_authed and (viewer_is_cohost or my_rsvp_status is not None)
+    my_rsvp_status, my_paid_confirmed = _my_rsvp_fields(all_rsvps, auth_user)
+    can_see_guests = viewer_is_cohost or my_rsvp_status is not None
     return EventOut(
         id=str(event.id),
         slug=event.slug,

--- a/backend/tests/test_event_guest_list_visibility.py
+++ b/backend/tests/test_event_guest_list_visibility.py
@@ -7,8 +7,9 @@ Only hosts and people who have RSVP'd should see guests.
 import pytest
 from community.models import RSVPStatus
 from ninja_jwt.tokens import RefreshToken
-from tests._public_rsvp_helpers import make_official_event
 from users.models import User
+
+from tests._public_rsvp_helpers import make_official_event
 
 
 @pytest.fixture

--- a/backend/tests/test_event_guest_list_visibility.py
+++ b/backend/tests/test_event_guest_list_visibility.py
@@ -2,69 +2,91 @@ import pytest
 from community.models import RSVPStatus
 from ninja_jwt.tokens import RefreshToken
 from users.models import User
+from users.permissions import PermissionKey
+from users.roles import Role
 
 from tests._public_rsvp_helpers import make_official_event
 
 
 @pytest.fixture
-def auth_user(db):
-    return User.objects.create_user(phone_number="+15551234567")
+def other_user(db):
+    return User.objects.create_user(phone_number="+15559876543")
 
 
 @pytest.fixture
-def auth_headers(auth_user):
-    refresh = RefreshToken.for_user(auth_user)
+def other_auth_headers(other_user):
+    refresh = RefreshToken.for_user(other_user)
+    return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}
+
+
+@pytest.fixture
+def event_manager_headers(db):
+    user = User.objects.create_user(phone_number="+15550001111")
+    role = Role.objects.create(name="event_manager", permissions=[PermissionKey.MANAGE_EVENTS])
+    user.roles.add(role)
+    refresh = RefreshToken.for_user(user)
     return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}
 
 
 @pytest.mark.django_db
 class TestEventGuestListVisibility:
     def test_unauthenticated_user_cannot_see_guests(self, api_client):
-        """Unsigned-in visitor should get empty guest list even on public event."""
         event = make_official_event()
         response = api_client.get(f"/api/community/events/{event.id}/")
         assert response.status_code == 200
         assert response.json()["guests"] == []
 
-    def test_rsvp_attendee_can_see_guests(self, api_client, db):
-        """Signed-in attendee can see guest list."""
-        user = User.objects.create_user(phone_number="+15551234567")
+    def test_rsvp_attendee_can_see_guests(self, api_client, test_user, auth_headers):
         event = make_official_event()
-        event.rsvps.create(user=user, status=RSVPStatus.ATTENDING)
+        event.rsvps.create(user=test_user, status=RSVPStatus.ATTENDING)
 
-        refresh = RefreshToken.for_user(user)
-        headers = {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}
-        response = api_client.get(f"/api/community/events/{event.id}/", **headers)
+        response = api_client.get(f"/api/community/events/{event.id}/", **auth_headers)
         assert response.status_code == 200
         guests = response.json()["guests"]
         assert len(guests) > 0
-        assert any(g["user_id"] == str(user.id) for g in guests)
+        assert any(g["user_id"] == str(test_user.id) for g in guests)
 
-    def test_non_rsvp_member_cannot_see_guests(self, api_client, db):
-        """Signed-in member who hasn't RSVP'd gets empty guest list."""
-        user = User.objects.create_user(phone_number="+15551234567")
-        other_user = User.objects.create_user(phone_number="+15559876543")
+    def test_non_rsvp_member_cannot_see_guests(
+        self, api_client, test_user, auth_headers, other_user
+    ):
         event = make_official_event()
         event.rsvps.create(user=other_user, status=RSVPStatus.ATTENDING)
 
-        refresh = RefreshToken.for_user(user)
-        headers = {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}
-        response = api_client.get(f"/api/community/events/{event.id}/", **headers)
+        response = api_client.get(f"/api/community/events/{event.id}/", **auth_headers)
         assert response.status_code == 200
         assert response.json()["guests"] == []
 
-    def test_host_can_see_guests(self, api_client, db):
-        """Host can see guest list."""
-        host = User.objects.create_user(phone_number="+15551234567")
-        attendee = User.objects.create_user(phone_number="+15559876543")
-        event = make_official_event(created_by=host)
-        event.co_hosts.add(host)
-        event.rsvps.create(user=attendee, status=RSVPStatus.ATTENDING)
+    def test_host_can_see_guests(self, api_client, test_user, auth_headers, other_user):
+        event = make_official_event(created_by=test_user)
+        event.co_hosts.add(test_user)
+        event.rsvps.create(user=other_user, status=RSVPStatus.ATTENDING)
 
-        refresh = RefreshToken.for_user(host)
-        headers = {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}
-        response = api_client.get(f"/api/community/events/{event.id}/", **headers)
+        response = api_client.get(f"/api/community/events/{event.id}/", **auth_headers)
         assert response.status_code == 200
         guests = response.json()["guests"]
         assert len(guests) > 0
-        assert any(g["user_id"] == str(attendee.id) for g in guests)
+        assert any(g["user_id"] == str(other_user.id) for g in guests)
+
+    def test_event_manager_can_see_guests_without_rsvp(
+        self, api_client, event_manager_headers, other_user
+    ):
+        event = make_official_event()
+        event.rsvps.create(user=other_user, status=RSVPStatus.ATTENDING)
+
+        response = api_client.get(f"/api/community/events/{event.id}/", **event_manager_headers)
+        assert response.status_code == 200
+        guests = response.json()["guests"]
+        assert len(guests) > 0
+        assert any(g["user_id"] == str(other_user.id) for g in guests)
+
+    @pytest.mark.parametrize("status", [RSVPStatus.CANT_GO, RSVPStatus.REMOVED])
+    def test_cancelled_or_removed_rsvp_cannot_see_guests(
+        self, api_client, test_user, auth_headers, other_user, status
+    ):
+        event = make_official_event()
+        event.rsvps.create(user=test_user, status=status)
+        event.rsvps.create(user=other_user, status=RSVPStatus.ATTENDING)
+
+        response = api_client.get(f"/api/community/events/{event.id}/", **auth_headers)
+        assert response.status_code == 200
+        assert response.json()["guests"] == []

--- a/backend/tests/test_event_guest_list_visibility.py
+++ b/backend/tests/test_event_guest_list_visibility.py
@@ -1,9 +1,3 @@
-"""Tests for guest list visibility on event detail endpoint.
-
-Unauthenticated users should NOT see the guest list, even on public RSVP-eligible events.
-Only hosts and people who have RSVP'd should see guests.
-"""
-
 import pytest
 from community.models import RSVPStatus
 from ninja_jwt.tokens import RefreshToken

--- a/backend/tests/test_event_guest_list_visibility.py
+++ b/backend/tests/test_event_guest_list_visibility.py
@@ -1,0 +1,75 @@
+"""Tests for guest list visibility on event detail endpoint.
+
+Unauthenticated users should NOT see the guest list, even on public RSVP-eligible events.
+Only hosts and people who have RSVP'd should see guests.
+"""
+
+import pytest
+from community.models import RSVPStatus
+from ninja_jwt.tokens import RefreshToken
+from tests._public_rsvp_helpers import make_official_event
+from users.models import User
+
+
+@pytest.fixture
+def auth_user(db):
+    return User.objects.create_user(phone_number="+15551234567")
+
+
+@pytest.fixture
+def auth_headers(auth_user):
+    refresh = RefreshToken.for_user(auth_user)
+    return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}
+
+
+@pytest.mark.django_db
+class TestEventGuestListVisibility:
+    def test_unauthenticated_user_cannot_see_guests(self, api_client):
+        """Unsigned-in visitor should get empty guest list even on public event."""
+        event = make_official_event()
+        response = api_client.get(f"/api/community/events/{event.id}/")
+        assert response.status_code == 200
+        assert response.json()["guests"] == []
+
+    def test_rsvp_attendee_can_see_guests(self, api_client, db):
+        """Signed-in attendee can see guest list."""
+        user = User.objects.create_user(phone_number="+15551234567")
+        event = make_official_event()
+        event.rsvps.create(user=user, status=RSVPStatus.ATTENDING)
+
+        refresh = RefreshToken.for_user(user)
+        headers = {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}
+        response = api_client.get(f"/api/community/events/{event.id}/", **headers)
+        assert response.status_code == 200
+        guests = response.json()["guests"]
+        assert len(guests) > 0
+        assert any(g["user_id"] == str(user.id) for g in guests)
+
+    def test_non_rsvp_member_cannot_see_guests(self, api_client, db):
+        """Signed-in member who hasn't RSVP'd gets empty guest list."""
+        user = User.objects.create_user(phone_number="+15551234567")
+        other_user = User.objects.create_user(phone_number="+15559876543")
+        event = make_official_event()
+        event.rsvps.create(user=other_user, status=RSVPStatus.ATTENDING)
+
+        refresh = RefreshToken.for_user(user)
+        headers = {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}
+        response = api_client.get(f"/api/community/events/{event.id}/", **headers)
+        assert response.status_code == 200
+        assert response.json()["guests"] == []
+
+    def test_host_can_see_guests(self, api_client, db):
+        """Host can see guest list."""
+        host = User.objects.create_user(phone_number="+15551234567")
+        attendee = User.objects.create_user(phone_number="+15559876543")
+        event = make_official_event(created_by=host)
+        event.co_hosts.add(host)
+        event.rsvps.create(user=attendee, status=RSVPStatus.ATTENDING)
+
+        refresh = RefreshToken.for_user(host)
+        headers = {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}
+        response = api_client.get(f"/api/community/events/{event.id}/", **headers)
+        assert response.status_code == 200
+        guests = response.json()["guests"]
+        assert len(guests) > 0
+        assert any(g["user_id"] == str(attendee.id) for g in guests)

--- a/backend/tests/test_rsvp.py
+++ b/backend/tests/test_rsvp.py
@@ -287,15 +287,21 @@ class TestRSVP:
             content_type="application/json",
             **auth_headers,
         )
-        # other_user (not creator) fetches event
+        # other_user (not creator, but RSVP'd, so allowed to see the guest list)
+        api_client.post(
+            f"/api/community/events/{rsvp_event.id}/rsvp/",
+            {"status": RSVPStatus.MAYBE},
+            content_type="application/json",
+            **other_headers,
+        )
         response = api_client.get(
             f"/api/community/events/{rsvp_event.id}/",
             **other_headers,
         )
         assert response.status_code == 200
         guests = response.json()["guests"]
-        assert len(guests) == 1
-        assert guests[0]["phone"] is None
+        assert len(guests) == 2
+        assert all(g["phone"] is None for g in guests)
 
     def test_guest_list_flags_non_members(self, api_client, auth_headers, rsvp_event):
         non_member = User.objects.create_user(

--- a/backend/tests/test_rsvp_payment_revoke.py
+++ b/backend/tests/test_rsvp_payment_revoke.py
@@ -258,6 +258,7 @@ class TestPaymentStatusVisibility:
         nosy = django_user_model.objects.create_user(
             phone_number="+14155550403", first_name="Nosy", is_member=True
         )
+        EventRSVP.objects.create(event=event, user=nosy, status=RSVPStatus.ATTENDING)
         assert self._guests(api_client, event, _headers(nosy))["Payer"] is False
 
     def test_flag_off_hides_payment_status_from_the_host_too(

--- a/backend/tests/users/test_hide_last_name.py
+++ b/backend/tests/users/test_hide_last_name.py
@@ -178,13 +178,14 @@ def hidden_headers(hidden_user):
 
 @pytest.mark.django_db
 class TestEventGuestListHidesLastName:
-    def test_non_admin_sees_first_name_only(self, api_client, auth_headers, hidden_user):
+    def test_non_admin_sees_first_name_only(self, api_client, auth_headers, test_user, hidden_user):
         event = Event.objects.create(
             title="Guest List Event",
             start_datetime=future_iso(days=10),
             rsvp_enabled=True,
         )
         EventRSVP.objects.create(event=event, user=hidden_user, status=RSVPStatus.ATTENDING)
+        EventRSVP.objects.create(event=event, user=test_user, status=RSVPStatus.ATTENDING)
         response = api_client.get(f"/api/community/events/{event.id}/", **auth_headers)
         assert response.status_code == 200
         guest = next(g for g in response.json()["guests"] if g["user_id"] == str(hidden_user.pk))

--- a/frontend/src/screens/events/RsvpGuestList.test.tsx
+++ b/frontend/src/screens/events/RsvpGuestList.test.tsx
@@ -38,6 +38,18 @@ describe('RsvpGuestList', () => {
     expect(screen.queryByRole('link', { name: /sam/i })).not.toBeInTheDocument();
     expect(screen.getByText('Sam')).toBeInTheDocument();
   });
+
+  it('shows a genuinely-empty message when there are no attendees', () => {
+    const event = makeEvent({ guests: [], attendingCount: 0 });
+    renderList(event);
+    expect(screen.getByText('no one yet')).toBeInTheDocument();
+  });
+
+  it('shows a gated message when guests are hidden but attendees exist', () => {
+    const event = makeEvent({ guests: [], attendingCount: 3 });
+    renderList(event);
+    expect(screen.getByText("rsvp to see who's going")).toBeInTheDocument();
+  });
 });
 
 describe('RsvpGuestList — cant go / waitlist visibility (Issue 1042)', () => {

--- a/frontend/src/screens/events/RsvpGuestList.tsx
+++ b/frontend/src/screens/events/RsvpGuestList.tsx
@@ -51,7 +51,12 @@ export function RsvpGuestList({ event, canSeeInvited }: Props) {
   const visible = active === 'invited' ? [] : buckets[active];
 
   if (tabs.every((t) => counts[t.key] === 0)) {
-    return <p className="text-muted text-xs">no one yet</p>;
+    const guestListHidden = event.guests.length === 0 && event.attendingCount > 0;
+    return (
+      <p className="text-muted text-xs">
+        {guestListHidden ? "rsvp to see who's going" : 'no one yet'}
+      </p>
+    );
   }
 
   return (


### PR DESCRIPTION
## Summary
- Unsigned-in visitors could see the guest list on public RSVP-eligible events
- Guest list is now gated on: authenticated AND (is host OR has RSVP'd)
- Only event hosts and people who have RSVP'd can see who's attending

Closes #1267

## Test plan
- [ ] Verify unauthenticated visitor gets empty guest list on event detail
- [ ] Verify authenticated non-RSVP member gets empty guest list
- [ ] Verify RSVP attendee can see guest list
- [ ] Verify host can see guest list