### PR TITLE
fix: 1344 - remove going/heads stat from attendance report

### DIFF
--- a/frontend/src/screens/admin/AttendanceReportScreen.test.tsx
+++ b/frontend/src/screens/admin/AttendanceReportScreen.test.tsx
@@ -64,7 +64,7 @@ beforeEach(() => {
 });
 
 describe('AttendanceReportScreen', () => {
-  it('renders per-event attended / no-show / going counts', () => {
+  it('renders per-event attended / no-show counts', () => {
     mockResult({
       data: {
         events: [makeRow()],
@@ -80,7 +80,6 @@ describe('AttendanceReportScreen', () => {
     const row = screen.getByRole('link');
     expect(row).toHaveTextContent('4 attended');
     expect(row).toHaveTextContent('1 no-show');
-    expect(row).toHaveTextContent('6 going');
     expect(row).toHaveAttribute('href', '/events/e1/report');
   });
 

--- a/frontend/src/screens/admin/AttendanceReportScreen.tsx
+++ b/frontend/src/screens/admin/AttendanceReportScreen.tsx
@@ -120,7 +120,6 @@ function AttendanceRow({ row, linkable }: { row: EventAttendanceRow; linkable: b
       <div className="flex shrink-0 flex-wrap justify-end gap-1 text-xs">
         <Stat label="attended" value={row.attendedCount} />
         <Stat label="no-show" value={row.noShowCount} />
-        <Stat label="going (heads)" value={row.goingCount} />
       </div>
     </>
   );


### PR DESCRIPTION
## Overview

Removes the confusing "going (heads)" stat tile from the per-event attendance report rows, per user feedback submitted from the admin attendance page ("what does the (heads) mean... we dont need the n going item at all").

Stacked on #1346 (fix-1320-attendance-official-vs-club) — merge that first.

## Test plan

- [x] Updated Vitest coverage to drop the removed assertion
- [x] `make agent-frontend-typecheck` passes
- [x] `make agent-frontend-lint` passes

Closes #1344
