### PR TITLE
fix: 1238 - poll finalize bypasses capacity, plus-ones, payment gate

### DIFF
--- a/backend/community/_poll_finalize.py
+++ b/backend/community/_poll_finalize.py
@@ -1,0 +1,77 @@
+from notifications.service import create_waitlist_promoted_notifications
+
+from community._event_rsvps import _apply_rsvp_in_transaction
+from community._validation import Code, ValidationException
+from community.models import Event, EventRSVP, PollAvailability, PollOption, RSVPStatus
+
+
+def _yes_votes(winning_option: PollOption) -> list:
+    """Winning option's yes-votes, oldest first.
+
+    Ordering makes who gets a seat under capacity deterministic rather than
+    arbitrary row order. voted_at is auto_now, so this is really "least recently
+    changed their vote" — the only ordering signal PollVote records.
+    """
+    return list(
+        winning_option.votes.filter(availability=PollAvailability.YES)
+        .select_related("user")
+        .order_by("voted_at")
+    )
+
+
+def _seat_voter(event: Event, user, existing: EventRSVP | None) -> bool:
+    """Seat one yes-voter through the shared RSVP write path.
+
+    return(bool): True if they were waitlisted for non-payment on a gated event.
+    """
+    # Polls carry no +1 concept; only an existing row's standing +1 survives.
+    has_plus_one = existing is not None and existing.has_plus_one
+    try:
+        _apply_rsvp_in_transaction(event.id, user, RSVPStatus.ATTENDING, has_plus_one)
+        return False
+    except ValidationException as exc:
+        if exc.code != Code.Event.PAYMENT_CONFIRMATION_REQUIRED:
+            raise
+    # Unpaid on a gated event: waitlist rather than seat unconfirmed or drop them,
+    # so confirming payment promotes them through the normal path.
+    _apply_rsvp_in_transaction(event.id, user, RSVPStatus.WAITLISTED, has_plus_one)
+    return True
+
+
+def _seat_or_skip(event: Event, user, existing: EventRSVP | None) -> bool:
+    """Seat a voter, absorbing the reasons a single voter can't be seated.
+
+    return(bool): True if they were waitlisted for non-payment on a gated event.
+    """
+    # A member who explicitly said they can't go must not be resurrected by finalize.
+    if existing is not None and existing.status == RSVPStatus.CANT_GO:
+        return False
+    try:
+        return _seat_voter(event, user, existing)
+    except ValidationException:
+        # RSVPs disabled/closed for this event, or this voter can no longer see
+        # it — one unseatable voter must not fail the whole finalize.
+        return False
+
+
+def seat_yes_voters(event: Event, winning_option: PollOption) -> None:
+    """Seat the winning option's yes-voters via the shared RSVP write path.
+
+    Routing through _apply_rsvp_in_transaction is what makes finalize honor
+    capacity/waitlist, the payment gate, plus-ones and rsvp_enabled instead of
+    re-implementing (and drifting from) each one.
+    """
+    votes = _yes_votes(winning_option)
+    if not votes:
+        return
+    existing_rsvps = {
+        r.user_id: r
+        for r in EventRSVP.objects.filter(event=event, user_id__in=[v.user_id for v in votes])
+    }
+    unpaid_user_ids = [
+        str(vote.user_id)
+        for vote in votes
+        if _seat_or_skip(event, vote.user, existing_rsvps.get(vote.user_id))
+    ]
+    if unpaid_user_ids:
+        create_waitlist_promoted_notifications(event, unpaid_user_ids, unpaid_user_ids)

--- a/backend/community/_polls.py
+++ b/backend/community/_polls.py
@@ -27,17 +27,16 @@ from community._event_poll_schemas import (
 )
 from community._event_viewer import resolve_event_viewer
 from community._events import _enforce_event_read_visibility
+from community._poll_finalize import seat_yes_voters
 from community._shared import ErrorOut, _authenticated_user, _optional_jwt
 from community._validation import Code, raise_validation
 from community.models import (
     Event,
     EventPoll,
-    EventRSVP,
     EventStatus,
     PollAvailability,
     PollOption,
     PollVote,
-    RSVPStatus,
 )
 
 router = Router()
