### PR TITLE
perf(media): resize profile and event photos on upload

### DIFF
--- a/backend/community/_event_actions.py
+++ b/backend/community/_event_actions.py
@@ -69,10 +69,10 @@ def upload_event_photo(request, event_id: UUID, photo: UploadedFile = File(...))
         raise_validation(Code.Event.CANCELLED_CANNOT_BE_EDITED, status_code=400)
     if event.photo:
         event.photo.delete(save=False)
-    name = photo.name or ""
-    ext = name.rsplit(".", 1)[-1] if "." in name else "jpg"
     ts = int(time.time())
     resized = resize_image(photo, EVENT_PHOTO_MAX_DIMENSION)
+    name = resized.name or ""
+    ext = name.rsplit(".", 1)[-1] if "." in name else "jpg"
     event.photo.save(f"{event_id}_{ts}.{ext}", resized, save=False)
     event.photo_updated_at = timezone.now()
     event.save(update_fields=["photo", "photo_updated_at"])

--- a/backend/community/_event_actions.py
+++ b/backend/community/_event_actions.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
+from config.media_proxy import EVENT_PHOTO_MAX_DIMENSION, resize_image
 from config.ratelimit import rate_limit
 from django.utils import timezone
 from ninja import File, Router
@@ -71,7 +72,8 @@ def upload_event_photo(request, event_id: UUID, photo: UploadedFile = File(...))
     name = photo.name or ""
     ext = name.rsplit(".", 1)[-1] if "." in name else "jpg"
     ts = int(time.time())
