### PR TITLE
fix: 1333 - rename attendance page to check in

### DIFF
--- a/frontend/src/screens/events/EventAttendanceScreen.test.tsx
+++ b/frontend/src/screens/events/EventAttendanceScreen.test.tsx
@@ -56,7 +56,7 @@ describe('EventAttendanceScreen', () => {
     useAuthStore.setState({ status: 'authed', user: CREATOR, accessToken: 'tok' });
     renderScreen();
 
-    expect(screen.getByRole('heading', { name: /attendance/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /check-in/i })).toBeInTheDocument();
     expect(screen.getByText(BASE_EVENT.title)).toBeInTheDocument();
   });
 
@@ -65,7 +65,7 @@ describe('EventAttendanceScreen', () => {
     renderScreen();
 
     expect(screen.getByText(/only the host or a co-host/i)).toBeInTheDocument();
-    expect(screen.queryByRole('heading', { name: /^attendance$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /^check-in$/i })).not.toBeInTheDocument();
   });
 
   it('blocks even the creator when rsvp is disabled', () => {
@@ -83,6 +83,6 @@ describe('EventAttendanceScreen', () => {
     renderScreen();
 
     expect(screen.getByText(/rsvps are off for this event/i)).toBeInTheDocument();
-    expect(screen.queryByRole('heading', { name: /^attendance$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /^check-in$/i })).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/events/EventAttendanceScreen.tsx
+++ b/frontend/src/screens/events/EventAttendanceScreen.tsx
@@ -39,7 +39,7 @@ export default function EventAttendanceScreen() {
   return (
     <ContentContainer>
       <BackLink eventId={event.id} />
-      <h1 className="mb-1 text-2xl font-medium tracking-tight">attendance</h1>
+      <h1 className="mb-1 text-2xl font-medium tracking-tight">check-in</h1>
       <p className="text-foreground-secondary mb-6 text-sm">{event.title}</p>
       <EventAttendancePanel event={event} />
     </ContentContainer>


### PR DESCRIPTION
## Overview

The original issue text is just **"check in"** — no further detail. It was submitted from the per-event check-in report page (`/events/:id/report`) via the in-app feedback widget, as one of three related pieces of feedback filed in quick succession about check-in/attendance UX on the same event (the other two, #1331 and #1332, are being fixed separately and are not touched here). The auto-generated title "attendance page rename" was inferred by a labeling bot, not written by the reporter.

**My interpretation:** the user is pointing out an inconsistency — the kebab menu on the event detail page already links to `/events/:id/attendance` with the label **"check-in"**, but the page you land on displays the heading **"attendance"**. This PR makes the page heading match the menu label it's reached from.

Changed:
- `frontend/src/screens/events/EventAttendanceScreen.tsx` — `<h1>` heading: `attendance` → `check-in`
- `frontend/src/screens/events/EventAttendanceScreen.test.tsx` — updated heading-text assertions to match

Deliberately unchanged (to keep this a minimal, low-risk text change):
- Route path `/events/:id/attendance` and file names — renaming URLs is a larger, riskier change than this feedback justifies
- The admin-facing attendance report screens (`AttendanceReportScreen.tsx`, `MemberAttendanceTab.tsx` at `/admin/attendance`) — a separate aggregate-reporting concept, not what this per-event feedback is about
- The "back to attendance" link in `EventCheckInReportScreen.tsx` — already being changed by the sibling PR for #1331

**This is a judgment call on a one-line, ambiguous report. Please confirm this matches what the reporter meant before merging** — it's equally plausible they meant something else (e.g. a different nav entry point) that isn't obvious from "check in" alone.

## Test plan

- [x] `cd frontend && npx vitest run src/screens/events/EventAttendanceScreen.test.tsx` — 3 passed
- [x] `cd frontend && npx tsc --noEmit` — clean
- [x] `cd frontend && npx eslint src/screens/events/EventAttendanceScreen.tsx src/screens/events/EventAttendanceScreen.test.tsx` — clean
- [x] Grepped `frontend/src/screens/events/` and `frontend/src/layout/` for remaining user-facing "attendance" text — none left in the affected component tree

Closes #1333
