### PR TITLE
fix(calendar): default no-end events to 2h duration

### DIFF
--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -1,6 +1,8 @@
 import { hasPermission, Permission } from './permissions';
 import type { User } from './user';
 
+export const DEFAULT_EVENT_DURATION_MS = 2 * 60 * 60 * 1000;
+
 export const EventType = {
   Community: 'community',
   Official: 'official',

--- a/frontend/src/screens/calendar/AgendaList.tsx
+++ b/frontend/src/screens/calendar/AgendaList.tsx
@@ -2,7 +2,12 @@ import { format, isSameDay } from 'date-fns';
 import { useMemo, useState } from 'react';
 
 import { SegmentedControl } from '@/components/ui/SegmentedControl';
-import { type Event as PdaEvent, eventClass, EventType } from '@/models/event';
+import {
+  DEFAULT_EVENT_DURATION_MS,
+  type Event as PdaEvent,
+  eventClass,
+  EventType,
+} from '@/models/event';
 import { EventBadge } from '@/screens/events/EventBadge';
 import { EventCardBadges } from '@/screens/events/EventCardBadges';
 import { cn } from '@/utils/cn';
@@ -44,7 +49,7 @@ function upcomingEvents(events: PdaEvent[]): PdaEvent[] {
   return events
     .filter((e) => {
       if (!e.startDatetime) return false;
-      const end = e.endDatetime ?? e.startDatetime;
+      const end = e.endDatetime ?? new Date(e.startDatetime.getTime() + DEFAULT_EVENT_DURATION_MS);
       return end >= now;
     })
     .sort((a, b) => (a.startDatetime?.getTime() ?? 0) - (b.startDatetime?.getTime() ?? 0));

--- a/frontend/src/screens/calendar/CalendarScreen.tsx
+++ b/frontend/src/screens/calendar/CalendarScreen.tsx
@@ -8,7 +8,12 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useEvents } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
 import { useIsWideScreen } from '@/hooks/useResponsive';
-import { type Event as PdaEvent, eventClass, eventPath } from '@/models/event';
+import {
+  DEFAULT_EVENT_DURATION_MS,
+  type Event as PdaEvent,
+  eventClass,
+  eventPath,
+} from '@/models/event';
 
 import { AgendaList } from './AgendaList';
 import { makeLocalizer } from './calendarLocalizer';
@@ -23,7 +28,7 @@ import { WideWeekView } from './WideWeekView';
 function toBigCalEvent(e: PdaEvent): BigCalEvent | null {
   // TBD events have no date — skip them on the calendar.
   if (!e.startDatetime) return null;
-  const end = e.endDatetime ?? new Date(e.startDatetime.getTime() + 60 * 60 * 1000);
+  const end = e.endDatetime ?? new Date(e.startDatetime.getTime() + DEFAULT_EVENT_DURATION_MS);
   return { id: e.id, title: e.title, start: e.startDatetime, end, resource: e };
 }
 

--- a/frontend/src/utils/eventCalendar.ts
+++ b/frontend/src/utils/eventCalendar.ts
@@ -1,9 +1,9 @@
-import { type Event, eventPath } from '@/models/event';
+import { DEFAULT_EVENT_DURATION_MS, type Event, eventPath } from '@/models/event';
 
 export function googleCalendarUrl(event: Event): string | null {
   if (!event.startDatetime) return null;
   const start = event.startDatetime;
-  const end = event.endDatetime ?? new Date(start.getTime() + 2 * 60 * 60 * 1000);
+  const end = event.endDatetime ?? new Date(start.getTime() + DEFAULT_EVENT_DURATION_MS);
   const dates = `${formatIcsDate(start)}/${formatIcsDate(end)}`;
   const details = buildDescription(event);
   const params = new URLSearchParams({


### PR DESCRIPTION
## summary

- fixes #1277: events with no `endDatetime` were dropped from the agenda/list view the instant they started, since the fallback used `startDatetime` itself as the end
- default no-end events to a 2-hour duration, consistent across all three places in the codebase that encode "how long does a no-end event last"
- extracted `DEFAULT_EVENT_DURATION_MS` to `frontend/src/models/event.ts` as the single source of truth

## changes

- `frontend/src/models/event.ts` — add `DEFAULT_EVENT_DURATION_MS` constant (2h)
- `frontend/src/screens/calendar/AgendaList.tsx` — `upcomingEvents` now treats a no-end event as still upcoming for 2h after start, matching the grid view
- `frontend/src/screens/calendar/CalendarScreen.tsx` — `toBigCalEvent`'s fallback changed from 1h to 2h, using the shared constant
- `frontend/src/utils/eventCalendar.ts` — `googleCalendarUrl`'s existing 2h fallback now uses the shared constant instead of a literal

## test plan

- [x] `pnpm exec tsc -b --noEmit --pretty false` passes
- [x] `pnpm exec eslint` on changed files passes with no warnings
- [x] `AgendaList.test.tsx`, `CalendarScreen.test.tsx`, `eventCalendar.test.ts` — 18 tests pass

Closes #1277
