### PR TITLE
feat: 1324 - import historical partiful attendance via csv upload

### DIFF
--- a/backend/community/_attendance_import.py
+++ b/backend/community/_attendance_import.py
@@ -1,0 +1,196 @@
+import logging
+
+from config.audit import AuditTarget, AuditTargetType, audit_log
+from config.auth import gated_jwt
+from config.ratelimit import rate_limit
+from django.utils import timezone
+from ninja import File, Router
+from ninja.files import UploadedFile
+from ninja.responses import Status
+from users.models import User
+from users.permissions import PermissionKey
+
+from community._attendance_import_matching import match_rows, parse_partiful_csv
+from community._attendance_import_schemas import (
+    AttendanceImportCommitIn,
+    AttendanceImportCommitOut,
+    AttendanceImportPreviewOut,
+    EventOptionOut,
+)
+from community._shared import ErrorOut
+from community._validation import Code, raise_validation
+from community.models import (
+    AttendanceStatus,
+    Event,
+    EventStatus,
+    EventType,
+    PageVisibility,
+    RSVPStatus,
+)
+
+router = Router()
+
+_MAX_CSV_SIZE = 2 * 1024 * 1024  # 2 MB
+_ALLOWED_CSV_TYPES = {"text/csv", "application/vnd.ms-excel", "text/plain"}
+
+
+def _require_manage_events(request, action: str) -> None:
+    if not request.auth.has_permission(PermissionKey.MANAGE_EVENTS):
+        audit_log(
+            logging.WARNING,
+            "permission_denied",
+            request,
+            persist=False,
+            target=AuditTarget(type=AuditTargetType.EVENT, id="", details={"action": action}),
+        )
+        raise_validation(Code.Perm.DENIED, status_code=403, action=action)
+
+
+@router.get(
+    "/events/attendance-import/events/",
+    response={200: list[EventOptionOut], 403: ErrorOut},
+    auth=gated_jwt,
+)
+def list_attendance_import_event_options(request, q: str = ""):
+    """Existing events an admin can pick as the import target, newest first."""
+    _require_manage_events(request, "list_attendance_import_event_options")
+    events = Event.objects.exclude(status=EventStatus.DELETED).order_by("-start_datetime")
+    if q.strip():
+        events = events.filter(title__icontains=q.strip())
+    return Status(
+        200,
+        [
+            EventOptionOut(id=str(e.id), title=e.title, start_datetime=e.start_datetime)
+            for e in events[:25]
+        ],
+    )
+
+
+@router.post(
+    "/events/attendance-import/preview/",
+    response={200: AttendanceImportPreviewOut, 400: ErrorOut, 403: ErrorOut, 429: ErrorOut},
+    auth=gated_jwt,
+)
+@rate_limit(key_func=lambda r: str(r.auth.pk), rate="20/h")
+def preview_attendance_import(request, csv_file: UploadedFile = File(...)):  # ty: ignore[call-non-callable]
+    """Parse a raw Partiful export and return matched vs needs-review rows.
+
+    No writes happen here — this is read-only preview against existing users.
+    """
+    _require_manage_events(request, "preview_attendance_import")
+    if csv_file.content_type not in _ALLOWED_CSV_TYPES:
+        raise_validation(Code.AttendanceImport.CSV_MALFORMED, status_code=400)
+    if csv_file.size and csv_file.size > _MAX_CSV_SIZE:
+        raise_validation(Code.AttendanceImport.CSV_MALFORMED, status_code=400)
+
+    rows = parse_partiful_csv(csv_file.read())
+    matched, needs_review = match_rows(rows)
+    return Status(200, AttendanceImportPreviewOut(matched=matched, needs_review=needs_review))
+
+
+def _resolve_event(payload: AttendanceImportCommitIn, request) -> Event:
+    if payload.event_id:
+        try:
+            return Event.objects.get(id=payload.event_id)
+        except Event.DoesNotExist:
+            raise_validation(Code.Event.NOT_FOUND, status_code=404)
+
+    if not payload.event_title or not payload.event_date:
+        raise_validation(Code.AttendanceImport.EVENT_OR_TITLE_REQUIRED, status_code=400)
+
+    start = timezone.make_aware(
+        timezone.datetime.combine(payload.event_date, timezone.datetime.min.time())
+    )
+    return Event.objects.create(
+        title=payload.event_title,
+        start_datetime=start,
+        event_type=EventType.COMMUNITY,
+        visibility=PageVisibility.PUBLIC,
+        status=EventStatus.ACTIVE,
+        rsvp_enabled=False,
+        created_by=request.auth,
+    )
+
+
+def _resolve_status_and_attendance(row) -> tuple[str, str]:
+    """Map a Partiful row to (RSVPStatus, AttendanceStatus).
+
+    Checked in → attended. RSVP'd going but not checked in → the canonical
+    no-show shape (attending + didnt_go, see _rsvp_counts.no_show_q). Anything
+    else (maybe/declined, never checked in) makes no attendance claim.
+    """
+    if row.checked_in:
+        return RSVPStatus.ATTENDING, AttendanceStatus.ATTENDED
+    if row.partiful_status.lower() == "going":
+        return RSVPStatus.ATTENDING, AttendanceStatus.DIDNT_GO
+    return RSVPStatus.MAYBE, AttendanceStatus.UNKNOWN
+
+
+def _apply_row(event: Event, row, user: User) -> bool:
+    """Upsert one EventRSVP for a resolved import row. return(bool): True if created."""
+    rsvp_status, attendance = _resolve_status_and_attendance(row)
+    _, created = event.rsvps.update_or_create(
+        user=user,
+        defaults={"status": rsvp_status, "attendance": attendance},
+    )
+    return created
+
+
+@router.post(
+    "/events/attendance-import/commit/",
+    response={
+        200: AttendanceImportCommitOut,
+        400: ErrorOut,
+        403: ErrorOut,
+        404: ErrorOut,
+        429: ErrorOut,
+    },
+    auth=gated_jwt,
+)
+@rate_limit(key_func=lambda r: str(r.auth.pk), rate="20/h")
+def commit_attendance_import(request, payload: AttendanceImportCommitIn):
+    """Write reviewed rows into EventRSVP/AttendanceStatus, creating the event if needed."""
+    _require_manage_events(request, "commit_attendance_import")
+
+    event = _resolve_event(payload, request)
+    user_ids = {r.user_id for r in payload.rows if r.user_id and not r.skip}
+    users_by_id = {str(u.id): u for u in User.objects.filter(id__in=user_ids)}
+
+    created_count = updated_count = skipped_count = 0
+    for row in payload.rows:
+        if row.skip or not row.user_id:
+            skipped_count += 1
+            continue
+        user = users_by_id.get(row.user_id)
+        if user is None:
+            skipped_count += 1
+            continue
+        if _apply_row(event, row, user):
+            created_count += 1
+        else:
+            updated_count += 1
+
+    audit_log(
+        logging.INFO,
+        "attendance_import_committed",
+        request,
+        target=AuditTarget(
+            type=AuditTargetType.EVENT,
+            id=str(event.id),
+            details={
+                "created_count": created_count,
+                "updated_count": updated_count,
+                "skipped_count": skipped_count,
+            },
+        ),
+    )
+    return Status(
+        200,
+        AttendanceImportCommitOut(
+            event_id=str(event.id),
+            event_title=event.title,
+            created_count=created_count,
+            updated_count=updated_count,
+            skipped_count=skipped_count,
+        ),
+    )

--- a/backend/community/_attendance_import.py
+++ b/backend/community/_attendance_import.py
@@ -83,6 +83,14 @@ def preview_attendance_import(request, csv_file: UploadedFile = File(...)):  # t
     return Status(200, AttendanceImportPreviewOut(matched=matched, needs_review=needs_review))
 
 
+def _require_all_rows_resolved(payload: AttendanceImportCommitIn) -> None:
+    for row in payload.rows:
+        if not row.user_id and not row.skip:
+            raise_validation(
+                Code.AttendanceImport.AMBIGUOUS_USER_PICK, status_code=400, row_index=row.row_index
+            )
+
+
 def _resolve_event(payload: AttendanceImportCommitIn, request) -> Event:
     if payload.event_id:
         try:
@@ -140,6 +148,7 @@ def _apply_row(event: Event, row, user: User) -> bool:
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="20/h")
 def commit_attendance_import(request, payload: AttendanceImportCommitIn):
     _require_manage_events(request, "commit_attendance_import")
+    _require_all_rows_resolved(payload)
 
     event = _resolve_event(payload, request)
     user_ids = {r.user_id for r in payload.rows if r.user_id and not r.skip}

--- a/backend/community/_attendance_import.py
+++ b/backend/community/_attendance_import.py
@@ -71,15 +71,28 @@ def list_attendance_import_event_options(request, q: str = ""):
     auth=gated_jwt,
 )
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="20/h")
-def preview_attendance_import(request, csv_file: UploadedFile = File(...)):  # ty: ignore[call-non-callable]
+def preview_attendance_import(
+    request,
+    csv_file: UploadedFile = File(...),  # ty: ignore[call-non-callable]
+    event_id: str | None = None,
+):
     _require_manage_events(request, "preview_attendance_import")
     if csv_file.content_type not in _ALLOWED_CSV_TYPES:
         raise_validation(Code.AttendanceImport.CSV_MALFORMED, status_code=400)
     if csv_file.size and csv_file.size > _MAX_CSV_SIZE:
         raise_validation(Code.AttendanceImport.CSV_MALFORMED, status_code=400)
 
+    existing_rsvp_user_ids: set[str] = set()
+    if event_id:
+        existing_rsvp_user_ids = {
+            str(uid)
+            for uid in Event.objects.filter(id=event_id)
+            .exclude(rsvps__user_id=None)
+            .values_list("rsvps__user_id", flat=True)
+        }
+
     rows = parse_partiful_csv(csv_file.read())
-    matched, needs_review = match_rows(rows)
+    matched, needs_review = match_rows(rows, existing_rsvp_user_ids)
     return Status(200, AttendanceImportPreviewOut(matched=matched, needs_review=needs_review))
 
 
@@ -110,13 +123,13 @@ def _resolve_event(payload: AttendanceImportCommitIn, request) -> Event:
         event_type=EventType.COMMUNITY,
         visibility=PageVisibility.PUBLIC,
         status=EventStatus.ACTIVE,
-        rsvp_enabled=False,
+        rsvp_enabled=True,
         created_by=request.auth,
     )
 
 
 def _resolve_status_and_attendance(row) -> tuple[str, str]:
-    """Going+not-checked-in must map to attending+didnt_go — the no-show shape _rsvp_counts.no_show_q expects."""
+    """Going+not-checked-in must map to attending+didnt_go — the didn't-go shape _rsvp_counts.no_show_q expects."""
     if row.checked_in:
         return RSVPStatus.ATTENDING, AttendanceStatus.ATTENDED
     if row.partiful_status.lower() == "going":

--- a/backend/community/_attendance_import.py
+++ b/backend/community/_attendance_import.py
@@ -30,7 +30,7 @@ from community.models import (
 
 router = Router()
 
-_MAX_CSV_SIZE = 2 * 1024 * 1024  # 2 MB
+_MAX_CSV_SIZE = 2 * 1024 * 1024
 _ALLOWED_CSV_TYPES = {"text/csv", "application/vnd.ms-excel", "text/plain"}
 
 
@@ -52,7 +52,6 @@ def _require_manage_events(request, action: str) -> None:
     auth=gated_jwt,
 )
 def list_attendance_import_event_options(request, q: str = ""):
-    """Existing events an admin can pick as the import target, newest first."""
     _require_manage_events(request, "list_attendance_import_event_options")
     events = Event.objects.exclude(status=EventStatus.DELETED).order_by("-start_datetime")
     if q.strip():
@@ -73,10 +72,6 @@ def list_attendance_import_event_options(request, q: str = ""):
 )
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="20/h")
 def preview_attendance_import(request, csv_file: UploadedFile = File(...)):  # ty: ignore[call-non-callable]
-    """Parse a raw Partiful export and return matched vs needs-review rows.
-
-    No writes happen here — this is read-only preview against existing users.
-    """
     _require_manage_events(request, "preview_attendance_import")
     if csv_file.content_type not in _ALLOWED_CSV_TYPES:
         raise_validation(Code.AttendanceImport.CSV_MALFORMED, status_code=400)
@@ -113,12 +108,7 @@ def _resolve_event(payload: AttendanceImportCommitIn, request) -> Event:
 
 
 def _resolve_status_and_attendance(row) -> tuple[str, str]:
-    """Map a Partiful row to (RSVPStatus, AttendanceStatus).
-
-    Checked in → attended. RSVP'd going but not checked in → the canonical
-    no-show shape (attending + didnt_go, see _rsvp_counts.no_show_q). Anything
-    else (maybe/declined, never checked in) makes no attendance claim.
-    """
+    """Going+not-checked-in must map to attending+didnt_go — the no-show shape _rsvp_counts.no_show_q expects."""
     if row.checked_in:
         return RSVPStatus.ATTENDING, AttendanceStatus.ATTENDED
     if row.partiful_status.lower() == "going":
@@ -149,7 +139,6 @@ def _apply_row(event: Event, row, user: User) -> bool:
 )
 @rate_limit(key_func=lambda r: str(r.auth.pk), rate="20/h")
 def commit_attendance_import(request, payload: AttendanceImportCommitIn):
-    """Write reviewed rows into EventRSVP/AttendanceStatus, creating the event if needed."""
     _require_manage_events(request, "commit_attendance_import")
 
     event = _resolve_event(payload, request)

--- a/backend/community/_attendance_import_matching.py
+++ b/backend/community/_attendance_import_matching.py
@@ -40,7 +40,9 @@ def _matches_name(user: User, name_lower: str) -> bool:
     return name_lower in {c.strip().lower() for c in candidates if c}
 
 
-def match_row(row_index: int, raw_row: dict[str, str], pool: list[User]) -> ImportRowOut:
+def match_row(
+    row_index: int, raw_row: dict[str, str], pool: list[User], existing_rsvp_user_ids: set[str]
+) -> ImportRowOut:
     raw_name = raw_row.get("name", "")
     name_lower = raw_name.strip().lower()
     checked_in = raw_row.get("checked in", "").strip().lower() == "yes"
@@ -57,6 +59,7 @@ def match_row(row_index: int, raw_row: dict[str, str], pool: list[User]) -> Impo
             checked_in=checked_in,
             matched_user_id=str(user.id),
             matched_full_name=user.full_name,
+            has_existing_rsvp=str(user.id) in existing_rsvp_user_ids,
         )
 
     return ImportRowOut(
@@ -73,10 +76,13 @@ def match_row(row_index: int, raw_row: dict[str, str], pool: list[User]) -> Impo
     )
 
 
-def match_rows(rows: list[dict[str, str]]) -> tuple[list[ImportRowOut], list[ImportRowOut]]:
+def match_rows(
+    rows: list[dict[str, str]], existing_rsvp_user_ids: set[str] | None = None
+) -> tuple[list[ImportRowOut], list[ImportRowOut]]:
     pool = _candidate_pool()
+    existing = existing_rsvp_user_ids or set()
     matched, needs_review = [], []
     for i, row in enumerate(rows):
-        result = match_row(i, row, pool)
+        result = match_row(i, row, pool, existing)
         (matched if result.matched_user_id else needs_review).append(result)
     return matched, needs_review

--- a/backend/community/_attendance_import_matching.py
+++ b/backend/community/_attendance_import_matching.py
@@ -1,0 +1,82 @@
+import csv
+import io
+
+from users.models import User
+
+from community._attendance_import_schemas import ImportCandidateOut, ImportRowOut
+from community._validation import Code, raise_validation
+
+REQUIRED_COLUMNS = {"name", "status", "checked in"}
+
+
+def parse_partiful_csv(raw: bytes) -> list[dict[str, str]]:
+    try:
+        text = raw.decode("utf-8-sig")
+    except UnicodeDecodeError:
+        raise_validation(Code.AttendanceImport.CSV_MALFORMED, status_code=400)
+
+    reader = csv.DictReader(io.StringIO(text))
+    if reader.fieldnames is None:
+        raise_validation(Code.AttendanceImport.CSV_EMPTY, status_code=400)
+
+    headers = {(h or "").strip().lower() for h in reader.fieldnames}
+    if not REQUIRED_COLUMNS.issubset(headers):
+        raise_validation(Code.AttendanceImport.CSV_MALFORMED, status_code=400)
+
+    rows = [
+        {(k or "").strip().lower(): (v or "").strip() for k, v in row.items()} for row in reader
+    ]
+    if not rows:
+        raise_validation(Code.AttendanceImport.CSV_EMPTY, status_code=400)
+    return rows
+
+
+def _candidate_pool() -> list[User]:
+    return list(User.objects.active_members().filter(needs_onboarding=False))
+
+
+def _matches_name(user: User, name_lower: str) -> bool:
+    candidates = {user.full_name, user.nickname, f"{user.first_name} {user.nickname}".strip()}
+    return name_lower in {c.strip().lower() for c in candidates if c}
+
+
+def match_row(row_index: int, raw_row: dict[str, str], pool: list[User]) -> ImportRowOut:
+    raw_name = raw_row.get("name", "")
+    name_lower = raw_name.strip().lower()
+    checked_in = raw_row.get("checked in", "").strip().lower() == "yes"
+    partiful_status = raw_row.get("status", "")
+
+    matches = [u for u in pool if name_lower and _matches_name(u, name_lower)]
+
+    if len(matches) == 1:
+        user = matches[0]
+        return ImportRowOut(
+            row_index=row_index,
+            raw_name=raw_name,
+            partiful_status=partiful_status,
+            checked_in=checked_in,
+            matched_user_id=str(user.id),
+            matched_full_name=user.full_name,
+        )
+
+    return ImportRowOut(
+        row_index=row_index,
+        raw_name=raw_name,
+        partiful_status=partiful_status,
+        checked_in=checked_in,
+        candidates=[
+            ImportCandidateOut(
+                user_id=str(u.id), full_name=u.full_name, phone_number=u.phone_number
+            )
+            for u in matches
+        ],
+    )
+
+
+def match_rows(rows: list[dict[str, str]]) -> tuple[list[ImportRowOut], list[ImportRowOut]]:
+    pool = _candidate_pool()
+    matched, needs_review = [], []
+    for i, row in enumerate(rows):
+        result = match_row(i, row, pool)
+        (matched if result.matched_user_id else needs_review).append(result)
+    return matched, needs_review

--- a/backend/community/_attendance_import_schemas.py
+++ b/backend/community/_attendance_import_schemas.py
@@ -1,0 +1,54 @@
+from datetime import date, datetime
+
+from pydantic import BaseModel
+
+
+class ImportCandidateOut(BaseModel):
+    user_id: str
+    full_name: str
+    phone_number: str
+
+
+class ImportRowOut(BaseModel):
+    row_index: int
+    raw_name: str
+    partiful_status: str
+    checked_in: bool
+    matched_user_id: str | None = None
+    matched_full_name: str | None = None
+    candidates: list[ImportCandidateOut] = []
+
+
+class AttendanceImportPreviewOut(BaseModel):
+    matched: list[ImportRowOut] = []
+    needs_review: list[ImportRowOut] = []
+
+
+class ImportRowResolutionIn(BaseModel):
+    row_index: int
+    raw_name: str
+    partiful_status: str
+    checked_in: bool
+    user_id: str | None = None
+    skip: bool = False
+
+
+class AttendanceImportCommitIn(BaseModel):
+    event_id: str | None = None
+    event_title: str | None = None
+    event_date: date | None = None
+    rows: list[ImportRowResolutionIn]
+
+
+class AttendanceImportCommitOut(BaseModel):
+    event_id: str
+    event_title: str
+    created_count: int
+    updated_count: int
+    skipped_count: int
+
+
+class EventOptionOut(BaseModel):
+    id: str
+    title: str
+    start_datetime: datetime | None = None

--- a/backend/community/_attendance_import_schemas.py
+++ b/backend/community/_attendance_import_schemas.py
@@ -17,6 +17,7 @@ class ImportRowOut(BaseModel):
     matched_user_id: str | None = None
     matched_full_name: str | None = None
     candidates: list[ImportCandidateOut] = []
+    has_existing_rsvp: bool = False
 
 
 class AttendanceImportPreviewOut(BaseModel):

--- a/backend/community/_validation.py
+++ b/backend/community/_validation.py
@@ -176,6 +176,12 @@ class Code:
         TYPE_NOT_ALLOWED = "photo.type_not_allowed"  # params: { allowed: string[] }
         TOO_LARGE = "photo.too_large"  # params: { max_mb: int }
 
+    class AttendanceImport:
+        CSV_EMPTY = "attendance_import.csv_empty"
+        CSV_MALFORMED = "attendance_import.csv_malformed"
+        EVENT_OR_TITLE_REQUIRED = "attendance_import.event_or_title_required"
+        AMBIGUOUS_USER_PICK = "attendance_import.ambiguous_user_pick"  # params: { row_index: int }
+
     class Perm:
         DENIED = "perm.denied"  # params: { action?: str }
 

--- a/backend/community/api.py
+++ b/backend/community/api.py
@@ -1,5 +1,6 @@
 from ninja import Router
 
+from community._attendance_import import router as attendance_import_router
 from community._attendance_report import router as attendance_report_router
 from community._calendar import router as calendar_router
 from community._dev_tools import router as dev_tools_router
@@ -64,10 +65,11 @@ router.add_router("", join_request_submit_router)
 router.add_router("", join_request_resend_router)
 router.add_router("", login_link_router)
 router.add_router("", feedback_router)
-# Mount before events_router so the literal `/events/attendance-report/` and
-# `/events/attendance-analytics/members/` routes resolve before that router's
-# `/events/{event_id}/` parameterized route.
+# Mount before events_router so the literal `/events/attendance-report/`,
+# `/events/attendance-analytics/members/`, and `/events/attendance-import/*`
+# routes resolve before that router's `/events/{event_id}/` parameterized route.
 router.add_router("", attendance_report_router)
+router.add_router("", attendance_import_router)
 router.add_router("", events_router)
 router.add_router("", event_tags_router)
 router.add_router("", event_rsvps_router)

--- a/backend/community/api.py
+++ b/backend/community/api.py
@@ -65,9 +65,7 @@ router.add_router("", join_request_submit_router)
 router.add_router("", join_request_resend_router)
 router.add_router("", login_link_router)
 router.add_router("", feedback_router)
-# Mount before events_router so the literal `/events/attendance-report/`,
-# `/events/attendance-analytics/members/`, and `/events/attendance-import/*`
-# routes resolve before that router's `/events/{event_id}/` parameterized route.
+# Mount before events_router so literal /events/attendance-* routes resolve before its /events/{event_id}/ param route.
 router.add_router("", attendance_report_router)
 router.add_router("", attendance_import_router)
 router.add_router("", events_router)

--- a/backend/community/validation_codes.json
+++ b/backend/community/validation_codes.json
@@ -738,6 +738,30 @@
         ]
       }
     ],