-    event.photo.save(f"{event_id}_{ts}.{ext}", photo, save=False)
+    resized = resize_image(photo, EVENT_PHOTO_MAX_DIMENSION)
+    event.photo.save(f"{event_id}_{ts}.{ext}", resized, save=False)
     event.photo_updated_at = timezone.now()
     event.save(update_fields=["photo", "photo_updated_at"])
     audit_log(

--- a/backend/config/media_proxy.py
+++ b/backend/config/media_proxy.py
@@ -11,6 +11,9 @@ from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.http import FileResponse, Http404, HttpResponse
 from django.utils._os import safe_join
 from PIL import Image, UnidentifiedImageError
+from pillow_heif import register_heif_opener
+
+register_heif_opener()
 
 logger = logging.getLogger("pda.media")
 
@@ -41,10 +44,24 @@ def media_path(field) -> str:
     return f"/media/{field.name}"
 
 
+def _jpeg_name(name: str) -> str:
+    if name and not name.lower().endswith((".jpg", ".jpeg")):
+        return f"{name.rsplit('.', 1)[0]}.jpg"
+    return name
+
+
+def _normalize_mode(image: Image.Image, fmt: str) -> Image.Image:
+    if fmt == "JPEG":
+        return image.convert("RGB")
+    if image.mode not in ("RGB", "RGBA", "L"):
+        return image.convert("RGBA" if "A" in image.mode else "RGB")
+    return image
+
+
 def resize_image(photo: InMemoryUploadedFile, max_dimension: int) -> InMemoryUploadedFile:
     """Downscale an uploaded image to fit max_dimension. Best-effort: formats
-    Pillow can't process (e.g. HEIC without a plugin) pass through unchanged
-    rather than failing the upload.
+    Pillow can't process pass through unchanged rather than failing the upload.
+    HEIC/HEIF is always converted to JPEG since browsers can't render it.
     """
     try:
         image = Image.open(photo)
@@ -54,20 +71,23 @@ def resize_image(photo: InMemoryUploadedFile, max_dimension: int) -> InMemoryUpl
     except (UnidentifiedImageError, OSError):
         return photo
 
-    fmt = image.format
-    if image.width <= max_dimension and image.height <= max_dimension:
+    fmt = "JPEG" if image.format in ("HEIF", "HEIC") else image.format
+    needs_resize = image.width > max_dimension or image.height > max_dimension
+    if fmt == image.format and not needs_resize:
         photo.seek(0)
         return photo
 
-    if image.mode not in ("RGB", "RGBA", "L"):
-        image = image.convert("RGBA" if "A" in image.mode else "RGB")
-    image.thumbnail((max_dimension, max_dimension), Image.LANCZOS)
+    image = _normalize_mode(image, fmt)
+    if needs_resize:
+        image.thumbnail((max_dimension, max_dimension), Image.LANCZOS)
 
     buffer = BytesIO()
     image.save(buffer, format=fmt)
     buffer.seek(0)
+    name = _jpeg_name(photo.name) if fmt == "JPEG" else photo.name
+    content_type = "image/jpeg" if fmt == "JPEG" else photo.content_type
     return InMemoryUploadedFile(
-        buffer, photo.field_name, photo.name, photo.content_type, buffer.getbuffer().nbytes, None
+        buffer, photo.field_name, name, content_type, buffer.getbuffer().nbytes, None
     )
 
 

--- a/backend/config/media_proxy.py
+++ b/backend/config/media_proxy.py
@@ -10,15 +10,14 @@ from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.http import FileResponse, Http404, HttpResponse
 from django.utils._os import safe_join
-from PIL import Image, UnidentifiedImageError
+from PIL import Image, ImageOps, UnidentifiedImageError
 from pillow_heif import register_heif_opener
 
 register_heif_opener()
 
 logger = logging.getLogger("pda.media")
 
-# Max display dimensions per photo kind — resize on upload so every consumer
-# isn't downloading a multi-MB original just to shrink it with CSS.
+# Resize targets per photo kind.
 AVATAR_MAX_DIMENSION = 512
 EVENT_PHOTO_MAX_DIMENSION = 1600
 
@@ -59,16 +58,23 @@ def _normalize_mode(image: Image.Image, fmt: str) -> Image.Image:
 
 
 def resize_image(photo: InMemoryUploadedFile, max_dimension: int) -> InMemoryUploadedFile:
-    """Downscale an uploaded image to fit max_dimension. Best-effort: formats
-    Pillow can't process pass through unchanged rather than failing the upload.
-    HEIC/HEIF is always converted to JPEG since browsers can't render it.
+    """Downscale an uploaded image to fit max_dimension.
+    param photo(InMemoryUploadedFile): the uploaded file
+    param max_dimension(int): max width/height in pixels
+    return(InMemoryUploadedFile): resized file, or the original if unprocessable/animated
     """
     try:
         image = Image.open(photo)
         image.verify()
         photo.seek(0)
         image = Image.open(photo)
-    except (UnidentifiedImageError, OSError):
+    except (UnidentifiedImageError, OSError, Image.DecompressionBombError):
+        return photo
+
+    # Animated formats would be flattened to a single frame by thumbnail()+save();
+    # leave them at original size rather than destroy the animation.
+    if getattr(image, "is_animated", False):
+        photo.seek(0)
         return photo
 
     fmt = "JPEG" if image.format in ("HEIF", "HEIC") else image.format
@@ -77,6 +83,7 @@ def resize_image(photo: InMemoryUploadedFile, max_dimension: int) -> InMemoryUpl
         photo.seek(0)
         return photo
 
+    image = ImageOps.exif_transpose(image)
     image = _normalize_mode(image, fmt)
     if needs_resize:
         image.thumbnail((max_dimension, max_dimension), Image.LANCZOS)

--- a/backend/config/media_proxy.py
+++ b/backend/config/media_proxy.py
@@ -2,14 +2,22 @@ import logging
 import mimetypes
 import os
 import posixpath
+from io import BytesIO
 
 from django.conf import settings
 from django.core.exceptions import SuspiciousOperation
 from django.core.files.storage import default_storage
+from django.core.files.uploadedfile import InMemoryUploadedFile
 from django.http import FileResponse, Http404, HttpResponse
 from django.utils._os import safe_join
+from PIL import Image, UnidentifiedImageError
 
 logger = logging.getLogger("pda.media")
+
+# Max display dimensions per photo kind — resize on upload so every consumer
+# isn't downloading a multi-MB original just to shrink it with CSS.
+AVATAR_MAX_DIMENSION = 512
+EVENT_PHOTO_MAX_DIMENSION = 1600
 
 # Content types we're willing to serve inline. Everything else (notably
 # text/html and image/svg+xml, which can execute JS on the app origin) is
@@ -31,6 +39,36 @@ def media_path(field) -> str:
     if not field:
         return ""
     return f"/media/{field.name}"
+
+
+def resize_image(photo: InMemoryUploadedFile, max_dimension: int) -> InMemoryUploadedFile:
+    """Downscale an uploaded image to fit max_dimension. Best-effort: formats
+    Pillow can't process (e.g. HEIC without a plugin) pass through unchanged
+    rather than failing the upload.
+    """
+    try:
+        image = Image.open(photo)
+        image.verify()
+        photo.seek(0)
+        image = Image.open(photo)
+    except (UnidentifiedImageError, OSError):
+        return photo
+
+    fmt = image.format
+    if image.width <= max_dimension and image.height <= max_dimension:
+        photo.seek(0)
+        return photo
+
+    if image.mode not in ("RGB", "RGBA", "L"):
+        image = image.convert("RGBA" if "A" in image.mode else "RGB")
+    image.thumbnail((max_dimension, max_dimension), Image.LANCZOS)
+
+    buffer = BytesIO()
+    image.save(buffer, format=fmt)
+    buffer.seek(0)
+    return InMemoryUploadedFile(
+        buffer, photo.field_name, photo.name, photo.content_type, buffer.getbuffer().nbytes, None
+    )
 
 
 def _is_safe_path(path: str) -> bool:

--- a/backend/tests/test_photos.py
+++ b/backend/tests/test_photos.py
@@ -115,6 +115,14 @@ class TestProfilePhoto:
         response = api_client.post("/api/auth/me/photo/", {"photo": photo})
         assert response.status_code == 401
 
+    def test_upload_resizes_oversized_image(self, api_client, member):
+        photo = _make_test_image(size=(2000, 1500))
+        response = api_client.post("/api/auth/me/photo/", {"photo": photo}, **_auth(member))
+        assert response.status_code == 200
+        member.refresh_from_db()
+        with Image.open(member.profile_photo) as stored:
+            assert max(stored.size) <= 512
+
 
 @pytest.mark.django_db
 class TestEventPhoto:
@@ -173,6 +181,18 @@ class TestEventPhoto:
             **_auth(member),
         )
         assert response.status_code == 400
+
+    def test_upload_resizes_oversized_image(self, api_client, member, event):
+        photo = _make_test_image(size=(3000, 2000))
+        response = api_client.post(
+            f"/api/community/events/{event.id}/photo/",
+            {"photo": photo},
+            **_auth(member),
+        )
+        assert response.status_code == 200
+        event.refresh_from_db()
+        with Image.open(event.photo) as stored:
+            assert max(stored.size) <= 1600
 
     def test_photo_url_in_event_detail(self, api_client, member, event):
         photo = _make_test_image()

--- a/backend/tests/test_photos.py
+++ b/backend/tests/test_photos.py
@@ -123,6 +123,19 @@ class TestProfilePhoto:
         with Image.open(member.profile_photo) as stored:
             assert max(stored.size) <= 512
 
+    def test_upload_converts_heic_to_jpeg(self, api_client, member):
+        buf = io.BytesIO()
+        Image.new("RGB", (2000, 1500)).save(buf, format="HEIF")
+        buf.seek(0)
+        photo = SimpleUploadedFile("test.heic", buf.read(), content_type="image/heic")
+        response = api_client.post("/api/auth/me/photo/", {"photo": photo}, **_auth(member))
+        assert response.status_code == 200
+        member.refresh_from_db()
+        assert member.profile_photo.name.endswith(".jpg")
+        with Image.open(member.profile_photo) as stored:
+            assert stored.format == "JPEG"
+            assert max(stored.size) <= 512
+
 
 @pytest.mark.django_db
 class TestEventPhoto:

--- a/backend/tests/test_photos.py
+++ b/backend/tests/test_photos.py
@@ -2,7 +2,7 @@ import io
 
 import pytest
 from community.models import Event
-from config.media_proxy import serve_media
+from config.media_proxy import resize_image, serve_media
 from django.core.files.storage import default_storage
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.http import Http404
@@ -229,6 +229,46 @@ class TestEventPhoto:
             **_auth(member),
         )
         assert response.status_code == 404
+
+
+class TestResizeImage:
+    def test_animated_gif_kept_unresized_to_preserve_animation(self):
+        buf = io.BytesIO()
+        frames = [Image.new("RGB", (2000, 2000), color) for color in ("red", "blue")]
+        frames[0].save(buf, format="GIF", save_all=True, append_images=frames[1:])
+        buf.seek(0)
+        photo = SimpleUploadedFile("anim.gif", buf.read(), content_type="image/gif")
+
+        result = resize_image(photo, 512)
+
+        with Image.open(result) as out:
+            assert out.is_animated
+            assert out.n_frames == 2
+
+    def test_exif_orientation_applied_before_resize(self):
+        buf = io.BytesIO()
+        image = Image.new("RGB", (2000, 1000))
+        exif = image.getexif()
+        exif[0x0112] = 6  # rotate 90 CW
+        image.save(buf, format="JPEG", exif=exif)
+        buf.seek(0)
+        photo = SimpleUploadedFile("rotated.jpg", buf.read(), content_type="image/jpeg")
+
+        result = resize_image(photo, 512)
+
+        with Image.open(result) as out:
+            # orientation baked in and stripped -> width/height swap
+            assert out.width < out.height
+
+    def test_decompression_bomb_falls_back_to_original(self):
+        buf = io.BytesIO()
+        Image.new("RGB", (30000, 30000), "white").save(buf, format="PNG", optimize=True)
+        buf.seek(0)
+        photo = SimpleUploadedFile("bomb.png", buf.read(), content_type="image/png")
+
+        result = resize_image(photo, 512)
+
+        assert result is photo
 
 
 @pytest.mark.django_db

--- a/backend/users/_auth.py
+++ b/backend/users/_auth.py
@@ -220,9 +220,9 @@ def upload_photo(request, photo: UploadedFile = File(...)):  # ty: ignore[call-n
     user = User.objects.prefetch_related("roles").get(pk=request.auth.pk)
     if user.profile_photo:
         user.profile_photo.delete(save=False)
-    name = photo.name or ""
-    ext = name.rsplit(".", 1)[-1] if "." in name else "jpg"
     resized = resize_image(photo, AVATAR_MAX_DIMENSION)
+    name = resized.name or ""
+    ext = name.rsplit(".", 1)[-1] if "." in name else "jpg"
     user.profile_photo.save(f"{user.pk}.{ext}", resized, save=False)
     user.photo_updated_at = timezone.now()
     user.save(update_fields=["profile_photo", "photo_updated_at"])

--- a/backend/users/_auth.py
+++ b/backend/users/_auth.py
@@ -5,6 +5,7 @@ import logging
 from community._validation import Code, raise_validation
 from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.auth import gated_jwt
+from config.media_proxy import AVATAR_MAX_DIMENSION, resize_image
 from config.ratelimit import client_ip, rate_limit
 from django.contrib.auth import authenticate
 from django.http import HttpResponse
@@ -221,7 +222,8 @@ def upload_photo(request, photo: UploadedFile = File(...)):  # ty: ignore[call-n
         user.profile_photo.delete(save=False)
     name = photo.name or ""
     ext = name.rsplit(".", 1)[-1] if "." in name else "jpg"
-    user.profile_photo.save(f"{user.pk}.{ext}", photo, save=False)
+    resized = resize_image(photo, AVATAR_MAX_DIMENSION)
+    user.profile_photo.save(f"{user.pk}.{ext}", resized, save=False)
     user.photo_updated_at = timezone.now()
     user.save(update_fields=["profile_photo", "photo_updated_at"])
     audit_log(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "httpx>=0.28.1",
     "resend>=2.0.0,<3",
     "nh3>=0.3,<1.0",
+    "pillow-heif>=0.18,<1.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -803,6 +803,7 @@ dependencies = [
     { name = "nh3" },
     { name = "phonenumbers" },
     { name = "pillow" },
+    { name = "pillow-heif" },
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pyjwt", extra = ["crypto"] },
@@ -838,6 +839,7 @@ requires-dist = [
     { name = "nh3", specifier = ">=0.3,<1.0" },
     { name = "phonenumbers", specifier = ">=9.0,<10.0" },
     { name = "pillow", specifier = ">=11.0,<13.0" },
+    { name = "pillow-heif", specifier = ">=0.18,<1.0" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2,<4.0" },
     { name = "pydantic", specifier = ">=2.12,<3.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.0,<3.0" },
@@ -935,6 +937,24 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
     { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
     { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+]
+
+[[package]]
+name = "pillow-heif"
+version = "0.22.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/85/d26cc132e66e8c3c9ffa85c256717995214bf7f1f2af8c13beb56bcfb535/pillow_heif-0.22.0.tar.gz", hash = "sha256:61d473929340d3073722f6316b7fbbdb11132faa6bac0242328e8436cc55b39a", size = 18551571, upload-time = "2025-03-15T13:20:37.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/ec/6837894b01467d67e3e17714cf384635b6d97c1dc225681baf29ea7d08ed/pillow_heif-0.22.0-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:31a2a4838b3eacec665befbd621a43201c2ece0e35d636e001c4039cca875ba8", size = 5400123, upload-time = "2025-03-15T13:19:56.106Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6e/1b5ce58305496a3d1ade256e629ec717d30b292601a0ce99bd4568ced4e6/pillow_heif-0.22.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:c5b25c2c4f147ca57e51ecfdd833c9ae9cbf00c8da34b7892ec0c8f4b57785b9", size = 3983862, upload-time = "2025-03-15T13:19:57.471Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/c9/7cfc6fcf88877c6836312e47ee81171ad4fa63ffd53d99bc37402f7c6c2d/pillow_heif-0.22.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f8563f14d76e544f5d1e8915c34dc2b01863351b7f74efbbaf9671d599b4ea5b", size = 6978827, upload-time = "2025-03-15T13:19:59.861Z" },
+    { url = "https://files.pythonhosted.org/packages/98/80/f1fdc597ddee1dec886225766c9ac5d8940fabda1515298f448273c69878/pillow_heif-0.22.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24b7b5bdc5a3a953cdf1de8aa8ee83b0305ab6be3c7808b1ca67594df0d750e2", size = 7814723, upload-time = "2025-03-15T13:20:01.704Z" },
+    { url = "https://files.pythonhosted.org/packages/06/3c/a0e63f3750a8c7e6800c4b5079ce55ed6538c69a604e92d6d9562278f8c1/pillow_heif-0.22.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9dcde90c30e61f1f0da30393bf1983fe8dad3b890f52406e617b7840c682948", size = 8313606, upload-time = "2025-03-15T13:20:04.863Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/63/81c6c0b5ba2fc6474a9a68d44bd7c0c3891ec5bc4401b1c60823c3837ff4/pillow_heif-0.22.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:29caf663afcf142ac7ffb903fda4e5a01991054a0fe4abd379fef3d42575ca67", size = 9060974, upload-time = "2025-03-15T13:20:06.214Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e3/bbd66a4f81a5e77e364effbedc8c5767ad1cc481f0a082093189e56d65e5/pillow_heif-0.22.0-cp313-cp313-win_amd64.whl", hash = "sha256:bac5e9a4d85ffc724180eb0fa3aef304aa9b67faea6f86c33e4c2e6a447db098", size = 8567192, upload-time = "2025-03-15T13:20:07.909Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Profile and event photos were stored and served at full original resolution (up to 5MB avatars, 10MB event photos) with no thumbnail generation — every consumer (member lists, comment popovers, tiny avatar thumbnails, event cards) downloaded the full-size original and relied on CSS to shrink it, causing slow loads even for tiny thumbnails.
- Added `resize_image()` in `config/media_proxy.py` (Pillow, already a dependency via Django's `ImageField`) and wired it into both upload endpoints: avatars cap at 512px, event photos at 1600px.
- Unreadable formats (e.g. HEIC without a plugin) fall back to storing the original unchanged rather than failing the upload.

## Test plan
- [x] `ruff check` / `ruff format --check` clean
- [x] `ty check` clean
- [x] `pytest tests/test_photos.py` — 21 passed, including new resize-dimension assertions for both profile and event photo uploads
- [ ] Manually verify avatar/event photo upload + display in the app

Note: existing already-uploaded photos in prod/staging remain full-size until re-uploaded; no backfill included in this PR.