### PR TITLE
fix: 1339 - remove timestamp from check-in report

### DIFF
--- a/backend/community/_event_report.py
+++ b/backend/community/_event_report.py
@@ -115,7 +115,6 @@ def _csv_row(rsvp, viewer, can_see_phones: bool, columns: list[str]) -> list[str
         "phone": _csv_safe((rsvp.user.phone_number or "") if can_see_phones else ""),
         "rsvp_status": rsvp.status,
         "attendance": rsvp.attendance,
-        "checked_in_at": rsvp.checked_in_at.isoformat() if rsvp.checked_in_at else "",
         "cancelled_at": rsvp.cancelled_at.isoformat() if rsvp.cancelled_at else "",
         "plus_one": "yes" if rsvp.has_plus_one else "no",
     }

--- a/backend/community/_event_report_schemas.py
+++ b/backend/community/_event_report_schemas.py
@@ -36,7 +36,6 @@ REPORT_CSV_COLUMNS = (
     "phone",
     "rsvp_status",
     "attendance",
-    "checked_in_at",
     "cancelled_at",
     "plus_one",
 )

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -10807,7 +10807,7 @@
             "name": "columns",
             "required": false,
             "schema": {
-              "default": "name,phone,rsvp_status,attendance,checked_in_at,cancelled_at,plus_one",
+              "default": "name,phone,rsvp_status,attendance,cancelled_at,plus_one",
               "title": "Columns",
               "type": "string"
             }

--- a/frontend/src/api/eventCheckInReport.ts
+++ b/frontend/src/api/eventCheckInReport.ts
@@ -105,7 +105,6 @@ export const CSV_COLUMNS = [
   { key: 'phone', label: 'phone' },
   { key: 'rsvp_status', label: 'rsvp status' },
   { key: 'attendance', label: 'attendance' },
-  { key: 'checked_in_at', label: 'checked-in time' },
   { key: 'cancelled_at', label: 'canceled time' },
   { key: 'plus_one', label: 'plus-one' },
 ] as const;

--- a/frontend/src/screens/events/EventCheckInReportScreen.tsx
+++ b/frontend/src/screens/events/EventCheckInReportScreen.tsx
@@ -173,9 +173,6 @@ function AttendedRow({ person }: { person: AttendedPerson }) {
         {person.name}
         {!person.isMember ? <GuestBadge /> : null}
       </span>
-      {person.checkedInAt ? (
-        <span className="text-muted text-xs">{formatShortDateTime(person.checkedInAt)}</span>
-      ) : null}
     </li>
   );
 }


### PR DESCRIPTION
## Overview

Removes the check-in timestamp from the host event check-in report. Per user feedback: the timestamp reflects when a host marked someone as checked in, not when the attendee actually arrived, so it's misleading and unneeded.

Removed from both the CSV export column set (`REPORT_CSV_COLUMNS`, `_csv_row`) and the in-app report display (`AttendedRow`). The underlying `EventRSVP.checked_in_at` field and the JSON API's `checked_in_at` output are untouched — this only affects the report's display/export.

## Test plan

- [x] `backend/tests/test_event_check_in_report.py` — 25/25 passed
- [x] `frontend/src/screens/events/EventCheckInReportScreen.test.tsx` — 3/3 passed
- [x] `make agent-typecheck` / `make agent-frontend-typecheck` clean
- [x] `make agent-lint` / `make agent-frontend-lint` clean

Closes #1339
