### PR TITLE
feat(events): collect RSVP question answers in member RSVP UI

### DIFF
--- a/frontend/src/api/rsvp.test.ts
+++ b/frontend/src/api/rsvp.test.ts
@@ -38,7 +38,7 @@ describe('useSetRsvp', () => {
     vi.clearAllMocks();
   });
 
-  it('should post answers with the RSVP body', async () => {
+  it('should post questionnaire_responses with the RSVP body', async () => {
     const { Wrapper } = buildWrapper();
     vi.mocked(apiClient.post).mockResolvedValue({
       data: { id: EVENT_ID, title: 'potluck', my_rsvp: RsvpStatus.Attending },
@@ -47,14 +47,14 @@ describe('useSetRsvp', () => {
     result.current.mutate({
       eventId: EVENT_ID,
       status: RsvpStatus.Attending,
-      answers: { q1: 'vegan' },
+      questionnaireResponses: { q1: 'vegan' },
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(apiClient.post).toHaveBeenCalledWith(
       `/api/community/events/${EVENT_ID}/rsvp/`,
       expect.objectContaining({
         status: RsvpStatus.Attending,
-        answers: { q1: 'vegan' },
+        questionnaire_responses: { q1: 'vegan' },
       }),
     );
   });

--- a/frontend/src/api/rsvp.test.ts
+++ b/frontend/src/api/rsvp.test.ts
@@ -33,6 +33,33 @@ function buildWrapper() {
   return { qc, Wrapper };
 }
 
+describe('useSetRsvp', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should post answers with the RSVP body', async () => {
+    const { Wrapper } = buildWrapper();
+    vi.mocked(apiClient.post).mockResolvedValue({
+      data: { id: EVENT_ID, title: 'potluck', my_rsvp: RsvpStatus.Attending },
+    });
+    const { result } = renderHook(() => useSetRsvp(), { wrapper: Wrapper });
+    result.current.mutate({
+      eventId: EVENT_ID,
+      status: RsvpStatus.Attending,
+      answers: { q1: 'vegan' },
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(apiClient.post).toHaveBeenCalledWith(
+      `/api/community/events/${EVENT_ID}/rsvp/`,
+      expect.objectContaining({
+        status: RsvpStatus.Attending,
+        answers: { q1: 'vegan' },
+      }),
+    );
+  });
+});
+
 describe('useSetRsvp cache patching (issue 1242)', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/frontend/src/api/rsvp.ts
+++ b/frontend/src/api/rsvp.ts
@@ -20,7 +20,7 @@ interface SetRsvpArgs {
   // public EventComment or a host-only decline notification.
   comment?: string;
   paidConfirmed?: boolean;
-  answers?: Record<string, string | string[]>;
+  questionnaireResponses?: Record<string, string | string[]>;
 }
 
 // EventDetailScreen's :id route param can be the event's uuid or slug, so the cache key varies.
@@ -52,12 +52,12 @@ export function useSetRsvp() {
       hasPlusOne = false,
       comment,
       paidConfirmed,
-      answers = {},
+      questionnaireResponses = {},
     }: SetRsvpArgs) => {
       const { data } = await apiClient.post<WireEvent>(`/api/community/events/${eventId}/rsvp/`, {
         status,
         has_plus_one: hasPlusOne,
-        answers,
+        questionnaire_responses: questionnaireResponses,
         ...(comment === undefined ? {} : { comment }),
         ...(paidConfirmed ? { paid_confirmed: true } : {}),
       });

--- a/frontend/src/api/rsvp.ts
+++ b/frontend/src/api/rsvp.ts
@@ -20,6 +20,7 @@ interface SetRsvpArgs {
   // public EventComment or a host-only decline notification.
   comment?: string;
   paidConfirmed?: boolean;
+  answers?: Record<string, string | string[]>;
 }
 
 // EventDetailScreen's :id route param can be the event's uuid or slug, so the cache key varies.
@@ -51,10 +52,12 @@ export function useSetRsvp() {
       hasPlusOne = false,
       comment,
       paidConfirmed,
+      answers = {},
     }: SetRsvpArgs) => {
       const { data } = await apiClient.post<WireEvent>(`/api/community/events/${eventId}/rsvp/`, {
         status,
         has_plus_one: hasPlusOne,
+        answers,
         ...(comment === undefined ? {} : { comment }),
         ...(paidConfirmed ? { paid_confirmed: true } : {}),
       });

--- a/frontend/src/screens/events/MyRsvpSection.tsx
+++ b/frontend/src/screens/events/MyRsvpSection.tsx
@@ -73,7 +73,7 @@ export function MyRsvpSection({ event, token, locked = false }: Props) {
     comment?: string;
     hasPlusOne: boolean;
     paidConfirmed?: boolean;
-    answers: Record<string, RsvpAnswerValue>;
+    questionnaireResponses: Record<string, RsvpAnswerValue>;
   }) {
     setError(null);
     try {
@@ -90,7 +90,7 @@ export function MyRsvpSection({ event, token, locked = false }: Props) {
           eventId: event.id,
           status: args.status,
           hasPlusOne: args.hasPlusOne,
-          answers: args.answers,
+          questionnaireResponses: args.questionnaireResponses,
           ...(args.comment === undefined ? {} : { comment: args.comment }),
           ...(args.paidConfirmed ? { paidConfirmed: true } : {}),
         });
@@ -175,7 +175,7 @@ export function MyRsvpSection({ event, token, locked = false }: Props) {
           busy={busy}
           questions={event.rsvpQuestions}
           initialAnswers={Object.fromEntries(
-            Object.entries(event.myRsvpAnswers).map(([id, snap]) => [id, snap.answer]),
+            Object.entries(event.myQuestionnaireResponses).map(([id, snap]) => [id, snap.answer]),
           )}
           onConfirm={(args) => void confirmRsvp(args)}
           onRemove={box.mode === 'edit' ? () => void removeMyRsvp() : undefined}

--- a/frontend/src/screens/events/MyRsvpSection.tsx
+++ b/frontend/src/screens/events/MyRsvpSection.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/models/event';
 
 import { RsvpBox } from './RsvpBox';
+import type { RsvpAnswerValue } from './rsvpQuestions';
 
 interface Props {
   event: Event;
@@ -72,6 +73,7 @@ export function MyRsvpSection({ event, token, locked = false }: Props) {
     comment?: string;
     hasPlusOne: boolean;
     paidConfirmed?: boolean;
+    answers: Record<string, RsvpAnswerValue>;
   }) {
     setError(null);
     try {
@@ -88,6 +90,7 @@ export function MyRsvpSection({ event, token, locked = false }: Props) {
           eventId: event.id,
           status: args.status,
           hasPlusOne: args.hasPlusOne,
+          answers: args.answers,
           ...(args.comment === undefined ? {} : { comment: args.comment }),
           ...(args.paidConfirmed ? { paidConfirmed: true } : {}),
         });
@@ -170,6 +173,10 @@ export function MyRsvpSection({ event, token, locked = false }: Props) {
           allowComment={Boolean(token) || box.mode === 'create'}
           atCapacity={atCapacity}
           busy={busy}
+          questions={event.rsvpQuestions}
+          initialAnswers={Object.fromEntries(
+            Object.entries(event.myRsvpAnswers).map(([id, snap]) => [id, snap.answer]),
+          )}
           onConfirm={(args) => void confirmRsvp(args)}
           onRemove={box.mode === 'edit' ? () => void removeMyRsvp() : undefined}
           onClose={() => {

--- a/frontend/src/screens/events/RsvpBox.test.tsx
+++ b/frontend/src/screens/events/RsvpBox.test.tsx
@@ -190,14 +190,7 @@ describe('RsvpBox', () => {
   });
 
   it('should keep status controls outside the questions/comment scroll region', () => {
-    render(
-      <RsvpBox
-        {...base}
-        mode="create"
-        questions={[requiredSelect]}
-        onConfirm={() => {}}
-      />,
-    );
+    render(<RsvpBox {...base} mode="create" questions={[requiredSelect]} onConfirm={() => {}} />);
     const scroll = screen.getByTestId('rsvp-details-scroll');
     expect(scroll).toContainElement(screen.getByText('how are you getting there?'));
     expect(scroll).toContainElement(screen.getByLabelText('comment (optional)'));

--- a/frontend/src/screens/events/RsvpBox.test.tsx
+++ b/frontend/src/screens/events/RsvpBox.test.tsx
@@ -189,6 +189,23 @@ describe('RsvpBox', () => {
     expect(screen.getByLabelText('anything else? (optional)')).toBeInTheDocument();
   });
 
+  it('should keep status controls outside the questions/comment scroll region', () => {
+    render(
+      <RsvpBox
+        {...base}
+        mode="create"
+        questions={[requiredSelect]}
+        onConfirm={() => {}}
+      />,
+    );
+    const scroll = screen.getByTestId('rsvp-details-scroll');
+    expect(scroll).toContainElement(screen.getByText('how are you getting there?'));
+    expect(scroll).toContainElement(screen.getByLabelText('comment (optional)'));
+    expect(scroll).not.toContainElement(screen.getByRole('button', { name: /i'm going/i }));
+    expect(scroll).not.toContainElement(screen.getByRole('button', { name: /add \+1/i }));
+    expect(scroll).not.toContainElement(screen.getByRole('button', { name: /^confirm$/i }));
+  });
+
   it('should hide questions when status is can’t go', () => {
     render(<RsvpBox {...base} mode="create" questions={[requiredSelect]} onConfirm={() => {}} />);
     fireEvent.click(screen.getByRole('button', { name: /can't go/i }));

--- a/frontend/src/screens/events/RsvpBox.test.tsx
+++ b/frontend/src/screens/events/RsvpBox.test.tsx
@@ -57,7 +57,7 @@ describe('RsvpBox', () => {
         status: RsvpStatus.Attending,
         comment: 'snacks',
         hasPlusOne: false,
-        answers: {},
+        questionnaireResponses: {},
       }),
     );
   });
@@ -217,7 +217,7 @@ describe('RsvpBox', () => {
     expect(onConfirm).toHaveBeenCalledWith(
       expect.objectContaining({
         status: RsvpStatus.Attending,
-        answers: { 'q-transport': 'driving' },
+        questionnaireResponses: { 'q-transport': 'driving' },
       }),
     );
   });

--- a/frontend/src/screens/events/RsvpBox.test.tsx
+++ b/frontend/src/screens/events/RsvpBox.test.tsx
@@ -6,6 +6,7 @@ import { RsvpStatus } from '@/models/event';
 import { makeEvent, makePaidEvent } from '@/test/fixtures';
 
 import { RsvpBox } from './RsvpBox';
+import type { RsvpQuestionDraft } from './rsvpQuestions';
 
 const mockUseFlag = vi.hoisted(() => vi.fn(() => true));
 vi.mock('@/api/featureFlags', () => ({ useFlag: mockUseFlag }));
@@ -17,6 +18,22 @@ const base = {
   allowPlusOnes: true,
   onClose: () => {},
   event: makeEvent(),
+};
+
+const requiredSelect: RsvpQuestionDraft = {
+  id: 'q-transport',
+  label: 'how are you getting there?',
+  fieldType: 'select',
+  options: ['driving', 'transit'],
+  required: true,
+};
+
+const optionalText: RsvpQuestionDraft = {
+  id: 'q-notes',
+  label: 'anything else?',
+  fieldType: 'textarea',
+  options: [],
+  required: false,
 };
 
 describe('RsvpBox', () => {
@@ -40,6 +57,7 @@ describe('RsvpBox', () => {
         status: RsvpStatus.Attending,
         comment: 'snacks',
         hasPlusOne: false,
+        answers: {},
       }),
     );
   });
@@ -156,6 +174,60 @@ describe('RsvpBox', () => {
     expect(onConfirm).toHaveBeenCalledWith(
       expect.objectContaining({ status: RsvpStatus.Attending }),
     );
+  });
+
+  it('should show questions when attending', () => {
+    render(
+      <RsvpBox
+        {...base}
+        mode="create"
+        questions={[requiredSelect, optionalText]}
+        onConfirm={() => {}}
+      />,
+    );
+    expect(screen.getByText('how are you getting there?')).toBeInTheDocument();
+    expect(screen.getByLabelText('anything else? (optional)')).toBeInTheDocument();
+  });
+
+  it('should hide questions when status is can’t go', () => {
+    render(<RsvpBox {...base} mode="create" questions={[requiredSelect]} onConfirm={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /can't go/i }));
+    expect(screen.queryByText('how are you getting there?')).not.toBeInTheDocument();
+  });
+
+  it('should block confirm when a required question is unanswered', () => {
+    const onConfirm = vi.fn();
+    render(<RsvpBox {...base} mode="create" questions={[requiredSelect]} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
+    expect(onConfirm).not.toHaveBeenCalled();
+    expect(screen.getByText(/required/i)).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'how are you getting there?' })).toHaveAttribute(
+      'aria-invalid',
+      'true',
+    );
+  });
+
+  it('should confirm after answering required questions', () => {
+    const onConfirm = vi.fn();
+    render(<RsvpBox {...base} mode="create" questions={[requiredSelect]} onConfirm={onConfirm} />);
+    fireEvent.change(screen.getByRole('combobox', { name: 'how are you getting there?' }), {
+      target: { value: 'driving' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: RsvpStatus.Attending,
+        answers: { 'q-transport': 'driving' },
+      }),
+    );
+  });
+
+  it('should allow confirm for can’t go without answering required questions', () => {
+    const onConfirm = vi.fn();
+    render(<RsvpBox {...base} mode="create" questions={[requiredSelect]} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByRole('button', { name: /can't go/i }));
+    fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
+    expect(onConfirm).toHaveBeenCalledWith(expect.objectContaining({ status: RsvpStatus.CantGo }));
   });
 });
 

--- a/frontend/src/screens/events/RsvpBox.tsx
+++ b/frontend/src/screens/events/RsvpBox.tsx
@@ -20,7 +20,7 @@ interface ConfirmArgs {
   comment?: string;
   hasPlusOne: boolean;
   paidConfirmed?: boolean;
-  answers: Record<string, RsvpAnswerValue>;
+  questionnaireResponses: Record<string, RsvpAnswerValue>;
 }
 
 interface Props {
@@ -72,7 +72,7 @@ export function RsvpBox({
   const showQuestions =
     questions.length > 0 && (status === RsvpStatus.Attending || status === RsvpStatus.Maybe);
 
-  function filledAnswers(): Record<string, RsvpAnswerValue> {
+  function filledQuestionnaireResponses(): Record<string, RsvpAnswerValue> {
     const next: Record<string, RsvpAnswerValue> = {};
     if (!showQuestions) return next;
     for (const q of questions) {
@@ -86,7 +86,11 @@ export function RsvpBox({
 
   function submit(paidConfirmed: boolean) {
     const trimmed = comment.trim();
-    const args: ConfirmArgs = { status, hasPlusOne, answers: filledAnswers() };
+    const args: ConfirmArgs = {
+      status,
+      hasPlusOne,
+      questionnaireResponses: filledQuestionnaireResponses(),
+    };
     if (showComment && trimmed) args.comment = trimmed;
     if (paidConfirmed) args.paidConfirmed = true;
     onConfirm(args);

--- a/frontend/src/screens/events/RsvpBox.tsx
+++ b/frontend/src/screens/events/RsvpBox.tsx
@@ -7,6 +7,12 @@ import { type Event, type RsvpInputStatus, RsvpStatus } from '@/models/event';
 
 import { PaymentConfirmStep } from './PaymentConfirmStep';
 import { RsvpCommentField } from './RsvpCommentField';
+import { RsvpQuestionFields } from './RsvpQuestionFields';
+import {
+  missingRequiredQuestionIds,
+  type RsvpAnswerValue,
+  type RsvpQuestionDraft,
+} from './rsvpQuestions';
 import { usePaymentGate } from './usePaymentGate';
 
 interface ConfirmArgs {
@@ -14,6 +20,7 @@ interface ConfirmArgs {
   comment?: string;
   hasPlusOne: boolean;
   paidConfirmed?: boolean;
+  answers: Record<string, RsvpAnswerValue>;
 }
 
 interface Props {
@@ -26,6 +33,8 @@ interface Props {
   allowComment?: boolean;
   atCapacity?: boolean;
   busy?: boolean;
+  questions?: readonly RsvpQuestionDraft[];
+  initialAnswers?: Readonly<Record<string, RsvpAnswerValue | undefined>>;
   onConfirm: (args: ConfirmArgs) => void;
   onRemove?: (() => void) | undefined;
   onClose: () => void;
@@ -41,6 +50,8 @@ export function RsvpBox({
   allowComment,
   atCapacity = false,
   busy = false,
+  questions = [],
+  initialAnswers = {},
   onConfirm,
   onRemove,
   onClose,
@@ -49,21 +60,49 @@ export function RsvpBox({
   const [comment, setComment] = useState('');
   const [hasPlusOne, setHasPlusOne] = useState(initialHasPlusOne);
   const [showPayment, setShowPayment] = useState(false);
+  const [answers, setAnswers] = useState<Record<string, RsvpAnswerValue | undefined>>(() => ({
+    ...initialAnswers,
+  }));
+  const [questionErrors, setQuestionErrors] = useState<Record<string, string | undefined>>({});
   const needsPaymentFor = usePaymentGate(event);
 
   const showComment = allowComment ?? mode === 'create';
   const showPlusOne = allowPlusOnes;
   const joiningWaitlist = status === RsvpStatus.Attending && atCapacity;
+  const showQuestions =
+    questions.length > 0 && (status === RsvpStatus.Attending || status === RsvpStatus.Maybe);
+
+  function filledAnswers(): Record<string, RsvpAnswerValue> {
+    const next: Record<string, RsvpAnswerValue> = {};
+    if (!showQuestions) return next;
+    for (const q of questions) {
+      const value = answers[q.id];
+      if (value?.trim()) {
+        next[q.id] = value;
+      }
+    }
+    return next;
+  }
 
   function submit(paidConfirmed: boolean) {
     const trimmed = comment.trim();
-    const args: ConfirmArgs = { status, hasPlusOne };
+    const args: ConfirmArgs = { status, hasPlusOne, answers: filledAnswers() };
     if (showComment && trimmed) args.comment = trimmed;
     if (paidConfirmed) args.paidConfirmed = true;
     onConfirm(args);
   }
 
   function confirm() {
+    if (showQuestions) {
+      const missing = missingRequiredQuestionIds(questions, answers);
+      if (missing.length > 0) {
+        const next: Record<string, string | undefined> = {};
+        for (const id of missing) next[id] = 'required';
+        setQuestionErrors(next);
+        return;
+      }
+    }
+    setQuestionErrors({});
     if (needsPaymentFor(status)) {
       setShowPayment(true);
       return;
@@ -85,34 +124,53 @@ export function RsvpBox({
           }}
         />
       ) : (
-        <div className="flex flex-col gap-4">
-          <RsvpStatusPicker
-            value={status}
-            onSelect={setStatus}
-            disabled={busy}
-            labelFor={(s, defaultLabel) =>
-              s === RsvpStatus.Attending && atCapacity ? 'join the waitlist' : defaultLabel
-            }
-          />
+        <div className="flex max-h-[min(70vh,32rem)] flex-col gap-4">
+          <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pe-1">
+            <RsvpStatusPicker
+              value={status}
+              onSelect={setStatus}
+              disabled={busy}
+              labelFor={(s, defaultLabel) =>
+                s === RsvpStatus.Attending && atCapacity ? 'join the waitlist' : defaultLabel
+              }
+            />
 
-          {showPlusOne ? (
-            <div className="flex justify-center">
-              <Button
-                type="button"
-                variant={hasPlusOne ? 'primary' : 'secondary'}
-                onClick={() => {
-                  setHasPlusOne(!hasPlusOne);
-                }}
+            {showPlusOne ? (
+              <div className="flex justify-center">
+                <Button
+                  type="button"
+                  variant={hasPlusOne ? 'primary' : 'secondary'}
+                  onClick={() => {
+                    setHasPlusOne(!hasPlusOne);
+                  }}
+                  disabled={busy}
+                >
+                  {hasPlusOne ? 'remove +1' : 'add +1'}
+                </Button>
+              </div>
+            ) : null}
+
+            {showQuestions ? (
+              <RsvpQuestionFields
+                questions={questions}
+                answers={answers}
+                errors={questionErrors}
                 disabled={busy}
-              >
-                {hasPlusOne ? 'remove +1' : 'add +1'}
-              </Button>
-            </div>
-          ) : null}
+                onChange={(questionId, value) => {
+                  setAnswers((prev) => ({ ...prev, [questionId]: value }));
+                  setQuestionErrors((prev) => {
+                    if (!prev[questionId]) return prev;
+                    const { [questionId]: _removed, ...rest } = prev;
+                    return rest;
+                  });
+                }}
+              />
+            ) : null}
 
-          {showComment ? <RsvpCommentField value={comment} onChange={setComment} /> : null}
+            {showComment ? <RsvpCommentField value={comment} onChange={setComment} /> : null}
+          </div>
 
-          <div className="flex items-center justify-between gap-2">
+          <div className="border-border flex shrink-0 items-center justify-between gap-2 border-t pt-3">
             {mode === 'edit' && onRemove ? (
               <Button type="button" variant="secondary" onClick={onRemove} disabled={busy}>
                 remove rsvp

--- a/frontend/src/screens/events/RsvpBox.tsx
+++ b/frontend/src/screens/events/RsvpBox.tsx
@@ -129,50 +129,55 @@ export function RsvpBox({
         />
       ) : (
         <div className="flex max-h-[min(70vh,32rem)] flex-col gap-4">
-          <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pe-1">
-            <RsvpStatusPicker
-              value={status}
-              onSelect={setStatus}
-              disabled={busy}
-              labelFor={(s, defaultLabel) =>
-                s === RsvpStatus.Attending && atCapacity ? 'join the waitlist' : defaultLabel
-              }
-            />
+          <RsvpStatusPicker
+            value={status}
+            onSelect={setStatus}
+            disabled={busy}
+            labelFor={(s, defaultLabel) =>
+              s === RsvpStatus.Attending && atCapacity ? 'join the waitlist' : defaultLabel
+            }
+          />
 
-            {showPlusOne ? (
-              <div className="flex justify-center">
-                <Button
-                  type="button"
-                  variant={hasPlusOne ? 'primary' : 'secondary'}
-                  onClick={() => {
-                    setHasPlusOne(!hasPlusOne);
-                  }}
-                  disabled={busy}
-                >
-                  {hasPlusOne ? 'remove +1' : 'add +1'}
-                </Button>
-              </div>
-            ) : null}
-
-            {showQuestions ? (
-              <RsvpQuestionFields
-                questions={questions}
-                answers={answers}
-                errors={questionErrors}
-                disabled={busy}
-                onChange={(questionId, value) => {
-                  setAnswers((prev) => ({ ...prev, [questionId]: value }));
-                  setQuestionErrors((prev) => {
-                    if (!prev[questionId]) return prev;
-                    const { [questionId]: _removed, ...rest } = prev;
-                    return rest;
-                  });
+          {showPlusOne ? (
+            <div className="flex justify-center">
+              <Button
+                type="button"
+                variant={hasPlusOne ? 'primary' : 'secondary'}
+                onClick={() => {
+                  setHasPlusOne(!hasPlusOne);
                 }}
-              />
-            ) : null}
+                disabled={busy}
+              >
+                {hasPlusOne ? 'remove +1' : 'add +1'}
+              </Button>
+            </div>
+          ) : null}
 
-            {showComment ? <RsvpCommentField value={comment} onChange={setComment} /> : null}
-          </div>
+          {showQuestions || showComment ? (
+            <div
+              data-testid="rsvp-details-scroll"
+              className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto pe-1"
+            >
+              {showQuestions ? (
+                <RsvpQuestionFields
+                  questions={questions}
+                  answers={answers}
+                  errors={questionErrors}
+                  disabled={busy}
+                  onChange={(questionId, value) => {
+                    setAnswers((prev) => ({ ...prev, [questionId]: value }));
+                    setQuestionErrors((prev) => {
+                      if (!prev[questionId]) return prev;
+                      const { [questionId]: _removed, ...rest } = prev;
+                      return rest;
+                    });
+                  }}
+                />
+              ) : null}
+
+              {showComment ? <RsvpCommentField value={comment} onChange={setComment} /> : null}
+            </div>
+          ) : null}
 
           <div className="border-border flex shrink-0 items-center justify-between gap-2 border-t pt-3">
             {mode === 'edit' && onRemove ? (

--- a/frontend/src/screens/events/RsvpQuestionFields.test.tsx
+++ b/frontend/src/screens/events/RsvpQuestionFields.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { RsvpQuestionFields } from './RsvpQuestionFields';
+import type { RsvpQuestionDraft } from './rsvpQuestions';
+
+const questions: RsvpQuestionDraft[] = [
+  {
+    id: 'q-text',
+    label: 'notes',
+    fieldType: 'textarea',
+    options: [],
+    required: false,
+  },
+  {
+    id: 'q-one',
+    label: 'transport',
+    fieldType: 'select',
+    options: ['car', 'bus'],
+    required: true,
+  },
+  {
+    id: 'q-multi',
+    label: 'help with',
+    fieldType: 'checkbox',
+    options: ['setup', 'cleanup'],
+    required: false,
+  },
+];
+
+describe('RsvpQuestionFields', () => {
+  it('marks optional free response in the label', () => {
+    render(
+      <RsvpQuestionFields questions={questions} answers={{}} onChange={vi.fn()} errors={{}} />,
+    );
+    expect(screen.getByLabelText('notes (optional)')).toBeInTheDocument();
+  });
+
+  it('renders select one as a select and reports changes', () => {
+    const onChange = vi.fn();
+    render(
+      <RsvpQuestionFields questions={questions} answers={{}} onChange={onChange} errors={{}} />,
+    );
+    const select = screen.getByRole('combobox', { name: 'transport' });
+    fireEvent.change(select, { target: { value: 'car' } });
+    expect(onChange).toHaveBeenCalledWith('q-one', 'car');
+  });
+
+  it('toggles checkbox options as csv', () => {
+    const onChange = vi.fn();
+    render(
+      <RsvpQuestionFields
+        questions={questions}
+        answers={{ 'q-multi': 'setup' }}
+        onChange={onChange}
+        errors={{}}
+      />,
+    );
+    fireEvent.click(screen.getByRole('checkbox', { name: 'cleanup' }));
+    expect(onChange).toHaveBeenCalledWith('q-multi', 'setup,cleanup');
+    fireEvent.click(screen.getByRole('checkbox', { name: 'setup' }));
+    expect(onChange).toHaveBeenCalledWith('q-multi', '');
+  });
+
+  it('shows per-question errors', () => {
+    render(
+      <RsvpQuestionFields
+        questions={questions}
+        answers={{}}
+        onChange={vi.fn()}
+        errors={{ 'q-one': 'required' }}
+      />,
+    );
+    expect(screen.getByText('required')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/events/RsvpQuestionFields.tsx
+++ b/frontend/src/screens/events/RsvpQuestionFields.tsx
@@ -1,0 +1,39 @@
+import { QuestionField } from '@/components/questions/QuestionField';
+
+import type { RsvpAnswerValue, RsvpQuestionDraft } from './rsvpQuestions';
+
+interface Props {
+  questions: readonly RsvpQuestionDraft[];
+  answers: Readonly<Record<string, RsvpAnswerValue | undefined>>;
+  onChange: (questionId: string, value: RsvpAnswerValue) => void;
+  errors: Readonly<Record<string, string | undefined>>;
+  disabled?: boolean;
+}
+
+/** RSVP answers reuse the shared QuestionField so survey/RSVP UX stays aligned. */
+export function RsvpQuestionFields({
+  questions,
+  answers,
+  onChange,
+  errors,
+  disabled = false,
+}: Props) {
+  if (questions.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-4">
+      {questions.map((question) => (
+        <QuestionField
+          key={question.id}
+          question={question}
+          value={answers[question.id] ?? ''}
+          onChange={(v) => {
+            onChange(question.id, typeof v === 'string' ? v : '');
+          }}
+          error={errors[question.id]}
+          readOnly={disabled}
+        />
+      ))}
+    </div>
+  );
+}


### PR DESCRIPTION
Members answer configured questions when RSVPing; answers ride with
the existing RSVP submit path alongside payment confirmation.

Co-authored-by: Cursor <cursoragent@cursor.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>