### PR TITLE
fix: 1319 - add search and member count to attendance members tab

### DIFF
--- a/frontend/src/screens/admin/MemberAttendanceTab.test.tsx
+++ b/frontend/src/screens/admin/MemberAttendanceTab.test.tsx
@@ -158,4 +158,99 @@ describe('MemberAttendanceTab', () => {
     expect(screen.getByText('paused')).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'pause member' })).not.toBeInTheDocument();
   });
+
+  it('displays the member count', () => {
+    mockRows([makeMemberRow(), makeMemberRow({ userId: 'u2', fullName: 'Bob Smith' })]);
+    render(<MemberAttendanceTab />);
+    expect(screen.getByText('2 members')).toBeInTheDocument();
+  });
+
+  it('displays singular member count when only one member', () => {
+    mockRows([makeMemberRow()]);
+    render(<MemberAttendanceTab />);
+    expect(screen.getByText('1 member')).toBeInTheDocument();
+  });
+
+  it('hides member count when list is empty', () => {
+    mockRows([]);
+    render(<MemberAttendanceTab />);
+    expect(screen.queryByText(/^\d+ members?$/)).not.toBeInTheDocument();
+  });
+
+  it('filters members by search query (case-insensitive)', async () => {
+    mockRows([
+      makeMemberRow({ userId: 'u1', fullName: 'Ada Lovelace' }),
+      makeMemberRow({ userId: 'u2', fullName: 'Bob Smith' }),
+      makeMemberRow({ userId: 'u3', fullName: 'Charlie Chen' }),
+    ]);
+    const user = userEvent.setup();
+    render(<MemberAttendanceTab />);
+
+    const searchInput = screen.getByPlaceholderText('name');
+    await user.type(searchInput, 'ada');
+
+    expect(screen.getByText('ada lovelace')).toBeInTheDocument();
+    expect(screen.queryByText('bob smith')).not.toBeInTheDocument();
+    expect(screen.queryByText('charlie chen')).not.toBeInTheDocument();
+    expect(screen.getByText('1 member')).toBeInTheDocument();
+  });
+
+  it('updates member count when search filter is applied', async () => {
+    mockRows([
+      makeMemberRow({ userId: 'u1', fullName: 'Alice Brown' }),
+      makeMemberRow({ userId: 'u2', fullName: 'Amy Johnson' }),
+      makeMemberRow({ userId: 'u3', fullName: 'Bob Smith' }),
+    ]);
+    const user = userEvent.setup();
+    render(<MemberAttendanceTab />);
+
+    expect(screen.getByText('3 members')).toBeInTheDocument();
+
+    const searchInput = screen.getByPlaceholderText('name');
+    await user.type(searchInput, 'alice');
+
+    expect(screen.getByText('1 member')).toBeInTheDocument();
+  });
+
+  it('combines search filter with at-risk filter', async () => {
+    mockRows([
+      makeMemberRow({
+        userId: 'u1',
+        fullName: 'Alice Risk',
+        isPauseCandidate: true,
+        lastQualifyingAt: null,
+      }),
+      makeMemberRow({
+        userId: 'u2',
+        fullName: 'Bob Risk',
+        isPauseCandidate: true,
+        lastQualifyingAt: null,
+      }),
+      makeMemberRow({ userId: 'u3', fullName: 'Alice Safe', isPauseCandidate: false }),
+    ]);
+    const user = userEvent.setup();
+    render(<MemberAttendanceTab />);
+
+    await user.click(screen.getByRole('button', { name: 'at risk' }));
+    expect(screen.getByText('2 members')).toBeInTheDocument();
+
+    const searchInput = screen.getByPlaceholderText('name');
+    await user.type(searchInput, 'alice');
+
+    expect(screen.getByText('1 member')).toBeInTheDocument();
+    expect(screen.getByText('alice risk')).toBeInTheDocument();
+    expect(screen.queryByText('bob risk')).not.toBeInTheDocument();
+  });
+
+  it('shows empty state when search does not match any members', async () => {
+    mockRows([makeMemberRow({ fullName: 'Ada Lovelace' })]);
+    const user = userEvent.setup();
+    render(<MemberAttendanceTab />);
+
+    const searchInput = screen.getByPlaceholderText('name');
+    await user.type(searchInput, 'xyz');
+
+    expect(screen.getByText(/nothing here/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^\d+ members?$/)).not.toBeInTheDocument();
+  });
 });

--- a/frontend/src/screens/admin/MemberAttendanceTab.tsx
+++ b/frontend/src/screens/admin/MemberAttendanceTab.tsx
@@ -1,5 +1,5 @@
 import { format } from 'date-fns';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { toast } from 'sonner';
 
 import { extractApiErrorOr } from '@/api/apiErrors';
@@ -9,6 +9,7 @@ import {
 } from '@/api/memberAttendanceAnalytics';
 import { useUpdateUser } from '@/api/users';
 import { useAuthStore } from '@/auth/store';
+import { TextField } from '@/components/ui/TextField';
 import { useConfirm } from '@/components/ui/useConfirm';
 import { hasPermission, Permission } from '@/models/permissions';
 import { ContentError, ContentLoading } from '@/screens/public/ContentContainer';
@@ -20,14 +21,33 @@ type Filter = 'all' | 'at-risk';
 export function MemberAttendanceTab() {
   const { data = [], isPending, isError } = useMemberAttendanceAnalytics();
   const [filter, setFilter] = useState<Filter>('all');
+  const [searchQuery, setSearchQuery] = useState('');
+
+  const filtered = filter === 'at-risk' ? data.filter((m) => m.isPauseCandidate) : data;
+  const visible = useMemo(
+    () => filtered.filter((m) => m.fullName.toLowerCase().includes(searchQuery.toLowerCase())),
+    [filtered, searchQuery],
+  );
 
   if (isPending) return <ContentLoading />;
   if (isError) return <ContentError message="couldn't load member attendance — try refreshing" />;
 
-  const visible = filter === 'at-risk' ? data.filter((m) => m.isPauseCandidate) : data;
-
   return (
     <div>
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-end">
+        <div className="flex-1">
+          <TextField
+            label="search"
+            placeholder="name"
+            value={searchQuery}
+            maxLength={100}
+            onChange={(e) => {
+              setSearchQuery(e.target.value);
+            }}
+          />
+        </div>
+      </div>
+
       <div className="mb-3 flex items-center gap-2">
         <FilterButton
           active={filter === 'all'}
@@ -46,6 +66,12 @@ export function MemberAttendanceTab() {
           at risk
         </FilterButton>
       </div>
+
+      {visible.length > 0 ? (
+        <p className="text-foreground-tertiary mb-3 text-sm">
+          {visible.length === 1 ? '1 member' : `${String(visible.length)} members`}
+        </p>
+      ) : null}
 
       {visible.length === 0 ? (
         <p className="text-muted text-sm">nothing here 🌿</p>


### PR DESCRIPTION
## Overview

Adds a search input and a live member count to the members tab on the admin attendance page, per user feedback submitted from that page.

## Test plan

- [x] Added/updated Vitest coverage for search filtering (case-insensitive) and count display (singular/plural, updates with filters)
- [x] `make agent-frontend-typecheck` passes
- [x] `make agent-frontend-lint` passes

Closes #1319
