### PR TITLE
feat(events): add host RSVP response reporting

### DIFF
--- a/backend/tests/test_event_helpers.py
+++ b/backend/tests/test_event_helpers.py
@@ -69,8 +69,6 @@ class TestBuildGuestList:
         result = _build_guest_list([rsvp], can_see_phones=False)
         assert result[0].name == "member"
 
-
-
     def test_includes_questionnaire_responses_only_when_requested(self):
         rsvp = self._make_rsvp("u1", "Alice", RSVPStatus.ATTENDING, "+1555000")
         rsvp.questionnaire_responses = {"qid": {"label": "q", "answer": "yes"}}

--- a/backend/tests/test_event_helpers.py
+++ b/backend/tests/test_event_helpers.py
@@ -70,6 +70,16 @@ class TestBuildGuestList:
         assert result[0].name == "member"
 
 
+
+    def test_includes_answers_only_when_requested(self):
+        rsvp = self._make_rsvp("u1", "Alice", RSVPStatus.ATTENDING, "+1555000")
+        rsvp.answers = {"qid": {"label": "q", "answer": "yes"}}
+        hidden = _build_guest_list([rsvp], can_see_phones=False, include_answers=False)
+        assert hidden[0].answers == {}
+        shown = _build_guest_list([rsvp], can_see_phones=False, include_answers=True)
+        assert shown[0].answers == {"qid": {"label": "q", "answer": "yes"}}
+
+
 class TestFindMyRsvp:
     def _make_rsvp(self, user_id, status):
         return SimpleNamespace(user_id=user_id, status=status)

--- a/backend/tests/test_event_helpers.py
+++ b/backend/tests/test_event_helpers.py
@@ -71,13 +71,17 @@ class TestBuildGuestList:
 
 
 
-    def test_includes_answers_only_when_requested(self):
+    def test_includes_questionnaire_responses_only_when_requested(self):
         rsvp = self._make_rsvp("u1", "Alice", RSVPStatus.ATTENDING, "+1555000")
-        rsvp.answers = {"qid": {"label": "q", "answer": "yes"}}
-        hidden = _build_guest_list([rsvp], can_see_phones=False, include_answers=False)
-        assert hidden[0].answers == {}
-        shown = _build_guest_list([rsvp], can_see_phones=False, include_answers=True)
-        assert shown[0].answers == {"qid": {"label": "q", "answer": "yes"}}
+        rsvp.questionnaire_responses = {"qid": {"label": "q", "answer": "yes"}}
+        hidden = _build_guest_list(
+            [rsvp], can_see_phones=False, include_questionnaire_responses=False
+        )
+        assert hidden[0].questionnaire_responses == {}
+        shown = _build_guest_list(
+            [rsvp], can_see_phones=False, include_questionnaire_responses=True
+        )
+        assert shown[0].questionnaire_responses == {"qid": {"label": "q", "answer": "yes"}}
 
 
 class TestFindMyRsvp:

--- a/frontend/src/screens/events/EventDetailKebabMenu.test.tsx
+++ b/frontend/src/screens/events/EventDetailKebabMenu.test.tsx
@@ -151,7 +151,7 @@ describe('EventDetailKebabMenu', () => {
     expect(screen.queryByRole('menuitem', { name: /question responses/i })).not.toBeInTheDocument();
   });
 
