### PR TITLE
fix: 1332 - check-in report counts explicit no-show marks

### DIFF
--- a/backend/community/_event_report.py
+++ b/backend/community/_event_report.py
@@ -60,10 +60,6 @@ def _build_report(event: Event, viewer) -> CheckInReportOut:
     attended, no_shows, canceled, unmarked = [], [], [], []
     for rsvp in _report_rsvps(event):
         base = _person(rsvp, viewer, can_see_phones)
-        # ATTENDED overrides status (a host can check in a "maybe"); a no-show
-        # only counts if they were actually RSVP'd ATTENDING. CANT_GO is
-        # checked before no-show so a guest who told us in advance they
-        # weren't coming stays "canceled" even if a stray no-show mark exists.
         if rsvp.attendance == AttendanceStatus.ATTENDED:
             attended.append(
                 AttendedPersonOut(**base.model_dump(), checked_in_at=rsvp.checked_in_at)

--- a/backend/community/_event_report.py
+++ b/backend/community/_event_report.py
@@ -17,10 +17,10 @@ from community._event_report_schemas import (
     CheckInReportPersonOut,
 )
 from community._events import _can_edit_event
-from community._rsvp_counts import is_no_show
+from community._rsvp_counts import is_attended, is_didnt_go, is_no_show
 from community._shared import ErrorOut
 from community._validation import Code, raise_validation
-from community.models import AttendanceStatus, Event, FeatureFlag, RSVPStatus, flag_enabled
+from community.models import Event, FeatureFlag, RSVPStatus, flag_enabled
 
 router = Router()
 
@@ -60,7 +60,7 @@ def _build_report(event: Event, viewer) -> CheckInReportOut:
     attended, no_shows, didnt_go, canceled, unmarked = [], [], [], [], []
     for rsvp in _report_rsvps(event):
         base = _person(rsvp, viewer, can_see_phones)
-        if rsvp.attendance == AttendanceStatus.ATTENDED:
+        if is_attended(rsvp):
             attended.append(
                 AttendedPersonOut(**base.model_dump(), checked_in_at=rsvp.checked_in_at)
             )
@@ -72,7 +72,7 @@ def _build_report(event: Event, viewer) -> CheckInReportOut:
             )
         elif is_no_show(rsvp):
             no_shows.append(base)
-        elif rsvp.attendance == AttendanceStatus.DIDNT_GO:
+        elif is_didnt_go(rsvp):
             didnt_go.append(base)
         else:
             unmarked.append(base)

--- a/backend/community/_event_report.py
+++ b/backend/community/_event_report.py
@@ -57,7 +57,7 @@ def _build_report(event: Event, viewer) -> CheckInReportOut:
     co_host_ids = {str(c.id) for c in event.co_hosts.all()}
     can_see_phones = is_cohost(viewer, co_host_ids)
 
-    attended, no_shows, canceled, unmarked = [], [], [], []
+    attended, no_shows, didnt_go, canceled, unmarked = [], [], [], [], []
     for rsvp in _report_rsvps(event):
         base = _person(rsvp, viewer, can_see_phones)
         if rsvp.attendance == AttendanceStatus.ATTENDED:
@@ -72,16 +72,20 @@ def _build_report(event: Event, viewer) -> CheckInReportOut:
             )
         elif is_no_show(rsvp):
             no_shows.append(base)
+        elif rsvp.attendance == AttendanceStatus.DIDNT_GO:
+            didnt_go.append(base)
         else:
             unmarked.append(base)
 
     return CheckInReportOut(
         attended_count=len(attended),
         no_show_count=len(no_shows),
+        didnt_go_count=len(didnt_go),
         canceled_count=len(canceled),
         unmarked_count=len(unmarked),
         attended=attended,
         no_shows=no_shows,
+        didnt_go=didnt_go,
         canceled=canceled,
         unmarked=unmarked,
     )

--- a/backend/community/_event_report.py
+++ b/backend/community/_event_report.py
@@ -61,19 +61,21 @@ def _build_report(event: Event, viewer) -> CheckInReportOut:
     for rsvp in _report_rsvps(event):
         base = _person(rsvp, viewer, can_see_phones)
         # ATTENDED overrides status (a host can check in a "maybe"); a no-show