@@ -320,16 +319,9 @@ def finalize_event_poll(request, event_id: UUID, payload: EventPollFinalizeIn):
         event.start_datetime = winning_option.datetime
         event.datetime_tbd = False
         event.save(update_fields=["start_datetime", "datetime_tbd"])
-        yes_voter_ids = winning_option.votes.filter(availability=PollAvailability.YES).values_list(
-            "user_id", flat=True
-        )
-        for user_id in yes_voter_ids:
-            # paid_confirmed_at omitted from defaults: preserves an existing stamp, else unconfirmed.
-            EventRSVP.objects.update_or_create(
-                event=event,
-                user_id=user_id,
-                defaults={"status": RSVPStatus.ATTENDING, "cancelled_at": None},
-            )
+        # Save the date first: seating re-reads the event, and its past/upcoming
+        # check has to see the finalized start, not the pre-finalize TBD one.
+        seat_yes_voters(event, winning_option)
     broadcast_capacity_change(event_id)
     audit_log(
         logging.INFO,

--- a/backend/tests/test_poll_finalize_seating.py
+++ b/backend/tests/test_poll_finalize_seating.py
@@ -1,0 +1,160 @@
+"""Finalize seats yes-voters through the shared RSVP write path (Issue 1238)."""
+
+import json
+
+import pytest
+from community._event_helpers import promote_from_waitlist
+from community.models import (
+    Event,
+    EventPoll,
+    EventRSVP,
+    PollAvailability,
+    PollOption,
+    PollVote,
+    RSVPStatus,
+)
+from users.models import User
+
+from tests.conftest import future_iso
+
+
+def _finalize(api_client, headers, event, option):
+    return api_client.post(
+        f"/api/community/events/{event.id}/poll/finalize/",
+        data=json.dumps({"winning_option_id": str(option.id)}),
+        content_type="application/json",
+        **headers,
+    )
+
+
+def _vote_yes(option, user):
+    return PollVote.objects.create(option=option, user=user, availability=PollAvailability.YES)
+
+
+@pytest.fixture
+def rsvp_event(db, test_user):
+    return Event.objects.create(
+        title="RSVP Poll Event",
+        datetime_tbd=True,
+        rsvp_enabled=True,
+        created_by=test_user,
+    )
+
+
+@pytest.fixture
+def rsvp_poll(db, rsvp_event, test_user):
+    poll = EventPoll.objects.create(event=rsvp_event, created_by=test_user)
+    PollOption.objects.create(poll=poll, datetime=future_iso(days=120), display_order=0)
+    return poll
+
+
+@pytest.fixture
+def no_rsvp_event(db, test_user):
+    return Event.objects.create(
+        title="No RSVP Poll Event",
+        datetime_tbd=True,
+        created_by=test_user,
+    )
+
+
+@pytest.fixture
+def no_rsvp_poll(db, no_rsvp_event, test_user):
+    poll = EventPoll.objects.create(event=no_rsvp_event, created_by=test_user)
+    PollOption.objects.create(poll=poll, datetime=future_iso(days=120), display_order=0)
+    return poll
+
+
+@pytest.fixture
+def other_user(db):
+    return User.objects.create_user(phone_number="+12025550202", first_name="Other")
+
+
+@pytest.mark.django_db
+class TestFinalizeSeating:
+    def test_seats_yes_voter_as_attending(
+        self, api_client, auth_headers, rsvp_event, rsvp_poll, test_user
+    ):
+        option = rsvp_poll.options.first()
+        _vote_yes(option, test_user)
+
+        assert _finalize(api_client, auth_headers, rsvp_event, option).status_code == 200
+        assert EventRSVP.objects.get(event=rsvp_event, user=test_user).status == (
+            RSVPStatus.ATTENDING
+        )
+
+    def test_capacity_is_respected_overflow_waitlisted(
+        self, api_client, auth_headers, rsvp_event, rsvp_poll
+    ):
+        rsvp_event.max_attendees = 3
+        rsvp_event.save(update_fields=["max_attendees"])
+        option = rsvp_poll.options.first()
+        for i in range(5):
+            voter = User.objects.create_user(phone_number=f"+1202555{1000 + i}", first_name=f"V{i}")
+            _vote_yes(option, voter)
+
+        assert _finalize(api_client, auth_headers, rsvp_event, option).status_code == 200
+        assert EventRSVP.objects.filter(event=rsvp_event, status=RSVPStatus.ATTENDING).count() == 3
+        assert EventRSVP.objects.filter(event=rsvp_event, status=RSVPStatus.WAITLISTED).count() == 2
+
+    def test_waitlisted_voter_is_promoted_when_a_seat_frees(
+        self, api_client, auth_headers, rsvp_event, rsvp_poll
+    ):
+        rsvp_event.max_attendees = 1
+        rsvp_event.save(update_fields=["max_attendees"])
+        option = rsvp_poll.options.first()
+        seated = User.objects.create_user(phone_number="+12025557001", first_name="Seated")
+        waiting = User.objects.create_user(phone_number="+12025557002", first_name="Waiting")
+        _vote_yes(option, seated)
+        _vote_yes(option, waiting)
+        _finalize(api_client, auth_headers, rsvp_event, option)
+
+        seated_rsvp = EventRSVP.objects.get(event=rsvp_event, user=seated)
+        assert seated_rsvp.status == RSVPStatus.ATTENDING
+        seated_rsvp.delete()
+
+        promote_from_waitlist(rsvp_event)
+        assert EventRSVP.objects.get(event=rsvp_event, user=waiting).status == RSVPStatus.ATTENDING
+
+    def test_existing_plus_one_is_preserved(
+        self, api_client, auth_headers, rsvp_event, rsvp_poll, test_user
+    ):
+        rsvp_event.allow_plus_ones = True
+        rsvp_event.save(update_fields=["allow_plus_ones"])
+        option = rsvp_poll.options.first()
+        EventRSVP.objects.create(
+            event=rsvp_event, user=test_user, status=RSVPStatus.MAYBE, has_plus_one=True
+        )
+        _vote_yes(option, test_user)
+
+        _finalize(api_client, auth_headers, rsvp_event, option)
+        rsvp = EventRSVP.objects.get(event=rsvp_event, user=test_user)
+        assert rsvp.status == RSVPStatus.ATTENDING
+        assert rsvp.has_plus_one is True
+
+    def test_cancelled_rsvp_is_not_resurrected(
+        self, api_client, auth_headers, rsvp_event, rsvp_poll, test_user
+    ):
+        option = rsvp_poll.options.first()
+        EventRSVP.objects.create(event=rsvp_event, user=test_user, status=RSVPStatus.CANT_GO)
+        _vote_yes(option, test_user)
+
+        assert _finalize(api_client, auth_headers, rsvp_event, option).status_code == 200
+        assert EventRSVP.objects.get(event=rsvp_event, user=test_user).status == RSVPStatus.CANT_GO
+
+    def test_rsvp_disabled_event_seats_nobody(
+        self, api_client, auth_headers, no_rsvp_event, no_rsvp_poll, test_user
+    ):
+        option = no_rsvp_poll.options.first()
+        _vote_yes(option, test_user)
+
+        assert _finalize(api_client, auth_headers, no_rsvp_event, option).status_code == 200
+        assert not EventRSVP.objects.filter(event=no_rsvp_event).exists()
+
+    def test_non_yes_voters_are_not_seated(
+        self, api_client, auth_headers, rsvp_event, rsvp_poll, other_user
+    ):
+        option = rsvp_poll.options.first()
+        PollVote.objects.create(option=option, user=other_user, availability=PollAvailability.NO)
+
+        _finalize(api_client, auth_headers, rsvp_event, option)
+        assert not EventRSVP.objects.filter(event=rsvp_event, user=other_user).exists()

--- a/backend/tests/test_rsvp_payment_gate_bypass.py
+++ b/backend/tests/test_rsvp_payment_gate_bypass.py
@@ -107,9 +107,9 @@ class TestPaidConfirmedOnUngatedStatus:
 
 @pytest.mark.django_db
 class TestPollFinalizeDoesNotBypassGate:
-    def test_yes_voter_seated_unconfirmed_is_gated_on_next_write(
-        self, api_client, auth_headers, test_user
-    ):
+    def test_unpaid_yes_voter_is_waitlisted_not_seated(self, api_client, auth_headers, test_user):
+        """Finalize routes through the shared RSVP path, so an unpaid voter is
+        waitlisted with a path to confirm — never seated unconfirmed."""
         from community.models import EventPoll, PollAvailability, PollOption, PollVote
 
         event = _paid_event(test_user, datetime_tbd=True)
@@ -125,17 +125,35 @@ class TestPollFinalizeDoesNotBypassGate:
         )
         assert response.status_code == 200
         rsvp = EventRSVP.objects.get(event=event, user=test_user)
