### PR TITLE
feat(events): accept and validate member RSVP answers

### DIFF
--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -79,12 +79,27 @@ _GUEST_LIST_STATUS_ORDER = {
     RSVPStatus.WAITLISTED: 3,
 }
 
+def _can_see_guest_answers(requesting_user, creator, co_host_ids: set[str]) -> bool:
+    """Hosts, co-hosts, and event managers can see RSVP question answers."""
+    if requesting_user is None:
+        return False
+    if requesting_user.has_permission(PermissionKey.MANAGE_EVENTS):
+        return True
+    if creator is not None and requesting_user.pk == creator.pk:
+        return True
+    return str(requesting_user.pk) in co_host_ids
+
 
 def _build_guest_list(
-    rsvps, can_see_phones: bool, viewer=None, can_see_payment_status: bool = False
+    rsvps,
+    can_see_phones: bool,
+    viewer=None,
+    can_see_payment_status: bool = False,
+    *,
+    include_answers: bool = False,
 ) -> list[RSVPGuestOut]:
-    """Build guest list ordered going > maybe > can't go > waitlisted, with optional phone
-    and payment-status visibility."""
+    """Build guest list ordered going > maybe > can't go > waitlisted, with optional phone,
+    payment-status, and answer visibility."""
     ordered_rsvps = sorted(rsvps, key=lambda r: _GUEST_LIST_STATUS_ORDER.get(r.status, 99))
     return [
         RSVPGuestOut(
@@ -100,6 +115,7 @@ def _build_guest_list(
             plus_one_checked_in_at=r.plus_one_checked_in_at,
             is_member=r.user.is_member,
             paid_confirmed=bool(r.paid_confirmed_at) if can_see_payment_status else False,
+            answers=dict(r.questionnaire_responses or {}) if include_answers else {},
         )
         for r in ordered_rsvps
     ]
@@ -315,7 +331,8 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
     payment_status_visible = viewer_is_cohost and flag_enabled(
         FeatureFlag.EVENT_PAYMENT_CONFIRMATION
     )
-    all_rsvps = list(event.rsvps.all()) if event.rsvp_enabled else []
+    answers_visible = _can_see_guest_answers(auth_user, creator, co_host_ids)
+    all_rsvps = list(event.rsvps.all()) if event.rsvp_enabled or answers_visible else []
     all_invited = list(event.invited_users.all())
     invited = all_invited if _can_see_invited(auth_user, creator, co_host_ids) else []
 
@@ -357,11 +374,18 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
         co_host_names=[visible_display_name(u, auth_user) for u in co_hosts],
         co_host_photo_urls=[media_path(u.profile_photo) for u in co_hosts],
         guests=_gated(
-            _build_guest_list(all_rsvps, viewer_is_cohost, auth_user, payment_status_visible),
+            _build_guest_list(
+                all_rsvps,
+                viewer_is_cohost,
+                auth_user,
+                payment_status_visible,
+                include_answers=answers_visible,
+            ),
             [],
             can_see_guests,
         ),
         my_rsvp=my_rsvp_status,
+        my_rsvp_answers=_find_my_rsvp_answers(all_rsvps, auth_user),
         my_paid_confirmed=my_paid_confirmed,
         viewer_user_id=str(auth_user.pk) if auth_user else None,
         event_type=event.event_type,

--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -13,6 +13,7 @@ from users.permissions import PermissionKey
 
 from community._cohost_invite_helpers import get_my_pending_invite
 from community._event_cohost_helpers import _pending_cohost_invites_out
+from community._event_rsvp_answers import can_see_guest_answers, find_my_rsvp_answers
 from community._event_rsvp_serialize import event_rsvp_question_out
 from community._event_schemas import CancellationOut, EventOut, RSVPGuestOut, TagOut
 from community._rsvp_counts import (
@@ -79,17 +80,6 @@ _GUEST_LIST_STATUS_ORDER = {
     RSVPStatus.WAITLISTED: 3,
 }
 
-def _can_see_guest_answers(requesting_user, creator, co_host_ids: set[str]) -> bool:
-    """Hosts, co-hosts, and event managers can see RSVP question answers."""
-    if requesting_user is None:
-        return False
-    if requesting_user.has_permission(PermissionKey.MANAGE_EVENTS):
-        return True
-    if creator is not None and requesting_user.pk == creator.pk:
-        return True
-    return str(requesting_user.pk) in co_host_ids
-
-
 def _build_guest_list(
     rsvps,
     can_see_phones: bool,
@@ -129,16 +119,6 @@ def _find_my_rsvp(rsvps, user):
         if r.user_id == user.pk:
             return r
     return None
-
-
-def _find_my_rsvp_answers(rsvps, user) -> dict:
-    if user is None:
-        return {}
-    for r in rsvps:
-        if r.user_id == user.pk:
-            return dict(r.questionnaire_responses or {})
-    return {}
-
 
 def _my_rsvp_fields(rsvps, user) -> tuple[str | None, bool]:
     """(my_rsvp status, my_paid_confirmed) for the requesting user, or (None, False)."""
@@ -331,7 +311,7 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
     payment_status_visible = viewer_is_cohost and flag_enabled(
         FeatureFlag.EVENT_PAYMENT_CONFIRMATION
     )
-    answers_visible = _can_see_guest_answers(auth_user, creator, co_host_ids)
+    answers_visible = can_see_guest_answers(auth_user, creator, co_host_ids)
     all_rsvps = list(event.rsvps.all()) if event.rsvp_enabled or answers_visible else []
     all_invited = list(event.invited_users.all())
     invited = all_invited if _can_see_invited(auth_user, creator, co_host_ids) else []
@@ -385,7 +365,7 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
             can_see_guests,
         ),
         my_rsvp=my_rsvp_status,
-        my_rsvp_answers=_find_my_rsvp_answers(all_rsvps, auth_user),
+        my_rsvp_answers=find_my_rsvp_answers(all_rsvps, auth_user),
         my_paid_confirmed=my_paid_confirmed,
         viewer_user_id=str(auth_user.pk) if auth_user else None,
         event_type=event.event_type,

--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -13,7 +13,10 @@ from users.permissions import PermissionKey
 
 from community._cohost_invite_helpers import get_my_pending_invite
 from community._event_cohost_helpers import _pending_cohost_invites_out
-from community._event_rsvp_answers import can_see_guest_answers, find_my_rsvp_answers
+from community._event_rsvp_answers import (
+    can_see_guest_questionnaire_responses,
+    find_my_questionnaire_responses,
+)
 from community._event_rsvp_serialize import event_rsvp_question_out
 from community._event_schemas import CancellationOut, EventOut, RSVPGuestOut, TagOut
 from community._rsvp_counts import (
@@ -86,7 +89,7 @@ def _build_guest_list(
     viewer=None,
     can_see_payment_status: bool = False,
     *,
-    include_answers: bool = False,
+    include_questionnaire_responses: bool = False,
 ) -> list[RSVPGuestOut]:
     """Build guest list ordered going > maybe > can't go > waitlisted, with optional phone,
     payment-status, and answer visibility."""
@@ -105,7 +108,9 @@ def _build_guest_list(
             plus_one_checked_in_at=r.plus_one_checked_in_at,
             is_member=r.user.is_member,
             paid_confirmed=bool(r.paid_confirmed_at) if can_see_payment_status else False,
-            answers=dict(r.questionnaire_responses or {}) if include_answers else {},
+            questionnaire_responses=(
+                dict(r.questionnaire_responses or {}) if include_questionnaire_responses else {}
+            ),
         )
         for r in ordered_rsvps
     ]
@@ -311,8 +316,8 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
     payment_status_visible = viewer_is_cohost and flag_enabled(
         FeatureFlag.EVENT_PAYMENT_CONFIRMATION
     )
-    answers_visible = can_see_guest_answers(auth_user, creator, co_host_ids)
-    all_rsvps = list(event.rsvps.all()) if event.rsvp_enabled or answers_visible else []
+    responses_visible = can_see_guest_questionnaire_responses(auth_user, creator, co_host_ids)
+    all_rsvps = list(event.rsvps.all()) if event.rsvp_enabled or responses_visible else []
     all_invited = list(event.invited_users.all())
     invited = all_invited if _can_see_invited(auth_user, creator, co_host_ids) else []
 
@@ -359,13 +364,13 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
                 viewer_is_cohost,
                 auth_user,
                 payment_status_visible,
-                include_answers=answers_visible,
+                include_questionnaire_responses=responses_visible,
             ),
             [],
             can_see_guests,
         ),
         my_rsvp=my_rsvp_status,
