### PR TITLE
fix(auth): preserve event redirect on sign-in links

### DIFF
--- a/frontend/src/screens/events/EventDetailScreen.tsx
+++ b/frontend/src/screens/events/EventDetailScreen.tsx
@@ -6,7 +6,7 @@ import { useEvent } from '@/api/events';
 import { getStoredRsvpToken } from '@/api/rsvpTokenStorage';
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
-import { canManageEvent, canPublicRsvp } from '@/models/event';
+import { canManageEvent, canPublicRsvp, eventPath } from '@/models/event';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 import { formatEventDateTime } from '@/utils/datetime';
 import { linkifyText } from '@/utils/linkifyText';
@@ -269,10 +269,10 @@ function MemberRsvpControl({
 
 function AnonSection({ event }: { event: Event }) {
   if (canPublicRsvp(event)) return <PublicRsvpSection event={event} />;
-  return <LoginOrJoinSection />;
+  return <LoginOrJoinSection event={event} />;
 }
 
-function LoginOrJoinSection() {
+function LoginOrJoinSection({ event }: { event: Event }) {
   // Unauthed users miss: hosts, location, links, cost, invite, RSVP.
   return (
     <section className="border-border bg-surface mt-8 rounded-lg border p-6">
@@ -282,7 +282,7 @@ function LoginOrJoinSection() {
       </p>
       <div className="flex flex-wrap gap-3">
         <Link
-          to="/login"
+          to={`/login?redirect=${encodeURIComponent(eventPath(event))}`}
           className="bg-brand-600 text-brand-on hover:bg-brand-700 inline-flex h-10 items-center rounded-md px-4 text-sm font-medium"
         >
           sign in

--- a/frontend/src/screens/events/PublicRsvpForm.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.test.tsx
@@ -238,7 +238,10 @@ describe('PublicRsvpForm', () => {
     await fillRequired();
     fireEvent.click(screen.getByRole('button', { name: 'rsvp' }));
     await screen.findByText('looks like you already have an account — sign in to rsvp');
-    expect(screen.getByRole('link', { name: 'sign in' })).toHaveAttribute('href', '/login');
+    expect(screen.getByRole('link', { name: 'sign in' })).toHaveAttribute(
+      'href',
+      '/login?redirect=%2Fevents%2Ftest-event',
+    );
   });
 
   it('focuses the submit error alert so it is not missed below the fold', async () => {

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -285,7 +285,10 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
           <div role="alert" tabIndex={-1} ref={submitErrorRef} className="text-destructive text-sm">
             <p>{submitError.text}</p>
             {submitError.showSignIn ? (
-              <Link to="/login" className="text-info hover:underline">
+              <Link
+                to={`/login?redirect=${encodeURIComponent(eventPath(event))}`}
+                className="text-info hover:underline"
+              >
                 sign in
               </Link>
             ) : null}

--- a/frontend/src/screens/events/poll/EventPollCard.tsx
+++ b/frontend/src/screens/events/poll/EventPollCard.tsx
@@ -5,7 +5,7 @@ import { Link } from 'react-router-dom';
 import { useEventPoll } from '@/api/eventPolls';
 import { useAuthStore } from '@/auth/store';
 import { Button } from '@/components/ui/Button';
-import type { Event } from '@/models/event';
+import { type Event, eventPath } from '@/models/event';
 import { hasPermission, Permission, type UserLike } from '@/models/permissions';
 
 import { PollFinalizeDialog } from './PollFinalizeDialog';
@@ -76,7 +76,7 @@ export function EventPollCard({ event, className }: Props) {
           </Button>
         ) : (
           <Link
-            to="/login"
+            to={`/login?redirect=${encodeURIComponent(eventPath(event))}`}
             className="border-border-strong text-foreground-secondary hover:bg-background inline-flex h-10 items-center rounded-md border px-4 text-sm font-medium"
           >
             sign in to vote


### PR DESCRIPTION
## Summary

Closes #1274

Three sign-in links on event-related screens linked to a bare `/login`, so signing in from them dropped the user back on the default post-login route instead of returning them to the event. Each now builds the redirect the same way `EventDetailScreen.tsx`'s `ForbiddenNotice` already does — `` `/login?redirect=${encodeURIComponent(eventPath(event))}` `` — and `LoginScreen.tsx` / `safeRedirect` pick it up unchanged.

- `EventPollCard.tsx` — "sign in to vote" link
- `EventDetailScreen.tsx` — `LoginOrJoinSection`'s "sign in" link (now receives `event` from `AnonSection`)
- `PublicRsvpForm.tsx` — "sign in" link shown after a 409 (existing account) error

Updated one existing test assertion in `PublicRsvpForm.test.tsx` that checked the old bare `/login` href.

## Test plan

- [ ] sign in from poll "sign in to vote" link returns to the event
- [ ] sign in from anon event page "sign in" link returns to the event
- [ ] sign in from public rsvp 409 "sign in" link returns to the event
- [x] `npx tsc --noEmit` clean
- [x] `npx eslint` clean on changed files
- [x] `PublicRsvpForm.test.tsx` and `EventDetailScreen.test.tsx` pass (58/58)