-        # only counts if they were actually RSVP'd ATTENDING.
+        # only counts if they were actually RSVP'd ATTENDING. CANT_GO is
+        # checked before no-show so a guest who told us in advance they
+        # weren't coming stays "canceled" even if a stray no-show mark exists.
         if rsvp.attendance == AttendanceStatus.ATTENDED:
             attended.append(
                 AttendedPersonOut(**base.model_dump(), checked_in_at=rsvp.checked_in_at)
             )
-        elif is_no_show(rsvp):
-            no_shows.append(base)
         elif rsvp.status == RSVPStatus.CANT_GO:
             canceled.append(
                 CanceledPersonOut(
                     **base.model_dump(), cancelled_at=rsvp.cancelled_at or rsvp.updated_at
                 )
             )
+        elif is_no_show(rsvp):
+            no_shows.append(base)
         else:
             unmarked.append(base)
 

--- a/backend/community/_event_report_schemas.py
+++ b/backend/community/_event_report_schemas.py
@@ -21,10 +21,12 @@ class CanceledPersonOut(CheckInReportPersonOut):
 class CheckInReportOut(BaseModel):
     attended_count: int = 0
     no_show_count: int = 0
+    didnt_go_count: int = 0
     canceled_count: int = 0
     unmarked_count: int = 0
     attended: list[AttendedPersonOut] = []
     no_shows: list[CheckInReportPersonOut] = []
+    didnt_go: list[CheckInReportPersonOut] = []
     canceled: list[CanceledPersonOut] = []
     unmarked: list[CheckInReportPersonOut] = []
 

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -478,6 +478,19 @@
             "title": "Canceled Count",
             "type": "integer"
           },
