### PR TITLE
fix(events): allow saving an ongoing event without a future start time

### DIFF
--- a/frontend/src/screens/events/form/EventForm.tsx
+++ b/frontend/src/screens/events/form/EventForm.tsx
@@ -84,7 +84,12 @@ export function EventForm({ existing }: Props) {
   // draft whose start is now in the past) are visible immediately instead of
   // waiting for the first save attempt.
   const [errors, setErrors] = useState<Partial<Record<keyof EventFormValues, string>>>(() =>
-    existing ? validateEventForm(eventToFormValues(existing)) : {},
+    existing
+      ? validateEventForm(
+          eventToFormValues(existing),
+          existing.startDatetime ? existing.startDatetime.toISOString() : null,
+        )
+      : {},
   );
   const [serverError, setServerError] = useState<string | null>(null);
   const [pendingPhoto, setPendingPhoto] = useState<Blob | null>(null);
@@ -124,7 +129,10 @@ export function EventForm({ existing }: Props) {
       coHostIds,
       status: nextStatus,
     };
-    const errs = validateEventForm(merged);
+    const errs = validateEventForm(
+      merged,
+      existing?.startDatetime ? existing.startDatetime.toISOString() : undefined,
+    );
     if (Object.keys(errs).length > 0) {
       setErrors(errs);
       // Let the sections open first (via forceOpen), then scroll to the

--- a/frontend/src/screens/events/form/validateEventForm.test.ts
+++ b/frontend/src/screens/events/form/validateEventForm.test.ts
@@ -112,6 +112,19 @@ describe('validateEventForm', () => {
       const errors = validateEventForm(validValues({ startDatetime: past, status: 'draft' }));
       expect(errors.startDatetime).toBe('start must be in the future');
     });
+
+    it('allows an unchanged past startDatetime when editing (ongoing event)', () => {
+      const past = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+      const errors = validateEventForm(validValues({ startDatetime: past }), past);
+      expect(errors.startDatetime).toBeUndefined();
+    });
+
+    it('rejects a new past startDatetime when editing, even with an original', () => {
+      const originalPast = new Date(Date.now() - 60 * 60 * 1000).toISOString();
+      const newPast = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+      const errors = validateEventForm(validValues({ startDatetime: newPast }), originalPast);
+      expect(errors.startDatetime).toBe('start must be in the future');
+    });
   });
 
   describe('endDatetime', () => {

--- a/frontend/src/screens/events/form/validateEventForm.ts
+++ b/frontend/src/screens/events/form/validateEventForm.ts
@@ -3,7 +3,10 @@ import { DESCRIPTION_MAX_LENGTH } from '@/screens/events/form/EventFormDetails';
 
 type Errors = Partial<Record<keyof EventFormValues, string>>;
 
-export function validateEventForm(values: EventFormValues): Errors {
+export function validateEventForm(
+  values: EventFormValues,
+  originalStartDatetime?: string | null,
+): Errors {
   const errors: Errors = {};
   if (!values.title.trim()) errors.title = 'required';
   else if (values.title.length > 200) errors.title = 'under 200 chars';
@@ -12,11 +15,16 @@ export function validateEventForm(values: EventFormValues): Errors {
   if (values.location.length > 300) errors.location = 'under 300 chars';
 
   // Drafts can save without a start date (progress-capture). Active events
-  // must have one. Either way, if a start is present it must be in the future.
+  // must have one. Either way, if a start is present it must be in the future
+  // — unless it's unchanged from what was loaded, so editing an ongoing or
+  // just-ended event doesn't get blocked for a start time nobody touched.
   if (!values.datetimeTbd) {
     if (!values.startDatetime) {
       if (values.status !== 'draft') errors.startDatetime = 'required';
-    } else if (new Date(values.startDatetime).getTime() < Date.now() - 60_000) {
+    } else if (
+      values.startDatetime !== originalStartDatetime &&
+      new Date(values.startDatetime).getTime() < Date.now() - 60_000
+    ) {
       errors.startDatetime = 'start must be in the future';
     }
   }


### PR DESCRIPTION
Closes #1273

## Problem

`validateEventForm` unconditionally rejects a `startDatetime` more than 60s in the past, with no way to know what value was originally loaded. `EventForm` called it both on mount (pre-validating an existing event) and on submit, with no original-start-time context. Opening "edit" on an event that's currently happening — or within the 6-hour post-end grace window `eventEditGate.ts` deliberately allows — immediately showed "start must be in the future" and blocked saving any change, even ones that didn't touch the start time.

## Policy

- Editing an event whose start time is unchanged from what was loaded is always allowed, regardless of past/future.
- Changing the start time to a new value still requires that new value to be in the future.
- Creating a new event still requires a future start time (no original to compare against).

## Changes

- `validateEventForm(values, originalStartDatetime?)` — new optional second param; skips the future-only check when `values.startDatetime === originalStartDatetime`.
- `EventForm.tsx` — both call sites (mount pre-validation, submit) now pass `existing.startDatetime?.toISOString() ?? null/undefined` as the original.
- `eventEditGate.ts` untouched — not the bug.

## Test plan

- [x] `npx tsc -b --noEmit` — clean
- [x] `npx eslint` on changed files — clean
- [x] `npx vitest run validateEventForm.test.ts` — 22/22 passing, including 2 new cases: unchanged past start is allowed; changing to a new past start still errors
