### PR TITLE
feat(events): add RSVP question authoring to event form

### DIFF
--- a/frontend/src/api/eventMapper.test.ts
+++ b/frontend/src/api/eventMapper.test.ts
@@ -41,7 +41,7 @@ describe('mapEvent', () => {
     expect(result.guests[1]!.paidConfirmed).toBe(false);
   });
 
-  it('should map rsvp_questions and my_rsvp_answers', () => {
+  it('should map rsvp_questions and my_questionnaire_responses', () => {
     const result = mapEvent(
       wireEvent({
         rsvp_questions: [
@@ -53,7 +53,7 @@ describe('mapEvent', () => {
             required: true,
           },
         ],
-        my_rsvp_answers: { q1: { label: 'dietary?', answer: 'none' } },
+        my_questionnaire_responses: { q1: { label: 'dietary?', answer: 'none' } },
       }),
     );
     expect(result.rsvpQuestions).toEqual([
@@ -65,7 +65,9 @@ describe('mapEvent', () => {
         required: true,
       },
     ]);
-    expect(result.myRsvpAnswers).toEqual({ q1: { label: 'dietary?', answer: 'none' } });
+    expect(result.myQuestionnaireResponses).toEqual({
+      q1: { label: 'dietary?', answer: 'none' },
+    });
   });
 
   it('converts ISO start_datetime to Date', () => {

--- a/frontend/src/api/eventMapper.test.ts
+++ b/frontend/src/api/eventMapper.test.ts
@@ -41,6 +41,33 @@ describe('mapEvent', () => {
     expect(result.guests[1]!.paidConfirmed).toBe(false);
   });
 
+  it('should map rsvp_questions and my_rsvp_answers', () => {
+    const result = mapEvent(
+      wireEvent({
+        rsvp_questions: [
+          {
+            id: 'q1',
+            label: 'dietary?',
+            field_type: 'textarea',
+            options: [],
+            required: true,
+          },
+        ],
+        my_rsvp_answers: { q1: { label: 'dietary?', answer: 'none' } },
+      }),
+    );
+    expect(result.rsvpQuestions).toEqual([
+      {
+        id: 'q1',
+        label: 'dietary?',
+        fieldType: 'textarea',
+        options: [],
+        required: true,
+      },
+    ]);
+    expect(result.myRsvpAnswers).toEqual({ q1: { label: 'dietary?', answer: 'none' } });
+  });
+
   it('converts ISO start_datetime to Date', () => {
     const result = mapEvent(wireEvent({ start_datetime: '2026-01-05T09:05:03Z' }));
     expect(result.startDatetime!.getUTCFullYear()).toBe(2026);

--- a/frontend/src/api/eventMapper.ts
+++ b/frontend/src/api/eventMapper.ts
@@ -2,6 +2,7 @@ import type {
   AttendanceStatusValue,
   Event,
   EventGuest,
+  EventRsvpQuestion,
   EventTag,
   PendingCohostInvite,
 } from '@/models/event';
@@ -20,8 +21,9 @@ interface WireGuest {
   plus_one_attendance?: string;
   is_member?: boolean;
   paid_confirmed?: boolean;
-  answers?: Record<string, { label?: string; answer?: string }>;
+  questionnaire_responses?: Record<string, { label?: string; answer?: string }>;
 }
+
 
 export interface WireEvent {
   id: string;
@@ -64,11 +66,11 @@ export interface WireEvent {
   guests?: WireGuest[];
   my_rsvp?: string | null;
   my_paid_confirmed?: boolean;
-  my_rsvp_answers?: Record<string, { label?: string; answer?: string }>;
+  my_questionnaire_responses?: Record<string, { label?: string; answer?: string }>;
   rsvp_questions?: {
     id: string;
     label: string;
-    field_type: 'textarea' | 'select' | 'checkbox';
+    field_type: EventRsvpQuestion['fieldType'];
     options?: string[];
     required: boolean;
     display_order?: number;
@@ -114,9 +116,9 @@ function mapAttendance(value: string | undefined): AttendanceStatusValue {
   return AttendanceStatus.Unknown;
 }
 
-function mapMyRsvpAnswers(
+function mapQuestionnaireResponses(
   raw: Record<string, { label?: string; answer?: string }> | undefined,
-): Event['myRsvpAnswers'] {
+): Event['myQuestionnaireResponses'] {
   return Object.fromEntries(
     Object.entries(raw ?? {}).map(([id, snap]) => [
       id,
@@ -137,7 +139,7 @@ function mapGuest(g: WireGuest): EventGuest {
     plusOneAttendance: mapAttendance(g.plus_one_attendance),
     isMember: g.is_member ?? true,
     paidConfirmed: g.paid_confirmed ?? false,
-    answers: mapMyRsvpAnswers(g.answers),
+    questionnaireResponses: mapQuestionnaireResponses(g.questionnaire_responses),
   };
 }
 
@@ -197,7 +199,7 @@ export function mapEvent(e: WireEvent): Event {
     guests: (e.guests ?? []).map(mapGuest),
     myRsvp: e.my_rsvp ?? null,
     myPaidConfirmed: e.my_paid_confirmed ?? false,
-    myRsvpAnswers: mapMyRsvpAnswers(e.my_rsvp_answers),
+    myQuestionnaireResponses: mapQuestionnaireResponses(e.my_questionnaire_responses),
     rsvpQuestions: (e.rsvp_questions ?? []).map(mapRsvpQuestion),
     viewerUserId: e.viewer_user_id ?? null,
     surveySlugs: e.survey_slugs ?? [],

--- a/frontend/src/api/eventMapper.ts
+++ b/frontend/src/api/eventMapper.ts
@@ -24,7 +24,6 @@ interface WireGuest {
   questionnaire_responses?: Record<string, { label?: string; answer?: string }>;
 }
 
-
 export interface WireEvent {
   id: string;
   slug?: string;

--- a/frontend/src/api/eventMapper.ts
+++ b/frontend/src/api/eventMapper.ts
@@ -7,6 +7,8 @@ import type {
 } from '@/models/event';
 import { AttendanceStatus } from '@/models/event';
 
+import { mapRsvpQuestion } from './eventRsvpQuestions';
+
 interface WireGuest {
   user_id: string;
   name: string;
@@ -18,6 +20,7 @@ interface WireGuest {
   plus_one_attendance?: string;
   is_member?: boolean;
   paid_confirmed?: boolean;
+  answers?: Record<string, { label?: string; answer?: string }>;
 }
 
 export interface WireEvent {
@@ -61,6 +64,15 @@ export interface WireEvent {
   guests?: WireGuest[];
   my_rsvp?: string | null;
   my_paid_confirmed?: boolean;
+  my_rsvp_answers?: Record<string, { label?: string; answer?: string }>;
+  rsvp_questions?: {
+    id: string;
+    label: string;
+    field_type: 'textarea' | 'select' | 'checkbox';
+    options?: string[];
+    required: boolean;
+    display_order?: number;
+  }[];
   viewer_user_id?: string | null;
   survey_slugs?: string[];
   invited_user_ids?: string[];
@@ -102,6 +114,17 @@ function mapAttendance(value: string | undefined): AttendanceStatusValue {
   return AttendanceStatus.Unknown;
 }
 
+function mapMyRsvpAnswers(
+  raw: Record<string, { label?: string; answer?: string }> | undefined,
+): Event['myRsvpAnswers'] {
+  return Object.fromEntries(
+    Object.entries(raw ?? {}).map(([id, snap]) => [
+      id,
+      { label: snap.label ?? '', answer: snap.answer ?? '' },
+    ]),
+  );
+}
+
 function mapGuest(g: WireGuest): EventGuest {
   return {
     userId: g.user_id,
@@ -114,6 +137,7 @@ function mapGuest(g: WireGuest): EventGuest {
     plusOneAttendance: mapAttendance(g.plus_one_attendance),
     isMember: g.is_member ?? true,
     paidConfirmed: g.paid_confirmed ?? false,
+    answers: mapMyRsvpAnswers(g.answers),
   };
 }
 
@@ -173,6 +197,8 @@ export function mapEvent(e: WireEvent): Event {
     guests: (e.guests ?? []).map(mapGuest),
     myRsvp: e.my_rsvp ?? null,
     myPaidConfirmed: e.my_paid_confirmed ?? false,
+    myRsvpAnswers: mapMyRsvpAnswers(e.my_rsvp_answers),
+    rsvpQuestions: (e.rsvp_questions ?? []).map(mapRsvpQuestion),
     viewerUserId: e.viewer_user_id ?? null,
     surveySlugs: e.survey_slugs ?? [],
     invitedUserIds: e.invited_user_ids ?? [],

--- a/frontend/src/api/eventRsvpQuestions.test.ts
+++ b/frontend/src/api/eventRsvpQuestions.test.ts
@@ -3,7 +3,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { EventRsvpQuestion } from '@/models/event';
 
 import { apiClient } from './client';
-import { syncEventRsvpQuestions } from './eventRsvpQuestions';
+import {
+  DRAFT_RSVP_QUESTION_ID_PREFIX,
+  isDraftRsvpQuestionId,
+  newRsvpQuestionId,
+  syncEventRsvpQuestions,
+} from './eventRsvpQuestions';
 
 vi.mock('./client', () => ({
   apiClient: {
@@ -19,6 +24,15 @@ const q = (
   options: [],
   required: false,
   ...partial,
+});
+
+describe('draft RSVP question ids', () => {
+  it('should recognize and mint ids with the shared draft prefix', () => {
+    expect(DRAFT_RSVP_QUESTION_ID_PREFIX).toBe('q-');
+    expect(isDraftRsvpQuestionId(`${DRAFT_RSVP_QUESTION_ID_PREFIX}temp`)).toBe(true);
+    expect(isDraftRsvpQuestionId('keep')).toBe(false);
+    expect(newRsvpQuestionId().startsWith(DRAFT_RSVP_QUESTION_ID_PREFIX)).toBe(true);
+  });
 });
 
 describe('syncEventRsvpQuestions', () => {
@@ -49,9 +63,10 @@ describe('syncEventRsvpQuestions', () => {
     });
 
     const previous = [q({ id: 'keep', label: 'old' })];
+    const draftId = `${DRAFT_RSVP_QUESTION_ID_PREFIX}temp-new`;
     const result = await syncEventRsvpQuestions(
       'evt',
-      [q({ id: 'keep', label: 'updated' }), q({ id: 'q-temp-new', label: 'new' })],
+      [q({ id: 'keep', label: 'updated' }), q({ id: draftId, label: 'new' })],
       previous,
     );
 

--- a/frontend/src/api/eventRsvpQuestions.test.ts
+++ b/frontend/src/api/eventRsvpQuestions.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { EventRsvpQuestion } from '@/models/event';
+
+import { apiClient } from './client';
+import { syncEventRsvpQuestions } from './eventRsvpQuestions';
+
+vi.mock('./client', () => ({
+  apiClient: {
+    put: vi.fn(),
+  },
+}));
+
+const q = (
+  partial: Partial<EventRsvpQuestion> & Pick<EventRsvpQuestion, 'id'>,
+): EventRsvpQuestion => ({
+  label: 'q',
+  fieldType: 'textarea',
+  options: [],
+  required: false,
+  ...partial,
+});
+
+describe('syncEventRsvpQuestions', () => {
+  beforeEach(() => {
+    vi.mocked(apiClient.put).mockReset();
+  });
+
+  it('should replace all questions in one request', async () => {
+    vi.mocked(apiClient.put).mockResolvedValue({
+      data: [
+        {
+          id: 'keep',
+          label: 'updated',
+          field_type: 'textarea',
+          options: [],
+          required: false,
+          display_order: 0,
+        },
+        {
+          id: 'new',
+          label: 'new',
+          field_type: 'textarea',
+          options: [],
+          required: false,
+          display_order: 1,
+        },
+      ],
+    });
+
+    const previous = [q({ id: 'keep', label: 'old' })];
+    const result = await syncEventRsvpQuestions(
+      'evt',
+      [q({ id: 'keep', label: 'updated' }), q({ id: 'q-temp-new', label: 'new' })],
+      previous,
+    );
+
+    expect(apiClient.put).toHaveBeenCalledWith('/api/community/events/evt/rsvp-questions/', {
+      expected: [
+        {
+          id: 'keep',
+          label: 'old',
+          field_type: 'textarea',
+          options: [],
+          required: false,
+        },
+      ],
+      questions: [
+        {
+          id: 'keep',
+          label: 'updated',
+          field_type: 'textarea',
+          options: [],
+          required: false,
+        },
+        {
+          id: null,
+          label: 'new',
+          field_type: 'textarea',
+          options: [],
+          required: false,
+        },
+      ],
+    });
+    expect(result.map((question) => question.id)).toEqual(['keep', 'new']);
+  });
+});

--- a/frontend/src/api/eventRsvpQuestions.ts
+++ b/frontend/src/api/eventRsvpQuestions.ts
@@ -1,0 +1,52 @@
+import type { EventRsvpQuestion } from '@/models/event';
+
+import { apiClient } from './client';
+import type { components } from './types.gen';
+
+export type RsvpQuestionType = components['schemas']['EventRsvpQuestionIn']['field_type'];
+export const DEFAULT_RSVP_QUESTION_TYPE: RsvpQuestionType = 'textarea';
+
+interface WireQuestion {
+  id: string;
+  label: string;
+  field_type: RsvpQuestionType;
+  options?: string[];
+  required: boolean;
+  display_order?: number;
+}
+
+export function mapRsvpQuestion(w: WireQuestion): EventRsvpQuestion {
+  return {
+    id: w.id,
+    label: w.label,
+    fieldType: w.field_type,
+    options: w.options ?? [],
+    required: w.required,
+  };
+}
+
+function questionPayload(question: EventRsvpQuestion, newIdsAsNull: boolean) {
+  return {
+    id: newIdsAsNull && question.id.startsWith('q-') ? null : question.id,
+    label: question.label,
+    field_type: question.fieldType,
+    options: question.options,
+    required: question.required,
+  };
+}
+
+/** Replace questions atomically and return canonical server ids/order. */
+export async function syncEventRsvpQuestions(
+  eventId: string,
+  next: readonly EventRsvpQuestion[],
+  previous: readonly EventRsvpQuestion[],
+): Promise<EventRsvpQuestion[]> {
+  const { data } = await apiClient.put<WireQuestion[]>(
+    `/api/community/events/${eventId}/rsvp-questions/`,
+    {
+      expected: previous.map((question) => questionPayload(question, false)),
+      questions: next.map((question) => questionPayload(question, true)),
+    },
+  );
+  return data.map(mapRsvpQuestion);
+}

--- a/frontend/src/api/eventRsvpQuestions.ts
+++ b/frontend/src/api/eventRsvpQuestions.ts
@@ -7,6 +7,17 @@ import type { components } from './types.gen';
 export type RsvpQuestionType = components['schemas']['EventRsvpQuestionIn']['field_type'];
 export const DEFAULT_RSVP_QUESTION_TYPE: RsvpQuestionType = QuestionType.Textarea;
 
+/** Client-only draft ids; sent as null on sync so the server assigns UUIDs. */
+export const DRAFT_RSVP_QUESTION_ID_PREFIX = 'q-' as const;
+
+export function isDraftRsvpQuestionId(id: string): boolean {
+  return id.startsWith(DRAFT_RSVP_QUESTION_ID_PREFIX);
+}
+
+export function newRsvpQuestionId(): string {
+  return `${DRAFT_RSVP_QUESTION_ID_PREFIX}${crypto.randomUUID()}`;
+}
+
 interface WireQuestion {
   id: string;
   label: string;
@@ -28,7 +39,7 @@ export function mapRsvpQuestion(w: WireQuestion): EventRsvpQuestion {
 
 function questionPayload(question: EventRsvpQuestion, newIdsAsNull: boolean) {
   return {
-    id: newIdsAsNull && question.id.startsWith('q-') ? null : question.id,
+    id: newIdsAsNull && isDraftRsvpQuestionId(question.id) ? null : question.id,
     label: question.label,
     field_type: question.fieldType,
     options: question.options,

--- a/frontend/src/api/eventRsvpQuestions.ts
+++ b/frontend/src/api/eventRsvpQuestions.ts
@@ -1,10 +1,11 @@
 import type { EventRsvpQuestion } from '@/models/event';
 
 import { apiClient } from './client';
+import { QuestionType } from './questionTypes';
 import type { components } from './types.gen';
 
 export type RsvpQuestionType = components['schemas']['EventRsvpQuestionIn']['field_type'];
-export const DEFAULT_RSVP_QUESTION_TYPE: RsvpQuestionType = 'textarea';
+export const DEFAULT_RSVP_QUESTION_TYPE: RsvpQuestionType = QuestionType.Textarea;
 
 interface WireQuestion {
   id: string;

--- a/frontend/src/api/eventWrites.test.ts
+++ b/frontend/src/api/eventWrites.test.ts
@@ -12,6 +12,7 @@ import { makeEvent } from '@/test/fixtures';
 import {
   eventToFormValues,
   toPartialWireBody,
+  useCreateEvent,
   useInviteToEvent,
   useUpdateEvent,
   useUploadEventPhoto,
@@ -117,6 +118,45 @@ describe('toPartialWireBody', () => {
   it('maps tagIds to tag_ids, including an empty list (clears tags)', () => {
     expect(toPartialWireBody({ tagIds: ['t1', 't2'] })).toEqual({ tag_ids: ['t1', 't2'] });
     expect(toPartialWireBody({ tagIds: [] })).toEqual({ tag_ids: [] });
+  });
+});
+
+describe('useCreateEvent', () => {
+  it('should create the event and RSVP questions in one request', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({ data: makeEvent() });
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const Wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(QueryClientProvider, { client: qc }, children);
+    const { result } = renderHook(() => useCreateEvent(), { wrapper: Wrapper });
+    const values = eventToFormValues(makeEvent());
+
+    result.current.mutate({
+      ...values,
+      rsvpQuestions: [
+        {
+          id: 'q-new',
+          label: 'dietary?',
+          fieldType: 'textarea',
+          options: [],
+          required: true,
+        },
+      ],
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/api/community/events/',
+      expect.objectContaining({
+        rsvp_questions: [
+          {
+            label: 'dietary?',
+            field_type: 'textarea',
+            options: [],
+            required: true,
+          },
+        ],
+      }),
+    );
   });
 });
 

--- a/frontend/src/api/eventWrites.ts
+++ b/frontend/src/api/eventWrites.ts
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAuthStore } from '@/auth/store';
 import {
   type Event,
+  type EventRsvpQuestion,
   EventStatus as EventStatusEnum,
   EventType as EventTypeEnum,
   EventVisibility,
@@ -47,6 +48,10 @@ export interface EventFormValues {
   tagIds: string[];
   status: EventStatus;
 }
+
+type CreateEventValues = EventFormValues & {
+  rsvpQuestions?: readonly EventRsvpQuestion[];
+};
 
 type WireBody = Record<string, unknown>;
 
@@ -128,11 +133,15 @@ export function useCreateEvent() {
   const qc = useQueryClient();
   const isAuthed = useAuthStore((s) => s.status === 'authed');
   return useMutation({
-    mutationFn: async (values: EventFormValues) => {
-      const { data } = await apiClient.post<WireEvent>(
-        '/api/community/events/',
-        toWireBody(values),
-      );
+    mutationFn: async ({ rsvpQuestions = [], ...values }: CreateEventValues) => {
+      const body = toWireBody(values);
+      body.rsvp_questions = rsvpQuestions.map((question) => ({
+        label: question.label,
+        field_type: question.fieldType,
+        options: question.options,
+        required: question.required,
+      }));
+      const { data } = await apiClient.post<WireEvent>('/api/community/events/', body);
       return mapEvent(data);
     },
     onSuccess: (event) => {

--- a/frontend/src/components/questions/questionTypeOptions.test.ts
+++ b/frontend/src/components/questions/questionTypeOptions.test.ts
@@ -9,9 +9,9 @@ import type { components } from '@/api/types.gen';
 import {
   JOIN_QUESTION_TYPE_OPTIONS,
   QUESTION_TYPE_OPTIONS,
-  RSVP_QUESTION_TYPE_OPTIONS,
   questionOptionsError,
   questionTypeWantsOptions,
+  RSVP_QUESTION_TYPE_OPTIONS,
 } from './questionTypeOptions';
 
 type AssertExtends<_A extends B, B> = true;

--- a/frontend/src/components/questions/questionTypeOptions.test.ts
+++ b/frontend/src/components/questions/questionTypeOptions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
+import type { RsvpQuestionType } from '@/api/eventRsvpQuestions';
 import type { JoinQuestionType } from '@/api/join';
 import { QuestionType } from '@/api/questionTypes';
 import type { SurveyQuestionType } from '@/api/surveys';
@@ -8,6 +9,7 @@ import type { components } from '@/api/types.gen';
 import {
   JOIN_QUESTION_TYPE_OPTIONS,
   QUESTION_TYPE_OPTIONS,
+  RSVP_QUESTION_TYPE_OPTIONS,
   questionOptionsError,
   questionTypeWantsOptions,
 } from './questionTypeOptions';
@@ -19,6 +21,11 @@ type _JoinSubsetOfCatalog = AssertExtends<JoinQuestionType, QuestionType>;
 type _JoinMatchesOpenApi = AssertExtends<
   JoinQuestionType,
   components['schemas']['JoinFormQuestionType']
+>;
+type _RsvpSubsetOfCatalog = AssertExtends<RsvpQuestionType, QuestionType>;
+type _RsvpMatchesOpenApi = AssertExtends<
+  RsvpQuestionType,
+  components['schemas']['EventRsvpQuestionIn']['field_type']
 >;
 
 const FULL_TYPES: QuestionType[] = Object.values(QuestionType);
@@ -59,6 +66,14 @@ describe('question type options', () => {
       false,
       false,
       true,
+    ]);
+  });
+
+  it('should expose the RSVP subset projected from catalog metadata', () => {
+    expect(RSVP_QUESTION_TYPE_OPTIONS).toEqual([
+      { value: QuestionType.Textarea, label: 'long text', wantsOptions: false },
+      { value: QuestionType.Select, label: 'select', wantsOptions: true },
+      { value: QuestionType.Checkbox, label: 'checkbox', wantsOptions: true },
     ]);
   });
 });

--- a/frontend/src/components/questions/questionTypeOptions.ts
+++ b/frontend/src/components/questions/questionTypeOptions.ts
@@ -1,3 +1,4 @@
+import type { RsvpQuestionType } from '@/api/eventRsvpQuestions';
 import type { JoinQuestionType } from '@/api/join';
 import { QuestionType } from '@/api/questionTypes';
 
@@ -41,6 +42,19 @@ export type JoinQuestionTypeOption = QuestionTypeOption & { value: JoinQuestionT
 
 /** Join-form authoring subset, projected from the shared catalog metadata. */
 export const JOIN_QUESTION_TYPE_OPTIONS: JoinQuestionTypeOption[] = JOIN_QUESTION_TYPES.map(
+  (value) => ({ ...QUESTION_TYPE_OPTION_BY_TYPE[value], value }),
+);
+
+const RSVP_QUESTION_TYPES = [
+  QuestionType.Textarea,
+  QuestionType.Select,
+  QuestionType.Checkbox,
+] as const satisfies readonly RsvpQuestionType[];
+
+export type RsvpQuestionTypeOption = QuestionTypeOption & { value: RsvpQuestionType };
+
+/** RSVP authoring subset, projected from the shared catalog metadata. */
+export const RSVP_QUESTION_TYPE_OPTIONS: RsvpQuestionTypeOption[] = RSVP_QUESTION_TYPES.map(
   (value) => ({ ...QUESTION_TYPE_OPTION_BY_TYPE[value], value }),
 );
 

--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -1,13 +1,16 @@
 import { type ReactNode, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 
 interface Props {
   open: boolean;
   onClose: () => void;
   title: string;
   children: ReactNode;
+  /** Wider panel for tables / multi-column content. */
+  wide?: boolean;
 }
 
-export function Dialog({ open, onClose, title, children }: Props) {
+export function Dialog({ open, onClose, title, children, wide = false }: Props) {
   useEffect(() => {
     if (!open) return;
     function onKey(e: KeyboardEvent) {
@@ -20,7 +23,10 @@ export function Dialog({ open, onClose, title, children }: Props) {
   }, [open, onClose]);
 
   if (!open) return null;
-  return (
+
+  // Portal to body so dialog content (including nested <form>s) is not inside
+  // a parent page form — HTML forbids nested forms and browsers submit the outer one.
+  return createPortal(
     <div
       role="dialog"
       aria-modal="true"
@@ -29,14 +35,39 @@ export function Dialog({ open, onClose, title, children }: Props) {
     >
       <button
         type="button"
-        aria-label="close"
+        aria-label="dismiss"
         onClick={onClose}
         className="absolute inset-0 cursor-default bg-black/60"
       />
-      <div className="bg-surface relative w-full max-w-md rounded-lg p-5 shadow-(--shadow-xl)">
-        <h2 className="mb-4 text-base font-medium">{title}</h2>
+      <div
+        className={
+          wide
+            ? 'bg-surface relative max-h-[min(90vh,40rem)] w-full max-w-2xl overflow-y-auto rounded-lg p-5 shadow-(--shadow-xl)'
+            : 'bg-surface relative max-h-[min(90vh,40rem)] w-full max-w-md overflow-y-auto rounded-lg p-5 shadow-(--shadow-xl)'
+        }
+      >
+        <div className="mb-4 flex items-start justify-between gap-3">
+          <h2 className="text-base font-medium">{title}</h2>
+          <button
+            type="button"
+            aria-label="close"
+            onClick={onClose}
+            className="text-foreground-secondary hover:bg-surface-dim hover:text-foreground -me-1 -mt-1 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md transition-colors"
+          >
+            <CloseIcon />
+          </button>
+        </div>
         {children}
       </div>
-    </div>
+    </div>,
+    document.body,
+  );
+}
+
+function CloseIcon() {
+  return (
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+      <path d="M4 4l8 8M12 4l-8 8" stroke="currentColor" strokeWidth="1.75" strokeLinecap="round" />
+    </svg>
   );
 }

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -1,3 +1,5 @@
+import type { components } from '@/api/types.gen';
+
 import { hasPermission, Permission } from './permissions';
 import type { User } from './user';
 
@@ -77,7 +79,7 @@ export interface EventTag {
   slug: string;
 }
 
-export type EventRsvpQuestionType = 'textarea' | 'select' | 'checkbox';
+export type EventRsvpQuestionType = components['schemas']['EventRsvpQuestionIn']['field_type'];
 
 export interface EventRsvpQuestion {
   id: string;
@@ -99,7 +101,7 @@ export interface EventGuest {
   isMember: boolean;
   paidConfirmed: boolean;
   /** Host-only RSVP question snapshots; empty for non-hosts. */
-  answers: Record<string, { label: string; answer: string }>;
+  questionnaireResponses: Record<string, { label: string; answer: string }>;
 }
 
 export interface EventCancellation {
@@ -167,8 +169,8 @@ export interface Event {
   guests: EventGuest[];
   myRsvp: string | null;
   myPaidConfirmed: boolean;
-  /** Snapshot answers for the viewer's RSVP: questionId → { label, answer }. */
-  myRsvpAnswers: Record<string, { label: string; answer: string }>;
+  /** Snapshot responses for the viewer's RSVP: questionId → { label, answer }. */
+  myQuestionnaireResponses: Record<string, { label: string; answer: string }>;
   rsvpQuestions: EventRsvpQuestion[];
   viewerUserId: string | null;
   surveySlugs: string[];

--- a/frontend/src/models/event.ts
+++ b/frontend/src/models/event.ts
@@ -77,6 +77,16 @@ export interface EventTag {
   slug: string;
 }
 
+export type EventRsvpQuestionType = 'textarea' | 'select' | 'checkbox';
+
+export interface EventRsvpQuestion {
+  id: string;
+  label: string;
+  fieldType: EventRsvpQuestionType;
+  options: string[];
+  required: boolean;
+}
+
 export interface EventGuest {
   userId: string;
   name: string;
@@ -88,6 +98,8 @@ export interface EventGuest {
   plusOneAttendance: AttendanceStatusValue;
   isMember: boolean;
   paidConfirmed: boolean;
+  /** Host-only RSVP question snapshots; empty for non-hosts. */
+  answers: Record<string, { label: string; answer: string }>;
 }
 
 export interface EventCancellation {
@@ -155,6 +167,9 @@ export interface Event {
   guests: EventGuest[];
   myRsvp: string | null;
   myPaidConfirmed: boolean;
+  /** Snapshot answers for the viewer's RSVP: questionId → { label, answer }. */
+  myRsvpAnswers: Record<string, { label: string; answer: string }>;
+  rsvpQuestions: EventRsvpQuestion[];
   viewerUserId: string | null;
   surveySlugs: string[];
   invitedUserIds: string[];

--- a/frontend/src/screens/events/GuestChip.tsx
+++ b/frontend/src/screens/events/GuestChip.tsx
@@ -82,6 +82,7 @@ export function InvitedList({ event, row = false }: { event: Event; row?: boolea
               plusOneAttendance: AttendanceStatus.Unknown,
               isMember: true,
               paidConfirmed: false,
+              questionnaireResponses: {},
             }}
           />
         );

--- a/frontend/src/screens/events/form/EventForm.tsx
+++ b/frontend/src/screens/events/form/EventForm.tsx
@@ -4,6 +4,7 @@ import { toast } from 'sonner';
 
 import { getErrorParams, hasErrorCode } from '@/api/apiErrors';
 import { apiClient } from '@/api/client';
+import { syncEventRsvpQuestions } from '@/api/eventRsvpQuestions';
 import {
   emptyEventFormValues,
   type EventFormValues,
@@ -26,10 +27,12 @@ import type { User } from '@/models/user';
 
 import { EventHostSection } from '../EventHostSection';
 import { eventMemberSectionFlags } from '../eventMemberFlags';
+import type { RsvpQuestionDraft } from '../rsvpQuestions';
 import { EventFormBasics } from './EventFormBasics';
 import { EventFormDetails } from './EventFormDetails';
 import { EventFormLinks, EventFormMoney } from './EventFormLinksAndCost';
 import { EventFormPhoto } from './EventFormPhoto';
+import { EventFormQuestions } from './EventFormQuestions';
 import { EventFormRsvp } from './EventFormRsvp';
 import { EventFormTags } from './EventFormTags';
 import { validateEventForm } from './validateEventForm';
@@ -110,6 +113,12 @@ export function EventForm({ existing }: Props) {
   // then POST the poll. If the poll POST fails we still land on the new
   // event's detail page and the host can retry from there.
   const [bufferedPollOptions, setBufferedPollOptions] = useState<Date[] | null>(null);
+  const [rsvpQuestions, setRsvpQuestions] = useState<RsvpQuestionDraft[]>(
+    () => existing?.rsvpQuestions ?? [],
+  );
+  const [savedRsvpQuestions, setSavedRsvpQuestions] = useState<RsvpQuestionDraft[]>(
+    () => existing?.rsvpQuestions ?? [],
+  );
 
   const create = useCreateEvent();
   const update = useUpdateEvent(existing?.id ?? '');
@@ -187,11 +196,23 @@ export function EventForm({ existing }: Props) {
           if (!ok) return;
           await update.mutateAsync({ ...patchBody, force: true });
         }
+        try {
+          const synced = await syncEventRsvpQuestions(
+            existing.id,
+            rsvpQuestions,
+            savedRsvpQuestions,
+          );
+          setRsvpQuestions(synced);
+          setSavedRsvpQuestions(synced);
+        } catch (err) {
+          setServerError(extractEventError(err));
+          return;
+        }
         if (nextStatus === 'draft') toast.success('saved draft');
         void navigate(eventPath(existing));
         return;
       }
-      const created = await create.mutateAsync(merged);
+      const created = await create.mutateAsync({ ...merged, rsvpQuestions });
       if (pendingPhoto) {
         try {
           await uploadPhoto.mutateAsync({ eventId: created.id, blob: pendingPhoto });
@@ -329,6 +350,21 @@ export function EventForm({ existing }: Props) {
           forceOpen={hasAnyError(errors, RSVP_FIELDS)}
         >
           <EventFormRsvp values={values} onChange={patch} errors={errors} />
+        </CollapsibleCard>
+
+        <CollapsibleCard
+          title="questions"
+          summary={
+            rsvpQuestions.length > 0
+              ? `${String(rsvpQuestions.length)} question${rsvpQuestions.length === 1 ? '' : 's'}`
+              : undefined
+          }
+        >
+          <EventFormQuestions
+            rsvpEnabled={values.rsvpEnabled}
+            questions={rsvpQuestions}
+            onQuestionsChange={setRsvpQuestions}
+          />
         </CollapsibleCard>
 
         <CollapsibleCard

--- a/frontend/src/screens/events/form/EventFormQuestions.test.tsx
+++ b/frontend/src/screens/events/form/EventFormQuestions.test.tsx
@@ -1,0 +1,71 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import type { SyntheticEvent } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { RsvpQuestionDraft } from '../rsvpQuestions';
+import { EventFormQuestions } from './EventFormQuestions';
+
+const sample: RsvpQuestionDraft = {
+  id: 'q1',
+  label: 'bring anything?',
+  fieldType: 'textarea',
+  options: [],
+  required: true,
+};
+
+describe('EventFormQuestions', () => {
+  it('prompts to enable rsvp when rsvp is off', () => {
+    render(<EventFormQuestions rsvpEnabled={false} questions={[]} onQuestionsChange={vi.fn()} />);
+    expect(
+      screen.getByText(/enable rsvp to ask guests questions when they respond/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /add question/i })).not.toBeInTheDocument();
+  });
+
+  it('shows empty state and add button when rsvp is on', () => {
+    render(<EventFormQuestions rsvpEnabled questions={[]} onQuestionsChange={vi.fn()} />);
+    expect(screen.getByText('no questions yet')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /add question/i })).toBeInTheDocument();
+  });
+
+  it('lists questions with type and required marker', () => {
+    render(<EventFormQuestions rsvpEnabled questions={[sample]} onQuestionsChange={vi.fn()} />);
+    expect(screen.getByText('bring anything?')).toBeInTheDocument();
+    expect(screen.getByText(/long text/)).toBeInTheDocument();
+    expect(screen.getByText(/required/)).toBeInTheDocument();
+  });
+
+  it('removes a question when delete is clicked', () => {
+    const onQuestionsChange = vi.fn();
+    render(
+      <EventFormQuestions rsvpEnabled questions={[sample]} onQuestionsChange={onQuestionsChange} />,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /delete/i }));
+    expect(onQuestionsChange).toHaveBeenCalledWith([]);
+  });
+
+  it('opens add dialog from add question', () => {
+    render(<EventFormQuestions rsvpEnabled questions={[]} onQuestionsChange={vi.fn()} />);
+    fireEvent.click(screen.getByRole('button', { name: /add question/i }));
+    expect(screen.getByRole('dialog', { name: /add question/i })).toBeInTheDocument();
+  });
+
+  it('saving a question does not submit a wrapping event form', () => {
+    const onParentSubmit = vi.fn((e: SyntheticEvent) => {
+      e.preventDefault();
+    });
+    const onQuestionsChange = vi.fn();
+    render(
+      <form onSubmit={onParentSubmit}>
+        <EventFormQuestions rsvpEnabled questions={[]} onQuestionsChange={onQuestionsChange} />
+      </form>,
+    );
+    fireEvent.click(screen.getByRole('button', { name: /add question/i }));
+    fireEvent.change(screen.getByLabelText('question'), { target: { value: 'dietary needs' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    expect(onQuestionsChange).toHaveBeenCalledWith([
+      expect.objectContaining({ label: 'dietary needs' }),
+    ]);
+    expect(onParentSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/screens/events/form/EventFormQuestions.tsx
+++ b/frontend/src/screens/events/form/EventFormQuestions.tsx
@@ -1,0 +1,101 @@
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/Button';
+
+import { RSVP_QUESTION_TYPE_LABELS, type RsvpQuestionDraft } from '../rsvpQuestions';
+import { EventRsvpQuestionDialog } from './EventRsvpQuestionDialog';
+
+interface Props {
+  rsvpEnabled: boolean;
+  questions: RsvpQuestionDraft[];
+  onQuestionsChange: (next: RsvpQuestionDraft[]) => void;
+}
+
+export function EventFormQuestions({ rsvpEnabled, questions, onQuestionsChange }: Props) {
+  const [dialogQuestion, setDialogQuestion] = useState<RsvpQuestionDraft | null | undefined>(
+    undefined,
+  );
+  const dialogOpen = dialogQuestion !== undefined;
+
+  if (!rsvpEnabled) {
+    return (
+      <p className="text-muted text-sm">enable rsvp to ask guests questions when they respond</p>
+    );
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <p className="text-muted text-sm">shown when guests rsvp as going or maybe</p>
+        <Button
+          type="button"
+          variant="secondary"
+          onClick={() => {
+            setDialogQuestion(null);
+          }}
+        >
+          add question
+        </Button>
+      </div>
+      {questions.length === 0 ? (
+        <p className="text-muted text-sm">no questions yet</p>
+      ) : (
+        <ul className="flex flex-col gap-2">
+          {questions.map((q) => (
+            <li key={q.id}>
+              <article className="border-border bg-surface flex items-center justify-between gap-3 rounded-lg border p-3">
+                <div className="min-w-0">
+                  <p className="truncate text-sm font-medium">
+                    {q.label}
+                    {q.required ? (
+                      <span className="text-muted ms-1 text-xs">· required</span>
+                    ) : null}
+                  </p>
+                  <p className="text-muted text-xs">
+                    {RSVP_QUESTION_TYPE_LABELS[q.fieldType]}
+                    {q.options.length > 0 ? ` · ${String(q.options.length)} options` : ''}
+                  </p>
+                </div>
+                <div className="flex shrink-0 gap-1">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={() => {
+                      setDialogQuestion(q);
+                    }}
+                  >
+                    edit
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={() => {
+                      onQuestionsChange(questions.filter((item) => item.id !== q.id));
+                    }}
+                  >
+                    delete
+                  </Button>
+                </div>
+              </article>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <EventRsvpQuestionDialog
+        open={dialogOpen}
+        existing={dialogQuestion ?? undefined}
+        onClose={() => {
+          setDialogQuestion(undefined);
+        }}
+        onSave={(question) => {
+          if (dialogQuestion) {
+            onQuestionsChange(questions.map((item) => (item.id === question.id ? question : item)));
+          } else {
+            onQuestionsChange([...questions, question]);
+          }
+        }}
+      />
+    </div>
+  );
+}

--- a/frontend/src/screens/events/form/EventRsvpQuestionDialog.test.tsx
+++ b/frontend/src/screens/events/form/EventRsvpQuestionDialog.test.tsx
@@ -1,0 +1,104 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { RsvpQuestionDraft } from '../rsvpQuestions';
+import { EventRsvpQuestionDialog } from './EventRsvpQuestionDialog';
+
+describe('EventRsvpQuestionDialog', () => {
+  it('requires a question', () => {
+    const onSave = vi.fn();
+    render(<EventRsvpQuestionDialog open onClose={() => {}} onSave={onSave} />);
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    expect(screen.getByRole('alert')).toHaveTextContent(/question required/i);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('requires options for select one', () => {
+    const onSave = vi.fn();
+    render(<EventRsvpQuestionDialog open onClose={() => {}} onSave={onSave} />);
+    fireEvent.change(screen.getByLabelText('question'), { target: { value: 'pick one' } });
+    fireEvent.change(screen.getByLabelText('type'), { target: { value: 'select' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    expect(screen.getByRole('alert')).toHaveTextContent(/at least one option/i);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('saves a free response question', () => {
+    const onSave = vi.fn();
+    const onClose = vi.fn();
+    render(<EventRsvpQuestionDialog open onClose={onClose} onSave={onSave} />);
+    fireEvent.change(screen.getByLabelText('question'), { target: { value: 'notes' } });
+    fireEvent.click(screen.getByLabelText('required'));
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        label: 'notes',
+        fieldType: 'textarea',
+        options: [],
+        required: true,
+        id: expect.any(String) as string,
+      }),
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('saves select multiple with parsed options when editing', () => {
+    const existing: RsvpQuestionDraft = {
+      id: 'q-existing',
+      label: 'help',
+      fieldType: 'checkbox',
+      options: ['a'],
+      required: false,
+    };
+    const onSave = vi.fn();
+    render(<EventRsvpQuestionDialog open existing={existing} onClose={() => {}} onSave={onSave} />);
+    fireEvent.change(screen.getByLabelText('options'), { target: { value: 'setup\ncleanup' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    expect(onSave).toHaveBeenCalledWith({
+      id: 'q-existing',
+      label: 'help',
+      fieldType: 'checkbox',
+      options: ['setup', 'cleanup'],
+      required: false,
+    });
+  });
+
+  it('rejects commas in select multiple options', () => {
+    const onSave = vi.fn();
+    render(<EventRsvpQuestionDialog open onClose={() => {}} onSave={onSave} />);
+    fireEvent.change(screen.getByLabelText('question'), { target: { value: 'help' } });
+    fireEvent.change(screen.getByLabelText('type'), { target: { value: 'checkbox' } });
+    fireEvent.change(screen.getByLabelText('options'), { target: { value: 'yes, with a guest' } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/options cannot contain commas/i);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it('allows commas in select one options', () => {
+    const onSave = vi.fn();
+    render(<EventRsvpQuestionDialog open onClose={() => {}} onSave={onSave} />);
+    fireEvent.change(screen.getByLabelText('question'), { target: { value: 'bringing someone?' } });
+    fireEvent.change(screen.getByLabelText('type'), { target: { value: 'select' } });
+    fireEvent.change(screen.getByLabelText('options'), {
+      target: { value: 'yes, with a guest\nno' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ options: ['yes, with a guest', 'no'] }),
+    );
+  });
+
+  it('rejects options over the answer length limit', () => {
+    const onSave = vi.fn();
+    render(<EventRsvpQuestionDialog open onClose={() => {}} onSave={onSave} />);
+    fireEvent.change(screen.getByLabelText('question'), { target: { value: 'pick one' } });
+    fireEvent.change(screen.getByLabelText('type'), { target: { value: 'select' } });
+    fireEvent.change(screen.getByLabelText('options'), { target: { value: 'x'.repeat(201) } });
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    expect(screen.getByRole('alert')).toHaveTextContent(/options must be 200 characters or fewer/i);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/screens/events/form/EventRsvpQuestionDialog.tsx
+++ b/frontend/src/screens/events/form/EventRsvpQuestionDialog.tsx
@@ -1,0 +1,134 @@
+import type { SyntheticEvent } from 'react';
+import { useState } from 'react';
+
+import { DEFAULT_RSVP_QUESTION_TYPE } from '@/api/eventRsvpQuestions';
+import { questionOptionsError } from '@/components/questions/questionTypeOptions';
+import { Button } from '@/components/ui/Button';
+import { Dialog } from '@/components/ui/Dialog';
+import { Select } from '@/components/ui/Select';
+import { Textarea } from '@/components/ui/Textarea';
+import { TextField } from '@/components/ui/TextField';
+
+import {
+  newQuestionId,
+  parseOptionsText,
+  RSVP_QUESTION_TYPE_OPTIONS,
+  type RsvpQuestionDraft,
+  type RsvpQuestionType,
+  wantsOptions,
+} from '../rsvpQuestions';
+
+const MAX_OPTION_LENGTH = 200;
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onSave: (question: RsvpQuestionDraft) => void;
+  existing?: RsvpQuestionDraft | undefined;
+}
+
+export function EventRsvpQuestionDialog(props: Props) {
+  if (!props.open) return null;
+  return <EventRsvpQuestionDialogBody key={props.existing?.id ?? 'new'} {...props} />;
+}
+
+function EventRsvpQuestionDialogBody({ open, onClose, onSave, existing }: Props) {
+  const [label, setLabel] = useState(() => existing?.label ?? '');
+  const [fieldType, setFieldType] = useState<RsvpQuestionType>(
+    () => existing?.fieldType ?? DEFAULT_RSVP_QUESTION_TYPE,
+  );
+  const [required, setRequired] = useState(() => existing?.required ?? false);
+  const [optionsText, setOptionsText] = useState(() => existing?.options.join('\n') ?? '');
+  const [error, setError] = useState<string | null>(null);
+
+  function onSubmit(e: SyntheticEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    setError(null);
+    if (!label.trim()) {
+      setError('question required');
+      return;
+    }
+    const needsOptions = wantsOptions(fieldType);
+    const options = needsOptions ? parseOptionsText(optionsText) : [];
+    const optionsError = questionOptionsError(needsOptions, options);
+    if (optionsError) {
+      setError(optionsError);
+      return;
+    }
+    if (options.some((option) => option.length > MAX_OPTION_LENGTH)) {
+      setError(`options must be ${String(MAX_OPTION_LENGTH)} characters or fewer`);
+      return;
+    }
+    if (fieldType === 'checkbox' && options.some((option) => option.includes(','))) {
+      setError('options cannot contain commas');
+      return;
+    }
+    onSave({
+      id: existing?.id ?? newQuestionId(),
+      label: label.trim(),
+      fieldType,
+      options,
+      required,
+    });
+    onClose();
+  }
+
+  return (
+    <Dialog open={open} onClose={onClose} title={existing ? 'edit question' : 'add question'}>
+      <form onSubmit={onSubmit} className="flex flex-col gap-3">
+        <TextField
+          label="question"
+          value={label}
+          onChange={(e) => {
+            setLabel(e.target.value);
+          }}
+          maxLength={200}
+        />
+        <Select
+          label="type"
+          value={fieldType}
+          onChange={(e) => {
+            setFieldType(e.target.value as RsvpQuestionType);
+          }}
+          options={RSVP_QUESTION_TYPE_OPTIONS.map((o) => ({
+            value: o.value,
+            label: o.label,
+          }))}
+        />
+        {wantsOptions(fieldType) ? (
+          <Textarea
+            label="options"
+            value={optionsText}
+            onChange={(e) => {
+              setOptionsText(e.target.value);
+            }}
+            hint="one per line"
+            rows={5}
+          />
+        ) : null}
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={required}
+            onChange={(e) => {
+              setRequired(e.target.checked);
+            }}
+          />
+          <span>required</span>
+        </label>
+        {error ? (
+          <p role="alert" className="text-destructive text-sm">
+            {error}
+          </p>
+        ) : null}
+        <div className="mt-2 flex justify-end gap-2">
+          <Button variant="ghost" onClick={onClose} type="button">
+            cancel
+          </Button>
+          <Button type="submit">save</Button>
+        </div>
+      </form>
+    </Dialog>
+  );
+}

--- a/frontend/src/screens/events/form/EventRsvpQuestionDialog.tsx
+++ b/frontend/src/screens/events/form/EventRsvpQuestionDialog.tsx
@@ -2,6 +2,7 @@ import type { SyntheticEvent } from 'react';
 import { useState } from 'react';
 
 import { DEFAULT_RSVP_QUESTION_TYPE } from '@/api/eventRsvpQuestions';
+import { QuestionType } from '@/api/questionTypes';
 import { questionOptionsError } from '@/components/questions/questionTypeOptions';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
@@ -60,7 +61,7 @@ function EventRsvpQuestionDialogBody({ open, onClose, onSave, existing }: Props)
       setError(`options must be ${String(MAX_OPTION_LENGTH)} characters or fewer`);
       return;
     }
-    if (fieldType === 'checkbox' && options.some((option) => option.includes(','))) {
+    if (fieldType === QuestionType.Checkbox && options.some((option) => option.includes(','))) {
       setError('options cannot contain commas');
       return;
     }

--- a/frontend/src/screens/events/rsvpQuestions.test.ts
+++ b/frontend/src/screens/events/rsvpQuestions.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import type { RsvpQuestionType } from '@/api/eventRsvpQuestions';
+import type { QuestionType } from '@/api/questionTypes';
+
+import {
+  isAnswerFilled,
+  missingRequiredQuestionIds,
+  parseOptionsText,
+  RSVP_QUESTION_TYPE_OPTIONS,
+  type RsvpQuestionDraft,
+  wantsOptions,
+} from './rsvpQuestions';
+
+type AssertExtends<_A extends B, B> = true;
+type _RsvpSubsetOfCatalog = AssertExtends<RsvpQuestionType, QuestionType>;
+
+const q = (
+  overrides: Partial<RsvpQuestionDraft> & Pick<RsvpQuestionDraft, 'id'>,
+): RsvpQuestionDraft => ({
+  label: 'q',
+  fieldType: 'textarea',
+  options: [],
+  required: false,
+  ...overrides,
+});
+
+describe('RSVP_QUESTION_TYPE_OPTIONS', () => {
+  it('should project the RSVP subset from catalog metadata', () => {
+    expect(RSVP_QUESTION_TYPE_OPTIONS.map((o) => o.value)).toEqual([
+      'textarea',
+      'select',
+      'checkbox',
+    ]);
+  });
+});
+
+describe('wantsOptions', () => {
+  it('is true only for choice types', () => {
+    expect(wantsOptions('textarea')).toBe(false);
+    expect(wantsOptions('select')).toBe(true);
+    expect(wantsOptions('checkbox')).toBe(true);
+  });
+});
+
+describe('parseOptionsText', () => {
+  it('splits trimmed non-empty lines', () => {
+    expect(parseOptionsText('  a\n\nb  \n')).toEqual(['a', 'b']);
+  });
+});
+
+describe('isAnswerFilled', () => {
+  it('treats empty or whitespace as unfilled', () => {
+    expect(isAnswerFilled(undefined)).toBe(false);
+    expect(isAnswerFilled('')).toBe(false);
+    expect(isAnswerFilled('  ')).toBe(false);
+    expect(isAnswerFilled('yes')).toBe(true);
+  });
+});
+
+describe('missingRequiredQuestionIds', () => {
+  it('returns ids of required questions without answers', () => {
+    const questions = [
+      q({ id: 'a', required: true }),
+      q({ id: 'b', required: false }),
+      q({ id: 'c', required: true, fieldType: 'checkbox' }),
+    ];
+    expect(missingRequiredQuestionIds(questions, { a: 'ok', c: '' })).toEqual(['c']);
+    expect(missingRequiredQuestionIds(questions, { a: 'ok', c: 'x' })).toEqual([]);
+  });
+});

--- a/frontend/src/screens/events/rsvpQuestions.test.ts
+++ b/frontend/src/screens/events/rsvpQuestions.test.ts
@@ -1,45 +1,30 @@
 import { describe, expect, it } from 'vitest';
 
-import type { RsvpQuestionType } from '@/api/eventRsvpQuestions';
-import type { QuestionType } from '@/api/questionTypes';
+import { QuestionType } from '@/api/questionTypes';
 
 import {
   isAnswerFilled,
   missingRequiredQuestionIds,
   parseOptionsText,
-  RSVP_QUESTION_TYPE_OPTIONS,
   type RsvpQuestionDraft,
   wantsOptions,
 } from './rsvpQuestions';
-
-type AssertExtends<_A extends B, B> = true;
-type _RsvpSubsetOfCatalog = AssertExtends<RsvpQuestionType, QuestionType>;
 
 const q = (
   overrides: Partial<RsvpQuestionDraft> & Pick<RsvpQuestionDraft, 'id'>,
 ): RsvpQuestionDraft => ({
   label: 'q',
-  fieldType: 'textarea',
+  fieldType: QuestionType.Textarea,
   options: [],
   required: false,
   ...overrides,
 });
 
-describe('RSVP_QUESTION_TYPE_OPTIONS', () => {
-  it('should project the RSVP subset from catalog metadata', () => {
-    expect(RSVP_QUESTION_TYPE_OPTIONS.map((o) => o.value)).toEqual([
-      'textarea',
-      'select',
-      'checkbox',
-    ]);
-  });
-});
-
 describe('wantsOptions', () => {
   it('is true only for choice types', () => {
-    expect(wantsOptions('textarea')).toBe(false);
-    expect(wantsOptions('select')).toBe(true);
-    expect(wantsOptions('checkbox')).toBe(true);
+    expect(wantsOptions(QuestionType.Textarea)).toBe(false);
+    expect(wantsOptions(QuestionType.Select)).toBe(true);
+    expect(wantsOptions(QuestionType.Checkbox)).toBe(true);
   });
 });
 
@@ -63,7 +48,7 @@ describe('missingRequiredQuestionIds', () => {
     const questions = [
       q({ id: 'a', required: true }),
       q({ id: 'b', required: false }),
-      q({ id: 'c', required: true, fieldType: 'checkbox' }),
+      q({ id: 'c', required: true, fieldType: QuestionType.Checkbox }),
     ];
     expect(missingRequiredQuestionIds(questions, { a: 'ok', c: '' })).toEqual(['c']);
     expect(missingRequiredQuestionIds(questions, { a: 'ok', c: 'x' })).toEqual([]);

--- a/frontend/src/screens/events/rsvpQuestions.ts
+++ b/frontend/src/screens/events/rsvpQuestions.ts
@@ -1,5 +1,3 @@
-/** Draft / wire-aligned RSVP question helpers used by authoring + RSVP dialog. */
-
 import { newRsvpQuestionId, type RsvpQuestionType } from '@/api/eventRsvpQuestions';
 import {
   questionTypeWantsOptions,

--- a/frontend/src/screens/events/rsvpQuestions.ts
+++ b/frontend/src/screens/events/rsvpQuestions.ts
@@ -1,6 +1,9 @@
 /** Draft / wire-aligned RSVP question helpers used by authoring + RSVP dialog. */
 
-import type { RsvpQuestionType } from '@/api/eventRsvpQuestions';
+import {
+  newRsvpQuestionId,
+  type RsvpQuestionType,
+} from '@/api/eventRsvpQuestions';
 import {
   questionTypeWantsOptions,
   RSVP_QUESTION_TYPE_OPTIONS,
@@ -12,6 +15,7 @@ export type RsvpQuestionDraft = EventRsvpQuestion;
 export type RsvpAnswerValue = string;
 
 export { RSVP_QUESTION_TYPE_OPTIONS };
+export { newRsvpQuestionId as newQuestionId };
 
 const RESPONDENT_STATUSES = new Set<string>([
   RsvpServerStatus.Attending,
@@ -51,10 +55,6 @@ export function hasSavedQuestionnaireResponses(event: Event): boolean {
       isRsvpRespondentStatus(guest.status) &&
       Object.keys(guest.questionnaireResponses).length > 0,
   );
-}
-
-export function newQuestionId(): string {
-  return `q-${crypto.randomUUID()}`;
 }
 
 export { questionTypeWantsOptions as wantsOptions };

--- a/frontend/src/screens/events/rsvpQuestions.ts
+++ b/frontend/src/screens/events/rsvpQuestions.ts
@@ -2,8 +2,8 @@
 
 import type { RsvpQuestionType } from '@/api/eventRsvpQuestions';
 import {
-  RSVP_QUESTION_TYPE_OPTIONS,
   questionTypeWantsOptions,
+  RSVP_QUESTION_TYPE_OPTIONS,
 } from '@/components/questions/questionTypeOptions';
 import { type Event, type EventRsvpQuestion, RsvpServerStatus } from '@/models/event';
 

--- a/frontend/src/screens/events/rsvpQuestions.ts
+++ b/frontend/src/screens/events/rsvpQuestions.ts
@@ -1,0 +1,65 @@
+/** Draft / wire-aligned RSVP question helpers used by authoring + RSVP dialog. */
+
+import type { RsvpQuestionType } from '@/api/eventRsvpQuestions';
+import {
+  QUESTION_TYPE_OPTION_BY_TYPE,
+  type QuestionTypeOption,
+  questionTypeWantsOptions,
+} from '@/components/questions/questionTypeOptions';
+import { type Event, type EventRsvpQuestion, RsvpServerStatus } from '@/models/event';
+
+export type { RsvpQuestionType };
+export type RsvpQuestionDraft = EventRsvpQuestion;
+export type RsvpAnswerValue = string;
+
+const RSVP_QUESTION_TYPE_OPTION_BY_TYPE = {
+  textarea: QUESTION_TYPE_OPTION_BY_TYPE.textarea,
+  select: QUESTION_TYPE_OPTION_BY_TYPE.select,
+  checkbox: QUESTION_TYPE_OPTION_BY_TYPE.checkbox,
+} satisfies Record<RsvpQuestionType, QuestionTypeOption>;
+
+export const RSVP_QUESTION_TYPE_OPTIONS = Object.values(RSVP_QUESTION_TYPE_OPTION_BY_TYPE);
+
+const RESPONDENT_STATUSES = new Set<string>([
+  RsvpServerStatus.Attending,
+  RsvpServerStatus.Maybe,
+  RsvpServerStatus.Waitlisted,
+]);
+
+export const RSVP_QUESTION_TYPE_LABELS: Record<RsvpQuestionType, string> = Object.fromEntries(
+  RSVP_QUESTION_TYPE_OPTIONS.map((o) => [o.value, o.label]),
+) as Record<RsvpQuestionType, string>;
+
+export function parseOptionsText(text: string): string[] {
+  return text
+    .split('\n')
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export function isAnswerFilled(value: RsvpAnswerValue | undefined): boolean {
+  return Boolean(value?.trim());
+}
+
+export function missingRequiredQuestionIds(
+  questions: readonly RsvpQuestionDraft[],
+  answers: Readonly<Record<string, RsvpAnswerValue | undefined>>,
+): string[] {
+  return questions.filter((q) => q.required && !isAnswerFilled(answers[q.id])).map((q) => q.id);
+}
+
+export function isRsvpRespondentStatus(status: string): boolean {
+  return RESPONDENT_STATUSES.has(status);
+}
+
+export function hasSavedRsvpAnswers(event: Event): boolean {
+  return event.guests.some(
+    (guest) => isRsvpRespondentStatus(guest.status) && Object.keys(guest.answers).length > 0,
+  );
+}
+
+export function newQuestionId(): string {
+  return `q-${crypto.randomUUID()}`;
+}
+
+export { questionTypeWantsOptions as wantsOptions };

--- a/frontend/src/screens/events/rsvpQuestions.ts
+++ b/frontend/src/screens/events/rsvpQuestions.ts
@@ -2,8 +2,7 @@
 
 import type { RsvpQuestionType } from '@/api/eventRsvpQuestions';
 import {
-  QUESTION_TYPE_OPTION_BY_TYPE,
-  type QuestionTypeOption,
+  RSVP_QUESTION_TYPE_OPTIONS,
   questionTypeWantsOptions,
 } from '@/components/questions/questionTypeOptions';
 import { type Event, type EventRsvpQuestion, RsvpServerStatus } from '@/models/event';
@@ -12,13 +11,7 @@ export type { RsvpQuestionType };
 export type RsvpQuestionDraft = EventRsvpQuestion;
 export type RsvpAnswerValue = string;
 
-const RSVP_QUESTION_TYPE_OPTION_BY_TYPE = {
-  textarea: QUESTION_TYPE_OPTION_BY_TYPE.textarea,
-  select: QUESTION_TYPE_OPTION_BY_TYPE.select,
-  checkbox: QUESTION_TYPE_OPTION_BY_TYPE.checkbox,
-} satisfies Record<RsvpQuestionType, QuestionTypeOption>;
-
-export const RSVP_QUESTION_TYPE_OPTIONS = Object.values(RSVP_QUESTION_TYPE_OPTION_BY_TYPE);
+export { RSVP_QUESTION_TYPE_OPTIONS };
 
 const RESPONDENT_STATUSES = new Set<string>([
   RsvpServerStatus.Attending,
@@ -52,9 +45,11 @@ export function isRsvpRespondentStatus(status: string): boolean {
   return RESPONDENT_STATUSES.has(status);
 }
 
-export function hasSavedRsvpAnswers(event: Event): boolean {
+export function hasSavedQuestionnaireResponses(event: Event): boolean {
   return event.guests.some(
-    (guest) => isRsvpRespondentStatus(guest.status) && Object.keys(guest.answers).length > 0,
+    (guest) =>
+      isRsvpRespondentStatus(guest.status) &&
+      Object.keys(guest.questionnaireResponses).length > 0,
   );
 }
 

--- a/frontend/src/screens/events/rsvpQuestions.ts
+++ b/frontend/src/screens/events/rsvpQuestions.ts
@@ -1,9 +1,6 @@
 /** Draft / wire-aligned RSVP question helpers used by authoring + RSVP dialog. */
 
-import {
-  newRsvpQuestionId,
-  type RsvpQuestionType,
-} from '@/api/eventRsvpQuestions';
+import { newRsvpQuestionId, type RsvpQuestionType } from '@/api/eventRsvpQuestions';
 import {
   questionTypeWantsOptions,
   RSVP_QUESTION_TYPE_OPTIONS,
@@ -52,8 +49,7 @@ export function isRsvpRespondentStatus(status: string): boolean {
 export function hasSavedQuestionnaireResponses(event: Event): boolean {
   return event.guests.some(
     (guest) =>
-      isRsvpRespondentStatus(guest.status) &&
-      Object.keys(guest.questionnaireResponses).length > 0,
+      isRsvpRespondentStatus(guest.status) && Object.keys(guest.questionnaireResponses).length > 0,
   );
 }
 

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -27,6 +27,7 @@ export function makeGuest(overrides: Partial<EventGuest> = {}): EventGuest {
     plusOneAttendance: AttendanceStatus.Unknown,
     isMember: true,
     paidConfirmed: false,
+    answers: {},
     ...overrides,
   };
 }
@@ -75,6 +76,8 @@ export function makeEvent(overrides: Partial<Event> = {}): Event {
     ],
     myRsvp: null,
     myPaidConfirmed: false,
+    myRsvpAnswers: {},
+    rsvpQuestions: [],
     viewerUserId: null,
     surveySlugs: [],
     invitedUserIds: [],

--- a/frontend/src/test/fixtures.ts
+++ b/frontend/src/test/fixtures.ts
@@ -27,7 +27,7 @@ export function makeGuest(overrides: Partial<EventGuest> = {}): EventGuest {
     plusOneAttendance: AttendanceStatus.Unknown,
     isMember: true,
     paidConfirmed: false,
-    answers: {},
+    questionnaireResponses: {},
     ...overrides,
   };
 }
@@ -76,7 +76,7 @@ export function makeEvent(overrides: Partial<Event> = {}): Event {
     ],
     myRsvp: null,
     myPaidConfirmed: false,
-    myRsvpAnswers: {},
+    myQuestionnaireResponses: {},
     rsvpQuestions: [],
     viewerUserId: null,
     surveySlugs: [],


### PR DESCRIPTION
Hosts can configure RSVP questions on create/edit via shared dialog UI
and the sync API, while RSVP answer UI remains unchanged.

Co-authored-by: Cursor <cursoragent@cursor.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>