-        my_rsvp_answers=find_my_rsvp_answers(all_rsvps, auth_user),
+        my_questionnaire_responses=find_my_questionnaire_responses(all_rsvps, auth_user),
         my_paid_confirmed=my_paid_confirmed,
         viewer_user_id=str(auth_user.pk) if auth_user else None,
         event_type=event.event_type,

--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -83,6 +83,7 @@ _GUEST_LIST_STATUS_ORDER = {
     RSVPStatus.WAITLISTED: 3,
 }
 
+
 def _build_guest_list(
     rsvps,
     can_see_phones: bool,
@@ -124,6 +125,7 @@ def _find_my_rsvp(rsvps, user):
         if r.user_id == user.pk:
             return r
     return None
+
 
 def _my_rsvp_fields(rsvps, user) -> tuple[str | None, bool]:
     """(my_rsvp status, my_paid_confirmed) for the requesting user, or (None, False)."""

--- a/backend/community/_event_rsvp_answers.py
+++ b/backend/community/_event_rsvp_answers.py
@@ -1,5 +1,3 @@
-"""Validate and snapshot RSVP question answers."""
-
 from users.permissions import PermissionKey
 
 from community._field_limits import FieldLimit
@@ -14,8 +12,7 @@ from community.models import EventRsvpQuestion, RsvpQuestionType, RSVPStatus
 AnswersIn = dict[str, str]
 
 
-def can_see_guest_answers(requesting_user, creator, co_host_ids: set[str]) -> bool:
-    """Hosts, co-hosts, and event managers can see RSVP question answers."""
+def can_see_guest_questionnaire_responses(requesting_user, creator, co_host_ids: set[str]) -> bool:
     if requesting_user is None:
         return False
     if requesting_user.has_permission(PermissionKey.MANAGE_EVENTS):
@@ -25,7 +22,7 @@ def can_see_guest_answers(requesting_user, creator, co_host_ids: set[str]) -> bo
     return str(requesting_user.pk) in co_host_ids
 
 
-def find_my_rsvp_answers(rsvps, user) -> dict:
+def find_my_questionnaire_responses(rsvps, user) -> dict:
     if user is None:
         return {}
     for r in rsvps:
@@ -46,13 +43,13 @@ def _require_if_needed(q: EventRsvpQuestion, *, require_answers: bool) -> None:
     if require_answers and q.required:
         raise_validation(
             Code.Event.RSVP_ANSWER_REQUIRED,
-            field=f"answers.{q.id}",
+            field=f"questionnaire_responses.{q.id}",
             label=q.label,
         )
 
 
 def _normalize_answer(q: EventRsvpQuestion, answer: str) -> str:
-    field = f"answers.{q.id}"
+    field = f"questionnaire_responses.{q.id}"
     if q.field_type == RsvpQuestionType.CHECKBOX:
         return normalize_checkbox_csv(
             answer,
@@ -93,7 +90,7 @@ def build_rsvp_answers(
         if len(answer) > FieldLimit.DESCRIPTION:
             raise_validation(
                 Code.Event.RSVP_ANSWER_TOO_LONG,
-                field=f"answers.{key}",
+                field=f"questionnaire_responses.{key}",
                 label=q.label,
                 max=FieldLimit.DESCRIPTION,
             )

--- a/backend/community/_event_rsvp_answers.py
+++ b/backend/community/_event_rsvp_answers.py
@@ -1,0 +1,84 @@
+"""Validate and snapshot RSVP question answers."""
+
+from community._field_limits import FieldLimit
+from community._question_answers import (
+    assert_single_choice_member,
+    is_answer_empty,
+    normalize_checkbox_csv,
+)
+from community._validation import Code, raise_validation
+from community.models import EventRsvpQuestion, RsvpQuestionType, RSVPStatus
+
+AnswersIn = dict[str, str]
+
+
+def answers_required_for_status(status: str) -> bool:
+    return status in {
+        RSVPStatus.ATTENDING,
+        RSVPStatus.MAYBE,
+        RSVPStatus.WAITLISTED,
+    }
+
+
+def _require_if_needed(q: EventRsvpQuestion, *, require_answers: bool) -> None:
+    if require_answers and q.required:
+        raise_validation(
+            Code.Event.RSVP_ANSWER_REQUIRED,
+            field=f"answers.{q.id}",
+            label=q.label,
+        )
+
+
+def _normalize_answer(q: EventRsvpQuestion, answer: str) -> str:
+    field = f"answers.{q.id}"
+    if q.field_type == RsvpQuestionType.CHECKBOX:
+        return normalize_checkbox_csv(
+            answer,
+            q.options,
+            code=Code.Event.RSVP_ANSWER_INVALID_OPTION,
+            field=field,
+            label=q.label,
+        )
+
+    text = str(answer).strip()
+    if q.field_type == RsvpQuestionType.SELECT:
+        assert_single_choice_member(
+            text,
+            q.options,
+            code=Code.Event.RSVP_ANSWER_INVALID_OPTION,
+            field=field,
+            label=q.label,
+        )
+    return text
+
+
+def build_rsvp_answers(
+    questions: list[EventRsvpQuestion],
+    raw: AnswersIn | None,
+    *,
+    require_answers: bool,
+) -> dict:
+    """Return snapshot dict {qid: {label, answer}} or raise ValidationException."""
+    incoming = raw or {}
+    snapshot: dict = {}
+    for q in questions:
+        key = str(q.id)
+        answer = incoming.get(key)
+        if is_answer_empty(answer):
+            _require_if_needed(q, require_answers=require_answers)
+            continue
+        assert answer is not None
+        if len(answer) > FieldLimit.DESCRIPTION:
+            raise_validation(
+                Code.Event.RSVP_ANSWER_TOO_LONG,
+                field=f"answers.{key}",
+                label=q.label,
+                max=FieldLimit.DESCRIPTION,
+            )
+        normalized = _normalize_answer(q, answer)
+        # Checkbox ",,," normalizes to "" — treat as unanswered.
+        if is_answer_empty(normalized):
+            _require_if_needed(q, require_answers=require_answers)
+            continue
+        snapshot[key] = {"label": q.label, "answer": normalized}
+    return snapshot

--- a/backend/community/_event_rsvp_answers.py
+++ b/backend/community/_event_rsvp_answers.py
@@ -1,5 +1,7 @@
 """Validate and snapshot RSVP question answers."""
 
+from users.permissions import PermissionKey
+
 from community._field_limits import FieldLimit
 from community._question_answers import (
     assert_single_choice_member,
@@ -10,6 +12,26 @@ from community._validation import Code, raise_validation
 from community.models import EventRsvpQuestion, RsvpQuestionType, RSVPStatus
 
 AnswersIn = dict[str, str]
+
+
+def can_see_guest_answers(requesting_user, creator, co_host_ids: set[str]) -> bool:
+    """Hosts, co-hosts, and event managers can see RSVP question answers."""
+    if requesting_user is None:
+        return False
+    if requesting_user.has_permission(PermissionKey.MANAGE_EVENTS):
+        return True
+    if creator is not None and requesting_user.pk == creator.pk:
+        return True
+    return str(requesting_user.pk) in co_host_ids
+
+
+def find_my_rsvp_answers(rsvps, user) -> dict:
+    if user is None:
+        return {}
+    for r in rsvps:
+        if r.user_id == user.pk:
+            return dict(r.questionnaire_responses or {})
+    return {}
 
 
 def answers_required_for_status(status: str) -> bool:

--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import dataclass
 from datetime import datetime
 from uuid import UUID
 
@@ -220,14 +221,15 @@ def _rsvp_unchanged(
     )
 
 
-def _apply_rsvp_in_transaction(  # noqa: PLR0913
-    event_id,
-    user,
-    status: str,
-    has_plus_one: bool,
-    paid_confirmed: bool = False,
-    answers: dict[str, str] | None = None,
-) -> tuple[str, list[str], bool]:
+@dataclass(frozen=True, slots=True)
+class _RsvpApply:
+    status: str
+    has_plus_one: bool = False
+    paid_confirmed: bool = False
+    answers: dict[str, str] | None = None
+
+
+def _apply_rsvp_in_transaction(event_id, user, rsvp: _RsvpApply) -> tuple[str, list[str], bool]:
     """Execute RSVP upsert inside a locked transaction.
 
     Returns (final_status, promoted_user_ids, created). promoted_user_ids is the
@@ -251,15 +253,15 @@ def _apply_rsvp_in_transaction(  # noqa: PLR0913
     created = existing is None
 
     # Gate on the *requested* status, not the post-capacity one — else it slips through unconfirmed.
-    if not paid_confirmed and requires_payment_gate(event, existing, status):
+    if not rsvp.paid_confirmed and requires_payment_gate(event, existing, rsvp.status):
         raise_validation(Code.Event.PAYMENT_CONFIRMATION_REQUIRED, status_code=400)
 
-    final_status, final_plus_one = _resolve_rsvp_status(event, user, status, has_plus_one)
-    answers_snapshot = _snapshot_rsvp_answers(event, existing, final_status, answers)
+    final_status, final_plus_one = _resolve_rsvp_status(event, user, rsvp.status, rsvp.has_plus_one)
+    answers_snapshot = _snapshot_rsvp_answers(event, existing, final_status, rsvp.answers)
 
     was_attending = existing is not None and existing.status == RSVPStatus.ATTENDING
     had_plus_one = existing is not None and existing.has_plus_one
-    new_confirmed_at = _resolve_paid_confirmed_at(existing, paid_confirmed, final_status)
+    new_confirmed_at = _resolve_paid_confirmed_at(existing, rsvp.paid_confirmed, final_status)
 
     if _rsvp_unchanged(
         existing,
@@ -308,10 +310,12 @@ def upsert_rsvp(request, event_id: UUID, payload: RSVPIn):
         final_status, promoted_user_ids, _created = _apply_rsvp_in_transaction(
             event_id,
             request.auth,
-            payload.status,
-            payload.has_plus_one,
-            payload.paid_confirmed,
-            payload.questionnaire_responses,
+            _RsvpApply(
+                status=payload.status,
+                has_plus_one=payload.has_plus_one,
+                paid_confirmed=payload.paid_confirmed,
+                answers=payload.questionnaire_responses,
+            ),
         )
 
     sent_decline_note = _post_rsvp_comment(event_id, request.auth, final_status, payload.comment)

--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -313,7 +313,7 @@ def upsert_rsvp(request, event_id: UUID, payload: RSVPIn):
             payload.status,
             payload.has_plus_one,
             payload.paid_confirmed,
-            payload.answers,
+            payload.questionnaire_responses,
         )
 
     sent_decline_note = _post_rsvp_comment(event_id, request.auth, final_status, payload.comment)

--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -174,7 +174,9 @@ def _snapshot_rsvp_answers(
     final_status: str,
     answers: dict[str, str] | None,
 ) -> dict:
-    existing_answers = dict(existing.answers or {}) if existing is not None else {}
+    existing_answers = (
+        dict(existing.questionnaire_responses or {}) if existing is not None else {}
+    )
     if not answers_required_for_status(final_status):
         return existing_answers
 
@@ -216,7 +218,7 @@ def _rsvp_unchanged(
         existing.status == final_status
         and existing.has_plus_one == final_plus_one
         and existing.paid_confirmed_at == new_confirmed_at
-        and dict(existing.answers or {}) == answers_snapshot
+        and dict(existing.questionnaire_responses or {}) == answers_snapshot
     )
 
 
@@ -278,7 +280,7 @@ def _apply_rsvp_in_transaction(  # noqa: PLR0913
             "has_plus_one": final_plus_one,
             "cancelled_at": _resolve_cancelled_at(existing, final_status),
             "paid_confirmed_at": new_confirmed_at,
-            "answers": answers_snapshot,
+            "questionnaire_responses": answers_snapshot,
         },
     )
 

--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -174,9 +174,7 @@ def _snapshot_rsvp_answers(
     final_status: str,
     answers: dict[str, str] | None,
 ) -> dict:
-    existing_answers = (
-        dict(existing.questionnaire_responses or {}) if existing is not None else {}
-    )
+    existing_answers = dict(existing.questionnaire_responses or {}) if existing is not None else {}
     if not answers_required_for_status(final_status):
         return existing_answers
 

--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -202,7 +202,7 @@ def _snapshot_rsvp_answers(
     return historical_answers | current_answers
 
 
-def _apply_rsvp_in_transaction(
+def _apply_rsvp_in_transaction(  # noqa: PLR0913
     event_id,
     user,
     status: str,

--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -16,13 +16,13 @@ from notifications.service import (
     notify_rsvp_status_changed,
 )
 
-from community._event_rsvp_answers import answers_required_for_status, build_rsvp_answers
 from community._event_helpers import (
     _event_out,
     broadcast_capacity_change,
     load_event_with_stats_prefetch,
     promote_from_waitlist,
 )
+from community._event_rsvp_answers import answers_required_for_status, build_rsvp_answers
 from community._event_schemas import EventOut, RSVPIn
 from community._events import _can_edit_event, _enforce_event_read_visibility
 from community._public_rsvp_shared import _email_promoted_non_members
@@ -202,6 +202,24 @@ def _snapshot_rsvp_answers(
     return historical_answers | current_answers
 
 
+def _rsvp_unchanged(
+    existing: EventRSVP | None,
+    *,
+    final_status: str,
+    final_plus_one: bool,
+    new_confirmed_at,
+    answers_snapshot: dict,
+) -> bool:
+    if existing is None:
+        return False
+    return (
+        existing.status == final_status
+        and existing.has_plus_one == final_plus_one
+        and existing.paid_confirmed_at == new_confirmed_at
+        and dict(existing.answers or {}) == answers_snapshot
+    )
+
+
 def _apply_rsvp_in_transaction(  # noqa: PLR0913
     event_id,
     user,
@@ -243,12 +261,12 @@ def _apply_rsvp_in_transaction(  # noqa: PLR0913
     had_plus_one = existing is not None and existing.has_plus_one
     new_confirmed_at = _resolve_paid_confirmed_at(existing, paid_confirmed, final_status)
 
-    if (
-        existing is not None
-        and existing.status == final_status
-        and existing.has_plus_one == final_plus_one
-        and existing.paid_confirmed_at == new_confirmed_at
-        and dict(existing.answers or {}) == answers_snapshot
+    if _rsvp_unchanged(
+        existing,
+        final_status=final_status,
+        final_plus_one=final_plus_one,
+        new_confirmed_at=new_confirmed_at,
+        answers_snapshot=answers_snapshot,
     ):
         return final_status, [], False
 

--- a/backend/community/_event_rsvps.py
+++ b/backend/community/_event_rsvps.py
@@ -16,6 +16,7 @@ from notifications.service import (
     notify_rsvp_status_changed,
 )
 
+from community._event_rsvp_answers import answers_required_for_status, build_rsvp_answers
 from community._event_helpers import (
     _event_out,
     broadcast_capacity_change,
@@ -167,8 +168,47 @@ def payment_audit_details(event_id, user_id) -> dict:
     }
 
 
+def _snapshot_rsvp_answers(
+    event: Event,
+    existing: EventRSVP | None,
+    final_status: str,
+    answers: dict[str, str] | None,
+) -> dict:
+    existing_answers = dict(existing.answers or {}) if existing is not None else {}
+    if not answers_required_for_status(final_status):
+        return existing_answers
+
+    questions = list(event.rsvp_questions.all())
+    current_ids = {str(question.id) for question in questions}
+    if answers is None:
+        answers = {
+            question_id: snapshot["answer"]
+            for question_id, snapshot in existing_answers.items()
+            if question_id in current_ids
+        }
+        build_rsvp_answers(questions, answers, require_answers=True)
+        return existing_answers
+
+    current_answers = build_rsvp_answers(questions, answers, require_answers=True)
+    for question_id, snapshot in current_answers.items():
+        previous = existing_answers.get(question_id)
+        if previous is not None and previous["answer"] == snapshot["answer"]:
+            current_answers[question_id] = previous
+    historical_answers = {
+        question_id: snapshot
+        for question_id, snapshot in existing_answers.items()
+        if question_id not in current_ids
+    }
+    return historical_answers | current_answers
+
+
 def _apply_rsvp_in_transaction(
-    event_id, user, status: str, has_plus_one: bool, paid_confirmed: bool = False
+    event_id,
+    user,
+    status: str,
+    has_plus_one: bool,
+    paid_confirmed: bool = False,
+    answers: dict[str, str] | None = None,
 ) -> tuple[str, list[str], bool]:
     """Execute RSVP upsert inside a locked transaction.
 
@@ -183,7 +223,7 @@ def _apply_rsvp_in_transaction(
     # is locked under select_for_update.
     event = (
         Event.objects.select_for_update()
-        .prefetch_related("co_hosts", "invited_users")
+        .prefetch_related("co_hosts", "invited_users", "rsvp_questions")
         .get(id=event_id)
     )
 
@@ -197,6 +237,7 @@ def _apply_rsvp_in_transaction(
         raise_validation(Code.Event.PAYMENT_CONFIRMATION_REQUIRED, status_code=400)
 
     final_status, final_plus_one = _resolve_rsvp_status(event, user, status, has_plus_one)
+    answers_snapshot = _snapshot_rsvp_answers(event, existing, final_status, answers)
 
     was_attending = existing is not None and existing.status == RSVPStatus.ATTENDING
     had_plus_one = existing is not None and existing.has_plus_one
@@ -207,6 +248,7 @@ def _apply_rsvp_in_transaction(
         and existing.status == final_status
         and existing.has_plus_one == final_plus_one
         and existing.paid_confirmed_at == new_confirmed_at
+        and dict(existing.answers or {}) == answers_snapshot
     ):
         return final_status, [], False
 
@@ -218,6 +260,7 @@ def _apply_rsvp_in_transaction(
             "has_plus_one": final_plus_one,
             "cancelled_at": _resolve_cancelled_at(existing, final_status),
             "paid_confirmed_at": new_confirmed_at,
+            "answers": answers_snapshot,
         },
     )
 
@@ -245,7 +288,12 @@ def upsert_rsvp(request, event_id: UUID, payload: RSVPIn):
 
     with transaction.atomic():
         final_status, promoted_user_ids, _created = _apply_rsvp_in_transaction(
-            event_id, request.auth, payload.status, payload.has_plus_one, payload.paid_confirmed
+            event_id,
+            request.auth,
+            payload.status,
+            payload.has_plus_one,
+            payload.paid_confirmed,
+            payload.answers,
         )
 
     sent_decline_note = _post_rsvp_comment(event_id, request.auth, final_status, payload.comment)
@@ -322,7 +370,7 @@ def _delete_rsvp_in_transaction(event_id, user) -> tuple[Event, list[str]]:
     """
     event = (
         Event.objects.select_for_update()
-        .prefetch_related("co_hosts", "invited_users")
+        .prefetch_related("co_hosts", "invited_users", "rsvp_questions")
         .get(id=event_id)
     )
     if event.is_deleted:

--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -82,7 +82,6 @@ def validate_event_rsvp_question(payload: EventRsvpQuestionIn) -> None:
         raise_validation(Code.Event.RSVP_QUESTION_OPTION_NO_COMMA, field="options", status_code=400)
 
 
-
 def _looks_like_email(s: str) -> bool:
     return bool(_EMAIL_RE.match(s))
 

--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -178,7 +178,7 @@ class RSVPGuestOut(BaseModel):
     name: str
     status: RSVPStatus
     has_plus_one: bool = False
-    answers: dict = {}
+    questionnaire_responses: dict = {}
     phone: str | None = None
     photo_url: str = ""
     attendance: AttendanceStatus = AttendanceStatus.UNKNOWN
@@ -265,7 +265,7 @@ class EventOut(BaseModel):
     co_host_photo_urls: list[str] = []
     guests: list[RSVPGuestOut] = []
     my_rsvp: str | None = None
-    my_rsvp_answers: dict = {}
+    my_questionnaire_responses: dict = {}
     my_paid_confirmed: bool = False
     viewer_user_id: str | None = None
     event_type: str = EventType.COMMUNITY
@@ -301,7 +301,7 @@ class RSVPIn(BaseModel):
     # Not persisted on the RSVP — a non-empty value is a one-time post: a
     # public EventComment (going/maybe) or a host-only notification (can't go).
     comment: str | None = Field(default=None, max_length=FieldLimit.SHORT_TEXT)
-    answers: dict[str, RsvpAnswer] = Field(
+    questionnaire_responses: dict[str, RsvpAnswer] = Field(
         default_factory=dict,
         description="Question UUID to answer; checkbox values are comma-separated.",
     )

--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -5,7 +5,7 @@ from urllib.parse import urlparse
 from uuid import UUID
 
 import phonenumbers
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, WithJsonSchema, field_validator, model_validator
 
 from community._field_limits import FieldLimit
 from community._shared import require_url_path, validate_whatsapp_url
@@ -26,6 +26,7 @@ _EMAIL_RE = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
 
 RsvpQuestionFieldType = Literal["textarea", "select", "checkbox"]
 RsvpQuestionOption = Annotated[str, Field(max_length=FieldLimit.OPTION_TEXT)]
+RsvpAnswer = Annotated[str, WithJsonSchema({"type": "string", "maxLength": FieldLimit.DESCRIPTION})]
 
 
 class EventRsvpQuestionOut(BaseModel):
@@ -177,6 +178,7 @@ class RSVPGuestOut(BaseModel):
     name: str
     status: RSVPStatus
     has_plus_one: bool = False
+    answers: dict = {}
     phone: str | None = None
     photo_url: str = ""
     attendance: AttendanceStatus = AttendanceStatus.UNKNOWN
@@ -299,6 +301,10 @@ class RSVPIn(BaseModel):
     # Not persisted on the RSVP — a non-empty value is a one-time post: a
     # public EventComment (going/maybe) or a host-only notification (can't go).
     comment: str | None = Field(default=None, max_length=FieldLimit.SHORT_TEXT)
+    answers: dict[str, RsvpAnswer] = Field(
+        default_factory=dict,
+        description="Question UUID to answer; checkbox values are comma-separated.",
+    )
 
 
 class HostRSVPIn(BaseModel):

--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -20,8 +20,7 @@ from community.models import (
     RSVPStatus,
 )
 
-# Loose RFC-5322-ish email check — Pydantic's full EmailStr validator is
-# overkill for a free-text payment field, and we don't need DNS lookups.
+# Loose email check for free-text Zelle — EmailStr/DNS is overkill here.
 _EMAIL_RE = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
 
 RsvpQuestionFieldType = Literal["textarea", "select", "checkbox"]
@@ -77,16 +76,11 @@ class EventRsvpQuestionSyncPayload(BaseModel):
 def validate_event_rsvp_question(payload: EventRsvpQuestionIn) -> None:
     if payload.field_type in RSVP_CHOICE_TYPES and not payload.options:
         raise_validation(
-            Code.Event.RSVP_QUESTION_OPTIONS_REQUIRED,
-            field="options",
-            status_code=400,
+            Code.Event.RSVP_QUESTION_OPTIONS_REQUIRED, field="options", status_code=400
         )
     if payload.field_type == "checkbox" and any("," in option for option in payload.options):
-        raise_validation(
-            Code.Event.RSVP_QUESTION_OPTION_NO_COMMA,
-            field="options",
-            status_code=400,
-        )
+        raise_validation(Code.Event.RSVP_QUESTION_OPTION_NO_COMMA, field="options", status_code=400)
+
 
 
 def _looks_like_email(s: str) -> bool:
@@ -298,12 +292,11 @@ class RSVPIn(BaseModel):
     status: RSVPStatus
     has_plus_one: bool = False
     paid_confirmed: bool = False
-    # Not persisted on the RSVP — a non-empty value is a one-time post: a
-    # public EventComment (going/maybe) or a host-only notification (can't go).
+    # One-shot post (EventComment / host notify); not stored on the RSVP row.
     comment: str | None = Field(default=None, max_length=FieldLimit.SHORT_TEXT)
     questionnaire_responses: dict[str, RsvpAnswer] = Field(
         default_factory=dict,
-        description="Question UUID to answer; checkbox values are comma-separated.",
+        description="Question UUID → answer; checkbox values are comma-separated.",
     )
 
 

--- a/backend/community/_event_schemas.py
+++ b/backend/community/_event_schemas.py
@@ -296,7 +296,7 @@ class RSVPIn(BaseModel):
     comment: str | None = Field(default=None, max_length=FieldLimit.SHORT_TEXT)
     questionnaire_responses: dict[str, RsvpAnswer] = Field(
         default_factory=dict,
-        description="Question UUID → answer; checkbox values are comma-separated.",
+        description="Question UUID to answer; checkbox values are comma-separated.",
     )
 
 

--- a/backend/community/_public_rsvp_manage.py
+++ b/backend/community/_public_rsvp_manage.py
@@ -17,6 +17,7 @@ from community._event_helpers import _event_out, broadcast_capacity_change, prom
 from community._event_rsvps import (
     _apply_rsvp_in_transaction,
     _post_rsvp_comment,
+    _RsvpApply,
     _validate_rsvp_status,
     payment_audit_details,
 )
@@ -159,7 +160,9 @@ def update_my_rsvp(request, event_id, payload: PublicRsvpManageIn, token: str = 
 
     with transaction.atomic():
         final_status, promoted_user_ids, created = _apply_rsvp_in_transaction(
-            event.id, user, payload.status, False, payload.paid_confirmed
+            event.id,
+            user,
+            _RsvpApply(status=payload.status, paid_confirmed=payload.paid_confirmed),
         )
         rsvp_token = NonMemberRsvpToken.issue_or_extend(user)
 

--- a/backend/community/_public_rsvp_submit.py
+++ b/backend/community/_public_rsvp_submit.py
@@ -18,6 +18,7 @@ from community._event_helpers import _event_out, broadcast_capacity_change
 from community._event_rsvps import (
     _apply_rsvp_in_transaction,
     _post_rsvp_comment,
+    _RsvpApply,
     _validate_rsvp_status,
     payment_audit_details,
 )
@@ -241,7 +242,9 @@ def submit_public_rsvp(request, event_id, payload: PublicRsvpIn):
             phone=validated_phone,
         )
         final_status, promoted_user_ids, _rsvp_created = _apply_rsvp_in_transaction(
-            event.id, user, payload.status, False, payload.paid_confirmed
+            event.id,
+            user,
+            _RsvpApply(status=payload.status, paid_confirmed=payload.paid_confirmed),
         )
         token = NonMemberRsvpToken.issue_or_extend(user)
 

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -2340,6 +2340,12 @@
             ],
             "title": "My Pending Cohost Invite Id"
           },
+          "my_questionnaire_responses": {
+            "additionalProperties": true,
+            "default": {},
+            "title": "My Questionnaire Responses",
+            "type": "object"
+          },
           "my_rsvp": {
             "anyOf": [
               {
@@ -2350,12 +2356,6 @@
               }
             ],
             "title": "My Rsvp"
-          },
-          "my_rsvp_answers": {
-            "additionalProperties": true,
-            "default": {},
-            "title": "My Rsvp Answers",
-            "type": "object"
           },
           "other_link": {
             "default": "",
@@ -5241,12 +5241,6 @@
       },
       "RSVPGuestOut": {
         "properties": {
-          "answers": {
-            "additionalProperties": true,
-            "default": {},
-            "title": "Answers",
-            "type": "object"
-          },
           "attendance": {
             "allOf": [
               {
@@ -5322,6 +5316,12 @@
             ],
             "title": "Plus One Checked In At"
           },
+          "questionnaire_responses": {
+            "additionalProperties": true,
+            "default": {},
+            "title": "Questionnaire Responses",
+            "type": "object"
+          },
           "status": {
             "$ref": "#/components/schemas/RSVPStatus"
           },
@@ -5340,15 +5340,6 @@
       },
       "RSVPIn": {
         "properties": {
-          "answers": {
-            "additionalProperties": {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            "description": "Question UUID to answer; checkbox values are comma-separated.",
-            "title": "Answers",
-            "type": "object"
-          },
           "comment": {
             "anyOf": [
               {
@@ -5370,6 +5361,15 @@
             "default": false,
             "title": "Paid Confirmed",
             "type": "boolean"
+          },
+          "questionnaire_responses": {
+            "additionalProperties": {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            "description": "Question UUID to answer; checkbox values are comma-separated.",
+            "title": "Questionnaire Responses",
+            "type": "object"
           },
           "status": {
             "$ref": "#/components/schemas/RSVPStatus"

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -5241,6 +5241,12 @@
       },
       "RSVPGuestOut": {
         "properties": {
+          "answers": {
+            "additionalProperties": true,
+            "default": {},
+            "title": "Answers",
+            "type": "object"
+          },
           "attendance": {
             "allOf": [
               {
@@ -5334,6 +5340,15 @@
       },
       "RSVPIn": {
         "properties": {
+          "answers": {
+            "additionalProperties": {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            "description": "Question UUID to answer; checkbox values are comma-separated.",
+            "title": "Answers",
+            "type": "object"
+          },
           "comment": {
             "anyOf": [
               {

--- a/backend/tests/test_event_rsvp_questions.py
+++ b/backend/tests/test_event_rsvp_questions.py
@@ -1,0 +1,247 @@
+"""Tests for per-event RSVP questions and answers on RSVP."""
+
+import pytest
+from community._validation import Code
+from community.models import Event, EventRSVP, EventRsvpQuestion, RSVPStatus
+from ninja_jwt.tokens import RefreshToken
+from users.models import User
+
+from tests._asserts import assert_error_code
+from tests.conftest import future_iso
+
+
+@pytest.fixture
+def rsvp_event(db, test_user):
+    return Event.objects.create(
+        title="Questions Event",
+        start_datetime=future_iso(days=30),
+        end_datetime=future_iso(days=30, hours=2),
+        rsvp_enabled=True,
+        created_by=test_user,
+    )
+
+
+@pytest.fixture
+def other_user(db):
+    return User.objects.create_user(
+        phone_number="+12025550999",
+        password="otherpass",
+        first_name="Other",
+        last_name="Guest",
+    )
+
+
+@pytest.fixture
+def other_headers(other_user):
+    refresh = RefreshToken.for_user(other_user)
+    return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # type: ignore
+
+
+def _question_data(**overrides):
+    return {
+        "label": "how are you getting there?",
+        "field_type": "select",
+        "options": ["driving", "transit"],
+        "required": True,
+        **overrides,
+    }
+
+
+def _create_question(event, **overrides):
+    question = EventRsvpQuestion.objects.create(event=event, **_question_data(**overrides))
+    return {"id": str(question.id)}
+
+
+def _replace_question(api_client, auth_headers, event_id, **overrides):
+    return api_client.put(
+        f"/api/community/events/{event_id}/rsvp-questions/",
+        {"expected": [], "questions": [{"id": None, **_question_data(**overrides)}]},
+        content_type="application/json",
+        **auth_headers,
+    )
+
+
+@pytest.mark.django_db
+def test_event_out_includes_questions(api_client, auth_headers, rsvp_event):
+    _create_question(rsvp_event)
+    response = api_client.get(f"/api/community/events/{rsvp_event.id}/", **auth_headers)
+    assert response.status_code == 200
+    questions = response.json()["rsvp_questions"]
+    assert len(questions) == 1
+    assert questions[0]["label"] == "how are you getting there?"
+
+
+@pytest.mark.django_db
+class TestRsvpWithAnswers:
+    def test_required_answer_blocks_attending(
+        self, api_client, other_headers, auth_headers, rsvp_event
+    ):
+        q = _create_question(rsvp_event)
+        response = api_client.post(
+            f"/api/community/events/{rsvp_event.id}/rsvp/",
+            {"status": RSVPStatus.ATTENDING, "has_plus_one": False},
+            content_type="application/json",
+            **other_headers,
+        )
+        assert response.status_code == 422
+        assert_error_code(response, Code.Event.RSVP_ANSWER_REQUIRED)
+
+        ok = api_client.post(
+            f"/api/community/events/{rsvp_event.id}/rsvp/",
+            {
+                "status": RSVPStatus.ATTENDING,
+                "has_plus_one": False,
+                "answers": {q["id"]: "driving"},
+            },
+            content_type="application/json",
+            **other_headers,
+        )
+        assert ok.status_code == 200
+        rsvp = EventRSVP.objects.get(event=rsvp_event)
+        assert rsvp.answers[q["id"]]["answer"] == "driving"
+        assert ok.json()["my_rsvp_answers"][q["id"]]["answer"] == "driving"
+
+    def test_cant_go_skips_required_answers(
+        self, api_client, other_headers, auth_headers, rsvp_event
+    ):
+        _create_question(rsvp_event)
+        response = api_client.post(
+            f"/api/community/events/{rsvp_event.id}/rsvp/",
+            {"status": RSVPStatus.CANT_GO, "has_plus_one": False},
+            content_type="application/json",
+            **other_headers,
+        )
+        assert response.status_code == 200
+
+    def test_invalid_option_rejected(self, api_client, other_headers, auth_headers, rsvp_event):
+        q = _create_question(rsvp_event)
+        response = api_client.post(
+            f"/api/community/events/{rsvp_event.id}/rsvp/",
+            {
+                "status": RSVPStatus.MAYBE,
+                "answers": {q["id"]: "helicopter"},
+            },
+            content_type="application/json",
+            **other_headers,
+        )
+        assert response.status_code == 422
+        assert_error_code(response, Code.Event.RSVP_ANSWER_INVALID_OPTION)
+
+    def test_host_sees_guest_answers_member_does_not(
+        self, api_client, other_headers, auth_headers, rsvp_event, other_user
+    ):
+        q = _create_question(rsvp_event)
+        assert (
+            api_client.post(
+                f"/api/community/events/{rsvp_event.id}/rsvp/",
+                {
+                    "status": RSVPStatus.ATTENDING,
+                    "answers": {q["id"]: "transit"},
+                },
+                content_type="application/json",
+                **other_headers,
+            ).status_code
+            == 200
+        )
+
+        host_view = api_client.get(f"/api/community/events/{rsvp_event.id}/", **auth_headers).json()
+        host_guest = next(g for g in host_view["guests"] if g["user_id"] == str(other_user.pk))
+        assert host_guest["answers"][q["id"]]["answer"] == "transit"
+
+        member_view = api_client.get(
+            f"/api/community/events/{rsvp_event.id}/", **other_headers
+        ).json()
+        member_guest = next(g for g in member_view["guests"] if g["user_id"] == str(other_user.pk))
+        assert member_guest["answers"] == {}
+
+
+@pytest.mark.django_db
+class TestRsvpAnswerEdgeCases:
+    def test_checkbox_comma_only_required_rejected(
+        self, api_client, other_headers, auth_headers, rsvp_event
+    ):
+        q = _create_question(
+            rsvp_event,
+            field_type="checkbox",
+            options=["a", "b"],
+        )
+        response = api_client.post(
+            f"/api/community/events/{rsvp_event.id}/rsvp/",
+            {"status": RSVPStatus.ATTENDING, "answers": {q["id"]: ",,,"}},
+            content_type="application/json",
+            **other_headers,
+        )
+        assert response.status_code == 422
+        assert_error_code(response, Code.Event.RSVP_ANSWER_REQUIRED)
+
+    def test_checkbox_option_with_comma_rejected(self, api_client, auth_headers, rsvp_event):
+        response = _replace_question(
+            api_client,
+            auth_headers,
+            rsvp_event.id,
+            field_type="checkbox",
+            options=["a, b", "c"],
+        )
+        assert response.status_code == 400
+        assert_error_code(response, Code.Event.RSVP_QUESTION_OPTION_NO_COMMA)
+
+    def test_select_option_with_comma_allowed(self, api_client, auth_headers, rsvp_event):
+        response = _replace_question(
+            api_client,
+            auth_headers,
+            rsvp_event.id,
+            options=["yes, with a guest", "no"],
+        )
+
+        assert response.status_code == 200
+
+    def test_choice_option_over_max_length_rejected(self, api_client, auth_headers, rsvp_event):
+        response = _replace_question(
+            api_client,
+            auth_headers,
+            rsvp_event.id,
+            options=["x" * 201],
+        )
+
+        assert response.status_code == 422
+
+    def test_answer_too_long_uses_question_label(
+        self, api_client, other_headers, auth_headers, rsvp_event
+    ):
+        q = _create_question(
+            rsvp_event,
+            field_type="textarea",
+            options=[],
+            label="travel details",
+        )
+
+        response = api_client.post(
+            f"/api/community/events/{rsvp_event.id}/rsvp/",
+            {"status": RSVPStatus.ATTENDING, "answers": {q["id"]: "x" * 2001}},
+            content_type="application/json",
+            **other_headers,
+        )
+
+        assert response.status_code == 422
+        error = response.json()["detail"][0]
+        assert error["code"] == Code.Event.RSVP_ANSWER_TOO_LONG
+        assert error["params"]["label"] == "travel details"
+
+    def test_host_sees_guests_when_rsvp_disabled(
+        self, api_client, other_headers, auth_headers, rsvp_event, other_user
+    ):
+        q = _create_question(rsvp_event)
+        assert (
+            api_client.post(
+                f"/api/community/events/{rsvp_event.id}/rsvp/",
+                {"status": RSVPStatus.ATTENDING, "answers": {q["id"]: "driving"}},
+                content_type="application/json",
+                **other_headers,
+            ).status_code
+            == 200
+        )
+        rsvp_event.rsvp_enabled = False
+        rsvp_event.save(update_fields=["rsvp_enabled"])
+        host_view = api_client.get(f"/api/community/events/{rsvp_event.id}/", **auth_headers).json()
+        assert len(host_view["guests"]) == 1
+        assert host_view["guests"][0]["answers"][q["id"]]["answer"] == "driving"

--- a/backend/tests/test_event_rsvp_questions.py
+++ b/backend/tests/test_event_rsvp_questions.py
@@ -98,7 +98,7 @@ class TestRsvpWithAnswers:
         )
         assert ok.status_code == 200
         rsvp = EventRSVP.objects.get(event=rsvp_event)
-        assert rsvp.answers[q["id"]]["answer"] == "driving"
+        assert rsvp.questionnaire_responses[q["id"]]["answer"] == "driving"
         assert ok.json()["my_rsvp_answers"][q["id"]]["answer"] == "driving"
 
     def test_cant_go_skips_required_answers(

--- a/backend/tests/test_event_rsvp_questions.py
+++ b/backend/tests/test_event_rsvp_questions.py
@@ -1,8 +1,6 @@
-"""Tests for per-event RSVP questions and answers on RSVP."""
-
 import pytest
 from community._validation import Code
-from community.models import Event, EventRSVP, EventRsvpQuestion, RSVPStatus
+from community.models import Event, EventRSVP, EventRsvpQuestion, RsvpQuestionType, RSVPStatus
 from ninja_jwt.tokens import RefreshToken
 from users.models import User
 
@@ -40,7 +38,7 @@ def other_headers(other_user):
 def _question_data(**overrides):
     return {
         "label": "how are you getting there?",
-        "field_type": "select",
+        "field_type": RsvpQuestionType.SELECT,
         "options": ["driving", "transit"],
         "required": True,
         **overrides,
@@ -91,7 +89,7 @@ class TestRsvpWithAnswers:
             {
                 "status": RSVPStatus.ATTENDING,
                 "has_plus_one": False,
-                "answers": {q["id"]: "driving"},
+                "questionnaire_responses": {q["id"]: "driving"},
             },
             content_type="application/json",
             **other_headers,
@@ -99,7 +97,7 @@ class TestRsvpWithAnswers:
         assert ok.status_code == 200
         rsvp = EventRSVP.objects.get(event=rsvp_event)
         assert rsvp.questionnaire_responses[q["id"]]["answer"] == "driving"
-        assert ok.json()["my_rsvp_answers"][q["id"]]["answer"] == "driving"
+        assert ok.json()["my_questionnaire_responses"][q["id"]]["answer"] == "driving"
 
     def test_cant_go_skips_required_answers(
         self, api_client, other_headers, auth_headers, rsvp_event
@@ -119,7 +117,7 @@ class TestRsvpWithAnswers:
             f"/api/community/events/{rsvp_event.id}/rsvp/",
             {
                 "status": RSVPStatus.MAYBE,
-                "answers": {q["id"]: "helicopter"},
+                "questionnaire_responses": {q["id"]: "helicopter"},
             },
             content_type="application/json",
             **other_headers,
@@ -136,7 +134,7 @@ class TestRsvpWithAnswers:
                 f"/api/community/events/{rsvp_event.id}/rsvp/",
                 {
                     "status": RSVPStatus.ATTENDING,
-                    "answers": {q["id"]: "transit"},
+                    "questionnaire_responses": {q["id"]: "transit"},
                 },
                 content_type="application/json",
                 **other_headers,
@@ -146,13 +144,13 @@ class TestRsvpWithAnswers:
 
         host_view = api_client.get(f"/api/community/events/{rsvp_event.id}/", **auth_headers).json()
         host_guest = next(g for g in host_view["guests"] if g["user_id"] == str(other_user.pk))
-        assert host_guest["answers"][q["id"]]["answer"] == "transit"
+        assert host_guest["questionnaire_responses"][q["id"]]["answer"] == "transit"
 
         member_view = api_client.get(
             f"/api/community/events/{rsvp_event.id}/", **other_headers
         ).json()
         member_guest = next(g for g in member_view["guests"] if g["user_id"] == str(other_user.pk))
-        assert member_guest["answers"] == {}
+        assert member_guest["questionnaire_responses"] == {}
 
 
 @pytest.mark.django_db
@@ -162,12 +160,12 @@ class TestRsvpAnswerEdgeCases:
     ):
         q = _create_question(
             rsvp_event,
-            field_type="checkbox",
+            field_type=RsvpQuestionType.CHECKBOX,
             options=["a", "b"],
         )
         response = api_client.post(
             f"/api/community/events/{rsvp_event.id}/rsvp/",
-            {"status": RSVPStatus.ATTENDING, "answers": {q["id"]: ",,,"}},
+            {"status": RSVPStatus.ATTENDING, "questionnaire_responses": {q["id"]: ",,,"}},
             content_type="application/json",
             **other_headers,
         )
@@ -179,7 +177,7 @@ class TestRsvpAnswerEdgeCases:
             api_client,
             auth_headers,
             rsvp_event.id,
-            field_type="checkbox",
+            field_type=RsvpQuestionType.CHECKBOX,
             options=["a, b", "c"],
         )
         assert response.status_code == 400
@@ -210,14 +208,14 @@ class TestRsvpAnswerEdgeCases:
     ):
         q = _create_question(
             rsvp_event,
-            field_type="textarea",
+            field_type=RsvpQuestionType.TEXTAREA,
             options=[],
             label="travel details",
         )
 
         response = api_client.post(
             f"/api/community/events/{rsvp_event.id}/rsvp/",
-            {"status": RSVPStatus.ATTENDING, "answers": {q["id"]: "x" * 2001}},
+            {"status": RSVPStatus.ATTENDING, "questionnaire_responses": {q["id"]: "x" * 2001}},
             content_type="application/json",
             **other_headers,
         )
@@ -234,7 +232,7 @@ class TestRsvpAnswerEdgeCases:
         assert (
             api_client.post(
                 f"/api/community/events/{rsvp_event.id}/rsvp/",
-                {"status": RSVPStatus.ATTENDING, "answers": {q["id"]: "driving"}},
+                {"status": RSVPStatus.ATTENDING, "questionnaire_responses": {q["id"]: "driving"}},
                 content_type="application/json",
                 **other_headers,
             ).status_code
@@ -244,4 +242,4 @@ class TestRsvpAnswerEdgeCases:
         rsvp_event.save(update_fields=["rsvp_enabled"])
         host_view = api_client.get(f"/api/community/events/{rsvp_event.id}/", **auth_headers).json()
         assert len(host_view["guests"]) == 1
-        assert host_view["guests"][0]["answers"][q["id"]]["answer"] == "driving"
+        assert host_view["guests"][0]["questionnaire_responses"][q["id"]]["answer"] == "driving"

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -3249,15 +3249,15 @@ export interface components {
             my_paid_confirmed: boolean;
             /** My Pending Cohost Invite Id */
             my_pending_cohost_invite_id?: string | null;
-            /** My Rsvp */
-            my_rsvp?: string | null;
             /**
-             * My Rsvp Answers
+             * My Questionnaire Responses
              * @default {}
              */
-            my_rsvp_answers: {
+            my_questionnaire_responses: {
                 [key: string]: unknown;
             };
+            /** My Rsvp */
+            my_rsvp?: string | null;
             /**
              * Other Link
              * @default
@@ -4492,13 +4492,6 @@ export interface components {
         QuestionType: "text" | "textarea" | "radio" | "select" | "checkbox" | "number" | "boolean" | "rating" | "datetime_poll";
         /** RSVPGuestOut */
         RSVPGuestOut: {
-            /**
-             * Answers
-             * @default {}
-             */
-            answers: {
-                [key: string]: unknown;
-            };
             /** @default unknown */
             attendance: components["schemas"]["AttendanceStatus"];
             /** Checked In At */
@@ -4531,19 +4524,19 @@ export interface components {
             plus_one_attendance: components["schemas"]["AttendanceStatus"];
             /** Plus One Checked In At */
             plus_one_checked_in_at?: string | null;
+            /**
+             * Questionnaire Responses
+             * @default {}
+             */
+            questionnaire_responses: {
+                [key: string]: unknown;
+            };
             status: components["schemas"]["RSVPStatus"];
             /** User Id */
             user_id: string;
         };
         /** RSVPIn */
         RSVPIn: {
-            /**
-             * Answers
-             * @description Question UUID to answer; checkbox values are comma-separated.
-             */
-            answers?: {
-                [key: string]: string;
-            };
             /** Comment */
             comment?: string | null;
             /**
@@ -4556,6 +4549,13 @@ export interface components {
              * @default false
              */
             paid_confirmed: boolean;
+            /**
+             * Questionnaire Responses
+             * @description Question UUID to answer; checkbox values are comma-separated.
+             */
+            questionnaire_responses?: {
+                [key: string]: string;
+            };
             status: components["schemas"]["RSVPStatus"];
         };
         /**

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -4492,6 +4492,13 @@ export interface components {
         QuestionType: "text" | "textarea" | "radio" | "select" | "checkbox" | "number" | "boolean" | "rating" | "datetime_poll";
         /** RSVPGuestOut */
         RSVPGuestOut: {
+            /**
+             * Answers
+             * @default {}
+             */
+            answers: {
+                [key: string]: unknown;
+            };
             /** @default unknown */
             attendance: components["schemas"]["AttendanceStatus"];
             /** Checked In At */
@@ -4530,6 +4537,13 @@ export interface components {
         };
         /** RSVPIn */
         RSVPIn: {
+            /**
+             * Answers
+             * @description Question UUID to answer; checkbox values are comma-separated.
+             */
+            answers?: {
+                [key: string]: string;
+            };
             /** Comment */
             comment?: string | null;
             /**


### PR DESCRIPTION
Wire RSVP submit to snapshot answers against event questions, expose
my_rsvp_answers and host-visible guest answers on event payloads.

Co-authored-by: Cursor <cursoragent@cursor.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>