### PR TITLE
chore(railway): run cron-daily at 7am ET, deploy cron services from CI

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -30,6 +30,7 @@ jobs:
           RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
           RAILWAY_ENVIRONMENT: ${{ vars.RAILWAY_ENVIRONMENT_PRODUCTION }}
           RAILWAY_SERVICE_NAME: ${{ vars.RAILWAY_SERVICE_NAME_PRODUCTION }}
+          RAILWAY_CRON_SERVICE_NAMES: ${{ vars.RAILWAY_CRON_SERVICE_NAMES_PRODUCTION }}
         run: |
           echo "railway deploy context (production target)"
           echo "  github_ref=${GITHUB_REF}"
@@ -37,6 +38,7 @@ jobs:
           echo "  railway_project_id=${RAILWAY_PROJECT_ID}"
           echo "  railway_environment=${RAILWAY_ENVIRONMENT}"
           echo "  railway_service=${RAILWAY_SERVICE_NAME}"
+          echo "  railway_cron_services=${RAILWAY_CRON_SERVICE_NAMES}"
 
       - name: railway up (production token only in this job)
         env:
@@ -44,6 +46,7 @@ jobs:
           RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
           RAILWAY_ENVIRONMENT: ${{ vars.RAILWAY_ENVIRONMENT_PRODUCTION }}
           RAILWAY_SERVICE_NAME: ${{ vars.RAILWAY_SERVICE_NAME_PRODUCTION }}
+          RAILWAY_CRON_SERVICE_NAMES: ${{ vars.RAILWAY_CRON_SERVICE_NAMES_PRODUCTION }}
         run: |
           set -eu
           test -n "${RAILWAY_TOKEN}"
@@ -57,8 +60,22 @@ jobs:
             "${RAILWAY_CLI_IMAGE}")
           echo "railway cli version:"
           "${docker_run[@]}" railway --version
-          echo "railway up (verbose) — 404 here often means wrong project id, environment id/name, or service slug for this token"
-          "${docker_run[@]}" railway up --ci --verbose \
-            --project "${RAILWAY_PROJECT_ID}" \
-            --environment "${RAILWAY_ENVIRONMENT}" \
-            --service "${RAILWAY_SERVICE_NAME}"
+
+          deploy_service() {
+            local service="$1"
+            echo "railway up (verbose) for service '${service}' — 404 here often means wrong project id, environment id/name, or service slug for this token"
+            "${docker_run[@]}" railway up --ci --verbose \
+              --project "${RAILWAY_PROJECT_ID}" \
+              --environment "${RAILWAY_ENVIRONMENT}" \
+              --service "${service}"
+          }
+
+          deploy_service "${RAILWAY_SERVICE_NAME}"
+
+          # RAILWAY_CRON_SERVICE_NAMES_PRODUCTION: comma-separated cron service names, e.g. "cron-daily,cron-checkin-nudges"
+          if [ -n "${RAILWAY_CRON_SERVICE_NAMES}" ]; then
+            IFS=',' read -ra cron_services <<< "${RAILWAY_CRON_SERVICE_NAMES}"
+            for service in "${cron_services[@]}"; do
+              deploy_service "${service}"
+            done
+          fi

--- a/railway/cron-daily.toml
+++ b/railway/cron-daily.toml
@@ -4,6 +4,6 @@ dockerfilePath = "Dockerfile"
 
 [deploy]
 startCommand = "sh scripts/cron_daily.sh"
-cronSchedule = "0 3 * * *"
-restartPolicyType = "ON_FAILURE"
+cronSchedule = "0 12 * * *"
+restartPolicyType = "NEVER"
 restartPolicyMaxRetries = 10


### PR DESCRIPTION
## Summary

- `railway/cron-daily.toml`: schedule shifted to `0 12 * * *` UTC (7am ET during daylight saving / 8am ET during standard time — Railway cron schedules are fixed UTC, no DST awareness). `restartPolicyType` set to `NEVER` to match what Railway actually enforces on `cronSchedule`-enabled services (confirmed via API: `ON_FAILURE` is silently rejected/overridden for cron services).
- `deploy-railway.yml`: the manual production deploy workflow now also redeploys the Railway cron services (`cron-daily`, `cron-checkin-nudges`) alongside `pda`, so they pick up code changes the same way. Driven by a new `RAILWAY_CRON_SERVICE_NAMES_PRODUCTION` repo variable (comma-separated service names) — already set.

## Context

Follow-up to #1237, which added the config-as-code TOMLs. The two Railway services (`cron-daily`, `cron-checkin-nudges`) have since been created in production, connected to the repo, and configured to match their TOML files (build/start command/schedule) directly via the Railway API, since the dashboard's config-as-code auto-sync didn't pick up the TOML on its own. Env vars (`DATABASE_URL`, `SECRET_KEY`, etc.) are wired as `${{pda.KEY}}` references so they mirror the web service.

Auto-deploy-on-push needs to be manually disabled per cron service in the Railway dashboard (not exposed via API) to keep production deploys manual-only, matching the existing `pda` service.

## Test plan

- [ ] Trigger the `deploy railway (production)` workflow and confirm all three services (`pda`, `cron-daily`, `cron-checkin-nudges`) deploy successfully
- [ ] Confirm `cron-daily`'s next scheduled run lands at 7am ET