### PR TITLE
fix: 1317 - sort host attendance guest list, rename no-show label

### DIFF
--- a/backend/community/_event_cohost_helpers.py
+++ b/backend/community/_event_cohost_helpers.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from config.media_proxy import media_path
+from notifications._cohost_notifications import create_cohost_invite_notifications
+from notifications.service import broadcast_cohost_change, create_event_invite_notifications
+from users._helpers import visible_display_name
+from users.models import User as UserModel
+
+from community._cohost_invite_helpers import (
+    diff_cohost_invites,
+    get_pending_invites_for_event,
+    send_cohost_invite_emails,
+)
+from community._event_schemas import PendingCoHostInviteOut
+from community.models import Event
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+def _can_manage_cohost_invites(
+    requesting_user,
+    co_host_ids: set[str],
+) -> bool:
+    """Accepted co-hosts can see and rescind pending invites. Admins are
+    intentionally excluded — this is a host-only workflow, not admin moderation."""
+    if requesting_user is None:
+        return False
+    return str(requesting_user.pk) in co_host_ids
+
+
+def _pending_cohost_invites_out(
+    event: Event, auth_user, co_host_ids: set[str]
+) -> list[PendingCoHostInviteOut]:
+    if not _can_manage_cohost_invites(auth_user, co_host_ids):
+        return []
+    return [
+        PendingCoHostInviteOut(
+            id=str(inv.id),
+            user_id=str(inv.user_id),
+            user_name=visible_display_name(inv.user, auth_user),
+            user_photo_url=media_path(inv.user.profile_photo),
+            invited_at=inv.invited_at,
+        )
+        for inv in get_pending_invites_for_event(event)
+    ]
+
+
+def _update_co_hosts(
+    event: Event,
+    co_host_ids: Iterable[str],
+    updater: UserModel,
+) -> None:
+    """Reconcile cohost invites against the requested ids and broadcast updates.
+
+    With the invite-approval flow, this no longer mutates ``event.co_hosts``
+    directly for newly-added users — those go to ``EventCoHostInvite`` as
+    PENDING and only land in ``event.co_hosts`` once accepted. Removals still
+    take effect immediately (the rescind helper drops them from
+    ``event.co_hosts`` if they had been accepted).
+    """
+    next_ids = {str(uid) for uid in co_host_ids}
+    newly_invited, removed_accepted_ids = diff_cohost_invites(event, next_ids, updater)
+    if newly_invited:
+        create_cohost_invite_notifications(event, newly_invited, updater)
+        send_cohost_invite_emails(event, newly_invited, updater)
+
+    if newly_invited or removed_accepted_ids:
+        broadcast_cohost_change(
+            event,
+            exclude_user_ids={str(updater.pk)},
+            extra_user_ids=set(newly_invited) | set(removed_accepted_ids),
+        )
+
+
+def _update_invited_users(
+    event: Event,
+    invited_user_ids: Iterable[str],
+    inviter: UserModel,
+) -> None:
+    """Update event.invited_users and notify newly added users."""
+    id_list = list(invited_user_ids)
+    old_ids = set(event.invited_users.values_list("pk", flat=True))
+    invited = UserModel.objects.filter(pk__in=id_list)
+    event.invited_users.set(invited)
+    new_ids = {str(uid) for uid in id_list} - {str(uid) for uid in old_ids}
+    if new_ids:
+        create_event_invite_notifications(event, new_ids, inviter)

--- a/backend/community/_event_cohost_invites.py
+++ b/backend/community/_event_cohost_invites.py
@@ -27,7 +27,8 @@ from community._cohost_invite_helpers import (
     expire_stale_cohost_invites,
     send_cohost_invite_emails,
 )
-from community._event_helpers import _can_manage_cohost_invites, _event_out
+from community._event_cohost_helpers import _can_manage_cohost_invites
+from community._event_helpers import _event_out
 from community._event_schemas import EventOut
 from community._shared import ErrorOut
 from community._validation import Code, raise_validation

--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -7,30 +7,13 @@ from uuid import UUID
 from config.audit import AuditTarget, AuditTargetType, audit_log
 from config.media_proxy import media_path
 from django.db import transaction
-from notifications._cohost_notifications import create_cohost_invite_notifications
-from notifications.service import (
-    broadcast_cohost_change,
-    broadcast_event_update,
-    create_event_invite_notifications,
-    create_waitlist_promoted_notifications,
-)
+from notifications.service import broadcast_event_update, create_waitlist_promoted_notifications
 from users._helpers import visible_display_name
-from users.models import User as UserModel
 from users.permissions import PermissionKey
 
