### PR TITLE
feat: make rsvp notifications clickable (Issue 1294)

### DIFF
--- a/frontend/src/layout/NotificationRow.test.tsx
+++ b/frontend/src/layout/NotificationRow.test.tsx
@@ -62,9 +62,7 @@ describe('NotificationRow', () => {
       createdAt: '2026-07-10T00:00:00Z',
     };
 
-    render(
-      <NotificationRow n={rsvpNotification} onMarkRead={vi.fn()} onActivate={vi.fn()} />,
-    );
+    render(<NotificationRow n={rsvpNotification} onMarkRead={vi.fn()} onActivate={vi.fn()} />);
     await userEvent.click(screen.getByRole('button'));
 
     expect(mockNavigate).toHaveBeenCalledWith('/events/e456');

--- a/frontend/src/layout/NotificationRow.test.tsx
+++ b/frontend/src/layout/NotificationRow.test.tsx
@@ -50,4 +50,23 @@ describe('NotificationRow', () => {
     await userEvent.click(screen.getByRole('button'));
     expect(onMarkRead).toHaveBeenCalledTimes(1);
   });
+
+  it('navigates to event for rsvp status changed notification', async () => {
+    const rsvpNotification = {
+      id: 'n2',
+      notificationType: NotificationType.RsvpStatusChanged,
+      eventId: 'e456',
+      relatedUserId: null,
+      message: 'someone is going',
+      isRead: false,
+      createdAt: '2026-07-10T00:00:00Z',
+    };
+
+    render(
+      <NotificationRow n={rsvpNotification} onMarkRead={vi.fn()} onActivate={vi.fn()} />,
+    );
+    await userEvent.click(screen.getByRole('button'));
+
+    expect(mockNavigate).toHaveBeenCalledWith('/events/e456');
+  });
 });

--- a/frontend/src/layout/notificationTarget.ts
+++ b/frontend/src/layout/notificationTarget.ts
@@ -14,6 +14,7 @@ export function notificationTarget(n: AppNotification): string | null {
     case NotificationType.EventComment:
     case NotificationType.CommentReaction:
     case NotificationType.RsvpDeclinedNote:
+    case NotificationType.RsvpStatusChanged:
       return n.eventId ? `/events/${n.eventId}` : null;
     case NotificationType.CheckinNudge:
       return n.eventId ? `/events/${n.eventId}/attendance` : null;

--- a/frontend/src/models/notification.ts
+++ b/frontend/src/models/notification.ts
@@ -14,6 +14,7 @@ export const NotificationType = {
   EventComment: 'event_comment',
   CommentReaction: 'comment_reaction',
   RsvpDeclinedNote: 'rsvp_declined_note',
+  RsvpStatusChanged: 'rsvp_status_changed',
   CheckinNudge: 'checkin_nudge',
 } as const;
 


### PR DESCRIPTION
## Summary
- add `RsvpStatusChanged` to the frontend `NotificationType` constants
- wire `RsvpStatusChanged` into `notificationTarget` so clicking the notification navigates to the event page (same target as `RsvpDeclinedNote`, `EventComment`, `CommentReaction`)
- add a test case covering click-through navigation for an rsvp status changed notification

Closes #1294

## Test plan
- [x] scoped frontend tests: `pnpm exec vitest run src/layout/NotificationRow.test.tsx` — 3 passed
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint` on touched files — clean
- [ ] full backend suite not run (shared DB contention across worktrees causes spurious failures repo-wide) — no backend changes in this PR