### PR TITLE
fix: 1331 - check-in report back link returns to event

### DIFF
--- a/frontend/src/screens/events/EventCheckInReportScreen.test.tsx
+++ b/frontend/src/screens/events/EventCheckInReportScreen.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -63,6 +64,15 @@ describe('EventCheckInReportScreen', () => {
 
     expect(screen.getByRole('heading', { name: /check-in report/i })).toBeInTheDocument();
     expect(screen.getByText(BASE_EVENT.title)).toBeInTheDocument();
+  });
+
+  it('back link returns to the event, not the attendance page', async () => {
+    useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
+    renderScreen();
+
+    await userEvent.click(screen.getByRole('link', { name: /back to event/i }));
+
+    expect(screen.getByText('event detail')).toBeInTheDocument();
   });
 
   it('blocks non-host members with a forbidden notice', () => {

--- a/frontend/src/screens/events/EventCheckInReportScreen.tsx
+++ b/frontend/src/screens/events/EventCheckInReportScreen.tsx
@@ -190,10 +190,10 @@ function CanceledRow({ person }: { person: CanceledPerson }) {
 function BackLink({ eventId }: { eventId: string }) {
   return (
     <Link
-      to={`/events/${eventId}/attendance`}
+      to={`/events/${eventId}`}
       className="text-foreground-secondary hover:text-foreground mb-4 inline-flex items-center gap-1 text-sm"
     >
-      ← back to attendance
+      ← back to event
     </Link>
   );
 }


### PR DESCRIPTION
## Overview

The check-in report page (`/events/:id/report`) had a back link that pointed to the attendance page instead of the event page. Fixed it to link back to the event, matching the pattern used on the attendance page itself.

## Test plan

- [x] Added a test asserting the back link navigates to the event detail route
- [ ] Manual check: open an event's check-in report as a host and confirm the back link reads "back to event" and returns to the event page

Closes #1331
