### PR TITLE
feat(public-rsvp): collect and preserve custom answers

### DIFF
--- a/backend/community/_public_rsvp_manage.py
+++ b/backend/community/_public_rsvp_manage.py
@@ -15,9 +15,9 @@ from users.models import NonMemberRsvpToken, User
 
 from community._event_helpers import _event_out, broadcast_capacity_change, promote_from_waitlist
 from community._event_rsvps import (
-    _RsvpApply,
     _apply_rsvp_in_transaction,
     _post_rsvp_comment,
+    _RsvpApply,
     _validate_rsvp_status,
     payment_audit_details,
 )

--- a/backend/community/_public_rsvp_manage.py
+++ b/backend/community/_public_rsvp_manage.py
@@ -15,13 +15,13 @@ from users.models import NonMemberRsvpToken, User
 
 from community._event_helpers import _event_out, broadcast_capacity_change, promote_from_waitlist
 from community._event_rsvps import (
+    _RsvpApply,
     _apply_rsvp_in_transaction,
     _post_rsvp_comment,
-    _RsvpApply,
     _validate_rsvp_status,
     payment_audit_details,
 )
-from community._event_schemas import EventOut
+from community._event_schemas import EventOut, RsvpAnswer
 from community._field_limits import FieldLimit
 from community._public_rsvp_shared import (
     PublicRsvpOut,
@@ -61,6 +61,10 @@ class PublicRsvpManageIn(BaseModel):
     has_plus_one: bool = False
     paid_confirmed: bool = False
     comment: str | None = Field(default=None, max_length=FieldLimit.SHORT_TEXT)
+    answers: dict[str, RsvpAnswer] | None = Field(
+        default=None,
+        description="Question UUID to answer; omit or send null to preserve saved answers.",
+    )
 
 
 def _resolve_token_user(token: str) -> User:
@@ -149,7 +153,7 @@ def list_my_rsvps(request, token: str = ""):
 
 @router.post(
     "/public/my-rsvps/{event_id}/",
-    response={200: PublicRsvpOut, 400: ErrorOut, 404: ErrorOut, 429: ErrorOut},
+    response={200: PublicRsvpOut, 400: ErrorOut, 404: ErrorOut, 422: ErrorOut, 429: ErrorOut},
     auth=None,
 )
 @rate_limit(key_func=client_ip, rate="30/h")
@@ -162,7 +166,11 @@ def update_my_rsvp(request, event_id, payload: PublicRsvpManageIn, token: str = 
         final_status, promoted_user_ids, created = _apply_rsvp_in_transaction(
             event.id,
             user,
-            _RsvpApply(status=payload.status, paid_confirmed=payload.paid_confirmed),
+            _RsvpApply(
+                status=payload.status,
+                paid_confirmed=payload.paid_confirmed,
+                answers=payload.answers,
+            ),
         )
         rsvp_token = NonMemberRsvpToken.issue_or_extend(user)
 

--- a/backend/community/_public_rsvp_manage.py
+++ b/backend/community/_public_rsvp_manage.py
@@ -61,7 +61,7 @@ class PublicRsvpManageIn(BaseModel):
     has_plus_one: bool = False
     paid_confirmed: bool = False
     comment: str | None = Field(default=None, max_length=FieldLimit.SHORT_TEXT)
-    answers: dict[str, RsvpAnswer] | None = Field(
+    questionnaire_responses: dict[str, RsvpAnswer] | None = Field(
         default=None,
         description="Question UUID to answer; omit or send null to preserve saved answers.",
     )
@@ -169,7 +169,7 @@ def update_my_rsvp(request, event_id, payload: PublicRsvpManageIn, token: str = 
             _RsvpApply(
                 status=payload.status,
                 paid_confirmed=payload.paid_confirmed,
-                answers=payload.answers,
+                answers=payload.questionnaire_responses,
             ),
         )
         rsvp_token = NonMemberRsvpToken.issue_or_extend(user)

--- a/backend/community/_public_rsvp_submit.py
+++ b/backend/community/_public_rsvp_submit.py
@@ -16,12 +16,13 @@ from users.models import PUBLIC_FORM_PHONE_REGION, NonMemberRsvpToken, User, val
 
 from community._event_helpers import _event_out, broadcast_capacity_change
 from community._event_rsvps import (
+    _RsvpApply,
     _apply_rsvp_in_transaction,
     _post_rsvp_comment,
-    _RsvpApply,
     _validate_rsvp_status,
     payment_audit_details,
 )
+from community._event_schemas import RsvpAnswer
 from community._field_limits import FieldLimit
 from community._public_rsvp_shared import (
     PublicRsvpOut,
@@ -47,6 +48,10 @@ class PublicRsvpIn(BaseModel):
     has_plus_one: bool = False
     paid_confirmed: bool = False
     comment: str | None = Field(default=None, max_length=FieldLimit.SHORT_TEXT)
+    answers: dict[str, RsvpAnswer] = Field(
+        default_factory=dict,
+        description="Question UUID to answer; checkbox values are comma-separated.",
+    )
     # Honeypot: hidden field humans never fill in. A non-empty value is spam.
     website: str = Field(default="", max_length=FieldLimit.DISPLAY_NAME)
 
@@ -206,7 +211,14 @@ def check_public_rsvp_phone(request, event_id, payload: PublicRsvpPhoneCheckIn):
 
 @router.post(
     "/public/events/{event_id}/rsvp/",
-    response={200: PublicRsvpOut, 400: ErrorOut, 404: ErrorOut, 409: ErrorOut, 429: ErrorOut},
+    response={
+        200: PublicRsvpOut,
+        400: ErrorOut,
+        404: ErrorOut,
+        409: ErrorOut,
+        422: ErrorOut,
+        429: ErrorOut,
+    },
     auth=None,
 )
 @rate_limit(key_func=client_ip, rate="5/h")
@@ -244,7 +256,11 @@ def submit_public_rsvp(request, event_id, payload: PublicRsvpIn):
         final_status, promoted_user_ids, _rsvp_created = _apply_rsvp_in_transaction(
             event.id,
             user,
-            _RsvpApply(status=payload.status, paid_confirmed=payload.paid_confirmed),
+            _RsvpApply(
+                status=payload.status,
+                paid_confirmed=payload.paid_confirmed,
+                answers=payload.answers,
+            ),
         )
         token = NonMemberRsvpToken.issue_or_extend(user)
 

--- a/backend/community/_public_rsvp_submit.py
+++ b/backend/community/_public_rsvp_submit.py
@@ -48,7 +48,7 @@ class PublicRsvpIn(BaseModel):
     has_plus_one: bool = False
     paid_confirmed: bool = False
     comment: str | None = Field(default=None, max_length=FieldLimit.SHORT_TEXT)
-    answers: dict[str, RsvpAnswer] = Field(
+    questionnaire_responses: dict[str, RsvpAnswer] = Field(
         default_factory=dict,
         description="Question UUID to answer; checkbox values are comma-separated.",
     )
@@ -259,7 +259,7 @@ def submit_public_rsvp(request, event_id, payload: PublicRsvpIn):
             _RsvpApply(
                 status=payload.status,
                 paid_confirmed=payload.paid_confirmed,
-                answers=payload.answers,
+                answers=payload.questionnaire_responses,
             ),
         )
         token = NonMemberRsvpToken.issue_or_extend(user)

--- a/backend/community/_public_rsvp_submit.py
+++ b/backend/community/_public_rsvp_submit.py
@@ -16,9 +16,9 @@ from users.models import PUBLIC_FORM_PHONE_REGION, NonMemberRsvpToken, User, val
 
 from community._event_helpers import _event_out, broadcast_capacity_change
 from community._event_rsvps import (
-    _RsvpApply,
     _apply_rsvp_in_transaction,
     _post_rsvp_comment,
+    _RsvpApply,
     _validate_rsvp_status,
     payment_audit_details,
 )

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -4985,15 +4985,6 @@
       },
       "PublicRsvpIn": {
         "properties": {
-          "answers": {
-            "additionalProperties": {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            "description": "Question UUID to answer; checkbox values are comma-separated.",
-            "title": "Answers",
-            "type": "object"
-          },
           "comment": {
             "anyOf": [
               {
@@ -5037,6 +5028,15 @@
             "title": "Phone Number",
             "type": "string"
           },
+          "questionnaire_responses": {
+            "additionalProperties": {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            "description": "Question UUID to answer; checkbox values are comma-separated.",
+            "title": "Questionnaire Responses",
+            "type": "object"
+          },
           "status": {
             "maxLength": 20,
             "title": "Status",
@@ -5060,22 +5060,6 @@
       },
       "PublicRsvpManageIn": {
         "properties": {
-          "answers": {
-            "anyOf": [
-              {
-                "additionalProperties": {
-                  "maxLength": 2000,
-                  "type": "string"
-                },
-                "type": "object"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "description": "Question UUID to answer; omit or send null to preserve saved answers.",
-            "title": "Answers"
-          },
           "comment": {
             "anyOf": [
               {
@@ -5097,6 +5081,22 @@
             "default": false,
             "title": "Paid Confirmed",
             "type": "boolean"
+          },
+          "questionnaire_responses": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "maxLength": 2000,
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Question UUID to answer; omit or send null to preserve saved answers.",
+            "title": "Questionnaire Responses"
           },
           "status": {
             "title": "Status",

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -4985,6 +4985,15 @@
       },
       "PublicRsvpIn": {
         "properties": {
+          "answers": {
+            "additionalProperties": {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            "description": "Question UUID to answer; checkbox values are comma-separated.",
+            "title": "Answers",
+            "type": "object"
+          },
           "comment": {
             "anyOf": [
               {
@@ -5051,6 +5060,22 @@
       },
       "PublicRsvpManageIn": {
         "properties": {
+          "answers": {
+            "anyOf": [
+              {
+                "additionalProperties": {
+                  "maxLength": 2000,
+                  "type": "string"
+                },
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "Question UUID to answer; omit or send null to preserve saved answers.",
+            "title": "Answers"
+          },
           "comment": {
             "anyOf": [
               {
@@ -13858,6 +13883,16 @@
             },
             "description": "Conflict"
           },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Unprocessable Content"
+          },
           "429": {
             "content": {
               "application/json": {
@@ -14098,6 +14133,16 @@
               }
             },
             "description": "Not Found"
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Unprocessable Content"
           },
           "429": {
             "content": {

--- a/backend/tests/test_public_rsvp.py
+++ b/backend/tests/test_public_rsvp.py
@@ -446,12 +446,12 @@ class TestPublicRsvpComment:
 @pytest.mark.django_db
 class TestPublicRsvpAnswers:
     def test_persists_required_answers(self, api_client, official_event, fake_email_sender):
-        from community.models import EventRsvpQuestion
+        from community.models import EventRsvpQuestion, RsvpQuestionType
 
         q = EventRsvpQuestion.objects.create(
             event=official_event,
             label="transport?",
-            field_type="select",
+            field_type=RsvpQuestionType.SELECT,
             options=["driving", "transit"],
             required=True,
             display_order=0,
@@ -459,19 +459,19 @@ class TestPublicRsvpAnswers:
         response = post(
             api_client,
             official_event,
-            answers={str(q.id): "driving"},
+            questionnaire_responses={str(q.id): "driving"},
         )
         assert response.status_code == 200
         rsvp = EventRSVP.objects.get(event=official_event)
         assert rsvp.questionnaire_responses[str(q.id)]["answer"] == "driving"
 
     def test_required_answer_missing_rejected(self, api_client, official_event, fake_email_sender):
-        from community.models import EventRsvpQuestion
+        from community.models import EventRsvpQuestion, RsvpQuestionType
 
         EventRsvpQuestion.objects.create(
             event=official_event,
             label="transport?",
-            field_type="select",
+            field_type=RsvpQuestionType.SELECT,
             options=["driving", "transit"],
             required=True,
             display_order=0,

--- a/backend/tests/test_public_rsvp.py
+++ b/backend/tests/test_public_rsvp.py
@@ -463,7 +463,7 @@ class TestPublicRsvpAnswers:
         )
         assert response.status_code == 200
         rsvp = EventRSVP.objects.get(event=official_event)
-        assert rsvp.answers[str(q.id)]["answer"] == "driving"
+        assert rsvp.questionnaire_responses[str(q.id)]["answer"] == "driving"
 
     def test_required_answer_missing_rejected(self, api_client, official_event, fake_email_sender):
         from community.models import EventRsvpQuestion

--- a/backend/tests/test_public_rsvp.py
+++ b/backend/tests/test_public_rsvp.py
@@ -441,3 +441,41 @@ class TestPublicRsvpComment:
     def test_oversized_comment_is_rejected(self, api_client, official_event, fake_email_sender):
         response = post(api_client, official_event, comment="x" * 301)
         assert response.status_code == 422
+
+
+@pytest.mark.django_db
+class TestPublicRsvpAnswers:
+    def test_persists_required_answers(self, api_client, official_event, fake_email_sender):
+        from community.models import EventRsvpQuestion
+
+        q = EventRsvpQuestion.objects.create(
+            event=official_event,
+            label="transport?",
+            field_type="select",
+            options=["driving", "transit"],
+            required=True,
+            display_order=0,
+        )
+        response = post(
+            api_client,
+            official_event,
+            answers={str(q.id): "driving"},
+        )
+        assert response.status_code == 200
+        rsvp = EventRSVP.objects.get(event=official_event)
+        assert rsvp.answers[str(q.id)]["answer"] == "driving"
+
+    def test_required_answer_missing_rejected(self, api_client, official_event, fake_email_sender):
+        from community.models import EventRsvpQuestion
+
+        EventRsvpQuestion.objects.create(
+            event=official_event,
+            label="transport?",
+            field_type="select",
+            options=["driving", "transit"],
+            required=True,
+            display_order=0,
+        )
+        response = post(api_client, official_event)
+        assert response.status_code == 422
+        assert first_code(response) == Code.Event.RSVP_ANSWER_REQUIRED

--- a/backend/tests/test_public_rsvp_answer_updates.py
+++ b/backend/tests/test_public_rsvp_answer_updates.py
@@ -1,0 +1,107 @@
+import pytest
+from community._validation import Code
+from community.models import EventRSVP, EventRsvpQuestion, RSVPStatus
+from users.models import NonMemberRsvpToken
+
+from tests._public_rsvp_helpers import first_code, make_non_member, make_official_event
+
+
+@pytest.fixture
+def nonmember(db):
+    return make_non_member("+14155550001", "nm@example.com", name="non member")
+
+
+@pytest.fixture
+def official_event(db):
+    return make_official_event(title="Official A")
+
+
+def _post(api_client, event, token, body):
+    return api_client.post(
+        f"/api/community/public/my-rsvps/{event.id}/?token={token.token}",
+        body,
+        content_type="application/json",
+    )
+
+
+@pytest.mark.django_db
+class TestPublicRsvpAnswerUpdates:
+    def test_update_without_answers_preserves_existing_answers(
+        self, api_client, nonmember, official_event
+    ):
+        question = EventRsvpQuestion.objects.create(
+            event=official_event,
+            label="travel details",
+            field_type="textarea",
+            required=False,
+        )
+        EventRSVP.objects.create(
+            event=official_event,
+            user=nonmember,
+            status=RSVPStatus.ATTENDING,
+            answers={str(question.id): {"label": question.label, "answer": "taking transit"}},
+        )
+        token = NonMemberRsvpToken.issue_or_extend(nonmember)
+
+        response = _post(api_client, official_event, token, {"status": RSVPStatus.MAYBE})
+
+        assert response.status_code == 200
+        rsvp = EventRSVP.objects.get(event=official_event, user=nonmember)
+        assert rsvp.answers[str(question.id)]["answer"] == "taking transit"
+
+    def test_update_without_answers_validates_new_required_questions(
+        self, api_client, nonmember, official_event
+    ):
+        EventRSVP.objects.create(
+            event=official_event,
+            user=nonmember,
+            status=RSVPStatus.CANT_GO,
+        )
+        EventRsvpQuestion.objects.create(
+            event=official_event,
+            label="travel details",
+            field_type="textarea",
+            required=True,
+        )
+        token = NonMemberRsvpToken.issue_or_extend(nonmember)
+
+        response = _post(api_client, official_event, token, {"status": RSVPStatus.ATTENDING})
+
+        assert response.status_code == 422
+        assert first_code(response) == Code.Event.RSVP_ANSWER_REQUIRED
+
+    def test_explicit_answers_preserve_deleted_question_snapshots(
+        self, api_client, nonmember, official_event
+    ):
+        current = EventRsvpQuestion.objects.create(
+            event=official_event,
+            label="current",
+            field_type="textarea",
+            required=False,
+        )
+        deleted_id = "00000000-0000-0000-0000-000000000001"
+        EventRSVP.objects.create(
+            event=official_event,
+            user=nonmember,
+            status=RSVPStatus.ATTENDING,
+            answers={
+                deleted_id: {"label": "deleted", "answer": "historical"},
+                str(current.id): {"label": "old current label", "answer": "unchanged"},
+            },
+        )
+        token = NonMemberRsvpToken.issue_or_extend(nonmember)
+
+        response = _post(
+            api_client,
+            official_event,
+            token,
+            {
+                "status": RSVPStatus.MAYBE,
+                "answers": {str(current.id): "unchanged"},
+            },
+        )
+
+        assert response.status_code == 200
+        answers = EventRSVP.objects.get(event=official_event, user=nonmember).answers
+        assert answers[deleted_id]["answer"] == "historical"
+        assert answers[str(current.id)]["label"] == "old current label"

--- a/backend/tests/test_public_rsvp_answer_updates.py
+++ b/backend/tests/test_public_rsvp_answer_updates.py
@@ -1,6 +1,6 @@
 import pytest
 from community._validation import Code
-from community.models import EventRSVP, EventRsvpQuestion, RSVPStatus
+from community.models import EventRSVP, EventRsvpQuestion, RsvpQuestionType, RSVPStatus
 from users.models import NonMemberRsvpToken
 
 from tests._public_rsvp_helpers import first_code, make_non_member, make_official_event
@@ -32,14 +32,16 @@ class TestPublicRsvpAnswerUpdates:
         question = EventRsvpQuestion.objects.create(
             event=official_event,
             label="travel details",
-            field_type="textarea",
+            field_type=RsvpQuestionType.TEXTAREA,
             required=False,
         )
         EventRSVP.objects.create(
             event=official_event,
             user=nonmember,
             status=RSVPStatus.ATTENDING,
-            answers={str(question.id): {"label": question.label, "answer": "taking transit"}},
+            questionnaire_responses={
+                str(question.id): {"label": question.label, "answer": "taking transit"}
+            },
         )
         token = NonMemberRsvpToken.issue_or_extend(nonmember)
 
@@ -60,7 +62,7 @@ class TestPublicRsvpAnswerUpdates:
         EventRsvpQuestion.objects.create(
             event=official_event,
             label="travel details",
-            field_type="textarea",
+            field_type=RsvpQuestionType.TEXTAREA,
             required=True,
         )
         token = NonMemberRsvpToken.issue_or_extend(nonmember)
@@ -76,7 +78,7 @@ class TestPublicRsvpAnswerUpdates:
         current = EventRsvpQuestion.objects.create(
             event=official_event,
             label="current",
-            field_type="textarea",
+            field_type=RsvpQuestionType.TEXTAREA,
             required=False,
         )
         deleted_id = "00000000-0000-0000-0000-000000000001"
@@ -84,7 +86,7 @@ class TestPublicRsvpAnswerUpdates:
             event=official_event,
             user=nonmember,
             status=RSVPStatus.ATTENDING,
-            answers={
+            questionnaire_responses={
                 deleted_id: {"label": "deleted", "answer": "historical"},
                 str(current.id): {"label": "old current label", "answer": "unchanged"},
             },
@@ -97,11 +99,13 @@ class TestPublicRsvpAnswerUpdates:
             token,
             {
                 "status": RSVPStatus.MAYBE,
-                "answers": {str(current.id): "unchanged"},
+                "questionnaire_responses": {str(current.id): "unchanged"},
             },
         )
 
         assert response.status_code == 200
-        answers = EventRSVP.objects.get(event=official_event, user=nonmember).questionnaire_responses
+        answers = EventRSVP.objects.get(
+            event=official_event, user=nonmember
+        ).questionnaire_responses
         assert answers[deleted_id]["answer"] == "historical"
         assert answers[str(current.id)]["label"] == "old current label"

--- a/backend/tests/test_public_rsvp_answer_updates.py
+++ b/backend/tests/test_public_rsvp_answer_updates.py
@@ -47,7 +47,7 @@ class TestPublicRsvpAnswerUpdates:
 
         assert response.status_code == 200
         rsvp = EventRSVP.objects.get(event=official_event, user=nonmember)
-        assert rsvp.answers[str(question.id)]["answer"] == "taking transit"
+        assert rsvp.questionnaire_responses[str(question.id)]["answer"] == "taking transit"
 
     def test_update_without_answers_validates_new_required_questions(
         self, api_client, nonmember, official_event
@@ -102,6 +102,6 @@ class TestPublicRsvpAnswerUpdates:
         )
 
         assert response.status_code == 200
-        answers = EventRSVP.objects.get(event=official_event, user=nonmember).answers
+        answers = EventRSVP.objects.get(event=official_event, user=nonmember).questionnaire_responses
         assert answers[deleted_id]["answer"] == "historical"
         assert answers[str(current.id)]["label"] == "old current label"

--- a/frontend/src/api/publicRsvp.test.ts
+++ b/frontend/src/api/publicRsvp.test.ts
@@ -42,6 +42,7 @@ describe('useSubmitPublicRsvp', () => {
       phone_number: '+15550001111',
       status: 'attending',
       has_plus_one: false,
+      answers: {},
       website: '',
       paid_confirmed: false,
     };
@@ -71,6 +72,16 @@ describe('useUpdatePublicMyRsvp', () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(apiClient.post).toHaveBeenCalledWith(
+      '/api/community/public/my-rsvps/ev1/',
+      {
+        status: 'attending',
+        has_plus_one: false,
+        comment: 'hi',
+        paid_confirmed: false,
+      },
+      { params: { token } },
+    );
     expect(invalidate).toHaveBeenCalledWith({ queryKey: eventKeys.detail('ev1', false, token) });
     expect(invalidate).toHaveBeenCalledWith({ queryKey: eventCommentKeys.list('ev1') });
   });

--- a/frontend/src/api/publicRsvp.test.ts
+++ b/frontend/src/api/publicRsvp.test.ts
@@ -42,7 +42,7 @@ describe('useSubmitPublicRsvp', () => {
       phone_number: '+15550001111',
       status: 'attending',
       has_plus_one: false,
-      answers: {},
+      questionnaire_responses: {},
       website: '',
       paid_confirmed: false,
     };

--- a/frontend/src/api/publicRsvp.ts
+++ b/frontend/src/api/publicRsvp.ts
@@ -109,6 +109,7 @@ interface UpdateArgs {
   hasPlusOne: boolean;
   comment?: string;
   paidConfirmed?: boolean;
+  answers?: Record<string, string>;
 }
 
 function useManageInvalidate(token: string) {
@@ -126,12 +127,20 @@ function useManageInvalidate(token: string) {
 export function useUpdatePublicMyRsvp(token: string) {
   const invalidate = useManageInvalidate(token);
   return useMutation({
-    mutationFn: async ({ eventId, status, hasPlusOne, comment, paidConfirmed }: UpdateArgs) => {
+    mutationFn: async ({
+      eventId,
+      status,
+      hasPlusOne,
+      comment,
+      paidConfirmed,
+      answers,
+    }: UpdateArgs) => {
       const body: PublicRsvpManageIn = {
         status,
         has_plus_one: hasPlusOne,
         comment: comment ?? null,
         paid_confirmed: paidConfirmed ?? false,
+        ...(answers === undefined ? {} : { answers }),
       };
       const { data } = await apiClient.post<PublicRsvpOut>(`${MANAGE_BASE}${eventId}/`, body, {
         params: { token },

--- a/frontend/src/api/publicRsvp.ts
+++ b/frontend/src/api/publicRsvp.ts
@@ -109,7 +109,7 @@ interface UpdateArgs {
   hasPlusOne: boolean;
   comment?: string;
   paidConfirmed?: boolean;
-  answers?: Record<string, string>;
+  questionnaireResponses?: Record<string, string>;
 }
 
 function useManageInvalidate(token: string) {
@@ -133,14 +133,16 @@ export function useUpdatePublicMyRsvp(token: string) {
       hasPlusOne,
       comment,
       paidConfirmed,
-      answers,
+      questionnaireResponses,
     }: UpdateArgs) => {
       const body: PublicRsvpManageIn = {
         status,
         has_plus_one: hasPlusOne,
         comment: comment ?? null,
         paid_confirmed: paidConfirmed ?? false,
-        ...(answers === undefined ? {} : { answers }),
+        ...(questionnaireResponses === undefined
+          ? {}
+          : { questionnaire_responses: questionnaireResponses }),
       };
       const { data } = await apiClient.post<PublicRsvpOut>(`${MANAGE_BASE}${eventId}/`, body, {
         params: { token },

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -4382,13 +4382,6 @@ export interface components {
         };
         /** PublicRsvpIn */
         PublicRsvpIn: {
-            /**
-             * Answers
-             * @description Question UUID to answer; checkbox values are comma-separated.
-             */
-            answers?: {
-                [key: string]: string;
-            };
             /** Comment */
             comment?: string | null;
             /**
@@ -4415,6 +4408,13 @@ export interface components {
             paid_confirmed: boolean;
             /** Phone Number */
             phone_number: string;
+            /**
+             * Questionnaire Responses
+             * @description Question UUID to answer; checkbox values are comma-separated.
+             */
+            questionnaire_responses?: {
+                [key: string]: string;
+            };
             /** Status */
             status: string;
             /**
@@ -4425,13 +4425,6 @@ export interface components {
         };
         /** PublicRsvpManageIn */
         PublicRsvpManageIn: {
-            /**
-             * Answers
-             * @description Question UUID to answer; omit or send null to preserve saved answers.
-             */
-            answers?: {
-                [key: string]: string;
-            } | null;
             /** Comment */
             comment?: string | null;
             /**
@@ -4444,6 +4437,13 @@ export interface components {
              * @default false
              */
             paid_confirmed: boolean;
+            /**
+             * Questionnaire Responses
+             * @description Question UUID to answer; omit or send null to preserve saved answers.
+             */
+            questionnaire_responses?: {
+                [key: string]: string;
+            } | null;
             /** Status */
             status: string;
         };

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -4382,6 +4382,13 @@ export interface components {
         };
         /** PublicRsvpIn */
         PublicRsvpIn: {
+            /**
+             * Answers
+             * @description Question UUID to answer; checkbox values are comma-separated.
+             */
+            answers?: {
+                [key: string]: string;
+            };
             /** Comment */
             comment?: string | null;
             /**
@@ -4418,6 +4425,13 @@ export interface components {
         };
         /** PublicRsvpManageIn */
         PublicRsvpManageIn: {
+            /**
+             * Answers
+             * @description Question UUID to answer; omit or send null to preserve saved answers.
+             */
+            answers?: {
+                [key: string]: string;
+            } | null;
             /** Comment */
             comment?: string | null;
             /**
@@ -10166,6 +10180,15 @@ export interface operations {
                     "application/json": components["schemas"]["ErrorOut"];
                 };
             };
+            /** @description Unprocessable Content */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
             /** @description Too Many Requests */
             429: {
                 headers: {
@@ -10287,6 +10310,15 @@ export interface operations {
             };
             /** @description Not Found */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Unprocessable Content */
+            422: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/screens/events/MyRsvpSection.tsx
+++ b/frontend/src/screens/events/MyRsvpSection.tsx
@@ -82,7 +82,7 @@ export function MyRsvpSection({ event, token, locked = false }: Props) {
           eventId: event.id,
           status: args.status,
           hasPlusOne: args.hasPlusOne,
-          answers: args.answers,
+          questionnaireResponses: args.questionnaireResponses,
           ...(args.comment !== undefined ? { comment: args.comment } : {}),
           ...(args.paidConfirmed ? { paidConfirmed: true } : {}),
         });

--- a/frontend/src/screens/events/MyRsvpSection.tsx
+++ b/frontend/src/screens/events/MyRsvpSection.tsx
@@ -82,6 +82,7 @@ export function MyRsvpSection({ event, token, locked = false }: Props) {
           eventId: event.id,
           status: args.status,
           hasPlusOne: args.hasPlusOne,
+          answers: args.answers,
           ...(args.comment !== undefined ? { comment: args.comment } : {}),
           ...(args.paidConfirmed ? { paidConfirmed: true } : {}),
         });

--- a/frontend/src/screens/events/PublicRsvpCard.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpCard.test.tsx
@@ -73,6 +73,30 @@ describe('PublicRsvpCard', () => {
     );
   });
 
+  it('submits existing question answers when changing status', () => {
+    renderCard({
+      status: RsvpServerStatus.Attending,
+      event: {
+        myRsvpAnswers: { q1: { label: 'travel details', answer: 'taking transit' } },
+        rsvpQuestions: [
+          {
+            id: 'q1',
+            label: 'travel details',
+            fieldType: 'textarea',
+            options: [],
+            required: true,
+          },
+        ],
+      },
+    });
+
+    expect(screen.getByLabelText('travel details')).toHaveValue('taking transit');
+    fireEvent.click(screen.getByRole('button', { name: /^maybe$/i }));
+    expect(updateMutate).toHaveBeenCalledWith(
+      expect.objectContaining({ answers: { q1: 'taking transit' } }),
+    );
+  });
+
   it('renders the comment field', () => {
     renderCard({ status: RsvpServerStatus.Attending });
     expect(screen.getByLabelText('comment (optional)')).toBeInTheDocument();

--- a/frontend/src/screens/events/PublicRsvpCard.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpCard.test.tsx
@@ -77,7 +77,9 @@ describe('PublicRsvpCard', () => {
     renderCard({
       status: RsvpServerStatus.Attending,
       event: {
-        myRsvpAnswers: { q1: { label: 'travel details', answer: 'taking transit' } },
+        myQuestionnaireResponses: {
+          q1: { label: 'travel details', answer: 'taking transit' },
+        },
         rsvpQuestions: [
           {
             id: 'q1',
@@ -93,7 +95,7 @@ describe('PublicRsvpCard', () => {
     expect(screen.getByLabelText('travel details')).toHaveValue('taking transit');
     fireEvent.click(screen.getByRole('button', { name: /^maybe$/i }));
     expect(updateMutate).toHaveBeenCalledWith(
-      expect.objectContaining({ answers: { q1: 'taking transit' } }),
+      expect.objectContaining({ questionnaireResponses: { q1: 'taking transit' } }),
     );
   });
 

--- a/frontend/src/screens/events/PublicRsvpCard.tsx
+++ b/frontend/src/screens/events/PublicRsvpCard.tsx
@@ -46,7 +46,7 @@ export function PublicRsvpCard({ token, event, status }: Props) {
   const [comment, setComment] = useState('');
   const [answers, setAnswers] = useState<Record<string, RsvpAnswerValue>>(() =>
     Object.fromEntries(
-      Object.entries(event.myRsvpAnswers).map(([questionId, snapshot]) => [
+      Object.entries(event.myQuestionnaireResponses).map(([questionId, snapshot]) => [
         questionId,
         snapshot.answer,
       ]),
@@ -73,7 +73,7 @@ export function PublicRsvpCard({ token, event, status }: Props) {
         eventId: event.id,
         status: next,
         hasPlusOne: false,
-        answers,
+        questionnaireResponses: answers,
         ...(rsvpComment !== undefined ? { comment: rsvpComment } : {}),
         ...(paidConfirmed ? { paidConfirmed: true } : {}),
       });

--- a/frontend/src/screens/events/PublicRsvpCard.tsx
+++ b/frontend/src/screens/events/PublicRsvpCard.tsx
@@ -12,6 +12,8 @@ import { buildEventLinks } from '@/utils/eventLinks';
 
 import { PaymentConfirmStep } from './PaymentConfirmStep';
 import { RsvpCommentField } from './RsvpCommentField';
+import { RsvpQuestionFields } from './RsvpQuestionFields';
+import { missingRequiredQuestionIds, type RsvpAnswerValue } from './rsvpQuestions';
 import { usePaymentGate } from './usePaymentGate';
 
 const UPDATED_TOAST = 'rsvp updated — check your email for an updated link';
@@ -42,6 +44,15 @@ export function PublicRsvpCard({ token, event, status }: Props) {
   const cancel = useCancelPublicMyRsvp(token);
   const [error, setError] = useState<string | null>(null);
   const [comment, setComment] = useState('');
+  const [answers, setAnswers] = useState<Record<string, RsvpAnswerValue>>(() =>
+    Object.fromEntries(
+      Object.entries(event.myRsvpAnswers).map(([questionId, snapshot]) => [
+        questionId,
+        snapshot.answer,
+      ]),
+    ),
+  );
+  const [answerErrors, setAnswerErrors] = useState<Record<string, string>>({});
   const [pendingStatus, setPendingStatus] = useState<RsvpInputStatus | null>(null);
   const links = buildEventLinks(event);
   const busy = update.isPending || cancel.isPending;
@@ -49,11 +60,20 @@ export function PublicRsvpCard({ token, event, status }: Props) {
 
   async function applyRsvp(next: RsvpInputStatus, rsvpComment?: string, paidConfirmed?: boolean) {
     setError(null);
+    const missing =
+      next === RsvpServerStatus.CantGo
+        ? []
+        : missingRequiredQuestionIds(event.rsvpQuestions, answers);
+    if (missing.length > 0) {
+      setAnswerErrors(Object.fromEntries(missing.map((id) => [id, 'required'])));
+      return;
+    }
     try {
       await update.mutateAsync({
         eventId: event.id,
         status: next,
         hasPlusOne: false,
+        answers,
         ...(rsvpComment !== undefined ? { comment: rsvpComment } : {}),
         ...(paidConfirmed ? { paidConfirmed: true } : {}),
       });
@@ -139,6 +159,21 @@ export function PublicRsvpCard({ token, event, status }: Props) {
         ) : (
           <>
             <RsvpStatusPicker value={status} onSelect={changeStatus} disabled={busy} />
+
+            <RsvpQuestionFields
+              questions={event.rsvpQuestions}
+              answers={answers}
+              onChange={(id, value) => {
+                setAnswers((current) => ({ ...current, [id]: value }));
+                setAnswerErrors((current) => {
+                  if (!(id in current)) return current;
+                  const { [id]: _removed, ...rest } = current;
+                  return rest;
+                });
+              }}
+              errors={answerErrors}
+              disabled={busy}
+            />
 
             <RsvpCommentField value={comment} onChange={setComment} disabled={busy} />
             <Button variant="ghost" onClick={saveComment} disabled={busy || !comment.trim()}>

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -28,6 +28,8 @@ import {
 import { PaymentConfirmStep } from './PaymentConfirmStep';
 import { PublicRsvpPhoneStep } from './PublicRsvpPhoneStep';
 import { RsvpCommentField } from './RsvpCommentField';
+import { RsvpQuestionFields } from './RsvpQuestionFields';
+import { missingRequiredQuestionIds, type RsvpAnswerValue } from './rsvpQuestions';
 import { usePaymentGate } from './usePaymentGate';
 
 const MAX_NAME = 100;
@@ -80,6 +82,7 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
   const submit = useSubmitPublicRsvp();
   const navigate = useNavigate();
   const atCapacity = spotsLeft(event) === 0;
+  const questions = event.rsvpQuestions;
   const [status, setStatus] = useState<RsvpInputStatus | null>(null);
   const [phoneConfirmed, setPhoneConfirmed] = useState(false);
   const [isNonMember, setIsNonMember] = useState(false);
@@ -89,6 +92,7 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
   const [phone, setPhone] = useState('');
   const [comment, setComment] = useState('');
   const [website, setWebsite] = useState('');
+  const [answers, setAnswers] = useState<Record<string, RsvpAnswerValue | undefined>>({});
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [submitError, setSubmitError] = useState<SubmitError | null>(null);
   const [showPayment, setShowPayment] = useState(false);
@@ -113,6 +117,9 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
     else if (optionalEmail(email)) next.email = 'not a valid email';
     if (!phone.trim()) next.phone = 'phone required';
     else if (!isValidPhoneNumber(phone)) next.phone = 'invalid phone number';
+    for (const id of missingRequiredQuestionIds(questions, answers)) {
+      next[id] = 'required';
+    }
     setErrors(next);
     return Object.keys(next).length === 0;
   }
@@ -120,6 +127,11 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
   async function onSubmit(paidConfirmed: boolean) {
     setSubmitError(null);
     if (!status || !validate()) return;
+    const filledAnswers: Record<string, string> = {};
+    for (const q of questions) {
+      const value = answers[q.id];
+      if (value?.trim()) filledAnswers[q.id] = value;
+    }
     try {
       const result = await submit.mutateAsync({
         eventId: event.id,
@@ -131,6 +143,7 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
           status,
           has_plus_one: false,
           comment: comment.trim() || null,
+          answers: filledAnswers,
           website,
           paid_confirmed: paidConfirmed,
         },
@@ -275,6 +288,21 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
           required
         />
         <PhoneField label="phone" value={phone} onChange={setPhone} error={errors.phone} />
+
+        <RsvpQuestionFields
+          questions={questions}
+          answers={answers}
+          onChange={(id, value) => {
+            setAnswers((prev) => ({ ...prev, [id]: value }));
+            setErrors((prev) => {
+              if (!(id in prev)) return prev;
+              const { [id]: _removed, ...rest } = prev;
+              return rest;
+            });
+          }}
+          errors={errors}
+          disabled={submit.isPending}
+        />
 
         <RsvpCommentField
           value={comment}

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -143,7 +143,7 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
           status,
           has_plus_one: false,
           comment: comment.trim() || null,
-          answers: filledAnswers,
+          questionnaire_responses: filledAnswers,
           website,
           paid_confirmed: paidConfirmed,
         },

--- a/frontend/src/screens/events/PublicRsvpsScreen.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpsScreen.test.tsx
@@ -197,7 +197,7 @@ describe('PublicRsvpsScreen', () => {
         eventId: 'ev1',
         status: RsvpStatus.Maybe,
         hasPlusOne: false,
-        answers: {},
+        questionnaireResponses: {},
       });
     });
     expect(toastSuccess).toHaveBeenCalledWith(

--- a/frontend/src/screens/events/PublicRsvpsScreen.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpsScreen.test.tsx
@@ -197,6 +197,7 @@ describe('PublicRsvpsScreen', () => {
         eventId: 'ev1',
         status: RsvpStatus.Maybe,
         hasPlusOne: false,
+        answers: {},
       });
     });
     expect(toastSuccess).toHaveBeenCalledWith(


### PR DESCRIPTION
Extend public RSVP submission and management so non-members can answer
event questions without losing saved answers on later updates.

Co-authored-by: Cursor <cursoragent@cursor.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>