+    "AttendanceImport": [
+      {
+        "name": "CSV_EMPTY",
+        "value": "attendance_import.csv_empty",
+        "params": []
+      },
+      {
+        "name": "CSV_MALFORMED",
+        "value": "attendance_import.csv_malformed",
+        "params": []
+      },
+      {
+        "name": "EVENT_OR_TITLE_REQUIRED",
+        "value": "attendance_import.event_or_title_required",
+        "params": []
+      },
+      {
+        "name": "AMBIGUOUS_USER_PICK",
+        "value": "attendance_import.ambiguous_user_pick",
+        "params": [
+          "row_index"
+        ]
+      }
+    ],
     "Perm": [
       {
         "name": "DENIED",

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -3482,6 +3482,11 @@
             "title": "Checked In",
             "type": "boolean"
           },
+          "has_existing_rsvp": {
+            "default": false,
+            "title": "Has Existing Rsvp",
+            "type": "boolean"
+          },
           "matched_full_name": {
             "anyOf": [
               {
@@ -9150,7 +9155,24 @@
     "/api/community/events/attendance-import/preview/": {
       "post": {
         "operationId": "community__attendance_import_preview_attendance_import",
-        "parameters": [],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "event_id",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Event Id"
+            }
+          }
+        ],
         "requestBody": {
           "content": {
             "multipart/form-data": {

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -9020,7 +9020,6 @@
     },
     "/api/community/events/attendance-import/commit/": {
       "post": {
-        "description": "Write reviewed rows into EventRSVP/AttendanceStatus, creating the event if needed.",
         "operationId": "community__attendance_import_commit_attendance_import",
         "parameters": [],
         "requestBody": {
@@ -9098,7 +9097,6 @@
     },
     "/api/community/events/attendance-import/events/": {
       "get": {
-        "description": "Existing events an admin can pick as the import target, newest first.",
         "operationId": "community__attendance_import_list_attendance_import_event_options",
         "parameters": [
           {
@@ -9151,7 +9149,6 @@
     },
     "/api/community/events/attendance-import/preview/": {
       "post": {
-        "description": "Parse a raw Partiful export and return matched vs needs-review rows.\n\nNo writes happen here \u2014 this is read-only preview against existing users.",
         "operationId": "community__attendance_import_preview_attendance_import",
         "parameters": [],
         "requestBody": {

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -111,6 +111,111 @@
         "title": "ApproveJoinRequestOut",
         "type": "object"
       },
+      "AttendanceImportCommitIn": {
+        "properties": {
+          "event_date": {
+            "anyOf": [
+              {
+                "format": "date",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Event Date"
+          },
+          "event_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Event Id"
+          },
+          "event_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Event Title"
+          },
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/ImportRowResolutionIn"
+            },
+            "title": "Rows",
+            "type": "array"
+          }
+        },
+        "required": [
+          "rows"
+        ],
+        "title": "AttendanceImportCommitIn",
+        "type": "object"
+      },
+      "AttendanceImportCommitOut": {
+        "properties": {
+          "created_count": {
+            "title": "Created Count",
+            "type": "integer"
+          },
+          "event_id": {
+            "title": "Event Id",
+            "type": "string"
+          },
+          "event_title": {
+            "title": "Event Title",
+            "type": "string"
+          },
+          "skipped_count": {
+            "title": "Skipped Count",
+            "type": "integer"
+          },
+          "updated_count": {
+            "title": "Updated Count",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "event_id",
+          "event_title",
+          "created_count",
+          "updated_count",
+          "skipped_count"
+        ],
+        "title": "AttendanceImportCommitOut",
+        "type": "object"
+      },
+      "AttendanceImportPreviewOut": {
+        "properties": {
+          "matched": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/ImportRowOut"
+            },
+            "title": "Matched",
+            "type": "array"
+          },
+          "needs_review": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/ImportRowOut"
+            },
+            "title": "Needs Review",
+            "type": "array"
+          }
+        },
+        "title": "AttendanceImportPreviewOut",
+        "type": "object"
+      },
       "AttendanceIn": {
         "properties": {
           "attendance": {
@@ -1943,6 +2048,36 @@
         "title": "EventListOut",
         "type": "object"
       },
+      "EventOptionOut": {
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "start_datetime": {
+            "anyOf": [
+              {
+                "format": "date-time",
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Start Datetime"
+          },
+          "title": {
+            "title": "Title",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title"
+        ],
+        "title": "EventOptionOut",
+        "type": "object"
+      },
       "EventOut": {
         "properties": {
           "allow_plus_ones": {
@@ -3308,6 +3443,131 @@
           "paid_confirmed"
         ],
         "title": "HostRSVPPaymentIn",
+        "type": "object"
+      },
+      "ImportCandidateOut": {
+        "properties": {
+          "full_name": {
+            "title": "Full Name",
+            "type": "string"
+          },
+          "phone_number": {
+            "title": "Phone Number",
+            "type": "string"
+          },
+          "user_id": {
+            "title": "User Id",
+            "type": "string"
+          }
+        },
+        "required": [
+          "user_id",
+          "full_name",
+          "phone_number"
+        ],
+        "title": "ImportCandidateOut",
+        "type": "object"
+      },
+      "ImportRowOut": {
+        "properties": {
+          "candidates": {
+            "default": [],
+            "items": {
+              "$ref": "#/components/schemas/ImportCandidateOut"
+            },
+            "title": "Candidates",
+            "type": "array"
+          },
+          "checked_in": {
+            "title": "Checked In",
+            "type": "boolean"
+          },
+          "matched_full_name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Matched Full Name"
+          },
+          "matched_user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Matched User Id"
+          },
+          "partiful_status": {
+            "title": "Partiful Status",
+            "type": "string"
+          },
+          "raw_name": {
+            "title": "Raw Name",
+            "type": "string"
+          },
+          "row_index": {
+            "title": "Row Index",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "row_index",
+          "raw_name",
+          "partiful_status",
+          "checked_in"
+        ],
+        "title": "ImportRowOut",
+        "type": "object"
+      },
+      "ImportRowResolutionIn": {
+        "properties": {
+          "checked_in": {
+            "title": "Checked In",
+            "type": "boolean"
+          },
+          "partiful_status": {
+            "title": "Partiful Status",
+            "type": "string"
+          },
+          "raw_name": {
+            "title": "Raw Name",
+            "type": "string"
+          },
+          "row_index": {
+            "title": "Row Index",
+            "type": "integer"
+          },
+          "skip": {
+            "default": false,
+            "title": "Skip",
+            "type": "boolean"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          }
+        },
+        "required": [
+          "row_index",
+          "raw_name",
+          "partiful_status",
+          "checked_in"
+        ],
+        "title": "ImportRowResolutionIn",
         "type": "object"
       },
       "InviteIn": {
@@ -8753,6 +9013,216 @@
           }
         ],
         "summary": "Member Attendance Analytics",
+        "tags": [
+          "community"
+        ]
+      }
+    },
+    "/api/community/events/attendance-import/commit/": {
+      "post": {
+        "description": "Write reviewed rows into EventRSVP/AttendanceStatus, creating the event if needed.",
+        "operationId": "community__attendance_import_commit_attendance_import",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AttendanceImportCommitIn"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttendanceImportCommitOut"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "404": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Not Found"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          }
+        },
+        "security": [
+          {
+            "GatedJWTAuth": []
+          }
+        ],
+        "summary": "Commit Attendance Import",
+        "tags": [
+          "community"
+        ]
+      }
+    },
+    "/api/community/events/attendance-import/events/": {
+      "get": {
+        "description": "Existing events an admin can pick as the import target, newest first.",
+        "operationId": "community__attendance_import_list_attendance_import_event_options",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "q",
+            "required": false,
+            "schema": {
+              "default": "",
+              "title": "Q",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/EventOptionOut"
+                  },
+                  "title": "Response",
+                  "type": "array"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Forbidden"
+          }
+        },
+        "security": [
+          {
+            "GatedJWTAuth": []
+          }
+        ],
+        "summary": "List Attendance Import Event Options",
+        "tags": [
+          "community"
+        ]
+      }
+    },
+    "/api/community/events/attendance-import/preview/": {
+      "post": {
+        "description": "Parse a raw Partiful export and return matched vs needs-review rows.\n\nNo writes happen here \u2014 this is read-only preview against existing users.",
+        "operationId": "community__attendance_import_preview_attendance_import",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "properties": {
+                  "csv_file": {
+                    "format": "binary",
+                    "title": "Csv File",
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "csv_file"
+                ],
+                "title": "FileParams",
+                "type": "object"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AttendanceImportPreviewOut"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "400": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Bad Request"
+          },
+          "403": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Forbidden"
+          },
+          "429": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorOut"
+                }
+              }
+            },
+            "description": "Too Many Requests"
+          }
+        },
+        "security": [
+          {
+            "GatedJWTAuth": []
+          }
+        ],
+        "summary": "Preview Attendance Import",
         "tags": [
           "community"
         ]

--- a/backend/tests/test_attendance_import.py
+++ b/backend/tests/test_attendance_import.py
@@ -137,6 +137,27 @@ class TestPreviewEndpoint:
         assert len(body["needs_review"]) == 1
         assert len(body["needs_review"][0]["candidates"]) == 2
 
+    def test_no_event_id_leaves_has_existing_rsvp_false(self, api_client, events_admin, alice):
+        response = api_client.post(
+            "/api/community/events/attendance-import/preview/",
+            {"csv_file": _csv(["Alice Smith,Going,Yes,2026-01-01 00:00:00"])},
+            **_auth(events_admin),
+        )
+        body = response.json()
+        assert body["matched"][0]["has_existing_rsvp"] is False
+
+    def test_event_id_flags_rows_with_existing_rsvp(
+        self, api_client, events_admin, past_event, alice
+    ):
+        EventRSVP.objects.create(event=past_event, user=alice, status=RSVPStatus.ATTENDING)
+        response = api_client.post(
+            f"/api/community/events/attendance-import/preview/?event_id={past_event.id}",
+            {"csv_file": _csv(["Alice Smith,Going,Yes,2026-01-01 00:00:00"])},
+            **_auth(events_admin),
+        )
+        body = response.json()
+        assert body["matched"][0]["has_existing_rsvp"] is True
+
     def test_malformed_csv_rejected(self, api_client, events_admin):
         bad = SimpleUploadedFile(
             "bad.csv", b"not,the,right,headers\n1,2,3,4", content_type="text/csv"

--- a/backend/tests/test_attendance_import.py
+++ b/backend/tests/test_attendance_import.py
@@ -250,15 +250,15 @@ class TestCommitEndpoint:
         assert body["skipped_count"] == 1
         assert not EventRSVP.objects.filter(event=past_event, user=alice).exists()
 
-    def test_missing_user_id_is_skipped(self, api_client, events_admin, past_event):
+    def test_unresolved_row_is_rejected(self, api_client, events_admin, past_event):
         response = api_client.post(
             "/api/community/events/attendance-import/commit/",
-            {"event_id": str(past_event.id), "rows": [self._row(user_id=None)]},
+            {"event_id": str(past_event.id), "rows": [self._row(user_id=None, skip=False)]},
             content_type="application/json",
             **_auth(events_admin),
         )
-        body = response.json()
-        assert body["skipped_count"] == 1
+        assert response.status_code == 400
+        assert response.json()["detail"][0]["code"] == "attendance_import.ambiguous_user_pick"
 
     def test_existing_rsvp_is_updated_not_duplicated(
         self, api_client, events_admin, past_event, alice

--- a/backend/tests/test_attendance_import.py
+++ b/backend/tests/test_attendance_import.py
@@ -1,5 +1,3 @@
-"""Tests for the Partiful attendance CSV import (preview + commit)."""
-
 import pytest
 from community.models import AttendanceStatus, Event, EventRSVP, RSVPStatus
 from django.core.files.uploadedfile import SimpleUploadedFile

--- a/backend/tests/test_attendance_import.py
+++ b/backend/tests/test_attendance_import.py
@@ -1,0 +1,364 @@
+"""Tests for the Partiful attendance CSV import (preview + commit)."""
+
+import pytest
+from community.models import AttendanceStatus, Event, EventRSVP, RSVPStatus
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.utils import timezone
+from ninja_jwt.tokens import RefreshToken
+from users.models import Role, User
+from users.permissions import PermissionKey
+
+
+def _auth(user):
+    refresh = RefreshToken.for_user(user)
+    return {"HTTP_AUTHORIZATION": f"Bearer {refresh.access_token}"}  # ty: ignore[unresolved-attribute]
+
+
+def _csv(rows: list[str]) -> SimpleUploadedFile:
+    body = "Name,Status,Checked in,RSVP date\n" + "\n".join(rows)
+    return SimpleUploadedFile("partiful.csv", body.encode(), content_type="text/csv")
+
+
+@pytest.fixture
+def events_admin(db):
+    admin = User.objects.create_user(
+        phone_number="+12025552000", password="x", first_name="Admin", is_member=True
+    )
+    role = Role.objects.create(name="events_admin", permissions=[PermissionKey.MANAGE_EVENTS])
+    admin.roles.add(role)
+    return admin
+
+
+@pytest.fixture
+def plain_member(db):
+    return User.objects.create_user(
+        phone_number="+12025552001", password="x", first_name="Plain", is_member=True
+    )
+
+
+@pytest.fixture
+def alice(db):
+    return User.objects.create_user(
+        phone_number="+12025552002",
+        password="x",
+        first_name="Alice",
+        last_name="Smith",
+        is_member=True,
+    )
+
+
+@pytest.fixture
+def bob(db):
+    return User.objects.create_user(
+        phone_number="+12025552003", password="x", first_name="Bob", is_member=True
+    )
+
+
+@pytest.fixture
+def past_event(db, events_admin):
+    return Event.objects.create(
+        title="Past Potluck",
+        start_datetime=timezone.now() - timezone.timedelta(days=30),
+        created_by=events_admin,
+    )
+
+
+@pytest.mark.django_db
+class TestPreviewEndpoint:
+    def test_forbidden_without_permission(self, api_client, plain_member):
+        response = api_client.post(
+            "/api/community/events/attendance-import/preview/",
+            {"csv_file": _csv(["Alice Smith,Going,Yes,2026-01-01 00:00:00"])},
+            **_auth(plain_member),
+        )
+        assert response.status_code == 403
+
+    def test_unauthenticated_rejected(self, api_client):
+        response = api_client.post(
+            "/api/community/events/attendance-import/preview/",
+            {"csv_file": _csv(["Alice Smith,Going,Yes,2026-01-01 00:00:00"])},
+        )
+        assert response.status_code == 401
+
+    def test_exact_match_goes_to_matched(self, api_client, events_admin, alice):
+        response = api_client.post(
+            "/api/community/events/attendance-import/preview/",
+            {"csv_file": _csv(["Alice Smith,Going,Yes,2026-01-01 00:00:00"])},
+            **_auth(events_admin),
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert len(body["matched"]) == 1
+        assert body["matched"][0]["matched_user_id"] == str(alice.id)
+        assert body["needs_review"] == []
+
+    def test_match_is_case_insensitive(self, api_client, events_admin, alice):
+        response = api_client.post(
+            "/api/community/events/attendance-import/preview/",
+            {"csv_file": _csv(["alice smith,Going,Yes,2026-01-01 00:00:00"])},
+            **_auth(events_admin),
+        )
+        body = response.json()
+        assert len(body["matched"]) == 1
+
+    def test_unmatched_name_goes_to_needs_review(self, api_client, events_admin):
+        response = api_client.post(
+            "/api/community/events/attendance-import/preview/",
+            {"csv_file": _csv(["Nobody Here,Maybe,No,2026-01-01 00:00:00"])},
+            **_auth(events_admin),
+        )
+        body = response.json()
+        assert body["matched"] == []
+        assert len(body["needs_review"]) == 1
+        row = body["needs_review"][0]
+        assert row["raw_name"] == "Nobody Here"
+        assert row["candidates"] == []
+
+    def test_ambiguous_name_goes_to_needs_review_with_candidates(self, api_client, events_admin):
+        User.objects.create_user(
+            phone_number="+12025552010",
+            password="x",
+            first_name="Sam",
+            nickname="Sam",
+            is_member=True,
+        )
+        User.objects.create_user(
+            phone_number="+12025552011",
+            password="x",
+            first_name="Sammy",
+            nickname="Sam",
+            is_member=True,
+        )
+        response = api_client.post(
+            "/api/community/events/attendance-import/preview/",
+            {"csv_file": _csv(["Sam,Going,Yes,2026-01-01 00:00:00"])},
+            **_auth(events_admin),
+        )
+        body = response.json()
+        assert body["matched"] == []
+        assert len(body["needs_review"]) == 1
+        assert len(body["needs_review"][0]["candidates"]) == 2
+
+    def test_malformed_csv_rejected(self, api_client, events_admin):
+        bad = SimpleUploadedFile(
+            "bad.csv", b"not,the,right,headers\n1,2,3,4", content_type="text/csv"
+        )
+        response = api_client.post(
+            "/api/community/events/attendance-import/preview/",
+            {"csv_file": bad},
+            **_auth(events_admin),
+        )
+        assert response.status_code == 400
+
+    def test_empty_csv_rejected(self, api_client, events_admin):
+        empty = SimpleUploadedFile(
+            "empty.csv", b"Name,Status,Checked in,RSVP date\n", content_type="text/csv"
+        )
+        response = api_client.post(
+            "/api/community/events/attendance-import/preview/",
+            {"csv_file": empty},
+            **_auth(events_admin),
+        )
+        assert response.status_code == 400
+
+
+@pytest.mark.django_db
+class TestCommitEndpoint:
+    def _row(self, **overrides):
+        row = {
+            "row_index": 0,
+            "raw_name": "Alice Smith",
+            "partiful_status": "Going",
+            "checked_in": True,
+            "user_id": None,
+            "skip": False,
+        }
+        row.update(overrides)
+        return row
+
+    def test_forbidden_without_permission(self, api_client, plain_member, past_event):
+        response = api_client.post(
+            "/api/community/events/attendance-import/commit/",
+            {"event_id": str(past_event.id), "rows": []},
+            content_type="application/json",
+            **_auth(plain_member),
+        )
+        assert response.status_code == 403
+
+    def test_checked_in_row_marks_attended(self, api_client, events_admin, past_event, alice):
+        response = api_client.post(
+            "/api/community/events/attendance-import/commit/",
+            {
+                "event_id": str(past_event.id),
+                "rows": [self._row(user_id=str(alice.id), checked_in=True)],
+            },
+            content_type="application/json",
+            **_auth(events_admin),
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["created_count"] == 1
+        rsvp = EventRSVP.objects.get(event=past_event, user=alice)
+        assert rsvp.attendance == AttendanceStatus.ATTENDED
+        assert rsvp.status == RSVPStatus.ATTENDING
+
+    def test_going_but_not_checked_in_marks_no_show(
+        self, api_client, events_admin, past_event, alice
+    ):
+        response = api_client.post(
+            "/api/community/events/attendance-import/commit/",
+            {
+                "event_id": str(past_event.id),
+                "rows": [
+                    self._row(user_id=str(alice.id), checked_in=False, partiful_status="Going")
+                ],
+            },
+            content_type="application/json",
+            **_auth(events_admin),
+        )
+        assert response.status_code == 200
+        rsvp = EventRSVP.objects.get(event=past_event, user=alice)
+        assert rsvp.attendance == AttendanceStatus.DIDNT_GO
+        assert rsvp.status == RSVPStatus.ATTENDING
+
+    def test_maybe_not_checked_in_leaves_attendance_unknown(
+        self, api_client, events_admin, past_event, alice
+    ):
+        api_client.post(
+            "/api/community/events/attendance-import/commit/",
+            {
+                "event_id": str(past_event.id),
+                "rows": [
+                    self._row(user_id=str(alice.id), checked_in=False, partiful_status="Maybe")
+                ],
+            },
+            content_type="application/json",
+            **_auth(events_admin),
+        )
+        rsvp = EventRSVP.objects.get(event=past_event, user=alice)
+        assert rsvp.attendance == AttendanceStatus.UNKNOWN
+
+    def test_skip_row_is_not_written(self, api_client, events_admin, past_event, alice):
+        response = api_client.post(
+            "/api/community/events/attendance-import/commit/",
+            {
+                "event_id": str(past_event.id),
+                "rows": [self._row(user_id=str(alice.id), skip=True)],
+            },
+            content_type="application/json",
+            **_auth(events_admin),
+        )
+        body = response.json()
+        assert body["skipped_count"] == 1
+        assert not EventRSVP.objects.filter(event=past_event, user=alice).exists()
+
+    def test_missing_user_id_is_skipped(self, api_client, events_admin, past_event):
+        response = api_client.post(
+            "/api/community/events/attendance-import/commit/",
+            {"event_id": str(past_event.id), "rows": [self._row(user_id=None)]},
+            content_type="application/json",
+            **_auth(events_admin),
+        )
+        body = response.json()
+        assert body["skipped_count"] == 1
+
+    def test_existing_rsvp_is_updated_not_duplicated(
+        self, api_client, events_admin, past_event, alice
+    ):
+        EventRSVP.objects.create(
+            event=past_event,
+            user=alice,
+            status=RSVPStatus.MAYBE,
+            attendance=AttendanceStatus.UNKNOWN,
+        )
+        response = api_client.post(
+            "/api/community/events/attendance-import/commit/",
+            {
+                "event_id": str(past_event.id),
+                "rows": [self._row(user_id=str(alice.id), checked_in=True)],
+            },
+            content_type="application/json",
+            **_auth(events_admin),
+        )
+        body = response.json()
+        assert body["updated_count"] == 1
+        assert body["created_count"] == 0
+        assert EventRSVP.objects.filter(event=past_event, user=alice).count() == 1
+
+    def test_creates_event_when_no_event_id_given(self, api_client, events_admin, alice):
+        response = api_client.post(
+            "/api/community/events/attendance-import/commit/",
+            {
+                "event_title": "Legacy Mixer",
+                "event_date": "2025-06-13",
+                "rows": [self._row(user_id=str(alice.id), checked_in=True)],
+            },
+            content_type="application/json",
+            **_auth(events_admin),
+        )
+        assert response.status_code == 200
+        body = response.json()
+        assert body["event_title"] == "Legacy Mixer"
+        event = Event.objects.get(id=body["event_id"])
+        assert event.title == "Legacy Mixer"
+        assert EventRSVP.objects.filter(event=event, user=alice).exists()
+
+    def test_missing_event_and_title_rejected(self, api_client, events_admin, alice):
+        response = api_client.post(
+            "/api/community/events/attendance-import/commit/",
+            {"rows": [self._row(user_id=str(alice.id))]},
+            content_type="application/json",
+            **_auth(events_admin),
+        )
+        assert response.status_code == 400
+
+    def test_nonexistent_event_id_404s(self, api_client, events_admin, alice):
+        response = api_client.post(
+            "/api/community/events/attendance-import/commit/",
+            {
+                "event_id": "00000000-0000-0000-0000-000000000000",
+                "rows": [self._row(user_id=str(alice.id))],
+            },
+            content_type="application/json",
+            **_auth(events_admin),
+        )
+        assert response.status_code == 404
+
+    def test_appears_in_attendance_report_after_commit(
+        self, api_client, events_admin, past_event, alice, bob
+    ):
+        api_client.post(
+            "/api/community/events/attendance-import/commit/",
+            {
+                "event_id": str(past_event.id),
+                "rows": [
+                    self._row(user_id=str(alice.id), checked_in=True),
+                    self._row(user_id=str(bob.id), checked_in=False, partiful_status="Going"),
+                ],
+            },
+            content_type="application/json",
+            **_auth(events_admin),
+        )
+        response = api_client.get("/api/community/events/attendance-report/", **_auth(events_admin))
+        row = next(r for r in response.json()["events"] if r["event_id"] == str(past_event.id))
+        assert row["attended_count"] == 1
+        assert row["no_show_count"] == 1
+
+
+@pytest.mark.django_db
+class TestEventOptionsEndpoint:
+    def test_forbidden_without_permission(self, api_client, plain_member):
+        response = api_client.get(
+            "/api/community/events/attendance-import/events/", **_auth(plain_member)
+        )
+        assert response.status_code == 403
+
+    def test_lists_events_matching_query(self, api_client, events_admin, past_event):
+        response = api_client.get(
+            "/api/community/events/attendance-import/events/",
+            {"q": "potluck"},
+            **_auth(events_admin),
+        )
+        assert response.status_code == 200
+        titles = [e["title"] for e in response.json()]
+        assert "Past Potluck" in titles

--- a/frontend/src/api/attendanceImport.ts
+++ b/frontend/src/api/attendanceImport.ts
@@ -1,0 +1,173 @@
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { extractApiErrorOr } from './apiErrors';
+import { attendanceReportKey } from './attendanceReport';
+import { apiClient } from './client';
+
+export function reportAttendanceImportError(err: unknown): string {
+  return extractApiErrorOr(err, "couldn't process that — try again");
+}
+
+export interface ImportCandidate {
+  userId: string;
+  fullName: string;
+  phoneNumber: string;
+}
+
+export interface ImportRow {
+  rowIndex: number;
+  rawName: string;
+  partifulStatus: string;
+  checkedIn: boolean;
+  matchedUserId: string | null;
+  matchedFullName: string | null;
+  candidates: ImportCandidate[];
+}
+
+export interface AttendanceImportPreview {
+  matched: ImportRow[];
+  needsReview: ImportRow[];
+}
+
+export interface EventOption {
+  id: string;
+  title: string;
+  startDatetime: Date | null;
+}
+
+interface WireCandidate {
+  user_id: string;
+  full_name: string;
+  phone_number: string;
+}
+
+interface WireRow {
+  row_index: number;
+  raw_name: string;
+  partiful_status: string;
+  checked_in: boolean;
+  matched_user_id: string | null;
+  matched_full_name: string | null;
+  candidates: WireCandidate[];
+}
+
+interface WirePreview {
+  matched: WireRow[];
+  needs_review: WireRow[];
+}
+
+interface WireEventOption {
+  id: string;
+  title: string;
+  start_datetime: string | null;
+}
+
+function mapRow(w: WireRow): ImportRow {
+  return {
+    rowIndex: w.row_index,
+    rawName: w.raw_name,
+    partifulStatus: w.partiful_status,
+    checkedIn: w.checked_in,
+    matchedUserId: w.matched_user_id,
+    matchedFullName: w.matched_full_name,
+    candidates: w.candidates.map((c) => ({
+      userId: c.user_id,
+      fullName: c.full_name,
+      phoneNumber: c.phone_number,
+    })),
+  };
+}
+
+export function useAttendanceImportEventOptions(query: string) {
+  return useQuery({
+    queryKey: ['attendance-import-events', query],
+    queryFn: async () => {
+      const { data } = await apiClient.get<WireEventOption[]>(
+        '/api/community/events/attendance-import/events/',
+        { params: { q: query } },
+      );
+      return data.map<EventOption>((e) => ({
+        id: e.id,
+        title: e.title,
+        startDatetime: e.start_datetime ? new Date(e.start_datetime) : null,
+      }));
+    },
+    staleTime: 30_000,
+  });
+}
+
+export function usePreviewAttendanceImport() {
+  return useMutation({
+    mutationFn: async (file: File) => {
+      const formData = new FormData();
+      formData.append('csv_file', file);
+      const { data } = await apiClient.post<WirePreview>(
+        '/api/community/events/attendance-import/preview/',
+        formData,
+        { headers: { 'Content-Type': 'multipart/form-data' } },
+      );
+      return {
+        matched: data.matched.map(mapRow),
+        needsReview: data.needs_review.map(mapRow),
+      } satisfies AttendanceImportPreview;
+    },
+  });
+}
+
+export interface RowResolution {
+  rowIndex: number;
+  rawName: string;
+  partifulStatus: string;
+  checkedIn: boolean;
+  userId: string | null;
+  skip: boolean;
+}
+
+export interface CommitAttendanceImportInput {
+  eventId?: string;
+  eventTitle?: string;
+  eventDate?: string;
+  rows: RowResolution[];
+}
+
+interface WireCommitOut {
+  event_id: string;
+  event_title: string;
+  created_count: number;
+  updated_count: number;
+  skipped_count: number;
+}
+
+export function useCommitAttendanceImport() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: async (input: CommitAttendanceImportInput) => {
+      const { data } = await apiClient.post<WireCommitOut>(
+        '/api/community/events/attendance-import/commit/',
+        {
+          event_id: input.eventId,
+          event_title: input.eventTitle,
+          event_date: input.eventDate,
+          rows: input.rows.map((r) => ({
+            row_index: r.rowIndex,
+            raw_name: r.rawName,
+            partiful_status: r.partifulStatus,
+            checked_in: r.checkedIn,
+            user_id: r.userId,
+            skip: r.skip,
+          })),
+        },
+      );
+      return {
+        eventId: data.event_id,
+        eventTitle: data.event_title,
+        createdCount: data.created_count,
+        updatedCount: data.updated_count,
+        skippedCount: data.skipped_count,
+      };
+    },
+    onSuccess: () => {
+      void qc.invalidateQueries({ queryKey: attendanceReportKey });
+    },
+  });
+}

--- a/frontend/src/api/attendanceImport.ts
+++ b/frontend/src/api/attendanceImport.ts
@@ -22,6 +22,7 @@ export interface ImportRow {
   matchedUserId: string | null;
   matchedFullName: string | null;
   candidates: ImportCandidate[];
+  hasExistingRsvp: boolean;
 }
 
 export interface AttendanceImportPreview {
@@ -49,6 +50,7 @@ interface WireRow {
   matched_user_id: string | null;
   matched_full_name: string | null;
   candidates: WireCandidate[];
+  has_existing_rsvp: boolean;
 }
 
 interface WirePreview {
@@ -75,6 +77,7 @@ function mapRow(w: WireRow): ImportRow {
       fullName: c.full_name,
       phoneNumber: c.phone_number,
     })),
+    hasExistingRsvp: w.has_existing_rsvp,
   };
 }
 
