### PR TITLE
fix: correct attendance report test mock shape

### DIFF
--- a/frontend/src/screens/admin/AttendanceReportScreen.test.tsx
+++ b/frontend/src/screens/admin/AttendanceReportScreen.test.tsx
@@ -201,7 +201,13 @@ describe('AttendanceReportScreen', () => {
   });
 
   it('opens the partiful import dialog from the import button', async () => {
-    mockResult({ data: [] });
+    mockResult({
+      data: {
+        events: [],
+        officialNoShowCount: 0,
+        clubNoShowCount: 0,
+      },
+    });
     const user = userEvent.setup();
 
     renderScreen();


### PR DESCRIPTION
## Overview

The "opens the partiful import dialog from the import button" test in `AttendanceReportScreen.test.tsx` was crashing with `TypeError: Cannot read properties of undefined (reading 'length')` in `EventsTab` (`data.events.length === 0`). The test's mock passed `data: []` instead of the `{ events, officialNoShowCount, clubNoShowCount }` shape `EventsTab` expects, matching the pattern already used by every other test in the file. This was pre-existing breakage on `main`, unrelated to any other in-flight work.

## Test plan

- [x] `npx vitest run src/screens/admin/AttendanceReportScreen.test.tsx` — all 10 tests pass
- [x] `tsc -b --noEmit` — clean