-from community._cohost_invite_helpers import (
-    diff_cohost_invites,
-    get_my_pending_invite,
-    get_pending_invites_for_event,
-    send_cohost_invite_emails,
-)
-from community._event_schemas import (
-    CancellationOut,
-    EventOut,
-    PendingCoHostInviteOut,
-    RSVPGuestOut,
-    TagOut,
-)
+from community._cohost_invite_helpers import get_my_pending_invite
+from community._event_cohost_helpers import _pending_cohost_invites_out
+from community._event_schemas import CancellationOut, EventOut, RSVPGuestOut, TagOut
 from community._rsvp_counts import (
     _attending_headcount,
     _attending_headcount_db,
@@ -248,17 +231,6 @@ def _can_see_guests(requesting_user, viewer_is_cohost: bool, my_rsvp_status: str
     return my_rsvp_status is not None and my_rsvp_status not in _INACTIVE_RSVP_STATUSES
 
 
-def _can_manage_cohost_invites(
-    requesting_user,
-    co_host_ids: set[str],
-) -> bool:
-    """Accepted co-hosts can see and rescind pending invites. Admins are
-    intentionally excluded — this is a host-only workflow, not admin moderation."""
-    if requesting_user is None:
-        return False
-    return str(requesting_user.pk) in co_host_ids
-
-
 def _can_see_invite_only(
     user, co_host_ids: set[str], invited_user_ids: set[str], created_by_id
 ) -> bool:
@@ -306,23 +278,6 @@ def _get_datetime_poll_slug(event: Event) -> str | None:
         .first()
     )
     return poll_survey
-
-
-def _pending_cohost_invites_out(
-    event: Event, auth_user, co_host_ids: set[str]
-) -> list[PendingCoHostInviteOut]:
-    if not _can_manage_cohost_invites(auth_user, co_host_ids):
-        return []
-    return [
-        PendingCoHostInviteOut(
-            id=str(inv.id),
-            user_id=str(inv.user_id),
-            user_name=visible_display_name(inv.user, auth_user),
-            user_photo_url=media_path(inv.user.profile_photo),
-            invited_at=inv.invited_at,
-        )
-        for inv in get_pending_invites_for_event(event)
-    ]
 
 
 def _resolve_comment_count(event: Event) -> int:
@@ -414,48 +369,6 @@ def _event_out(event: Event, requesting_user=None) -> EventOut:
         my_pending_cohost_invite_id=my_pending_invite_id,
         tags=_tags_out(event),
     )
-
-
-def _update_co_hosts(
-    event: Event,
-    co_host_ids: Iterable[str],
-    updater: UserModel,
-) -> None:
-    """Reconcile cohost invites against the requested ids and broadcast updates.
-
-    With the invite-approval flow, this no longer mutates ``event.co_hosts``
-    directly for newly-added users — those go to ``EventCoHostInvite`` as
-    PENDING and only land in ``event.co_hosts`` once accepted. Removals still
-    take effect immediately (the rescind helper drops them from
-    ``event.co_hosts`` if they had been accepted).
-    """
-    next_ids = {str(uid) for uid in co_host_ids}
-    newly_invited, removed_accepted_ids = diff_cohost_invites(event, next_ids, updater)
-    if newly_invited:
-        create_cohost_invite_notifications(event, newly_invited, updater)
-        send_cohost_invite_emails(event, newly_invited, updater)
-
-    if newly_invited or removed_accepted_ids:
-        broadcast_cohost_change(
-            event,
-            exclude_user_ids={str(updater.pk)},
-            extra_user_ids=set(newly_invited) | set(removed_accepted_ids),
-        )
-
-
-def _update_invited_users(
-    event: Event,
-    invited_user_ids: Iterable[str],
-    inviter: UserModel,
-) -> None:
-    """Update event.invited_users and notify newly added users."""
-    id_list = list(invited_user_ids)
-    old_ids = set(event.invited_users.values_list("pk", flat=True))
-    invited = UserModel.objects.filter(pk__in=id_list)
-    event.invited_users.set(invited)
-    new_ids = {str(uid) for uid in id_list} - {str(uid) for uid in old_ids}
-    if new_ids:
-        create_event_invite_notifications(event, new_ids, inviter)
 
 
 def _can_edit_event(user, event: Event) -> bool:

--- a/backend/community/_event_helpers.py
+++ b/backend/community/_event_helpers.py
@@ -88,10 +88,20 @@ def is_cohost(requesting_user, co_host_ids: set[str]) -> bool:
     return str(requesting_user.pk) in co_host_ids
 
 
+_GUEST_LIST_STATUS_ORDER = {
+    RSVPStatus.ATTENDING: 0,
+    RSVPStatus.MAYBE: 1,
+    RSVPStatus.CANT_GO: 2,
+    RSVPStatus.WAITLISTED: 3,
+}
+
+
 def _build_guest_list(
     rsvps, can_see_phones: bool, viewer=None, can_see_payment_status: bool = False
 ) -> list[RSVPGuestOut]:
