### PR TITLE
fix: 1316 - slide refresh cookie expiry on token refresh

### DIFF
--- a/backend/config/settings.py
+++ b/backend/config/settings.py
@@ -75,7 +75,7 @@ DATABASES = {"default": dj_database_url.config(default="sqlite:///db.sqlite3", c
 
 NINJA_JWT = {
     "ACCESS_TOKEN_LIFETIME": timedelta(minutes=15),
-    "REFRESH_TOKEN_LIFETIME": timedelta(days=7),
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=30),
     "AUTH_HEADER_TYPES": ("Bearer",),
 }
 

--- a/backend/tests/test_auth_cookie.py
+++ b/backend/tests/test_auth_cookie.py
@@ -95,9 +95,9 @@ class TestRefreshViaCookie:
         assert response.status_code == 200
         assert "access" in response.json()
 
-    def test_refresh_reissues_sliding_refresh_cookie(self, api_client, test_user):
-        refresh = RefreshToken.for_user(test_user)
-        api_client.cookies[REFRESH_COOKIE_NAME] = str(refresh)
+    def test_refresh_reissues_refresh_cookie_with_later_expiry(self, api_client, test_user):
+        old_refresh = RefreshToken.for_user(test_user)
+        api_client.cookies[REFRESH_COOKIE_NAME] = str(old_refresh)
         response = api_client.post(
             "/api/auth/refresh/",
             {},
@@ -107,7 +107,12 @@ class TestRefreshViaCookie:
         cookie = response.cookies.get(REFRESH_COOKIE_NAME)
         assert cookie is not None
         assert cookie["httponly"] is True
-        assert RefreshToken(cookie.value) is not None
+        new_refresh = RefreshToken(cookie.value)
+        # The whole point of re-issuing is a fresh exp computed from "now", not
+        # copied from the old token — same-second in a fast test is fine, older
+        # is the bug this guards against.
+        assert new_refresh.payload["exp"] >= old_refresh.payload["exp"]
+        assert new_refresh.payload["jti"] != old_refresh.payload["jti"]
 
     def test_invalid_cookie_clears_cookie(self, api_client, test_user):
         api_client.cookies[REFRESH_COOKIE_NAME] = "not.a.valid.token"

--- a/backend/tests/test_auth_cookie.py
+++ b/backend/tests/test_auth_cookie.py
@@ -112,6 +112,24 @@ class TestRefreshViaCookie:
         assert new_refresh.payload["exp"] >= old_refresh.payload["exp"]
         assert new_refresh.payload["jti"] != old_refresh.payload["jti"]
 
+    def test_refresh_for_deleted_user_returns_401_without_error_log(
+        self, api_client, test_user, caplog
+    ):
+        refresh = RefreshToken.for_user(test_user)
+        test_user.delete()
+        api_client.cookies[REFRESH_COOKIE_NAME] = str(refresh)
+        response = api_client.post(
+            "/api/auth/refresh/",
+            {},
+            content_type="application/json",
+        )
+        assert response.status_code == 401
+        assert response.json()["detail"][0]["code"] == "auth.refresh_token_invalid"
+        cleared = response.cookies.get(REFRESH_COOKIE_NAME)
+        assert cleared is not None
+        assert cleared.value == ""
+        assert "pda.auth" not in {r.name for r in caplog.records if r.levelno >= 40}
+
     def test_invalid_cookie_clears_cookie(self, api_client, test_user):
         api_client.cookies[REFRESH_COOKIE_NAME] = "not.a.valid.token"
         response = api_client.post(

--- a/backend/tests/test_auth_cookie.py
+++ b/backend/tests/test_auth_cookie.py
@@ -95,6 +95,20 @@ class TestRefreshViaCookie:
         assert response.status_code == 200
         assert "access" in response.json()
 
+    def test_refresh_reissues_sliding_refresh_cookie(self, api_client, test_user):
+        refresh = RefreshToken.for_user(test_user)
+        api_client.cookies[REFRESH_COOKIE_NAME] = str(refresh)
+        response = api_client.post(
+            "/api/auth/refresh/",
+            {},
+            content_type="application/json",
+        )
+        assert response.status_code == 200
+        cookie = response.cookies.get(REFRESH_COOKIE_NAME)
+        assert cookie is not None
+        assert cookie["httponly"] is True
+        assert RefreshToken(cookie.value) is not None
+
     def test_invalid_cookie_clears_cookie(self, api_client, test_user):
         api_client.cookies[REFRESH_COOKIE_NAME] = "not.a.valid.token"
         response = api_client.post(

--- a/backend/tests/test_auth_cookie.py
+++ b/backend/tests/test_auth_cookie.py
@@ -108,9 +108,7 @@ class TestRefreshViaCookie:
         assert cookie is not None
         assert cookie["httponly"] is True
         new_refresh = RefreshToken(cookie.value)
-        # The whole point of re-issuing is a fresh exp computed from "now", not
-        # copied from the old token — same-second in a fast test is fine, older
-        # is the bug this guards against.
+        # >= not >: same-second is fine, older is the bug.
         assert new_refresh.payload["exp"] >= old_refresh.payload["exp"]
         assert new_refresh.payload["jti"] != old_refresh.payload["jti"]
 

--- a/backend/users/_auth.py
+++ b/backend/users/_auth.py
@@ -108,10 +108,7 @@ def refresh_token(request, response: HttpResponse):
         raise_validation(Code.Auth.REFRESH_TOKEN_INVALID, status_code=401)
     try:
         old_refresh = RefreshToken(token)
-        # RefreshToken(token) decodes an existing token verbatim, including its
-        # original exp claim — re-serializing it doesn't extend expiry. Minting
-        # a new one for the same user is what actually slides the idle timeout
-        # forward instead of leaving a fixed ceiling from login.
+        # Mint fresh, don't reuse old_refresh — it keeps the original exp.
         user = User.objects.get(pk=old_refresh.payload["user_id"])
         refresh = RefreshToken.for_user(user)
         set_refresh_cookie(response, str(refresh))

--- a/backend/users/_auth.py
+++ b/backend/users/_auth.py
@@ -113,7 +113,7 @@ def refresh_token(request, response: HttpResponse):
         refresh = RefreshToken.for_user(user)
         set_refresh_cookie(response, str(refresh))
         return Status(200, AccessOut(access=str(refresh.access_token)))
-    except TokenError:
+    except (TokenError, User.DoesNotExist):
         raise_validation(
             Code.Auth.REFRESH_TOKEN_INVALID, status_code=401, clear_refresh_cookie=True
         )

--- a/backend/users/_auth.py
+++ b/backend/users/_auth.py
@@ -108,6 +108,8 @@ def refresh_token(request, response: HttpResponse):
         raise_validation(Code.Auth.REFRESH_TOKEN_INVALID, status_code=401)
     try:
         refresh = RefreshToken(token)
+        # Slide the refresh cookie forward so it's an idle timeout, not a hard ceiling from login.
+        set_refresh_cookie(response, str(refresh))
         return Status(200, AccessOut(access=str(refresh.access_token)))
     except TokenError:
         raise_validation(

--- a/backend/users/_auth.py
+++ b/backend/users/_auth.py
@@ -107,8 +107,13 @@ def refresh_token(request, response: HttpResponse):
     if not token:
         raise_validation(Code.Auth.REFRESH_TOKEN_INVALID, status_code=401)
     try:
-        refresh = RefreshToken(token)
-        # Slide the refresh cookie forward so it's an idle timeout, not a hard ceiling from login.
+        old_refresh = RefreshToken(token)
+        # RefreshToken(token) decodes an existing token verbatim, including its
+        # original exp claim — re-serializing it doesn't extend expiry. Minting
+        # a new one for the same user is what actually slides the idle timeout
+        # forward instead of leaving a fixed ceiling from login.
+        user = User.objects.get(pk=old_refresh.payload["user_id"])
+        refresh = RefreshToken.for_user(user)
         set_refresh_cookie(response, str(refresh))
         return Status(200, AccessOut(access=str(refresh.access_token)))
     except TokenError:

--- a/frontend/src/api/auth.test.ts
+++ b/frontend/src/api/auth.test.ts
@@ -1,9 +1,8 @@
 import MockAdapter from 'axios-mock-adapter';
 import { beforeEach, describe, expect, it } from 'vitest';
 
-import { authClient } from './client';
-
 import { restoreSession } from './auth';
+import { authClient } from './client';
 
 const wireUser = {
   id: 'user-1',

--- a/frontend/src/api/auth.test.ts
+++ b/frontend/src/api/auth.test.ts
@@ -1,0 +1,73 @@
+import MockAdapter from 'axios-mock-adapter';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { authClient } from './client';
+
+import { restoreSession } from './auth';
+
+const wireUser = {
+  id: 'user-1',
+  phone_number: '+12125551234',
+  full_name: 'Alice',
+  needs_onboarding: false,
+  roles: [],
+};
+
+describe('restoreSession', () => {
+  let authMock: MockAdapter;
+
+  beforeEach(() => {
+    authMock = new MockAdapter(authClient);
+  });
+
+  it('returns the session on a successful refresh', async () => {
+    authMock.onPost('/api/auth/refresh/').reply(200, { access: 'tok-1' });
+    authMock.onGet('/api/auth/me/').reply(200, wireUser);
+
+    const result = await restoreSession();
+
+    expect(result?.access).toBe('tok-1');
+    expect(result?.user.id).toBe('user-1');
+  });
+
+  it('returns null immediately on a real 401 without retrying', async () => {
+    let calls = 0;
+    authMock.onPost('/api/auth/refresh/').reply(() => {
+      calls += 1;
+      return [401, { detail: 'invalid' }];
+    });
+
+    const result = await restoreSession();
+
+    expect(result).toBeNull();
+    expect(calls).toBe(1);
+  });
+
+  it('retries once and succeeds after a transient failure', async () => {
+    let calls = 0;
+    authMock.onPost('/api/auth/refresh/').reply(() => {
+      calls += 1;
+      if (calls === 1) return [500, { detail: 'server error' }];
+      return [200, { access: 'tok-2' }];
+    });
+    authMock.onGet('/api/auth/me/').reply(200, wireUser);
+
+    const result = await restoreSession();
+
+    expect(calls).toBe(2);
+    expect(result?.access).toBe('tok-2');
+  });
+
+  it('gives up and returns null after two transient failures', async () => {
+    let calls = 0;
+    authMock.onPost('/api/auth/refresh/').reply(() => {
+      calls += 1;
+      return [500, { detail: 'server error' }];
+    });
+
+    const result = await restoreSession();
+
+    expect(calls).toBe(2);
+    expect(result).toBeNull();
+  });
+});

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,4 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
+import { isAxiosError } from 'axios';
 
 import type { ConsentTypeValue } from '@/models/consent';
 import { normalizePermissions } from '@/models/permissions';
@@ -132,15 +133,26 @@ export async function magicLogin(token: string): Promise<{ access: string; user:
   return { access: data.access, user };
 }
 
+async function tryRestoreSession(): Promise<{ access: string; user: User } | null> {
+  const { data } = await authClient.post<AccessOut>('/api/auth/refresh/', {});
+  const user = await fetchMeWithToken(data.access);
+  return { access: data.access, user };
+}
+
 export async function restoreSession(): Promise<{ access: string; user: User } | null> {
-  // The refresh cookie is sent automatically. If it's missing/invalid, /refresh/
-  // returns 401 and we treat the session as gone.
+  // The refresh cookie is sent automatically. A real 401 means it's missing/
+  // invalid, so the session is genuinely gone. Anything else (network blip,
+  // cold start, 5xx) is transient — retry once before giving up, so a boot-time
+  // hiccup doesn't force a re-login on an otherwise-valid session.
   try {
-    const { data } = await authClient.post<AccessOut>('/api/auth/refresh/', {});
-    const user = await fetchMeWithToken(data.access);
-    return { access: data.access, user };
-  } catch {
-    return null;
+    return await tryRestoreSession();
+  } catch (err) {
+    if (isAxiosError(err) && err.response?.status === 401) return null;
+    try {
+      return await tryRestoreSession();
+    } catch {
+      return null;
+    }
   }
 }
 

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -140,10 +140,7 @@ async function tryRestoreSession(): Promise<{ access: string; user: User } | nul
 }
 
 export async function restoreSession(): Promise<{ access: string; user: User } | null> {
-  // The refresh cookie is sent automatically. A real 401 means it's missing/
-  // invalid, so the session is genuinely gone. Anything else (network blip,
-  // cold start, 5xx) is transient — retry once before giving up, so a boot-time
-  // hiccup doesn't force a re-login on an otherwise-valid session.
+  // Retry once unless it's a real 401 — avoids re-login on a transient 5xx.
   try {
     return await tryRestoreSession();
   } catch (err) {


### PR DESCRIPTION
## Overview

Fixes users getting logged out too often ("Not sure how often exactly, but I have to sign in so much"), reported from `/calendar`. This went through two rounds of investigation — the first commit on this branch had a partial fix that turned out not to actually work; see below.

**Two real bugs, confirmed by reading `ninja_jwt`'s actual token source and reproducing the retry gap:**

1. **`refresh_token()` never advanced the refresh token's real expiry.** It re-serialized the *decoded* `RefreshToken` (`RefreshToken(token)` → `str(refresh)`), which copies the original `exp` claim verbatim — `ninja_jwt.Token` only sets `exp` when building a brand-new token (`token is None`), not when re-encoding an existing one. So the refresh cookie's `max-age` moved forward on each call, but the JWT payload's own `exp` (what `check_exp()` actually validates) never did. Fixed by minting a genuinely new `RefreshToken.for_user(user)` on each refresh.
2. **`restoreSession()` treated every refresh failure as a real session expiry.** Access tokens are memory-only (Zustand, not persisted), so `restoreSession()` → `POST /auth/refresh/` runs on every reload/reopen/backgrounded-tab-resume. Any transient failure (network blip, Railway cold start, 5xx) was indistinguishable from a genuine 401 and forced a full logout — unlike the in-session interceptor (`client.ts`), which already made this distinction. Fixed by retrying once on non-401 failures before giving up, and only forcing logout on an actual 401.

`REFRESH_TOKEN_LIFETIME` also raised 7d → 30d as the idle-timeout ceiling (now a real ceiling, since bug 1 means it's genuinely extended on use).

## Test plan

- [x] `test_refresh_reissues_refresh_cookie_with_later_expiry` — asserts the new refresh token's `exp` is `>=` the old one's and its `jti` differs (previously would have failed pre-fix: same token re-serialized)
- [x] New `frontend/src/api/auth.test.ts` — covers immediate-null-on-401, retry-then-succeed on transient failure, and give-up-after-two-failures
- [x] Targeted pytest (`test_auth_cookie.py`, `test_auth.py`, `test_auth_gate.py`) — 57/57 passed
- [x] Frontend: `auth.test.ts`, `client.test.ts`, `store.test.ts` — 25/25 passed
- [x] `make agent-typecheck` / `make agent-frontend-typecheck` clean
- [x] `make agent-lint` / `make agent-frontend-lint` clean

Closes #1316
