### PR TITLE
fix(admin): sort members by actual join date

### DIFF
--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -5748,6 +5748,11 @@
             "title": "Calendar Feed Scope",
             "type": "string"
           },
+          "date_joined": {
+            "format": "date-time",
+            "title": "Date Joined",
+            "type": "string"
+          },
           "email": {
             "default": "",
             "title": "Email",
@@ -5900,6 +5905,7 @@
         "required": [
           "id",
           "phone_number",
+          "date_joined",
           "roles"
         ],
         "title": "UserOut",

--- a/backend/users/schemas.py
+++ b/backend/users/schemas.py
@@ -146,6 +146,7 @@ class UserOut(BaseModel):
     calendar_feed_scope: str = "all"
     # Only populated by the list_users annotation; None everywhere else.
     last_attended: datetime | None = None
+    date_joined: datetime
     roles: list[RoleOut]
 
     @classmethod
@@ -180,6 +181,7 @@ class UserOut(BaseModel):
             week_start=user.week_start,
             calendar_feed_scope=user.calendar_feed_scope,
             last_attended=getattr(user, "last_attended", None),
+            date_joined=user.date_joined,
             roles=[
                 RoleOut(
                     id=str(r.id),

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -4597,6 +4597,11 @@ export interface components {
              */
             calendar_feed_scope: string;
             /**
+             * Date Joined
+             * Format: date-time
+             */
+            date_joined: string;
+            /**
              * Email
              * @default
              */

--- a/frontend/src/api/users.ts
+++ b/frontend/src/api/users.ts
@@ -32,6 +32,7 @@ export interface Member {
   loginLinkRequested: boolean;
   // Most recent event the member was checked in as attended. null if never.
   lastAttendedAt: Date | null;
+  dateJoined: Date;
   roles: MemberRole[];
 }
 
@@ -61,6 +62,7 @@ interface WireMember {
   needs_onboarding?: boolean;
   login_link_requested?: boolean;
   last_attended?: string | null;
+  date_joined: string;
   roles: WireRole[];
 }
 
@@ -91,6 +93,7 @@ function fromWire(w: WireMember): Member {
     needsOnboarding: w.needs_onboarding ?? false,
     loginLinkRequested: w.login_link_requested ?? false,
     lastAttendedAt: w.last_attended ? new Date(w.last_attended) : null,
+    dateJoined: new Date(w.date_joined),
     roles: w.roles.map(mapRole),
   };
 }

--- a/frontend/src/screens/admin/MemberDetailScreen.test.tsx
+++ b/frontend/src/screens/admin/MemberDetailScreen.test.tsx
@@ -45,6 +45,7 @@ const member: Member = {
   needsOnboarding: false,
   loginLinkRequested: false,
   lastAttendedAt: null,
+  dateJoined: new Date('2026-01-01T00:00:00Z'),
   roles: [],
 };
 

--- a/frontend/src/screens/admin/MembersTab.tsx
+++ b/frontend/src/screens/admin/MembersTab.tsx
@@ -348,9 +348,8 @@ function sortMembers(members: Member[], sort: SortKey): Member[] {
     sorted.sort((a, b) => (b.lastAttendedAt?.getTime() ?? 0) - (a.lastAttendedAt?.getTime() ?? 0));
     return sorted;
   }
-  // 'newest' — the list arrives oldest-first (phone_number order ≈ creation),
-  // so reverse approximates newest-first, matching the prior behavior.
-  return sorted.reverse();
+  sorted.sort((a, b) => b.dateJoined.getTime() - a.dateJoined.getTime());
+  return sorted;
 }
 
 function MemberRow({ member }: { member: Member }) {

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -153,6 +153,7 @@ export function makeMember(overrides: Partial<Member> = {}): Member {
     needsOnboarding: false,
     loginLinkRequested: false,
     lastAttendedAt: null,
+    dateJoined: new Date('2026-01-01T00:00:00Z'),
     roles: [],
     ...overrides,
   };


### PR DESCRIPTION
## Summary

Closes #1279

- The members admin screen's "newest first" sort was just `sorted.reverse()` on the phone-number-ordered list — not actual creation order. Phone numbers aren't assigned sequentially by signup, so this produced an arbitrary order, not newest-first.
- Added `date_joined` (Django's built-in `AbstractUser.date_joined`, already populated on every user, no migration needed) end-to-end: backend `UserOut` schema → frontend `WireMember`/`Member` types → `sortMembers`'s `'newest'` branch now sorts by `dateJoined` descending, matching the existing `'lastAttended'` sort's style.

## Test plan

- [x] `cd frontend && npx tsc --noEmit` — clean
- [x] `cd frontend && npx eslint src/api/users.ts src/screens/admin/MembersTab.tsx --quiet` — clean
- [x] `cd backend && uv run ty check .` — no new diagnostics (105 pre-existing, all unrelated to changed files)
- [x] `cd backend && uv run pytest tests/users/test_users_admin_extended.py -q` — 38 passed