-    """Build guest list with optional phone and payment-status visibility."""
+    """Build guest list ordered going > maybe > can't go > waitlisted, with optional phone
+    and payment-status visibility."""
+    ordered_rsvps = sorted(rsvps, key=lambda r: _GUEST_LIST_STATUS_ORDER.get(r.status, 99))
     return [
         RSVPGuestOut(
             user_id=str(r.user_id),
@@ -105,7 +115,7 @@ def _build_guest_list(
             is_member=r.user.is_member,
             paid_confirmed=bool(r.paid_confirmed_at) if can_see_payment_status else False,
         )
-        for r in rsvps
+        for r in ordered_rsvps
     ]
 
 

--- a/backend/community/_event_update.py
+++ b/backend/community/_event_update.py
@@ -4,12 +4,12 @@ from uuid import UUID
 from config.audit import AuditTarget, AuditTargetType, audit_log
 from django.utils import timezone
 
+from community._event_cohost_helpers import _update_co_hosts
 from community._event_helpers import (
     _can_edit_event,
     _enforce_type_tag_permission,
     _is_invalid_typed_visibility,
     _set_event_tags,
-    _update_co_hosts,
     promote_from_waitlist,
 )
 from community._validation import Code, raise_validation

--- a/backend/tests/test_event_guest_list_visibility.py
+++ b/backend/tests/test_event_guest_list_visibility.py
@@ -90,3 +90,28 @@ class TestEventGuestListVisibility:
         response = api_client.get(f"/api/community/events/{event.id}/", **auth_headers)
         assert response.status_code == 200
         assert response.json()["guests"] == []
+
+    def test_guest_list_ordered_going_maybe_cant_go_waitlisted(
+        self, api_client, test_user, auth_headers
+    ):
+        event = make_official_event(created_by=test_user)
+        event.co_hosts.add(test_user)
+        waitlisted = User.objects.create_user(phone_number="+15551110001")
+        cant_go = User.objects.create_user(phone_number="+15551110002")
+        maybe = User.objects.create_user(phone_number="+15551110003")
+        going = User.objects.create_user(phone_number="+15551110004")
+        # created out of order to prove sort isn't relying on insertion/DB order
+        event.rsvps.create(user=waitlisted, status=RSVPStatus.WAITLISTED)
+        event.rsvps.create(user=cant_go, status=RSVPStatus.CANT_GO)
+        event.rsvps.create(user=maybe, status=RSVPStatus.MAYBE)
+        event.rsvps.create(user=going, status=RSVPStatus.ATTENDING)
+
+        response = api_client.get(f"/api/community/events/{event.id}/", **auth_headers)
+        assert response.status_code == 200
+        statuses = [g["status"] for g in response.json()["guests"]]
+        assert statuses == [
+            RSVPStatus.ATTENDING,
+            RSVPStatus.MAYBE,
+            RSVPStatus.CANT_GO,
+            RSVPStatus.WAITLISTED,
+        ]

--- a/frontend/src/screens/events/EventCheckInList.tsx
+++ b/frontend/src/screens/events/EventCheckInList.tsx
@@ -51,7 +51,7 @@ export function EventCheckInList({
                 />
                 <AttendanceButton
                   active={g.attendance === AttendanceStatus.NoShow}
-                  label="no-show"
+                  label="didn't attend"
                   onClick={() => {
                     onMark(g.userId, AttendanceStatus.NoShow);
                   }}


### PR DESCRIPTION
## Overview

On the host attendance page (`/events/{id}/attendance`), the guest check-in list had no defined sort order — it relied on prefetch/DB default order. This sorts the list going > maybe > can't go > waitlisted in `_build_guest_list` (`backend/community/_event_helpers.py`), the single function that builds the guest list served to the event detail endpoint the attendance page consumes.

Also renames the "no-show" attendance button label to "didn't attend" in `EventCheckInList.tsx`, per the lowercase user-facing text convention. The backend `AttendanceStatus.NO_SHOW` / `no_show` enum values are unchanged — only the display label changed.

(Issue 1317)

## Test plan

- [x] `backend/tests/test_event_guest_list_visibility.py::TestEventGuestListVisibility::test_guest_list_ordered_going_maybe_cant_go_waitlisted` — new test asserting guest order
- [x] `make agent-typecheck` (backend `ty` check)
- [x] `make agent-frontend-typecheck` (`tsc --noEmit`)
- [x] `make agent-lint` (ruff)
- [x] `make agent-frontend-lint` (eslint)
- [x] `make agent-frontend-test` (vitest, full suite passing)
- [x] Targeted pytest run of `test_event_guest_list_visibility.py` (8 passed)

Closes #1317