-        assert rsvp.status == RSVPStatus.ATTENDING
+        assert rsvp.status == RSVPStatus.WAITLISTED
         assert rsvp.paid_confirmed_at is None
 
-        response = api_client.post(
-            RSVP_URL.format(event_id=event.id),
-            {"status": RSVPStatus.ATTENDING, "has_plus_one": False},
+    def test_waitlisted_voter_is_seated_once_they_confirm_payment(
+        self, api_client, auth_headers, test_user
+    ):
+        from community.models import EventPoll, PollAvailability, PollOption, PollVote
+
+        event = _paid_event(test_user, datetime_tbd=True)
+        poll = EventPoll.objects.create(event=event, created_by=test_user)
+        option = PollOption.objects.create(poll=poll, datetime=future_iso(days=120))
+        PollVote.objects.create(option=option, user=test_user, availability=PollAvailability.YES)
+        api_client.post(
+            f"/api/community/events/{event.id}/poll/finalize/",
+            {"winning_option_id": str(option.id)},
             content_type="application/json",
             **auth_headers,
         )
-        assert response.status_code == 400
-        assert_error_code(response, Code.Event.PAYMENT_CONFIRMATION_REQUIRED)
+
+        response = api_client.post(
+            RSVP_URL.format(event_id=event.id),
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": False, "paid_confirmed": True},
+            content_type="application/json",
+            **auth_headers,
+        )
+        assert response.status_code == 200
+        rsvp = EventRSVP.objects.get(event=event, user=test_user)
+        assert rsvp.status == RSVPStatus.ATTENDING
+        assert rsvp.paid_confirmed_at is not None
 
     def test_yes_voter_with_existing_confirmation_keeps_it(
         self, api_client, auth_headers, test_user


### PR DESCRIPTION
## Overview

`finalize_event_poll()` wrote `EventRSVP` rows directly instead of routing through `_apply_rsvp_in_transaction()`, the shared write path every other RSVP flow uses. This meant poll finalize bypassed capacity limits, dropped plus-ones, skipped the payment-confirmation gate, could resurrect cancelled RSVPs, and ignored `rsvp_enabled`.

Fixes by replacing the direct-write loop with calls through the shared path (extracted into `backend/community/_poll_finalize.py` to keep `_polls.py` under the line cap), so finalize now inherits capacity/waitlist, payment-gate, plus-one, and cancellation semantics automatically instead of needing bespoke handling per feature.

**Design decisions:**
- Seating order: earliest `PollVote.voted_at` first (FIFO, matching the existing waitlist order). Note `voted_at` is `auto_now`, so it reflects last vote change, not first vote — the only ordering signal the model currently records.
- Payment gate: unpaid yes-voters are seated `WAITLISTED` (not auto-seated) and notified to confirm payment, rather than seated unpaid with no notification.
- Plus-ones: preserved from an existing RSVP row if present; new rows default to no plus-one (polls carry no +1 concept).

**Behavior change to flag for review:** on a paid event, finalizing now leaves unpaid yes-voters `WAITLISTED` instead of `ATTENDING`. Hosts finalizing a paid poll will see a smaller attending count than before — this is the correct outcome, but will look like a regression if not expected.

## Test plan

- [x] Scoped test run: `backend/tests/test_poll_finalize_seating.py` + `backend/tests/test_rsvp_payment_gate_bypass.py` (16 tests, all passing)
- [ ] TODO — manual QA: finalize a poll on a capacity-limited event and confirm waitlist behavior

## Breaking changes

Behavioral: paid-event poll finalize now waitlists unpaid yes-voters instead of seating them unpaid (see note above). No migration needed — existing rows untouched.

Closes #1238
