### PR TITLE
fix(events): hide comments card when rsvp is disabled

### DIFF
--- a/frontend/src/screens/events/EventMemberSection.test.tsx
+++ b/frontend/src/screens/events/EventMemberSection.test.tsx
@@ -265,10 +265,10 @@ describe('EventMemberSection — manage events permission holder (Issue 1189)', 
 describe('EventMemberSection — rsvp-disabled gates (#666, #667)', () => {
   const RSVP_ENABLED_EVENT: Event = { ...BASE_EVENT, rsvpEnabled: true };
 
-  it("renders the comments card regardless of rsvpEnabled — gating is the card's own job", () => {
+  it('hides the comments card when rsvp is disabled for the event', () => {
     useAuthStore.setState({ status: 'authed', user: STRANGER, accessToken: 'tok' });
     renderSection({ ...BASE_EVENT, rsvpEnabled: false });
-    expect(screen.getByTestId('comments-card')).toBeInTheDocument();
+    expect(screen.queryByTestId('comments-card')).not.toBeInTheDocument();
   });
 
   it('shows the comments section when rsvp is enabled', () => {

--- a/frontend/src/screens/events/EventMemberSection.tsx
+++ b/frontend/src/screens/events/EventMemberSection.tsx
@@ -70,7 +70,9 @@ export function EventMemberSection({ event, token }: Props) {
           <InvitedList event={event} />
         </Card>
       ) : null}
-      <EventCommentsCard eventId={event.id} {...(token ? { token } : {})} />
+      {event.rsvpEnabled ? (
+        <EventCommentsCard eventId={event.id} {...(token ? { token } : {})} />
+      ) : null}
       <EventAdminActions event={event} />
       <ReportEventButton eventId={event.id} />
     </div>


### PR DESCRIPTION
## Summary
- `EventMemberSection` rendered `EventCommentsCard` unconditionally, so the comments section stayed visible on events with RSVPs disabled entirely (not just "you haven't RSVP'd yet").
- Gate the card on `event.rsvpEnabled`, matching the pattern already used for other RSVP-dependent sections in this file.
- Updated the existing test that had asserted the old (buggy) behavior.

## Test plan
- [x] `make agent-frontend-typecheck` passes
- [x] `EventMemberSection.test.tsx` + `EventCommentsCard.test.tsx` pass, including new assertion that the comments card is hidden when `rsvpEnabled: false`
- [x] `make agent-lint` clean