### PR TITLE
chore: improve file-size-limit error clarity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,8 +296,11 @@ agent-complexity:
 	cd backend && env UV_NO_PROGRESS=1 uvx -q --with flake8-cognitive-complexity flake8 -q \
 		--max-cognitive-complexity 10 --select CCR001 .
 	violations=$$(find backend -name '*.py' -not -path '*/migrations/*' | while read f; do lines=$$(wc -l < "$$f"); if [ "$$lines" -gt 500 ]; then echo "$$f: $$lines lines"; fi; done); \
-	if [ -n "$$violations" ]; then echo "Error: files exceed 500-line limit:\n$$violations"; exit 1; fi
-
+	if [ -n "$$violations" ]; then \
+		echo "Error: files exceed 500-line limit:"; \
+		echo "$$violations"; \
+		exit 1; \
+	fi
 agent-frontend-lint:
 	cd frontend && pnpm exec eslint . --max-warnings 0
 


### PR DESCRIPTION
## Overview

Split the error message output across two separate `echo` calls so each violating file prints on its own line, instead of being smooshed into one line when `echo "...\n$$violations"` fails to expand the `\n` escape sequence.

## Test plan

- [ ] Run `make agent-complexity` on a branch that violates the 500-line limit and confirm the error message is now readable with each file on its own line

## Checklist

- [x] Changes follow project conventions
- [x] No breaking changes
