### PR TITLE
fix(calendar): add club-specific empty state to agenda filter

### DIFF
--- a/frontend/src/screens/calendar/AgendaList.tsx
+++ b/frontend/src/screens/calendar/AgendaList.tsx
@@ -91,6 +91,7 @@ export function AgendaList({ events, onSelectEvent }: Props) {
 
 function emptyMessage(filter: TypeFilter): string {
   if (filter === EventType.Official) return 'no pda official events coming up';
+  if (filter === EventType.Club) return 'no pda club events coming up';
   if (filter === EventType.Community) return 'no community events coming up';
   return 'nothing on the horizon — pop back later';
 }


### PR DESCRIPTION
## Summary

- `AgendaList.tsx`'s `emptyMessage()` fell through to the generic "nothing on the horizon" message when filtering the agenda to "pda club" with zero upcoming club events, instead of a club-specific message like the official/community filters already have.
- Added a case for `EventType.Club` returning `'no pda club events coming up'`, matching the wording pattern of the existing official/community messages and the `FILTER_OPTIONS` label ("pda club").

Closes #1278

## Test plan

- [x] `npx tsc -b --noEmit` — passes
- [x] `npx eslint src/screens/calendar/AgendaList.tsx --quiet` — passes
- [x] `vitest run src/screens/calendar/AgendaList.test.tsx` — 5/5 passing