+          "didnt_go": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/CheckInReportPersonOut"
+            },
+            "title": "Didnt Go",
+            "type": "array"
+          },
+          "didnt_go_count": {
+            "default": 0,
+            "title": "Didnt Go Count",
+            "type": "integer"
+          },
           "no_show_count": {
             "default": 0,
             "title": "No Show Count",

--- a/backend/tests/test_event_check_in_report.py
+++ b/backend/tests/test_event_check_in_report.py
@@ -206,6 +206,7 @@ class TestCheckInReportEndpoint:
         total = (
             data["attended_count"]
             + data["no_show_count"]
+            + data["didnt_go_count"]
             + data["canceled_count"]
             + data["unmarked_count"]
         )
@@ -268,6 +269,21 @@ class TestCheckInReportEndpoint:
         assert report["no_show_count"] == 0, "a cant-go marked didn't-attend isn't a no-show"
         assert report["canceled_count"] == 1
         assert report["canceled"][0]["user_id"] == str(member.pk)
+
+    def test_maybe_rsvp_marked_didnt_attend_is_in_didnt_go_not_unmarked(
+        self, api_client, past_event, members, host_user
+    ):
+        member = members[0]
+        rsvp = EventRSVP.objects.create(event=past_event, user=member, status=RSVPStatus.MAYBE)
+        rsvp.attendance = AttendanceStatus.DIDNT_GO
+        rsvp.save(update_fields=["attendance"])
+        report = api_client.get(
+            f"/api/community/events/{past_event.id}/report/", **_auth(host_user)
+        ).json()
+        assert report["didnt_go_count"] == 1, "a maybe marked didn't-attend isn't left unmarked"
+        assert report["didnt_go"][0]["user_id"] == str(member.pk)
+        assert report["no_show_count"] == 0
+        assert report["unmarked_count"] == 0
 
     def test_attending_rsvp_marked_didnt_attend_is_a_no_show(
         self, api_client, past_event, members, host_user
@@ -346,6 +362,7 @@ class TestCheckInReportCsvEndpoint:
         report_total = (
             report["attended_count"]
             + report["no_show_count"]
+            + report["didnt_go_count"]
             + report["canceled_count"]
             + report["unmarked_count"]
         )

--- a/frontend/src/api/eventCheckInReport.ts
+++ b/frontend/src/api/eventCheckInReport.ts
@@ -20,10 +20,12 @@ export interface CanceledPerson extends CheckInReportPerson {
 export interface CheckInReport {
   attendedCount: number;
   noShowCount: number;
+  didntGoCount: number;
   canceledCount: number;
   unmarkedCount: number;
   attended: AttendedPerson[];
   noShows: CheckInReportPerson[];
+  didntGo: CheckInReportPerson[];
   canceled: CanceledPerson[];
   unmarked: CheckInReportPerson[];
 }
@@ -46,10 +48,12 @@ interface WireCanceledPerson extends WirePerson {
 interface WireReport {
   attended_count: number;
   no_show_count: number;
+  didnt_go_count: number;
   canceled_count: number;
   unmarked_count: number;
   attended: WireAttendedPerson[];
   no_shows: WirePerson[];
+  didnt_go: WirePerson[];
   canceled: WireCanceledPerson[];
   unmarked: WirePerson[];
 }
@@ -58,6 +62,7 @@ function mapReport(w: WireReport): CheckInReport {
   return {
     attendedCount: w.attended_count,
     noShowCount: w.no_show_count,
+    didntGoCount: w.didnt_go_count,
     canceledCount: w.canceled_count,
     unmarkedCount: w.unmarked_count,
     attended: w.attended.map((p) => ({
@@ -68,6 +73,12 @@ function mapReport(w: WireReport): CheckInReport {
       checkedInAt: p.checked_in_at ? new Date(p.checked_in_at) : null,
     })),
     noShows: w.no_shows.map((p) => ({
+      userId: p.user_id,
+      name: p.name,
+      phone: p.phone,
+      isMember: p.is_member,
+    })),
+    didntGo: w.didnt_go.map((p) => ({
       userId: p.user_id,
       name: p.name,
       phone: p.phone,

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -2241,6 +2241,16 @@ export interface components {
              */
             canceled_count: number;
             /**
+             * Didnt Go
+             * @default []
+             */
+            didnt_go: components["schemas"]["CheckInReportPersonOut"][];
+            /**
+             * Didnt Go Count
+             * @default 0
+             */
+            didnt_go_count: number;
+            /**
              * No Show Count
              * @default 0
              */

--- a/frontend/src/screens/events/EventCheckInReportScreen.tsx
+++ b/frontend/src/screens/events/EventCheckInReportScreen.tsx
@@ -90,6 +90,7 @@ function ReportBody({
       <div className="flex flex-wrap gap-2 text-xs">
         <Pill label="attended" value={report.attendedCount} />
         <Pill label="no-show" value={report.noShowCount} />
+        <Pill label="didn't go" value={report.didntGoCount} />
         <Pill label="canceled" value={report.canceledCount} />
         <Pill label="unmarked" value={report.unmarkedCount} />
       </div>
@@ -99,6 +100,10 @@ function ReportBody({
       </PersonSection>
 
       <PersonSection title="no-shows" people={report.noShows} empty="no no-shows">
+        {(p) => <PersonRow key={p.userId} person={p} />}
+      </PersonSection>
+
+      <PersonSection title="didn't go" people={report.didntGo} empty="no one marked didn't go">
         {(p) => <PersonRow key={p.userId} person={p} />}
       </PersonSection>
 


### PR DESCRIPTION
## Overview

Original report: a guest showed as "unmarked" in the event check-in report even though a host explicitly marked them "didn't attend" — their original RSVP had been "maybe".

**Scope evolved during review** (see PR discussion): no-show is fixed repo-wide as "RSVP'd going (`status == ATTENDING`) and marked `DIDNT_GO`" — see the shared `is_no_show` helper in `backend/community/_rsvp_counts.py`, used consistently by the check-in report, the admin attendance report, and event stats. Broadening the no-show bucket itself wasn't the right fix.

Instead, the check-in report gets a distinct **didn't go** bucket: anyone marked `DIDNT_GO` who isn't a true no-show (wasn't RSVP'd `ATTENDING`) and didn't originally say they couldn't go (not `CANT_GO`) now lands there instead of the catch-all "unmarked" — this is the actual fix for the original bug.

Also includes a smaller, separate fix found along the way: `_build_report` checked the no-show condition before `CANT_GO`, so a guest who told us in advance they weren't coming (with a stray no-show mark on their RSVP) could get miscategorized as a no-show instead of staying "canceled". Reordered so `CANT_GO` is checked first.

## Test plan

- Full `backend/tests/test_event_check_in_report.py` suite passes (25 passed).
- New `test_maybe_rsvp_marked_didnt_attend_is_in_didnt_go_not_unmarked` covers the original bug scenario directly.

Closes #1332