### PR TITLE
fix: 1349 - only map checked-in users in partiful import

### DIFF
--- a/backend/community/_attendance_import.py
+++ b/backend/community/_attendance_import.py
@@ -92,7 +92,8 @@ def preview_attendance_import(
         }
 
     rows = parse_partiful_csv(csv_file.read())
-    matched, needs_review = match_rows(rows, existing_rsvp_user_ids)
+    checked_in_rows = [r for r in rows if r.get("checked in", "").lower() == "yes"]
+    matched, needs_review = match_rows(checked_in_rows, existing_rsvp_user_ids)
     return Status(200, AttendanceImportPreviewOut(matched=matched, needs_review=needs_review))
 
 

--- a/backend/tests/test_attendance_import.py
+++ b/backend/tests/test_attendance_import.py
@@ -102,7 +102,7 @@ class TestPreviewEndpoint:
     def test_unmatched_name_goes_to_needs_review(self, api_client, events_admin):
         response = api_client.post(
             "/api/community/events/attendance-import/preview/",
-            {"csv_file": _csv(["Nobody Here,Maybe,No,2026-01-01 00:00:00"])},
+            {"csv_file": _csv(["Nobody Here,Maybe,Yes,2026-01-01 00:00:00"])},
             **_auth(events_admin),
         )
         body = response.json()
@@ -111,6 +111,23 @@ class TestPreviewEndpoint:
         row = body["needs_review"][0]
         assert row["raw_name"] == "Nobody Here"
         assert row["candidates"] == []
+
+    def test_not_checked_in_rows_are_dropped(self, api_client, events_admin, alice):
+        response = api_client.post(
+            "/api/community/events/attendance-import/preview/",
+            {
+                "csv_file": _csv(
+                    [
+                        "Alice Smith,Going,No,2026-01-01 00:00:00",
+                        "Nobody Here,Maybe,No,2026-01-01 00:00:00",
+                    ]
+                )
+            },
+            **_auth(events_admin),
+        )
+        body = response.json()
+        assert body["matched"] == []
+        assert body["needs_review"] == []
 
     def test_ambiguous_name_goes_to_needs_review_with_candidates(self, api_client, events_admin):
         User.objects.create_user(


### PR DESCRIPTION
## Overview

The Partiful attendance import currently attempts to name-match every row in the uploaded CSV against existing members, including rows for people who RSVP'd but never checked in. That produces unnecessary "needs review" noise for attendees admins never intend to mark present. This PR filters the CSV to only checked-in rows (`checked in == "yes"`) before matching, so unmatched/ambiguous review only surfaces for people who actually showed up.

## Test plan

- [x] Added `test_not_checked_in_rows_are_dropped` covering rows with `checked in = No` are excluded from both `matched` and `needs_review`
- [x] Updated `test_unmatched_name_goes_to_needs_review` to use a checked-in row (previously relied on a not-checked-in row, which is now filtered out earlier in the pipeline)
- [x] `pytest backend/tests/test_attendance_import.py` — 24 passed

Closes #1349