-  it('links past-event question responses to rsvp management', async () => {
+  it('keeps "manage rsvps" label on past events with questions', async () => {
     vi.mocked(useFlag).mockReturnValue(false);
     renderMenu({
       eventHasEnded: true,
@@ -170,13 +170,13 @@ describe('EventDetailKebabMenu', () => {
     });
     await openMenu();
 
-    expect(screen.getByRole('menuitem', { name: /question responses/i })).toHaveAttribute(
+    expect(screen.getByRole('menuitem', { name: /manage rsvps/i })).toHaveAttribute(
       'href',
       '/events/ev1/manage-rsvps',
     );
   });
 
-  it('links saved answer history to rsvp management', async () => {
+  it('keeps "manage rsvps" when only saved answer history remains', async () => {
     vi.mocked(useFlag).mockReturnValue(false);
     renderMenu({
       eventHasEnded: true,
@@ -194,13 +194,13 @@ describe('EventDetailKebabMenu', () => {
     });
     await openMenu();
 
-    expect(screen.getByRole('menuitem', { name: /question responses/i })).toHaveAttribute(
+    expect(screen.getByRole('menuitem', { name: /manage rsvps/i })).toHaveAttribute(
       'href',
       '/events/ev1/manage-rsvps',
     );
   });
 
-  it('hides "question responses" when only declined snapshots remain', async () => {
+  it('hides "manage rsvps" when only declined snapshots remain', async () => {
     vi.mocked(useFlag).mockReturnValue(false);
     renderMenu({
       eventHasEnded: true,
@@ -219,7 +219,7 @@ describe('EventDetailKebabMenu', () => {
     });
     await openMenu();
 
-    expect(screen.queryByRole('menuitem', { name: /question responses/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: /manage rsvps/i })).not.toBeInTheDocument();
   });
 
   it('hides "manage rsvps" when the viewer cannot manage rsvps', async () => {

--- a/frontend/src/screens/events/EventDetailKebabMenu.test.tsx
+++ b/frontend/src/screens/events/EventDetailKebabMenu.test.tsx
@@ -185,7 +185,9 @@ describe('EventDetailKebabMenu', () => {
         rsvpQuestions: [],
         guests: [
           makeGuest({
-            answers: { deleted: { label: 'deleted question', answer: 'saved answer' } },
+            questionnaireResponses: {
+              deleted: { label: 'deleted question', answer: 'saved answer' },
+            },
           }),
         ],
       },
@@ -208,7 +210,9 @@ describe('EventDetailKebabMenu', () => {
         guests: [
           makeGuest({
             status: 'cant_go',
-            answers: { deleted: { label: 'deleted question', answer: 'saved answer' } },
+            questionnaireResponses: {
+              deleted: { label: 'deleted question', answer: 'saved answer' },
+            },
           }),
         ],
       },

--- a/frontend/src/screens/events/EventDetailKebabMenu.test.tsx
+++ b/frontend/src/screens/events/EventDetailKebabMenu.test.tsx
@@ -7,7 +7,7 @@ import { useFlag } from '@/api/featureFlags';
 import { useAuthStore } from '@/auth/store';
 import type { Event } from '@/models/event';
 import { EventStatus } from '@/models/event';
-import { makeEvent, makeUser } from '@/test/fixtures';
+import { makeEvent, makeGuest, makeUser } from '@/test/fixtures';
 
 import { EventDetailKebabMenu } from './EventDetailKebabMenu';
 
@@ -142,12 +142,80 @@ describe('EventDetailKebabMenu', () => {
     expect(manageRsvps).toHaveAttribute('href', '/events/ev1/manage-rsvps');
   });
 
-  it('hides "manage rsvps" once the event has ended', async () => {
+  it('hides rsvp management once the event has ended without question history', async () => {
     vi.mocked(useFlag).mockReturnValue(false);
     renderMenu({ eventHasEnded: true, canManageRsvps: true });
     await openMenu();
 
     expect(screen.queryByRole('menuitem', { name: /manage rsvps/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: /question responses/i })).not.toBeInTheDocument();
+  });
+
+  it('links past-event question responses to rsvp management', async () => {
+    vi.mocked(useFlag).mockReturnValue(false);
+    renderMenu({
+      eventHasEnded: true,
+      canManageRsvps: true,
+      event: {
+        rsvpQuestions: [
+          {
+            id: 'q1',
+            label: 'dietary?',
+            fieldType: 'textarea',
+            options: [],
+            required: false,
+          },
+        ],
+      },
+    });
+    await openMenu();
+
+    expect(screen.getByRole('menuitem', { name: /question responses/i })).toHaveAttribute(
+      'href',
+      '/events/ev1/manage-rsvps',
+    );
+  });
+
+  it('links saved answer history to rsvp management', async () => {
+    vi.mocked(useFlag).mockReturnValue(false);
+    renderMenu({
+      eventHasEnded: true,
+      canManageRsvps: true,
+      event: {
+        rsvpQuestions: [],
+        guests: [
+          makeGuest({
+            answers: { deleted: { label: 'deleted question', answer: 'saved answer' } },
+          }),
+        ],
+      },
+    });
+    await openMenu();
+
+    expect(screen.getByRole('menuitem', { name: /question responses/i })).toHaveAttribute(
+      'href',
+      '/events/ev1/manage-rsvps',
+    );
+  });
+
+  it('hides "question responses" when only declined snapshots remain', async () => {
+    vi.mocked(useFlag).mockReturnValue(false);
+    renderMenu({
+      eventHasEnded: true,
+      canManageRsvps: true,
+      event: {
+        rsvpQuestions: [],
+        guests: [
+          makeGuest({
+            status: 'cant_go',
+            answers: { deleted: { label: 'deleted question', answer: 'saved answer' } },
+          }),
+        ],
+      },
+    });
+    await openMenu();
+
+    expect(screen.queryByRole('menuitem', { name: /question responses/i })).not.toBeInTheDocument();
   });
 
   it('hides "manage rsvps" when the viewer cannot manage rsvps', async () => {

--- a/frontend/src/screens/events/EventDetailKebabMenu.tsx
+++ b/frontend/src/screens/events/EventDetailKebabMenu.tsx
@@ -10,6 +10,7 @@ import { Feature } from '@/models/featureFlags';
 import { EmailBlastDialog } from './EmailBlastDialog';
 import { canEditEvent } from './eventEditGate';
 import { GroupTextDialog } from './GroupTextDialog';
+import { hasSavedRsvpAnswers } from './rsvpQuestions';
 
 interface Props {
   event: Event;
@@ -26,7 +27,8 @@ export function EventDetailKebabMenu({ event, eventHasEnded, canManageRsvps }: P
   const reportFlagOn = useFlag(Feature.HostAttendanceReport);
   const user = useAuthStore((s) => s.user);
   const showCheckInReport = eventHasEnded && reportFlagOn;
-  const showManageRsvps = canManageRsvps && !eventHasEnded;
+  const hasQuestionHistory = event.rsvpQuestions.length > 0 || hasSavedRsvpAnswers(event);
+  const showManageRsvps = canManageRsvps && (!eventHasEnded || hasQuestionHistory);
   const showEmailBlast = event.status !== EventStatus.Draft && event.guests.length > 0;
   const showEdit = canEditEvent(event, user);
 
@@ -84,7 +86,7 @@ export function EventDetailKebabMenu({ event, eventHasEnded, canManageRsvps }: P
                 setOpen(false);
               }}
             >
-              manage rsvps
+              {eventHasEnded ? 'question responses' : 'manage rsvps'}
             </MenuLink>
           ) : null}
           <MenuLink

--- a/frontend/src/screens/events/EventDetailKebabMenu.tsx
+++ b/frontend/src/screens/events/EventDetailKebabMenu.tsx
@@ -87,7 +87,7 @@ export function EventDetailKebabMenu({ event, eventHasEnded, canManageRsvps }: P
                 setOpen(false);
               }}
             >
-              {eventHasEnded ? 'question responses' : 'manage rsvps'}
+              manage rsvps
             </MenuLink>
           ) : null}
           <MenuLink

--- a/frontend/src/screens/events/EventDetailKebabMenu.tsx
+++ b/frontend/src/screens/events/EventDetailKebabMenu.tsx
@@ -10,7 +10,7 @@ import { Feature } from '@/models/featureFlags';
 import { EmailBlastDialog } from './EmailBlastDialog';
 import { canEditEvent } from './eventEditGate';
 import { GroupTextDialog } from './GroupTextDialog';
-import { hasSavedRsvpAnswers } from './rsvpQuestions';
+import { hasSavedQuestionnaireResponses } from './rsvpQuestions';
 
 interface Props {
   event: Event;
@@ -27,7 +27,8 @@ export function EventDetailKebabMenu({ event, eventHasEnded, canManageRsvps }: P
   const reportFlagOn = useFlag(Feature.HostAttendanceReport);
   const user = useAuthStore((s) => s.user);
   const showCheckInReport = eventHasEnded && reportFlagOn;
-  const hasQuestionHistory = event.rsvpQuestions.length > 0 || hasSavedRsvpAnswers(event);
+  const hasQuestionHistory =
+    event.rsvpQuestions.length > 0 || hasSavedQuestionnaireResponses(event);
   const showManageRsvps = canManageRsvps && (!eventHasEnded || hasQuestionHistory);
   const showEmailBlast = event.status !== EventStatus.Draft && event.guests.length > 0;
   const showEdit = canEditEvent(event, user);

--- a/frontend/src/screens/events/EventManageRsvpsPanel.tsx
+++ b/frontend/src/screens/events/EventManageRsvpsPanel.tsx
@@ -12,28 +12,39 @@ import { isRsvpInputStatus, RSVP_GROUP_LABELS, RsvpServerStatus } from '@/models
 import { cn } from '@/utils/cn';
 import { eventRequiresPaymentConfirmation } from '@/utils/eventCost';
 
-export function EventManageRsvpsPanel({ event }: { event: Event }) {
+import { EventRsvpResponsesSection } from './EventRsvpResponsesSection';
+
+export function EventManageRsvpsPanel({
+  event,
+  readOnly = false,
+}: {
+  event: Event;
+  /** Past events: hide add/edit controls; still show question responses. */
+  readOnly?: boolean;
+}) {
   const setGuestRsvp = useSetGuestRsvp(event.id);
   const removeGuestRsvp = useRemoveGuestRsvp(event.id);
   const setGuestPayment = useSetGuestPayment(event.id);
-  const showPaymentStatus = eventRequiresPaymentConfirmation(event);
+  const showPaymentStatus = !readOnly && eventRequiresPaymentConfirmation(event);
 
   return (
-    <div className="flex flex-col gap-6">
-      <AddMemberSection
-        event={event}
-        isPending={setGuestRsvp.isPending}
-        onAdd={(userId) => {
-          setGuestRsvp.mutate(
-            { userId, status: RsvpServerStatus.Attending, hasPlusOne: false },
-            {
-              onError: (err) => {
-                toast.error(extractApiErrorOr(err, "couldn't add them — try again"));
+    <div className="flex flex-col gap-8">
+      {readOnly ? null : (
+        <AddMemberSection
+          event={event}
+          isPending={setGuestRsvp.isPending}
+          onAdd={(userId) => {
+            setGuestRsvp.mutate(
+              { userId, status: RsvpServerStatus.Attending, hasPlusOne: false },
+              {
+                onError: (err) => {
+                  toast.error(extractApiErrorOr(err, "couldn't add them — try again"));
+                },
               },
-            },
-          );
-        }}
-      />
+            );
+          }}
+        />
+      )}
       {event.guests.length === 0 ? (
         <p className="text-muted text-sm">no one yet 🌿</p>
       ) : (
@@ -45,6 +56,7 @@ export function EventManageRsvpsPanel({ event }: { event: Event }) {
               key={group.status}
               label={group.label}
               guests={guests}
+              readOnly={readOnly}
               onChangeStatus={(userId, status, hasPlusOne) => {
                 setGuestRsvp.mutate(
                   { userId, status, hasPlusOne },
@@ -88,6 +100,7 @@ export function EventManageRsvpsPanel({ event }: { event: Event }) {
           );
         })
       )}
+      <EventRsvpResponsesSection event={event} />
     </div>
   );
 }
@@ -134,6 +147,7 @@ function GuestGroup({
   onRemove,
   onTogglePaid,
   isPending,
+  readOnly,
 }: {
   label: string;
   guests: EventGuest[];
@@ -141,6 +155,7 @@ function GuestGroup({
   onRemove: (userId: string) => void;
   onTogglePaid?: ((userId: string, paidConfirmed: boolean) => void) | undefined;
   isPending: boolean;
+  readOnly: boolean;
 }) {
   return (
     <div className="flex flex-col gap-2">
@@ -152,6 +167,7 @@ function GuestGroup({
           <GuestRow
             key={g.userId}
             guest={g}
+            readOnly={readOnly}
             onChangeStatus={onChangeStatus}
             onRemove={onRemove}
             onTogglePaid={onTogglePaid}
@@ -209,14 +225,31 @@ function GuestRow({
   onRemove,
   onTogglePaid,
   isPending,
+  readOnly,
 }: {
   guest: EventGuest;
   onChangeStatus: (userId: string, status: RsvpInputStatus, hasPlusOne: boolean) => void;
   onRemove: (userId: string) => void;
   onTogglePaid?: ((userId: string, paidConfirmed: boolean) => void) | undefined;
   isPending: boolean;
+  readOnly: boolean;
 }) {
   const currentStatus = isRsvpInputStatus(guest.status) ? guest.status : null;
+
+  if (readOnly) {
+    return (
+      <li className="border-border flex items-center justify-between gap-2 rounded-md border p-2">
+        <span className="text-foreground text-sm">
+          {guest.name}
+          {!guest.isMember ? ' (not a member)' : ''}
+        </span>
+        <span className="text-muted text-xs">
+          {currentStatus ?? guest.status}
+          {guest.hasPlusOne ? ' · +1' : ''}
+        </span>
+      </li>
+    );
+  }
 
   if (!guest.isMember) {
     return (

--- a/frontend/src/screens/events/EventManageRsvpsScreen.test.tsx
+++ b/frontend/src/screens/events/EventManageRsvpsScreen.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useEvent } from '@/api/events';
 import { useAuthStore } from '@/auth/store';
-import { makeEvent, makeUser } from '@/test/fixtures';
+import { makeEvent, makeGuest, makeUser } from '@/test/fixtures';
 
 import EventManageRsvpsScreen from './EventManageRsvpsScreen';
 
@@ -54,7 +54,7 @@ describe('EventManageRsvpsScreen', () => {
     expect(screen.getByText(/only the host or a co-host/i)).toBeInTheDocument();
   });
 
-  it('shows a forbidden notice for a past event', () => {
+  it('shows a forbidden notice for a past event with no questions', () => {
     vi.mocked(useEvent).mockReturnValue({
       data: makeEvent({
         createdById: 'user-creator',
@@ -69,6 +69,34 @@ describe('EventManageRsvpsScreen', () => {
     renderScreen();
 
     expect(screen.getByText(/event has already happened/i)).toBeInTheDocument();
+  });
+
+  it('lets a host review question responses on a past event', () => {
+    vi.mocked(useEvent).mockReturnValue({
+      data: makeEvent({
+        createdById: 'user-creator',
+        coHostIds: ['user-creator'],
+        guests: [],
+        isPast: true,
+        rsvpQuestions: [
+          {
+            id: 'q1',
+            label: 'dietary?',
+            fieldType: 'textarea',
+            options: [],
+            required: false,
+          },
+        ],
+      }),
+      isPending: false,
+      isError: false,
+    } as ReturnType<typeof useEvent>);
+    useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
+    renderScreen();
+
+    expect(screen.getByRole('heading', { name: /manage rsvps/i })).toBeInTheDocument();
+    expect(screen.getByText(/guest edits are closed/i)).toBeInTheDocument();
+    expect(screen.getByRole('region', { name: /question responses/i })).toBeInTheDocument();
   });
 
   it('shows a forbidden notice when rsvps are disabled', () => {
@@ -86,6 +114,56 @@ describe('EventManageRsvpsScreen', () => {
     renderScreen();
 
     expect(screen.getByText(/rsvps are off/i)).toBeInTheDocument();
+  });
+
+  it('lets a host review responses when rsvps are off but questions remain', () => {
+    vi.mocked(useEvent).mockReturnValue({
+      data: makeEvent({
+        createdById: 'user-creator',
+        coHostIds: ['user-creator'],
+        guests: [],
+        rsvpEnabled: false,
+        rsvpQuestions: [
+          {
+            id: 'q1',
+            label: 'dietary?',
+            fieldType: 'textarea',
+            options: [],
+            required: false,
+          },
+        ],
+      }),
+      isPending: false,
+      isError: false,
+    } as ReturnType<typeof useEvent>);
+    useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
+    renderScreen();
+
+    expect(screen.getByRole('heading', { name: /manage rsvps/i })).toBeInTheDocument();
+    expect(screen.getByText(/reviewing question responses/i)).toBeInTheDocument();
+  });
+
+  it('lets a host review responses when only saved answer snapshots remain', () => {
+    vi.mocked(useEvent).mockReturnValue({
+      data: makeEvent({
+        createdById: 'user-creator',
+        coHostIds: ['user-creator'],
+        rsvpEnabled: false,
+        rsvpQuestions: [],
+        guests: [
+          makeGuest({
+            answers: { deleted: { label: 'deleted question', answer: 'saved answer' } },
+          }),
+        ],
+      }),
+      isPending: false,
+      isError: false,
+    } as ReturnType<typeof useEvent>);
+    useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
+    renderScreen();
+
+    expect(screen.getByRole('heading', { name: /manage rsvps/i })).toBeInTheDocument();
+    expect(screen.getByText('saved answer')).toBeInTheDocument();
   });
 
   it('renders the panel heading for a host on a future rsvp-enabled event', () => {

--- a/frontend/src/screens/events/EventManageRsvpsScreen.test.tsx
+++ b/frontend/src/screens/events/EventManageRsvpsScreen.test.tsx
@@ -152,7 +152,9 @@ describe('EventManageRsvpsScreen', () => {
         rsvpQuestions: [],
         guests: [
           makeGuest({
-            answers: { deleted: { label: 'deleted question', answer: 'saved answer' } },
+            questionnaireResponses: {
+              deleted: { label: 'deleted question', answer: 'saved answer' },
+            },
           }),
         ],
       }),

--- a/frontend/src/screens/events/EventManageRsvpsScreen.tsx
+++ b/frontend/src/screens/events/EventManageRsvpsScreen.tsx
@@ -7,6 +7,7 @@ import { canManageEvent } from '@/models/event';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 
 import { EventManageRsvpsPanel } from './EventManageRsvpsPanel';
+import { hasSavedRsvpAnswers } from './rsvpQuestions';
 
 export default function EventManageRsvpsScreen() {
   const { id } = useParams<{ id: string }>();
@@ -27,10 +28,8 @@ export default function EventManageRsvpsScreen() {
       <ForbiddenNotice eventId={event.id} message="only the host or a co-host can manage rsvps" />
     );
   }
-  if (event.isPast) {
-    return <ForbiddenNotice eventId={event.id} message="this event has already happened" />;
-  }
-  if (!event.rsvpEnabled) {
+  const hasQuestionHistory = event.rsvpQuestions.length > 0 || hasSavedRsvpAnswers(event);
+  if (!event.rsvpEnabled && !hasQuestionHistory) {
     return (
       <ForbiddenNotice
         eventId={event.id}
@@ -38,13 +37,23 @@ export default function EventManageRsvpsScreen() {
       />
     );
   }
+  // Past events / RSVPs-off with questions stay open so hosts can review responses.
+  if (event.isPast && !hasQuestionHistory) {
+    return <ForbiddenNotice eventId={event.id} message="this event has already happened" />;
+  }
 
   return (
     <ContentContainer>
       <BackLink eventId={event.id} />
       <h1 className="mb-1 text-2xl font-medium tracking-tight">manage rsvps</h1>
       <p className="text-foreground-secondary mb-6 text-sm">{event.title}</p>
-      <EventManageRsvpsPanel event={event} />
+      {event.isPast ? (
+        <p className="text-muted mb-4 text-sm">this event is over — guest edits are closed</p>
+      ) : null}
+      {!event.rsvpEnabled ? (
+        <p className="text-muted mb-4 text-sm">rsvps are off — reviewing question responses</p>
+      ) : null}
+      <EventManageRsvpsPanel event={event} readOnly={event.isPast || !event.rsvpEnabled} />
     </ContentContainer>
   );
 }

--- a/frontend/src/screens/events/EventManageRsvpsScreen.tsx
+++ b/frontend/src/screens/events/EventManageRsvpsScreen.tsx
@@ -7,7 +7,7 @@ import { canManageEvent } from '@/models/event';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 
 import { EventManageRsvpsPanel } from './EventManageRsvpsPanel';
-import { hasSavedRsvpAnswers } from './rsvpQuestions';
+import { hasSavedQuestionnaireResponses } from './rsvpQuestions';
 
 export default function EventManageRsvpsScreen() {
   const { id } = useParams<{ id: string }>();
@@ -28,7 +28,8 @@ export default function EventManageRsvpsScreen() {
       <ForbiddenNotice eventId={event.id} message="only the host or a co-host can manage rsvps" />
     );
   }
-  const hasQuestionHistory = event.rsvpQuestions.length > 0 || hasSavedRsvpAnswers(event);
+  const hasQuestionHistory =
+    event.rsvpQuestions.length > 0 || hasSavedQuestionnaireResponses(event);
   if (!event.rsvpEnabled && !hasQuestionHistory) {
     return (
       <ForbiddenNotice

--- a/frontend/src/screens/events/EventRsvpResponsesSection.test.tsx
+++ b/frontend/src/screens/events/EventRsvpResponsesSection.test.tsx
@@ -115,7 +115,7 @@ describe('EventRsvpResponsesSection', () => {
     expect(screen.getByText('vegan')).toBeInTheDocument();
   });
 
-  it('keeps edited-question answers under their snapshot labels', () => {
+  it('shows answers under the current question when the snapshot label differs', () => {
     render(
       <EventRsvpResponsesSection
         event={makeEvent({
@@ -142,7 +142,37 @@ describe('EventRsvpResponsesSection', () => {
     );
 
     expect(screen.getByText('new question')).toBeInTheDocument();
-    expect(screen.getByText('old question')).toBeInTheDocument();
+    expect(screen.queryByText('old question')).not.toBeInTheDocument();
     expect(screen.getByText('old answer')).toBeInTheDocument();
+  });
+
+  it('tallies choice answers even when the snapshot label was renamed', () => {
+    render(
+      <EventRsvpResponsesSection
+        event={makeEvent({
+          rsvpQuestions: [
+            {
+              id: 'q1',
+              label: 'transport now',
+              fieldType: QuestionType.Select,
+              options: ['driving', 'transit'],
+              required: true,
+            },
+          ],
+          guests: [
+            makeGuest({
+              userId: 'a',
+              name: 'alice',
+              status: RsvpServerStatus.Attending,
+              questionnaireResponses: {
+                q1: { label: 'transport before', answer: 'driving' },
+              },
+            }),
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByRole('list')).toHaveTextContent(/driving\s*1/);
   });
 });

--- a/frontend/src/screens/events/EventRsvpResponsesSection.test.tsx
+++ b/frontend/src/screens/events/EventRsvpResponsesSection.test.tsx
@@ -1,0 +1,147 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { RsvpServerStatus } from '@/models/event';
+import { makeEvent, makeGuest } from '@/test/fixtures';
+
+import { EventRsvpResponsesSection } from './EventRsvpResponsesSection';
+
+describe('EventRsvpResponsesSection', () => {
+  it('renders nothing when the event has no questions', () => {
+    const { container } = render(
+      <EventRsvpResponsesSection event={makeEvent({ rsvpQuestions: [] })} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows per-guest answers and choice tallies', () => {
+    const event = makeEvent({
+      rsvpQuestions: [
+        {
+          id: 'q1',
+          label: 'how are you getting there?',
+          fieldType: 'select',
+          options: ['driving', 'transit'],
+          required: true,
+        },
+        {
+          id: 'q2',
+          label: 'notes',
+          fieldType: 'textarea',
+          options: [],
+          required: false,
+        },
+      ],
+      guests: [
+        makeGuest({
+          userId: 'a',
+          name: 'alice',
+          status: RsvpServerStatus.Attending,
+          answers: {
+            q1: { label: 'how are you getting there?', answer: 'driving' },
+            q2: { label: 'notes', answer: 'bringing chips' },
+          },
+        }),
+        makeGuest({
+          userId: 'b',
+          name: 'bob',
+          status: RsvpServerStatus.Maybe,
+          answers: {
+            q1: { label: 'how are you getting there?', answer: 'transit' },
+          },
+        }),
+        makeGuest({
+          userId: 'c',
+          name: 'cara',
+          status: RsvpServerStatus.CantGo,
+          answers: {},
+        }),
+      ],
+    });
+
+    render(<EventRsvpResponsesSection event={event} />);
+
+    expect(screen.getByRole('heading', { name: /question responses/i })).toBeInTheDocument();
+    expect(screen.getByText('2 guests with going / maybe / waitlist')).toBeInTheDocument();
+    expect(screen.getByText('alice')).toBeInTheDocument();
+    expect(screen.getByText('bob')).toBeInTheDocument();
+    expect(screen.queryByText('cara')).not.toBeInTheDocument();
+    expect(screen.getByText('bringing chips')).toBeInTheDocument();
+    const tallies = screen.getByRole('list');
+    expect(tallies).toHaveTextContent(/driving\s*1/);
+    expect(tallies).toHaveTextContent(/transit\s*1/);
+  });
+
+  it('shows empty state when no going/maybe guests', () => {
+    render(
+      <EventRsvpResponsesSection
+        event={makeEvent({
+          rsvpQuestions: [
+            {
+              id: 'q1',
+              label: 'q',
+              fieldType: 'textarea',
+              options: [],
+              required: false,
+            },
+          ],
+          guests: [makeGuest({ status: RsvpServerStatus.CantGo })],
+        })}
+      />,
+    );
+    expect(screen.getByText('no responses yet')).toBeInTheDocument();
+  });
+
+  it('keeps deleted-question answers visible via snapshot labels', () => {
+    render(
+      <EventRsvpResponsesSection
+        event={makeEvent({
+          rsvpQuestions: [],
+          guests: [
+            makeGuest({
+              userId: 'a',
+              name: 'alice',
+              status: RsvpServerStatus.Attending,
+              answers: {
+                orphan: { label: 'old dietary question', answer: 'vegan' },
+              },
+            }),
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByText('old dietary question')).toBeInTheDocument();
+    expect(screen.getByText('vegan')).toBeInTheDocument();
+  });
+
+  it('keeps edited-question answers under their snapshot labels', () => {
+    render(
+      <EventRsvpResponsesSection
+        event={makeEvent({
+          rsvpQuestions: [
+            {
+              id: 'q1',
+              label: 'new question',
+              fieldType: 'textarea',
+              options: [],
+              required: false,
+            },
+          ],
+          guests: [
+            makeGuest({
+              userId: 'a',
+              name: 'alice',
+              answers: {
+                q1: { label: 'old question', answer: 'old answer' },
+              },
+            }),
+          ],
+        })}
+      />,
+    );
+
+    expect(screen.getByText('new question')).toBeInTheDocument();
+    expect(screen.getByText('old question')).toBeInTheDocument();
+    expect(screen.getByText('old answer')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/screens/events/EventRsvpResponsesSection.test.tsx
+++ b/frontend/src/screens/events/EventRsvpResponsesSection.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
+import { QuestionType } from '@/api/questionTypes';
 import { RsvpServerStatus } from '@/models/event';
 import { makeEvent, makeGuest } from '@/test/fixtures';
 
@@ -20,14 +21,14 @@ describe('EventRsvpResponsesSection', () => {
         {
           id: 'q1',
           label: 'how are you getting there?',
-          fieldType: 'select',
+          fieldType: QuestionType.Select,
           options: ['driving', 'transit'],
           required: true,
         },
         {
           id: 'q2',
           label: 'notes',
-          fieldType: 'textarea',
+          fieldType: QuestionType.Textarea,
           options: [],
           required: false,
         },
@@ -37,7 +38,7 @@ describe('EventRsvpResponsesSection', () => {
           userId: 'a',
           name: 'alice',
           status: RsvpServerStatus.Attending,
-          answers: {
+          questionnaireResponses: {
             q1: { label: 'how are you getting there?', answer: 'driving' },
             q2: { label: 'notes', answer: 'bringing chips' },
           },
@@ -46,7 +47,7 @@ describe('EventRsvpResponsesSection', () => {
           userId: 'b',
           name: 'bob',
           status: RsvpServerStatus.Maybe,
-          answers: {
+          questionnaireResponses: {
             q1: { label: 'how are you getting there?', answer: 'transit' },
           },
         }),
@@ -54,7 +55,7 @@ describe('EventRsvpResponsesSection', () => {
           userId: 'c',
           name: 'cara',
           status: RsvpServerStatus.CantGo,
-          answers: {},
+          questionnaireResponses: {},
         }),
       ],
     });
@@ -80,7 +81,7 @@ describe('EventRsvpResponsesSection', () => {
             {
               id: 'q1',
               label: 'q',
-              fieldType: 'textarea',
+              fieldType: QuestionType.Textarea,
               options: [],
               required: false,
             },
@@ -102,7 +103,7 @@ describe('EventRsvpResponsesSection', () => {
               userId: 'a',
               name: 'alice',
               status: RsvpServerStatus.Attending,
-              answers: {
+              questionnaireResponses: {
                 orphan: { label: 'old dietary question', answer: 'vegan' },
               },
             }),
@@ -122,7 +123,7 @@ describe('EventRsvpResponsesSection', () => {
             {
               id: 'q1',
               label: 'new question',
-              fieldType: 'textarea',
+              fieldType: QuestionType.Textarea,
               options: [],
               required: false,
             },
@@ -131,7 +132,7 @@ describe('EventRsvpResponsesSection', () => {
             makeGuest({
               userId: 'a',
               name: 'alice',
-              answers: {
+              questionnaireResponses: {
                 q1: { label: 'old question', answer: 'old answer' },
               },
             }),

--- a/frontend/src/screens/events/EventRsvpResponsesSection.tsx
+++ b/frontend/src/screens/events/EventRsvpResponsesSection.tsx
@@ -1,11 +1,10 @@
 import { QuestionType } from '@/api/questionTypes';
 import type { Event, EventGuest, EventRsvpQuestion } from '@/models/event';
-import { RsvpServerStatus } from '@/models/event';
+import { rsvpGroupLabel } from '@/models/event';
 
 import { isRsvpRespondentStatus } from './rsvpQuestions';
 
 interface ResponseColumn {
-  key: string;
   id: string;
   label: string;
   fieldType?: EventRsvpQuestion['fieldType'];
@@ -16,26 +15,27 @@ interface Props {
   event: Event;
 }
 
-/** Live questions plus orphaned snapshot keys so edits/deletes keep history visible. */
+/** Live questions, plus deleted-question ids that still have saved guest answers. */
 function responseColumns(
   questions: readonly EventRsvpQuestion[],
   guests: readonly EventGuest[],
 ): ResponseColumn[] {
   const cols: ResponseColumn[] = questions.map((q) => ({
-    key: `${q.id}:${q.label}`,
     id: q.id,
     label: q.label,
     fieldType: q.fieldType,
     options: q.options,
   }));
-  const seen = new Set(cols.map((column) => column.key));
+  const liveIds = new Set(cols.map((column) => column.id));
+  const orphanLabels = new Map<string, string>();
   for (const g of guests) {
     for (const [qid, snap] of Object.entries(g.questionnaireResponses)) {
-      const key = `${qid}:${snap.label}`;
-      if (seen.has(key)) continue;
-      seen.add(key);
-      cols.push({ key, id: qid, label: snap.label, options: [] });
+      if (liveIds.has(qid) || orphanLabels.has(qid)) continue;
+      orphanLabels.set(qid, snap.label);
     }
+  }
+  for (const [qid, label] of orphanLabels) {
+    cols.push({ id: qid, label, options: [] });
   }
   return cols;
 }
@@ -63,7 +63,7 @@ export function EventRsvpResponsesSection({ event }: Props) {
         <div className="flex flex-col gap-3">
           <h3 className="text-muted text-xs font-medium tracking-wide">tallies</h3>
           {choiceColumns.map((q) => (
-            <ChoiceTallyCard key={q.key} question={q} guests={respondents} />
+            <ChoiceTallyCard key={q.id} question={q} guests={respondents} />
           ))}
         </div>
       ) : null}
@@ -78,7 +78,7 @@ export function EventRsvpResponsesSection({ event }: Props) {
                 <th className="px-3 py-2">guest</th>
                 <th className="px-3 py-2">status</th>
                 {columns.map((q) => (
-                  <th key={q.key} className="px-3 py-2">
+                  <th key={q.id} className="px-3 py-2">
                     {q.label}
                   </th>
                 ))}
@@ -88,10 +88,10 @@ export function EventRsvpResponsesSection({ event }: Props) {
               {respondents.map((g) => (
                 <tr key={g.userId} className="border-border border-t align-top">
                   <td className="text-foreground px-3 py-2">{g.name}</td>
-                  <td className="text-muted px-3 py-2 text-xs">{statusLabel(g.status)}</td>
+                  <td className="text-muted px-3 py-2 text-xs">{rsvpGroupLabel(g.status)}</td>
                   {columns.map((q) => (
-                    <td key={q.key} className="text-foreground px-3 py-2 whitespace-pre-wrap">
-                      {renderAnswerForColumn(g.questionnaireResponses[q.id], q)}
+                    <td key={q.id} className="text-foreground px-3 py-2 whitespace-pre-wrap">
+                      {renderAnswer(g.questionnaireResponses[q.id]?.answer)}
                     </td>
                   ))}
                 </tr>
@@ -110,15 +110,12 @@ function ChoiceTallyCard({ question, guests }: { question: ResponseColumn; guest
 
   let answered = 0;
   for (const g of guests) {
-    const snap = g.questionnaireResponses[question.id];
-    if (snap?.label !== question.label) continue;
+    const answer = g.questionnaireResponses[question.id]?.answer;
+    if (!answer?.trim()) continue;
     const values =
       question.fieldType === QuestionType.Checkbox
-        ? snap.answer.split(',').filter(Boolean)
-        : snap.answer
-          ? [snap.answer]
-          : [];
-    if (values.length === 0) continue;
+        ? answer.split(',').filter(Boolean)
+        : [answer];
     answered += 1;
     for (const v of values) {
       counts.set(v, (counts.get(v) ?? 0) + 1);
@@ -143,17 +140,8 @@ function ChoiceTallyCard({ question, guests }: { question: ResponseColumn; guest
   );
 }
 
-function statusLabel(status: string): string {
-  if (status === RsvpServerStatus.Attending) return 'going';
-  if (status === RsvpServerStatus.Maybe) return 'maybe';
-  if (status === RsvpServerStatus.Waitlisted) return 'waitlist';
-  return status;
-}
-
-function renderAnswerForColumn(
-  snap: { label: string; answer: string } | undefined,
-  column: ResponseColumn,
-): string {
-  if (snap?.label !== column.label) return '—';
-  return snap.answer.trim().replaceAll(',', ', ') || '—';
+function renderAnswer(answer: string | undefined): string {
+  const trimmed = answer?.trim();
+  if (!trimmed) return '—';
+  return trimmed.replaceAll(',', ', ');
 }

--- a/frontend/src/screens/events/EventRsvpResponsesSection.tsx
+++ b/frontend/src/screens/events/EventRsvpResponsesSection.tsx
@@ -113,9 +113,7 @@ function ChoiceTallyCard({ question, guests }: { question: ResponseColumn; guest
     const answer = g.questionnaireResponses[question.id]?.answer;
     if (!answer?.trim()) continue;
     const values =
-      question.fieldType === QuestionType.Checkbox
-        ? answer.split(',').filter(Boolean)
-        : [answer];
+      question.fieldType === QuestionType.Checkbox ? answer.split(',').filter(Boolean) : [answer];
     answered += 1;
     for (const v of values) {
       counts.set(v, (counts.get(v) ?? 0) + 1);

--- a/frontend/src/screens/events/EventRsvpResponsesSection.tsx
+++ b/frontend/src/screens/events/EventRsvpResponsesSection.tsx
@@ -1,0 +1,158 @@
+import type { Event, EventGuest, EventRsvpQuestion } from '@/models/event';
+import { RsvpServerStatus } from '@/models/event';
+
+import { isRsvpRespondentStatus } from './rsvpQuestions';
+
+interface ResponseColumn {
+  key: string;
+  id: string;
+  label: string;
+  fieldType?: EventRsvpQuestion['fieldType'];
+  options: string[];
+}
+
+interface Props {
+  event: Event;
+}
+
+/** Live questions plus orphaned snapshot keys so edits/deletes keep history visible. */
+function responseColumns(
+  questions: readonly EventRsvpQuestion[],
+  guests: readonly EventGuest[],
+): ResponseColumn[] {
+  const cols: ResponseColumn[] = questions.map((q) => ({
+    key: `${q.id}:${q.label}`,
+    id: q.id,
+    label: q.label,
+    fieldType: q.fieldType,
+    options: q.options,
+  }));
+  const seen = new Set(cols.map((column) => column.key));
+  for (const g of guests) {
+    for (const [qid, snap] of Object.entries(g.answers)) {
+      const key = `${qid}:${snap.label}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      cols.push({ key, id: qid, label: snap.label, options: [] });
+    }
+  }
+  return cols;
+}
+
+export function EventRsvpResponsesSection({ event }: Props) {
+  const respondents = event.guests.filter((guest) => isRsvpRespondentStatus(guest.status));
+  const columns = responseColumns(event.rsvpQuestions, respondents);
+  if (columns.length === 0) return null;
+
+  const choiceColumns = columns.filter(
+    (q) => q.fieldType === 'select' || q.fieldType === 'checkbox',
+  );
+
+  return (
+    <section aria-label="question responses" className="flex flex-col gap-4">
+      <div>
+        <h2 className="text-base font-medium">question responses</h2>
+        <p className="text-muted text-sm">
+          {String(respondents.length)} guest{respondents.length === 1 ? '' : 's'} with going / maybe
+          / waitlist
+        </p>
+      </div>
+
+      {choiceColumns.length > 0 ? (
+        <div className="flex flex-col gap-3">
+          <h3 className="text-muted text-xs font-medium tracking-wide">tallies</h3>
+          {choiceColumns.map((q) => (
+            <ChoiceTallyCard key={q.key} question={q} guests={respondents} />
+          ))}
+        </div>
+      ) : null}
+
+      {respondents.length === 0 ? (
+        <p className="text-muted text-sm">no responses yet</p>
+      ) : (
+        <div className="border-border bg-surface overflow-x-auto rounded-lg border">
+          <table className="w-full text-left text-sm">
+            <thead className="bg-background text-muted text-xs">
+              <tr>
+                <th className="px-3 py-2">guest</th>
+                <th className="px-3 py-2">status</th>
+                {columns.map((q) => (
+                  <th key={q.key} className="px-3 py-2">
+                    {q.label}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {respondents.map((g) => (
+                <tr key={g.userId} className="border-border border-t align-top">
+                  <td className="text-foreground px-3 py-2">{g.name}</td>
+                  <td className="text-muted px-3 py-2 text-xs">{statusLabel(g.status)}</td>
+                  {columns.map((q) => (
+                    <td key={q.key} className="text-foreground px-3 py-2 whitespace-pre-wrap">
+                      {renderAnswerForColumn(g.answers[q.id], q)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function ChoiceTallyCard({ question, guests }: { question: ResponseColumn; guests: EventGuest[] }) {
+  const counts = new Map<string, number>();
+  for (const opt of question.options) counts.set(opt, 0);
+
+  let answered = 0;
+  for (const g of guests) {
+    const snap = g.answers[question.id];
+    if (snap?.label !== question.label) continue;
+    const values =
+      question.fieldType === 'checkbox'
+        ? snap.answer.split(',').filter(Boolean)
+        : snap.answer
+          ? [snap.answer]
+          : [];
+    if (values.length === 0) continue;
+    answered += 1;
+    for (const v of values) {
+      counts.set(v, (counts.get(v) ?? 0) + 1);
+    }
+  }
+
+  return (
+    <div className="border-border bg-surface rounded-lg border p-3">
+      <p className="text-foreground mb-1 text-sm font-medium">{question.label}</p>
+      <p className="text-muted mb-2 text-xs">
+        {String(answered)} answer{answered === 1 ? '' : 's'}
+      </p>
+      <ul className="flex flex-col gap-1 text-sm">
+        {[...counts.entries()].map(([opt, n]) => (
+          <li key={opt} className="flex justify-between gap-4">
+            <span className="text-foreground">{opt}</span>
+            <span className="text-muted tabular-nums">{String(n)}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function statusLabel(status: string): string {
+  if (status === RsvpServerStatus.Attending) return 'going';
+  if (status === RsvpServerStatus.Maybe) return 'maybe';
+  if (status === RsvpServerStatus.Waitlisted) return 'waitlist';
+  return status;
+}
+
+function renderAnswerForColumn(
+  snap: { label: string; answer: string } | undefined,
+  column: ResponseColumn,
+): string {
+  if (snap?.label !== column.label) return '—';
+  return snap.answer.trim().replaceAll(',', ', ') || '—';
+}

--- a/frontend/src/screens/events/EventRsvpResponsesSection.tsx
+++ b/frontend/src/screens/events/EventRsvpResponsesSection.tsx
@@ -1,3 +1,4 @@
+import { QuestionType } from '@/api/questionTypes';
 import type { Event, EventGuest, EventRsvpQuestion } from '@/models/event';
 import { RsvpServerStatus } from '@/models/event';
 
@@ -29,7 +30,7 @@ function responseColumns(
   }));
   const seen = new Set(cols.map((column) => column.key));
   for (const g of guests) {
-    for (const [qid, snap] of Object.entries(g.answers)) {
+    for (const [qid, snap] of Object.entries(g.questionnaireResponses)) {
       const key = `${qid}:${snap.label}`;
       if (seen.has(key)) continue;
       seen.add(key);
@@ -45,7 +46,7 @@ export function EventRsvpResponsesSection({ event }: Props) {
   if (columns.length === 0) return null;
 
   const choiceColumns = columns.filter(
-    (q) => q.fieldType === 'select' || q.fieldType === 'checkbox',
+    (q) => q.fieldType === QuestionType.Select || q.fieldType === QuestionType.Checkbox,
   );
 
   return (
@@ -90,7 +91,7 @@ export function EventRsvpResponsesSection({ event }: Props) {
                   <td className="text-muted px-3 py-2 text-xs">{statusLabel(g.status)}</td>
                   {columns.map((q) => (
                     <td key={q.key} className="text-foreground px-3 py-2 whitespace-pre-wrap">
-                      {renderAnswerForColumn(g.answers[q.id], q)}
+                      {renderAnswerForColumn(g.questionnaireResponses[q.id], q)}
                     </td>
                   ))}
                 </tr>
@@ -109,10 +110,10 @@ function ChoiceTallyCard({ question, guests }: { question: ResponseColumn; guest
 
   let answered = 0;
   for (const g of guests) {
-    const snap = g.answers[question.id];
+    const snap = g.questionnaireResponses[question.id];
     if (snap?.label !== question.label) continue;
     const values =
-      question.fieldType === 'checkbox'
+      question.fieldType === QuestionType.Checkbox
         ? snap.answer.split(',').filter(Boolean)
         : snap.answer
           ? [snap.answer]


### PR DESCRIPTION
Expose saved answer snapshots only to event managers and keep response
reports available after questions, RSVPs, or the event itself close.

Co-authored-by: Cursor <cursoragent@cursor.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>