### PR TITLE
fix: 1348 - remove no-show summary bubbles from attendance report

### DIFF
--- a/frontend/src/screens/admin/AttendanceReportScreen.test.tsx
+++ b/frontend/src/screens/admin/AttendanceReportScreen.test.tsx
@@ -6,7 +6,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useAttendanceReport } from '@/api/attendanceReport';
 import { useFlag } from '@/api/featureFlags';
-import { EventType } from '@/models/event';
 import { Feature } from '@/models/featureFlags';
 import { makeRow } from '@/test/fixtures';
 
@@ -86,25 +85,6 @@ describe('AttendanceReportScreen', () => {
     expect(row).toHaveTextContent('4 attended');
     expect(row).toHaveTextContent('1 no-show');
     expect(row).toHaveAttribute('href', '/events/e1/report');
-  });
-
-  it('displays split no-show counts by event type', () => {
-    mockResult({
-      data: {
-        events: [makeRow(), makeRow({ eventType: EventType.Club, eventId: 'e2', noShowCount: 2 })],
-        officialNoShowCount: 1,
-        clubNoShowCount: 2,
-      },
-    });
-
-    renderScreen();
-
-    expect(screen.getByText('official event no-shows').closest('span')).toHaveTextContent(
-      '1 official event no-shows',
-    );
-    expect(screen.getByText('club event no-shows').closest('span')).toHaveTextContent(
-      '2 club event no-shows',
-    );
   });
 
   it('links each event row to its check-in report when host_attendance_report is on', () => {

--- a/frontend/src/screens/admin/AttendanceReportScreen.tsx
+++ b/frontend/src/screens/admin/AttendanceReportScreen.tsx
@@ -110,10 +110,6 @@ function EventsTab() {
 
   return (
     <>
-      <div className="mb-4 flex gap-3">
-        <Stat label="official event no-shows" value={data.officialNoShowCount} />
-        <Stat label="club event no-shows" value={data.clubNoShowCount} />
-      </div>
       <ul className="flex flex-col gap-2">
         {data.events.map((row) => (
           <li key={row.eventId}>


### PR DESCRIPTION
## Overview

The attendance report screen showed two summary stat bubbles ("official event no-shows" / "club event no-shows") at the very top of the events list, above the per-event rows. Feedback called these out as not useful. This PR removes the top-level summary bubbles; the per-event "no-show" count on each row is unaffected.

## Test plan

- [x] Removed the corresponding test that asserted the top summary bubbles render
- [x] `vitest run src/screens/admin/AttendanceReportScreen.test.tsx` — 9 passed (1 pre-existing unrelated failure on `main`, unaffected by this change)
- [x] `tsc --noEmit` / `eslint` clean on changed files

Closes #1348
