### PR TITLE
fix(ui): use design tokens instead of hardcoded colors for dark mode

### DIFF
--- a/frontend/src/components/AutosaveStatus.tsx
+++ b/frontend/src/components/AutosaveStatus.tsx
@@ -21,9 +21,9 @@ export function AutosaveStatus({ status, className }: Props) {
       aria-live="polite"
       className={cn(
         'inline-flex items-center rounded-full px-2 py-0.5 text-xs',
-        status === 'saved' && 'bg-green-100 text-green-800',
+        status === 'saved' && 'bg-success-subtle text-success',
         status === 'saving' && 'bg-surface-dim text-foreground-tertiary',
-        status === 'error' && 'bg-red-100 text-red-700',
+        status === 'error' && 'bg-destructive-subtle text-destructive',
         className,
       )}
     >

--- a/frontend/src/screens/admin/EventManagementScreen.tsx
+++ b/frontend/src/screens/admin/EventManagementScreen.tsx
@@ -180,7 +180,9 @@ function EventRow({ event }: { event: Event }) {
       </div>
       <div className="flex shrink-0 items-center gap-2 text-xs">
         {event.eventType === EventType.Official ? (
-          <span className="rounded-full bg-blue-100 px-2 py-0.5 text-blue-900">official</span>
+          <span className="rounded-full bg-blue-100 px-2 py-0.5 text-blue-900 dark:bg-blue-900/40 dark:text-blue-200">
+            official
+          </span>
         ) : null}
         {event.eventType === EventType.Club ? (
           <span

--- a/frontend/src/screens/events/EventAdminActions.tsx
+++ b/frontend/src/screens/events/EventAdminActions.tsx
@@ -119,7 +119,7 @@ function AdminActionRow({
             onClick={() => {
               setDeleteOpen(true);
             }}
-            className="border-red-300 font-medium text-red-700 hover:bg-red-50"
+            className="border-destructive-border text-destructive hover:bg-destructive-subtle font-medium"
           >
             delete
           </Button>

--- a/frontend/src/screens/events/form/EventForm.tsx
+++ b/frontend/src/screens/events/form/EventForm.tsx
@@ -341,7 +341,7 @@ export function EventForm({ existing }: Props) {
         {serverError ? (
           <p
             role="alert"
-            className="rounded-[var(--radius-md)] border border-red-200 bg-red-50 p-3 text-sm text-red-700"
+            className="border-destructive-border bg-destructive-subtle text-destructive rounded-[var(--radius-md)] border p-3 text-sm"
           >
             {serverError}
           </p>

--- a/frontend/src/screens/events/poll/PollCreateDialog.tsx
+++ b/frontend/src/screens/events/poll/PollCreateDialog.tsx
@@ -140,7 +140,7 @@ function PollCreateDialogBody({ onClose, eventId, onBuffer, initialOptions }: Pr
         {error ? (
           <p
             role="alert"
-            className="rounded-md border border-red-200 bg-red-50 p-2 text-sm text-red-700"
+            className="border-destructive-border bg-destructive-subtle text-destructive rounded-md border p-2 text-sm"
           >
             {error}
           </p>

--- a/frontend/src/screens/events/poll/PollFinalizeDialog.tsx
+++ b/frontend/src/screens/events/poll/PollFinalizeDialog.tsx
@@ -109,7 +109,7 @@ export function PollFinalizeDialog({ open, onClose, event, poll }: Props) {
         {error ? (
           <p
             role="alert"
-            className="rounded-md border border-red-200 bg-red-50 p-2 text-sm text-red-700"
+            className="border-destructive-border bg-destructive-subtle text-destructive rounded-md border p-2 text-sm"
           >
             {error}
           </p>

--- a/frontend/src/screens/events/poll/PollManageDialog.tsx
+++ b/frontend/src/screens/events/poll/PollManageDialog.tsx
@@ -99,7 +99,9 @@ export function PollManageDialog({ open, onClose, poll }: Props) {
         <div className="border-border flex flex-col gap-2 border-t pt-3">
           {confirmDelete ? (
             <>
-              <p className="text-sm text-red-700">delete the whole poll? this can't be undone.</p>
+              <p className="text-destructive text-sm">
+                delete the whole poll? this can't be undone.
+              </p>
               <div className="flex gap-2">
                 <Button
                   variant="ghost"
@@ -115,7 +117,7 @@ export function PollManageDialog({ open, onClose, poll }: Props) {
                     void onDeletePoll();
                   }}
                   disabled={busy}
-                  className="bg-red-600 hover:bg-red-700"
+                  className="bg-destructive hover:bg-destructive/90"
                 >
                   {deletePoll.isPending ? 'deleting…' : 'yes, delete'}
                 </Button>
@@ -128,7 +130,7 @@ export function PollManageDialog({ open, onClose, poll }: Props) {
                 setConfirmDelete(true);
               }}
               disabled={busy}
-              className="self-start text-red-700"
+              className="text-destructive self-start"
             >
               delete poll
             </Button>
@@ -209,7 +211,7 @@ function OptionRow({
               void remove();
             }}
             disabled={disabled}
-            className="text-red-700"
+            className="text-destructive"
           >
             remove
           </Button>

--- a/frontend/src/screens/surveys/SurveyScreen.tsx
+++ b/frontend/src/screens/surveys/SurveyScreen.tsx
@@ -114,7 +114,7 @@ function SurveyForm({ survey }: { survey: Survey }) {
           </Button>
         ) : null}
 
-        {submit.isSuccess && !readOnly ? <p className="text-sm text-green-700">saved ✓</p> : null}
+        {submit.isSuccess && !readOnly ? <p className="text-success text-sm">saved ✓</p> : null}
       </form>
     </ContentContainer>
   );


### PR DESCRIPTION
## Summary
- Replace hardcoded Tailwind red/green colors with the app's semantic design tokens (`text-destructive`, `bg-destructive-subtle`, `border-destructive-border`, `text-success`, `bg-success-subtle`) so error/success states render correctly in dark mode
- Add missing `dark:` variant to the "official" event badge in `EventManagementScreen.tsx`, matching the existing pattern in `MyEventsScreen.tsx`
- No new dependency on the destructive button variant — `PollManageDialog.tsx`'s delete-confirm button gets hand-added `bg-destructive hover:bg-destructive/90` classes since `Button.tsx` has no destructive variant yet

Closes #1275

## Files changed
- `frontend/src/screens/events/form/EventForm.tsx`
- `frontend/src/screens/events/poll/PollFinalizeDialog.tsx`
- `frontend/src/screens/events/poll/PollCreateDialog.tsx`
- `frontend/src/screens/events/poll/PollManageDialog.tsx`
- `frontend/src/screens/events/EventAdminActions.tsx`
- `frontend/src/components/AutosaveStatus.tsx`
- `frontend/src/screens/admin/EventManagementScreen.tsx`
- `frontend/src/screens/surveys/SurveyScreen.tsx`

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npx eslint <changed files> --quiet` passes
- [ ] Manually verify in devtools with `prefers-color-scheme: dark` emulation:
  - [ ] event form error box is legible (destructive-subtle bg / destructive text)
  - [ ] poll create/finalize/manage dialog error and delete-confirm states are legible
  - [ ] event admin actions "delete" button is legible
  - [ ] autosave "saved"/"error" pills are legible
  - [ ] "official" event badge in event management screen has a dark variant
  - [ ] survey "saved ✓" text is legible