@@ -98,13 +101,16 @@ export function useAttendanceImportEventOptions(query: string) {
 
 export function usePreviewAttendanceImport() {
   return useMutation({
-    mutationFn: async (file: File) => {
+    mutationFn: async ({ file, eventId }: { file: File; eventId?: string | undefined }) => {
       const formData = new FormData();
       formData.append('csv_file', file);
       const { data } = await apiClient.post<WirePreview>(
         '/api/community/events/attendance-import/preview/',
         formData,
-        { headers: { 'Content-Type': 'multipart/form-data' } },
+        {
+          headers: { 'Content-Type': 'multipart/form-data' },
+          params: eventId ? { event_id: eventId } : undefined,
+        },
       );
       return {
         matched: data.matched.map(mapRow),

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -684,6 +684,68 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/community/events/attendance-import/commit/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Commit Attendance Import
+         * @description Write reviewed rows into EventRSVP/AttendanceStatus, creating the event if needed.
+         */
+        post: operations["community__attendance_import_commit_attendance_import"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/community/events/attendance-import/events/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List Attendance Import Event Options
+         * @description Existing events an admin can pick as the import target, newest first.
+         */
+        get: operations["community__attendance_import_list_attendance_import_event_options"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/community/events/attendance-import/preview/": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Preview Attendance Import
+         * @description Parse a raw Partiful export and return matched vs needs-review rows.
+         *
+         *     No writes happen here — this is read-only preview against existing users.
+         */
+        post: operations["community__attendance_import_preview_attendance_import"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/community/events/attendance-report/": {
         parameters: {
             query?: never;
@@ -2093,6 +2155,43 @@ export interface components {
             /** User Id */
             user_id?: string | null;
         };
+        /** AttendanceImportCommitIn */
+        AttendanceImportCommitIn: {
+            /** Event Date */
+            event_date?: string | null;
+            /** Event Id */
+            event_id?: string | null;
+            /** Event Title */
+            event_title?: string | null;
+            /** Rows */
+            rows: components["schemas"]["ImportRowResolutionIn"][];
+        };
+        /** AttendanceImportCommitOut */
+        AttendanceImportCommitOut: {
+            /** Created Count */
+            created_count: number;
+            /** Event Id */
+            event_id: string;
+            /** Event Title */
+            event_title: string;
+            /** Skipped Count */
+            skipped_count: number;
+            /** Updated Count */
+            updated_count: number;
+        };
+        /** AttendanceImportPreviewOut */
+        AttendanceImportPreviewOut: {
+            /**
+             * Matched
+             * @default []
+             */
+            matched: components["schemas"]["ImportRowOut"][];
+            /**
+             * Needs Review
+             * @default []
+             */
+            needs_review: components["schemas"]["ImportRowOut"][];
+        };
         /** AttendanceIn */
         AttendanceIn: {
             attendance: components["schemas"]["AttendanceStatus"];
@@ -2979,6 +3078,15 @@ export interface components {
              */
             zelle_info: string;
         };
+        /** EventOptionOut */
+        EventOptionOut: {
+            /** Id */
+            id: string;
+            /** Start Datetime */
+            start_datetime?: string | null;
+            /** Title */
+            title: string;
+        };
         /** EventOut */
         EventOut: {
             /**
@@ -3557,6 +3665,53 @@ export interface components {
         HostRSVPPaymentIn: {
             /** Paid Confirmed */
             paid_confirmed: boolean;
+        };
+        /** ImportCandidateOut */
+        ImportCandidateOut: {
+            /** Full Name */
+            full_name: string;
+            /** Phone Number */
+            phone_number: string;
+            /** User Id */
+            user_id: string;
+        };
+        /** ImportRowOut */
+        ImportRowOut: {
+            /**
+             * Candidates
+             * @default []
+             */
+            candidates: components["schemas"]["ImportCandidateOut"][];
+            /** Checked In */
+            checked_in: boolean;
+            /** Matched Full Name */
+            matched_full_name?: string | null;
+            /** Matched User Id */
+            matched_user_id?: string | null;
+            /** Partiful Status */
+            partiful_status: string;
+            /** Raw Name */
+            raw_name: string;
+            /** Row Index */
+            row_index: number;
+        };
+        /** ImportRowResolutionIn */
+        ImportRowResolutionIn: {
+            /** Checked In */
+            checked_in: boolean;
+            /** Partiful Status */
+            partiful_status: string;
+            /** Raw Name */
+            raw_name: string;
+            /** Row Index */
+            row_index: number;
+            /**
+             * Skip
+             * @default false
+             */
+            skip: boolean;
+            /** User Id */
+            user_id?: string | null;
         };
         /** InviteIn */
         InviteIn: {
@@ -6700,6 +6855,154 @@ export interface operations {
             };
             /** @description Forbidden */
             403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
+    community__attendance_import_commit_attendance_import: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AttendanceImportCommitIn"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AttendanceImportCommitOut"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Not Found */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
+    community__attendance_import_list_attendance_import_event_options: {
+        parameters: {
+            query?: {
+                q?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EventOptionOut"][];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+        };
+    };
+    community__attendance_import_preview_attendance_import: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "multipart/form-data": {
+                    /**
+                     * Csv File
+                     * Format: binary
+                     */
+                    csv_file: string;
+                };
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AttendanceImportPreviewOut"];
+                };
+            };
+            /** @description Bad Request */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Forbidden */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ErrorOut"];
+                };
+            };
+            /** @description Too Many Requests */
+            429: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -693,10 +693,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /**
-         * Commit Attendance Import
-         * @description Write reviewed rows into EventRSVP/AttendanceStatus, creating the event if needed.
-         */
+        /** Commit Attendance Import */
         post: operations["community__attendance_import_commit_attendance_import"];
         delete?: never;
         options?: never;
@@ -711,10 +708,7 @@ export interface paths {
             path?: never;
             cookie?: never;
         };
-        /**
-         * List Attendance Import Event Options
-         * @description Existing events an admin can pick as the import target, newest first.
-         */
+        /** List Attendance Import Event Options */
         get: operations["community__attendance_import_list_attendance_import_event_options"];
         put?: never;
         post?: never;
@@ -733,12 +727,7 @@ export interface paths {
         };
         get?: never;
         put?: never;
-        /**
-         * Preview Attendance Import
-         * @description Parse a raw Partiful export and return matched vs needs-review rows.
-         *
-         *     No writes happen here — this is read-only preview against existing users.
-         */
+        /** Preview Attendance Import */
         post: operations["community__attendance_import_preview_attendance_import"];
         delete?: never;
         options?: never;
@@ -3684,6 +3673,11 @@ export interface components {
             candidates: components["schemas"]["ImportCandidateOut"][];
             /** Checked In */
             checked_in: boolean;
+            /**
+             * Has Existing Rsvp
+             * @default false
+             */
+            has_existing_rsvp: boolean;
             /** Matched Full Name */
             matched_full_name?: string | null;
             /** Matched User Id */
@@ -6957,7 +6951,9 @@ export interface operations {
     };
     community__attendance_import_preview_attendance_import: {
         parameters: {
-            query?: never;
+            query?: {
+                event_id?: string | null;
+            };
             header?: never;
             path?: never;
             cookie?: never;

--- a/frontend/src/api/validationCodes.gen.ts
+++ b/frontend/src/api/validationCodes.gen.ts
@@ -172,6 +172,12 @@ export const Code = {
     TypeNotAllowed: 'photo.type_not_allowed',
     TooLarge: 'photo.too_large',
   },
+  AttendanceImport: {
+    CsvEmpty: 'attendance_import.csv_empty',
+    CsvMalformed: 'attendance_import.csv_malformed',
+    EventOrTitleRequired: 'attendance_import.event_or_title_required',
+    AmbiguousUserPick: 'attendance_import.ambiguous_user_pick',
+  },
   Perm: {
     Denied: 'perm.denied',
   },
@@ -359,6 +365,10 @@ export type ValidationCode =
   | 'join_request.guidelines_consent_required'
   | 'photo.type_not_allowed'
   | 'photo.too_large'
+  | 'attendance_import.csv_empty'
+  | 'attendance_import.csv_malformed'
+  | 'attendance_import.event_or_title_required'
+  | 'attendance_import.ambiguous_user_pick'
   | 'perm.denied'
   | 'rate.limited'
   | 'page.members_only'
@@ -519,6 +529,10 @@ export const CODE_PARAMS: Record<ValidationCode, readonly string[]> = {
   'join_request.guidelines_consent_required': [],
   'photo.type_not_allowed': ['allowed'],
   'photo.too_large': ['max_mb'],
+  'attendance_import.csv_empty': [],
+  'attendance_import.csv_malformed': [],
+  'attendance_import.event_or_title_required': [],
+  'attendance_import.ambiguous_user_pick': ['row_index'],
   'perm.denied': ['action'],
   'rate.limited': [],
   'page.members_only': [],

--- a/frontend/src/api/validationCodes.ts
+++ b/frontend/src/api/validationCodes.ts
@@ -395,6 +395,16 @@ function messageForKnownCode(code: KnownCode, err: FieldError): string {
       return maxMb !== null ? `photo must be under ${String(maxMb)} mb` : 'photo is too large';
     }
 
+    // Attendance import
+    case Code.AttendanceImport.CsvEmpty:
+      return "that csv doesn't have any rows — export attendees from partiful and try again";
+    case Code.AttendanceImport.CsvMalformed:
+      return "couldn't read that csv — make sure it's the raw partiful export";
+    case Code.AttendanceImport.EventOrTitleRequired:
+      return 'pick an existing event or give the new event a name and date';
+    case Code.AttendanceImport.AmbiguousUserPick:
+      return 'pick a member for that row before continuing';
+
     // Permission / rate
     case Code.Perm.Denied:
       return "you don't have permission to do that";

--- a/frontend/src/screens/admin/AttendanceImportDialog.tsx
+++ b/frontend/src/screens/admin/AttendanceImportDialog.tsx
@@ -39,6 +39,7 @@ export function AttendanceImportDialog({ open, onClose }: Props) {
   const [target, setTarget] = useState<EventTarget>({});
   const [preview, setPreview] = useState<AttendanceImportPreview | null>(null);
   const [resolutions, setResolutions] = useState<Record<number, RowResolution>>({});
+  const [pickedFullNames, setPickedFullNames] = useState<Record<number, string | null>>({});
 
   const previewMutation = usePreviewAttendanceImport();
   const commitMutation = useCommitAttendanceImport();
@@ -48,6 +49,7 @@ export function AttendanceImportDialog({ open, onClose }: Props) {
     setTarget({});
     setPreview(null);
     setResolutions({});
+    setPickedFullNames({});
   }
 
   function handleClose() {
@@ -56,20 +58,23 @@ export function AttendanceImportDialog({ open, onClose }: Props) {
   }
 
   function handleFileReady(file: File) {
-    previewMutation.mutate(file, {
-      onSuccess: (result) => {
-        setPreview(result);
-        const initial: Record<number, RowResolution> = {};
-        for (const row of [...result.matched, ...result.needsReview]) {
-          initial[row.rowIndex] = rowToResolution(row);
-        }
-        setResolutions(initial);
-        setStep('review');
+    previewMutation.mutate(
+      { file, eventId: target.eventId },
+      {
+        onSuccess: (result) => {
+          setPreview(result);
+          const initial: Record<number, RowResolution> = {};
+          for (const row of [...result.matched, ...result.needsReview]) {
+            initial[row.rowIndex] = rowToResolution(row);
+          }
+          setResolutions(initial);
+          setStep('review');
+        },
+        onError: (err) => {
+          toast.error(reportAttendanceImportError(err));
+        },
       },
-      onError: (err) => {
-        toast.error(reportAttendanceImportError(err));
-      },
-    });
+    );
   }
 
   function handleCommit() {
@@ -128,12 +133,14 @@ export function AttendanceImportDialog({ open, onClose }: Props) {
                 resolution={{
                   userId: resolutions[row.rowIndex]?.userId ?? null,
                   skip: resolutions[row.rowIndex]?.skip ?? false,
+                  pickedFullName: pickedFullNames[row.rowIndex],
                 }}
-                onResolve={(userId, skip) => {
+                onResolve={(userId, skip, fullName) => {
                   setResolutions((prev) => ({
                     ...prev,
                     [row.rowIndex]: { ...rowToResolution(row), userId, skip },
                   }));
+                  setPickedFullNames((prev) => ({ ...prev, [row.rowIndex]: fullName ?? null }));
                 }}
               />
             ))}

--- a/frontend/src/screens/admin/AttendanceImportDialog.tsx
+++ b/frontend/src/screens/admin/AttendanceImportDialog.tsx
@@ -1,0 +1,156 @@
+import { useState } from 'react';
+import { toast } from 'sonner';
+
+import {
+  type AttendanceImportPreview,
+  type ImportRow,
+  reportAttendanceImportError,
+  type RowResolution,
+  useCommitAttendanceImport,
+  usePreviewAttendanceImport,
+} from '@/api/attendanceImport';
+import { Button } from '@/components/ui/Button';
+import { Dialog } from '@/components/ui/Dialog';
+
+import { AttendanceImportEventStep, type EventTarget } from './AttendanceImportEventStep';
+import { AttendanceImportReviewRow } from './AttendanceImportReviewRow';
+import { AttendanceImportUploadStep } from './AttendanceImportUploadStep';
+
+type Step = 'event' | 'upload' | 'review';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+function rowToResolution(row: ImportRow): RowResolution {
+  return {
+    rowIndex: row.rowIndex,
+    rawName: row.rawName,
+    partifulStatus: row.partifulStatus,
+    checkedIn: row.checkedIn,
+    userId: row.matchedUserId,
+    skip: false,
+  };
+}
+
+export function AttendanceImportDialog({ open, onClose }: Props) {
+  const [step, setStep] = useState<Step>('event');
+  const [target, setTarget] = useState<EventTarget>({});
+  const [preview, setPreview] = useState<AttendanceImportPreview | null>(null);
+  const [resolutions, setResolutions] = useState<Record<number, RowResolution>>({});
+
+  const previewMutation = usePreviewAttendanceImport();
+  const commitMutation = useCommitAttendanceImport();
+
+  function reset() {
+    setStep('event');
+    setTarget({});
+    setPreview(null);
+    setResolutions({});
+  }
+
+  function handleClose() {
+    reset();
+    onClose();
+  }
+
+  function handleFileReady(file: File) {
+    previewMutation.mutate(file, {
+      onSuccess: (result) => {
+        setPreview(result);
+        const initial: Record<number, RowResolution> = {};
+        for (const row of [...result.matched, ...result.needsReview]) {
+          initial[row.rowIndex] = rowToResolution(row);
+        }
+        setResolutions(initial);
+        setStep('review');
+      },
+      onError: (err) => {
+        toast.error(reportAttendanceImportError(err));
+      },
+    });
+  }
+
+  function handleCommit() {
+    if (!preview) return;
+    commitMutation.mutate(
+      { ...target, rows: Object.values(resolutions) },
+      {
+        onSuccess: (result) => {
+          toast.success(`imported attendance for ${result.eventTitle.toLowerCase()} ✓`);
+          handleClose();
+        },
+        onError: (err) => {
+          toast.error(reportAttendanceImportError(err));
+        },
+      },
+    );
+  }
+
+  const allRows = preview ? [...preview.matched, ...preview.needsReview] : [];
+  const unresolvedCount = allRows.filter((r) => {
+    const res = resolutions[r.rowIndex];
+    return !res || (!res.userId && !res.skip);
+  }).length;
+
+  return (
+    <Dialog open={open} onClose={handleClose} title="import partiful attendance">
+      {step === 'event' ? (
+        <AttendanceImportEventStep
+          onNext={(t) => {
+            setTarget(t);
+            setStep('upload');
+          }}
+        />
+      ) : null}
+
+      {step === 'upload' ? (
+        <AttendanceImportUploadStep
+          onFileReady={handleFileReady}
+          isPending={previewMutation.isPending}
+        />
+      ) : null}
+
+      {step === 'review' && preview ? (
+        <div className="flex flex-col gap-3">
+          <p className="text-muted text-sm">
+            {preview.matched.length} matched automatically
+            {preview.needsReview.length > 0
+              ? `, ${String(preview.needsReview.length)} need review`
+              : ''}
+          </p>
+          <div className="flex max-h-96 flex-col gap-2 overflow-y-auto">
+            {allRows.map((row) => (
+              <AttendanceImportReviewRow
+                key={row.rowIndex}
+                row={row}
+                resolution={{
+                  userId: resolutions[row.rowIndex]?.userId ?? null,
+                  skip: resolutions[row.rowIndex]?.skip ?? false,
+                }}
+                onResolve={(userId, skip) => {
+                  setResolutions((prev) => ({
+                    ...prev,
+                    [row.rowIndex]: { ...rowToResolution(row), userId, skip },
+                  }));
+                }}
+              />
+            ))}
+          </div>
+          {unresolvedCount > 0 ? (
+            <p className="text-muted text-xs">
+              {unresolvedCount} row{unresolvedCount === 1 ? '' : 's'} still need a member or skip
+            </p>
+          ) : null}
+          <Button
+            disabled={unresolvedCount > 0 || commitMutation.isPending}
+            onClick={handleCommit}
+          >
+            {commitMutation.isPending ? 'importing…' : 'confirm import'}
+          </Button>
+        </div>
+      ) : null}
+    </Dialog>
+  );
+}

--- a/frontend/src/screens/admin/AttendanceImportDialog.tsx
+++ b/frontend/src/screens/admin/AttendanceImportDialog.tsx
@@ -143,10 +143,7 @@ export function AttendanceImportDialog({ open, onClose }: Props) {
               {unresolvedCount} row{unresolvedCount === 1 ? '' : 's'} still need a member or skip
             </p>
           ) : null}
-          <Button
-            disabled={unresolvedCount > 0 || commitMutation.isPending}
-            onClick={handleCommit}
-          >
+          <Button disabled={unresolvedCount > 0 || commitMutation.isPending} onClick={handleCommit}>
             {commitMutation.isPending ? 'importing…' : 'confirm import'}
           </Button>
         </div>

--- a/frontend/src/screens/admin/AttendanceImportEventStep.tsx
+++ b/frontend/src/screens/admin/AttendanceImportEventStep.tsx
@@ -1,0 +1,159 @@
+import { format } from 'date-fns';
+import { useState } from 'react';
+
+import { type EventOption, useAttendanceImportEventOptions } from '@/api/attendanceImport';
+import { Button } from '@/components/ui/Button';
+import { TextField } from '@/components/ui/TextField';
+
+export interface EventTarget {
+  eventId?: string;
+  eventTitle?: string;
+  eventDate?: string;
+}
+
+interface Props {
+  onNext: (target: EventTarget) => void;
+}
+
+export function AttendanceImportEventStep({ onNext }: Props) {
+  const [mode, setMode] = useState<'existing' | 'new'>('existing');
+  const [query, setQuery] = useState('');
+  const [newTitle, setNewTitle] = useState('');
+  const [newDate, setNewDate] = useState('');
+  const { data: options = [] } = useAttendanceImportEventOptions(query);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div
+        role="tablist"
+        aria-label="event source"
+        className="border-border-strong bg-surface flex w-full rounded-full border p-1"
+      >
+        <ModeButton active={mode === 'existing'} onClick={() => { setMode('existing'); }}>
+          existing event
+        </ModeButton>
+        <ModeButton active={mode === 'new'} onClick={() => { setMode('new'); }}>
+          new event
+        </ModeButton>
+      </div>
+
+      {mode === 'existing' ? (
+        <ExistingEventPicker
+          query={query}
+          onQueryChange={setQuery}
+          options={options}
+          onPick={(id) => { onNext({ eventId: id }); }}
+        />
+      ) : (
+        <NewEventFields
+          title={newTitle}
+          date={newDate}
+          onTitleChange={setNewTitle}
+          onDateChange={setNewDate}
+          onNext={() => { onNext({ eventTitle: newTitle, eventDate: newDate }); }}
+        />
+      )}
+    </div>
+  );
+}
+
+function ModeButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={`flex-1 rounded-full px-3 py-1 text-sm transition-colors ${
+        active ? 'bg-brand-600 text-brand-on' : 'text-foreground-secondary hover:bg-surface-dim'
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function ExistingEventPicker({
+  query,
+  onQueryChange,
+  options,
+  onPick,
+}: {
+  query: string;
+  onQueryChange: (v: string) => void;
+  options: EventOption[];
+  onPick: (eventId: string) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      <TextField
+        label="search events"
+        value={query}
+        onChange={(e) => { onQueryChange(e.target.value); }}
+        placeholder="search by title"
+      />
+      {options.length === 0 ? (
+        <p className="text-muted text-sm">no events found</p>
+      ) : (
+        <ul className="border-border bg-surface max-h-64 overflow-y-auto rounded-md border">
+          {options.map((o) => (
+            <li key={o.id}>
+              <button
+                type="button"
+                onClick={() => { onPick(o.id); }}
+                className="hover:bg-background flex w-full items-center justify-between px-3 py-2 text-start text-sm"
+              >
+                <span>{o.title.toLowerCase()}</span>
+                <span className="text-muted text-xs">
+                  {o.startDatetime ? format(o.startDatetime, 'MMM d, yyyy').toLowerCase() : ''}
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function NewEventFields({
+  title,
+  date,
+  onTitleChange,
+  onDateChange,
+  onNext,
+}: {
+  title: string;
+  date: string;
+  onTitleChange: (v: string) => void;
+  onDateChange: (v: string) => void;
+  onNext: () => void;
+}) {
+  return (
+    <div className="flex flex-col gap-3">
+      <TextField
+        label="event name"
+        value={title}
+        onChange={(e) => { onTitleChange(e.target.value); }}
+        placeholder="e.g. summer potluck"
+      />
+      <TextField
+        label="event date"
+        type="date"
+        value={date}
+        onChange={(e) => { onDateChange(e.target.value); }}
+      />
+      <Button disabled={!title.trim() || !date} onClick={onNext}>
+        continue
+      </Button>
+    </div>
+  );
+}

--- a/frontend/src/screens/admin/AttendanceImportEventStep.tsx
+++ b/frontend/src/screens/admin/AttendanceImportEventStep.tsx
@@ -29,10 +29,20 @@ export function AttendanceImportEventStep({ onNext }: Props) {
         aria-label="event source"
         className="border-border-strong bg-surface flex w-full rounded-full border p-1"
       >
-        <ModeButton active={mode === 'existing'} onClick={() => { setMode('existing'); }}>
+        <ModeButton
+          active={mode === 'existing'}
+          onClick={() => {
+            setMode('existing');
+          }}
+        >
           existing event
         </ModeButton>
-        <ModeButton active={mode === 'new'} onClick={() => { setMode('new'); }}>
+        <ModeButton
+          active={mode === 'new'}
+          onClick={() => {
+            setMode('new');
+          }}
+        >
           new event
         </ModeButton>
       </div>
@@ -42,7 +52,9 @@ export function AttendanceImportEventStep({ onNext }: Props) {
           query={query}
           onQueryChange={setQuery}
           options={options}
-          onPick={(id) => { onNext({ eventId: id }); }}
+          onPick={(id) => {
+            onNext({ eventId: id });
+          }}
         />
       ) : (
         <NewEventFields
@@ -50,7 +62,9 @@ export function AttendanceImportEventStep({ onNext }: Props) {
           date={newDate}
           onTitleChange={setNewTitle}
           onDateChange={setNewDate}
-          onNext={() => { onNext({ eventTitle: newTitle, eventDate: newDate }); }}
+          onNext={() => {
+            onNext({ eventTitle: newTitle, eventDate: newDate });
+          }}
         />
       )}
     </div>
@@ -97,7 +111,9 @@ function ExistingEventPicker({
       <TextField
         label="search events"
         value={query}
-        onChange={(e) => { onQueryChange(e.target.value); }}
+        onChange={(e) => {
+          onQueryChange(e.target.value);
+        }}
         placeholder="search by title"
       />
       {options.length === 0 ? (
@@ -108,7 +124,9 @@ function ExistingEventPicker({
             <li key={o.id}>
               <button
                 type="button"
-                onClick={() => { onPick(o.id); }}
+                onClick={() => {
+                  onPick(o.id);
+                }}
                 className="hover:bg-background flex w-full items-center justify-between px-3 py-2 text-start text-sm"
               >
                 <span>{o.title.toLowerCase()}</span>
@@ -142,14 +160,18 @@ function NewEventFields({
       <TextField
         label="event name"
         value={title}
-        onChange={(e) => { onTitleChange(e.target.value); }}
+        onChange={(e) => {
+          onTitleChange(e.target.value);
+        }}
         placeholder="e.g. summer potluck"
       />
       <TextField
         label="event date"
         type="date"
         value={date}
-        onChange={(e) => { onDateChange(e.target.value); }}
+        onChange={(e) => {
+          onDateChange(e.target.value);
+        }}
       />
       <Button disabled={!title.trim() || !date} onClick={onNext}>
         continue

--- a/frontend/src/screens/admin/AttendanceImportReviewRow.tsx
+++ b/frontend/src/screens/admin/AttendanceImportReviewRow.tsx
@@ -7,14 +7,18 @@ import { formatPhone } from '@/utils/formatPhone';
 
 interface Props {
   row: ImportRow;
-  resolution: { userId: string | null; skip: boolean };
-  onResolve: (userId: string | null, skip: boolean) => void;
+  resolution: {
+    userId: string | null;
+    skip: boolean;
+    pickedFullName?: string | null | undefined;
+  };
+  onResolve: (userId: string | null, skip: boolean, fullName?: string | null) => void;
 }
 
 export function AttendanceImportReviewRow({ row, resolution, onResolve }: Props) {
   const [term, setTerm] = useState('');
   const { data: searchResults = [] } = useUserSearch(term);
-  const resolvedName = resolvedUserName(row, resolution.userId);
+  const resolvedName = resolvedUserName(row, resolution.userId, resolution.pickedFullName);
 
   if (resolution.skip) {
     return (
@@ -36,7 +40,12 @@ export function AttendanceImportReviewRow({ row, resolution, onResolve }: Props)
   if (resolvedName) {
     return (
       <RowShell row={row}>
-        <span className="text-foreground text-xs">→ {resolvedName.toLowerCase()}</span>
+        <span className="text-foreground text-xs">
+          → {resolvedName.toLowerCase()}
+          {row.hasExistingRsvp ? (
+            <span className="text-warning ml-1">(overwrites existing rsvp)</span>
+          ) : null}
+        </span>
         <Button
           variant="ghost"
           className="h-7 px-2 text-xs"
@@ -85,7 +94,7 @@ export function AttendanceImportReviewRow({ row, resolution, onResolve }: Props)
         onTermChange={setTerm}
         results={searchResults}
         onPick={(u) => {
-          onResolve(u.id, false);
+          onResolve(u.id, false, u.fullName);
         }}
       />
     </div>
@@ -112,10 +121,14 @@ function RowLabel({ row }: { row: ImportRow }) {
   );
 }
 
-function resolvedUserName(row: ImportRow, userId: string | null): string | null {
+function resolvedUserName(
+  row: ImportRow,
+  userId: string | null,
+  pickedFullName?: string | null,
+): string | null {
   if (!userId) return null;
   if (userId === row.matchedUserId) return row.matchedFullName;
-  return row.candidates.find((c) => c.userId === userId)?.fullName ?? 'selected';
+  return row.candidates.find((c) => c.userId === userId)?.fullName ?? pickedFullName ?? 'selected';
 }
 
 function SearchPicker({

--- a/frontend/src/screens/admin/AttendanceImportReviewRow.tsx
+++ b/frontend/src/screens/admin/AttendanceImportReviewRow.tsx
@@ -1,0 +1,139 @@
+import { useState } from 'react';
+
+import { type ImportRow } from '@/api/attendanceImport';
+import { type MemberSearchResult, useUserSearch } from '@/api/userSearch';
+import { Button } from '@/components/ui/Button';
+import { formatPhone } from '@/utils/formatPhone';
+
+interface Props {
+  row: ImportRow;
+  resolution: { userId: string | null; skip: boolean };
+  onResolve: (userId: string | null, skip: boolean) => void;
+}
+
+export function AttendanceImportReviewRow({ row, resolution, onResolve }: Props) {
+  const [term, setTerm] = useState('');
+  const { data: searchResults = [] } = useUserSearch(term);
+  const resolvedName = resolvedUserName(row, resolution.userId);
+
+  if (resolution.skip) {
+    return (
+      <RowShell row={row}>
+        <span className="text-muted text-xs italic">skipped</span>
+        <Button variant="ghost" className="h-7 px-2 text-xs" onClick={() => { onResolve(null, false); }}>
+          undo
+        </Button>
+      </RowShell>
+    );
+  }
+
+  if (resolvedName) {
+    return (
+      <RowShell row={row}>
+        <span className="text-foreground text-xs">→ {resolvedName.toLowerCase()}</span>
+        <Button variant="ghost" className="h-7 px-2 text-xs" onClick={() => { onResolve(null, false); }}>
+          change
+        </Button>
+      </RowShell>
+    );
+  }
+
+  return (
+    <div className="border-border bg-surface flex flex-col gap-2 rounded-lg border p-3">
+      <div className="flex items-center justify-between gap-3">
+        <RowLabel row={row} />
+        <Button variant="ghost" className="h-7 px-2 text-xs" onClick={() => { onResolve(null, true); }}>
+          skip
+        </Button>
+      </div>
+      {row.candidates.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {row.candidates.map((c) => (
+            <button
+              key={c.userId}
+              type="button"
+              onClick={() => { onResolve(c.userId, false); }}
+              className="bg-surface-dim hover:bg-background rounded-full px-2.5 py-1 text-xs"
+            >
+              {c.fullName.toLowerCase()} · {formatPhone(c.phoneNumber)}
+            </button>
+          ))}
+        </div>
+      ) : null}
+      <SearchPicker
+        term={term}
+        onTermChange={setTerm}
+        results={searchResults}
+        onPick={(u) => {
+          onResolve(u.id, false);
+        }}
+      />
+    </div>
+  );
+}
+
+function RowShell({ row, children }: { row: ImportRow; children: React.ReactNode }) {
+  return (
+    <div className="border-border bg-surface flex items-center justify-between gap-3 rounded-lg border p-3">
+      <RowLabel row={row} />
+      <div className="flex items-center gap-2">{children}</div>
+    </div>
+  );
+}
+
+function RowLabel({ row }: { row: ImportRow }) {
+  return (
+    <div className="min-w-0 flex-1">
+      <p className="text-foreground truncate text-sm font-medium">{row.rawName}</p>
+      <p className="text-foreground-tertiary truncate text-xs">
+        {row.partifulStatus.toLowerCase()} · {row.checkedIn ? 'checked in' : 'not checked in'}
+      </p>
+    </div>
+  );
+}
+
+function resolvedUserName(row: ImportRow, userId: string | null): string | null {
+  if (!userId) return null;
+  if (userId === row.matchedUserId) return row.matchedFullName;
+  return row.candidates.find((c) => c.userId === userId)?.fullName ?? 'selected';
+}
+
+function SearchPicker({
+  term,
+  onTermChange,
+  results,
+  onPick,
+}: {
+  term: string;
+  onTermChange: (v: string) => void;
+  results: MemberSearchResult[];
+  onPick: (u: MemberSearchResult) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-1">
+      <input
+        value={term}
+        onChange={(e) => { onTermChange(e.target.value); }}
+        placeholder="search members by name or phone"
+        aria-label={`search a member to match "${term}"`}
+        className="border-border-strong bg-background h-8 w-full rounded-md border px-2 text-xs outline-none"
+      />
+      {term.trim().length >= 2 && results.length > 0 ? (
+        <ul className="border-border max-h-32 overflow-y-auto rounded-md border">
+          {results.map((m) => (
+            <li key={m.id}>
+              <button
+                type="button"
+                onClick={() => { onPick(m); }}
+                className="hover:bg-background flex w-full items-center justify-between px-2 py-1 text-start text-xs"
+              >
+                <span>{m.fullName.toLowerCase()}</span>
+                <span className="text-muted">{formatPhone(m.phoneNumber)}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/screens/admin/AttendanceImportReviewRow.tsx
+++ b/frontend/src/screens/admin/AttendanceImportReviewRow.tsx
@@ -20,7 +20,13 @@ export function AttendanceImportReviewRow({ row, resolution, onResolve }: Props)
     return (
       <RowShell row={row}>
         <span className="text-muted text-xs italic">skipped</span>
-        <Button variant="ghost" className="h-7 px-2 text-xs" onClick={() => { onResolve(null, false); }}>
+        <Button
+          variant="ghost"
+          className="h-7 px-2 text-xs"
+          onClick={() => {
+            onResolve(null, false);
+          }}
+        >
           undo
         </Button>
       </RowShell>
@@ -31,7 +37,13 @@ export function AttendanceImportReviewRow({ row, resolution, onResolve }: Props)
     return (
       <RowShell row={row}>
         <span className="text-foreground text-xs">→ {resolvedName.toLowerCase()}</span>
-        <Button variant="ghost" className="h-7 px-2 text-xs" onClick={() => { onResolve(null, false); }}>
+        <Button
+          variant="ghost"
+          className="h-7 px-2 text-xs"
+          onClick={() => {
+            onResolve(null, false);
+          }}
+        >
           change
         </Button>
       </RowShell>
@@ -42,7 +54,13 @@ export function AttendanceImportReviewRow({ row, resolution, onResolve }: Props)
     <div className="border-border bg-surface flex flex-col gap-2 rounded-lg border p-3">
       <div className="flex items-center justify-between gap-3">
         <RowLabel row={row} />
-        <Button variant="ghost" className="h-7 px-2 text-xs" onClick={() => { onResolve(null, true); }}>
+        <Button
+          variant="ghost"
+          className="h-7 px-2 text-xs"
+          onClick={() => {
+            onResolve(null, true);
+          }}
+        >
           skip
         </Button>
       </div>
@@ -52,7 +70,9 @@ export function AttendanceImportReviewRow({ row, resolution, onResolve }: Props)
             <button
               key={c.userId}
               type="button"
-              onClick={() => { onResolve(c.userId, false); }}
+              onClick={() => {
+                onResolve(c.userId, false);
+              }}
               className="bg-surface-dim hover:bg-background rounded-full px-2.5 py-1 text-xs"
             >
               {c.fullName.toLowerCase()} · {formatPhone(c.phoneNumber)}
@@ -113,7 +133,9 @@ function SearchPicker({
     <div className="flex flex-col gap-1">
       <input
         value={term}
-        onChange={(e) => { onTermChange(e.target.value); }}
+        onChange={(e) => {
+          onTermChange(e.target.value);
+        }}
         placeholder="search members by name or phone"
         aria-label={`search a member to match "${term}"`}
         className="border-border-strong bg-background h-8 w-full rounded-md border px-2 text-xs outline-none"
@@ -124,7 +146,9 @@ function SearchPicker({
             <li key={m.id}>
               <button
                 type="button"
-                onClick={() => { onPick(m); }}
+                onClick={() => {
+                  onPick(m);
+                }}
                 className="hover:bg-background flex w-full items-center justify-between px-2 py-1 text-start text-xs"
               >
                 <span>{m.fullName.toLowerCase()}</span>

--- a/frontend/src/screens/admin/AttendanceImportUploadStep.tsx
+++ b/frontend/src/screens/admin/AttendanceImportUploadStep.tsx
@@ -1,0 +1,41 @@
+import { useRef, useState } from 'react';
+
+import { Button } from '@/components/ui/Button';
+
+interface Props {
+  onFileReady: (file: File) => void;
+  isPending: boolean;
+}
+
+export function AttendanceImportUploadStep({ onFileReady, isPending }: Props) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [fileName, setFileName] = useState<string | null>(null);
+
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setFileName(file.name);
+    onFileReady(file);
+  }
+
+  return (
+    <div className="flex flex-col gap-3">
+      <p className="text-muted text-sm">
+        upload the raw partiful attendee export for this event (csv with name, status, checked
+        in, rsvp date columns)
+      </p>
+      <input
+        ref={inputRef}
+        type="file"
+        accept=".csv,text/csv"
+        className="sr-only"
+        onChange={handleChange}
+        aria-label="partiful csv file"
+      />
+      <Button variant="secondary" onClick={() => inputRef.current?.click()} disabled={isPending}>
+        {fileName ?? 'choose csv file'}
+      </Button>
+      {isPending ? <p className="text-muted text-sm">reading file…</p> : null}
+    </div>
+  );
+}

--- a/frontend/src/screens/admin/AttendanceImportUploadStep.tsx
+++ b/frontend/src/screens/admin/AttendanceImportUploadStep.tsx
@@ -21,8 +21,8 @@ export function AttendanceImportUploadStep({ onFileReady, isPending }: Props) {
   return (
     <div className="flex flex-col gap-3">
       <p className="text-muted text-sm">
-        upload the raw partiful attendee export for this event (csv with name, status, checked in,
-        rsvp date columns)
+        upload the raw partiful attendee export for this event (csv with name, status, checked in
+        columns)
       </p>
       <input
         ref={inputRef}

--- a/frontend/src/screens/admin/AttendanceImportUploadStep.tsx
+++ b/frontend/src/screens/admin/AttendanceImportUploadStep.tsx
@@ -21,8 +21,8 @@ export function AttendanceImportUploadStep({ onFileReady, isPending }: Props) {
   return (
     <div className="flex flex-col gap-3">
       <p className="text-muted text-sm">
-        upload the raw partiful attendee export for this event (csv with name, status, checked
-        in, rsvp date columns)
+        upload the raw partiful attendee export for this event (csv with name, status, checked in,
+        rsvp date columns)
       </p>
       <input
         ref={inputRef}

--- a/frontend/src/screens/admin/AttendanceReportScreen.test.tsx
+++ b/frontend/src/screens/admin/AttendanceReportScreen.test.tsx
@@ -21,6 +21,11 @@ vi.mock('@/api/featureFlags', () => ({
 vi.mock('./MemberAttendanceTab', () => ({
   MemberAttendanceTab: () => <div>members tab content</div>,
 }));
+vi.mock('@/api/attendanceImport', () => ({
+  useAttendanceImportEventOptions: vi.fn(() => ({ data: [] })),
+  usePreviewAttendanceImport: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useCommitAttendanceImport: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
 
 const mockUseReport = vi.mocked(useAttendanceReport);
 const mockUseFlag = vi.mocked(useFlag);
@@ -134,5 +139,16 @@ describe('AttendanceReportScreen', () => {
     await user.click(screen.getByRole('tab', { name: 'members' }));
 
     expect(screen.getByText('members tab content')).toBeInTheDocument();
+  });
+
+  it('opens the partiful import dialog from the import button', async () => {
+    mockResult({ data: [] });
+    const user = userEvent.setup();
+
+    renderScreen();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    await user.click(screen.getByRole('button', { name: 'import from partiful' }));
+
+    expect(screen.getByRole('dialog', { name: 'import partiful attendance' })).toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/admin/AttendanceReportScreen.tsx
+++ b/frontend/src/screens/admin/AttendanceReportScreen.tsx
@@ -26,11 +26,21 @@ export default function AttendanceReportScreen() {
           <h1 className="mb-1 text-2xl font-medium tracking-tight">attendance</h1>
           <p className="text-muted text-sm">who actually showed up, per event and per member</p>
         </div>
-        <Button variant="secondary" onClick={() => { setImportOpen(true); }}>
+        <Button
+          variant="secondary"
+          onClick={() => {
+            setImportOpen(true);
+          }}
+        >
           import from partiful
         </Button>
       </header>
-      <AttendanceImportDialog open={importOpen} onClose={() => { setImportOpen(false); }} />
+      <AttendanceImportDialog
+        open={importOpen}
+        onClose={() => {
+          setImportOpen(false);
+        }}
+      />
 
       {membersTabEnabled ? (
         <div

--- a/frontend/src/screens/admin/AttendanceReportScreen.tsx
+++ b/frontend/src/screens/admin/AttendanceReportScreen.tsx
@@ -4,10 +4,12 @@ import { Link } from 'react-router-dom';
 
 import { type EventAttendanceRow, useAttendanceReport } from '@/api/attendanceReport';
 import { useFlag } from '@/api/featureFlags';
+import { Button } from '@/components/ui/Button';
 import { Feature } from '@/models/featureFlags';
 import { ContentContainer, ContentError, ContentLoading } from '@/screens/public/ContentContainer';
 import { cn } from '@/utils/cn';
 
+import { AttendanceImportDialog } from './AttendanceImportDialog';
 import { MemberAttendanceTab } from './MemberAttendanceTab';
 
 type Tab = 'events' | 'members';
@@ -15,13 +17,20 @@ type Tab = 'events' | 'members';
 export default function AttendanceReportScreen() {
   const membersTabEnabled = useFlag(Feature.AdminAttendanceAnalytics);
   const [tab, setTab] = useState<Tab>('events');
+  const [importOpen, setImportOpen] = useState(false);
 
   return (
     <ContentContainer>
-      <header className="mb-4">
-        <h1 className="mb-1 text-2xl font-medium tracking-tight">attendance</h1>
-        <p className="text-muted text-sm">who actually showed up, per event and per member</p>
+      <header className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <h1 className="mb-1 text-2xl font-medium tracking-tight">attendance</h1>
+          <p className="text-muted text-sm">who actually showed up, per event and per member</p>
+        </div>
+        <Button variant="secondary" onClick={() => { setImportOpen(true); }}>
+          import from partiful
+        </Button>
       </header>
+      <AttendanceImportDialog open={importOpen} onClose={() => { setImportOpen(false); }} />
 
       {membersTabEnabled ? (
         <div


### PR DESCRIPTION
## Overview

Adds an admin-only CSV upload to the attendance admin page that backfills historical event attendance from Partiful's per-event attendee export, writing directly into the existing `EventRSVP.attendance` / `AttendanceStatus` model so "last attended" and per-event attendance reporting stay accurate further back than the app's own launch.

Issue #507 (attendance tracking epic) explicitly scoped this out — "do NOT rebuild capture" — leaving only per-event check-in and the aggregate reporting layer. This PR is the missing historical-import path referenced in that epic's open questions.

### Design decisions (please weigh in if you disagree)

- **One CSV = one event, not a batch importer.** Partiful's raw export has no event identity in it (just attendee rows), so the admin picks or creates the target event *first* in the UI, then uploads that single event's CSV against it. This avoids inventing a combined multi-event CSV format.
- **Exact (case-insensitive) name matching only — no fuzzy matching.** Matches against `full_name`/`nickname` of active members. Anything not confidently and uniquely matched (0 or 2+ candidates) goes into a "needs review" bucket returned in the same preview response, where the admin manually search-selects a `User` or skips the row. Deliberately did not reach for a fuzzy-matching library (Levenshtein etc.) per YAGNI — exact match + manual review covers the real failure modes (nicknames, typos) without new dependencies.
- **Permission gate reused, not added.** The issue assumed an "attendance-admin permission" already existed; it didn't. Reused `PermissionKey.MANAGE_EVENTS` / `Permission.ManageEvents` — the same gate already used by `/events/attendance-report/` and `/events/attendance-analytics/members/`. No new permission was added.
- **Partiful → PDA status mapping:** `Checked in = Yes` → `attendance=ATTENDED`. RSVP'd "Going" but not checked in → the canonical no-show shape (`status=ATTENDING`, `attendance=DIDNT_GO`), matching how `_rsvp_counts.no_show_q` already defines a no-show elsewhere in the codebase. Anything else (Maybe/declined, never checked in) leaves `attendance=UNKNOWN` — no attendance claim is made for rows PDA can't actually verify.
- **New-event creation defaults:** community/public/active, `rsvp_enabled=False` (it's a historical backfill, not open for new signups). No future-date validation — the whole point is past events.

### What's new

**Backend** (`backend/community/`)
- `_attendance_import.py` — `GET .../attendance-import/events/` (search existing events), `POST .../attendance-import/preview/` (parse + match, no writes), `POST .../attendance-import/commit/` (create/link event, upsert EventRSVP from reviewed rows)
- `_attendance_import_matching.py` — CSV parsing + exact-match logic
- `_attendance_import_schemas.py` — pydantic schemas
- New `Code.AttendanceImport` validation codes in `_validation.py`

**Frontend** (`frontend/src/`)
- `api/attendanceImport.ts` — TanStack Query hooks
- `screens/admin/AttendanceImportDialog.tsx` + `AttendanceImportEventStep.tsx` + `AttendanceImportUploadStep.tsx` + `AttendanceImportReviewRow.tsx` — event picker → CSV upload → review (auto-matched + manual search-select/skip for the rest) → confirm
- Wired into the existing `/admin/attendance` screen (already gated by `Permission.ManageEvents`) as an "import from partiful" button
- `types.gen.ts` / `validationCodes.gen.ts` regenerated via `make frontend-types`; `validationCodes.ts` updated with copy for the new codes (exhaustive switch, existing pattern)

## Test plan

- [x] 21 backend pytest tests (`backend/tests/test_attendance_import.py`): permission gating (403/401), exact match, case-insensitive match, unmatched → needs_review, ambiguous (2+ candidates) → needs_review with candidate list, malformed/empty CSV rejected (400), checked-in → attended, going-not-checked-in → no-show mapping, maybe-not-checked-in → unknown, skip row not written, missing user_id skipped, existing RSVP updated not duplicated, event creation vs linking an existing event, missing event/title rejected (400), nonexistent event_id (404), committed rows show up in the existing attendance-report aggregate
- [x] Frontend: added a test to the existing `AttendanceReportScreen.test.tsx` covering the import button opening the dialog; full existing suite still green (142 files / 1168 tests)
- [x] `make agent-typecheck`, `make agent-lint`, `make agent-complexity`, `make check-codes` — all clean
- [x] `make agent-frontend-typecheck`, `make agent-frontend-lint`, `make agent-frontend-test` — all clean
- [ ] `make agent-test` (full backend suite) — 6 pre-existing failures unrelated to this change (SSE/`pg_notify` tests and one concurrency-race test that need real Postgres, not SQLite; documented as a known local-dev limitation). All attendance-import, attendance-report, and check-in-report tests pass.

## Open questions / follow-ups deliberately deferred

- No feature flag was added — gating is permission-only, matching the existing attendance-report/analytics endpoints. Flag it if you'd rather ship this behind a flag first.
- The CSV column-name matching is case-insensitive on header names (`Name`, `Status`, `Checked in`) but assumes Partiful's exact header set; if Partiful's export format drifts, `_attendance_import_matching.REQUIRED_COLUMNS` will need updating.
- No bulk "apply this pick to all rows with the same raw name" — each ambiguous/unmatched row is resolved individually. Could be a follow-up if imports commonly have the same unresolved name across many events.

Closes #1324
