### PR TITLE
fix: 1280 - members count reflects search and role filters

### DIFF
--- a/frontend/src/screens/admin/MembersScreen.test.tsx
+++ b/frontend/src/screens/admin/MembersScreen.test.tsx
@@ -96,13 +96,11 @@ function mockUsersResult(overrides: Partial<ReturnType<typeof useUsers>>) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.mocked(useRoles).mockReturnValue(
-    {
-      data: [],
-      isPending: false,
-      isError: false,
-    } as unknown as ReturnType<typeof useRoles>,
-  );
+  vi.mocked(useRoles).mockReturnValue({
+    data: [],
+    isPending: false,
+    isError: false,
+  } as unknown as ReturnType<typeof useRoles>);
   useAuthStore.setState({
     status: 'authed',
     user: adminUser(),
@@ -393,16 +391,14 @@ describe('MembersScreen', () => {
       user: adminUser([Permission.ManageUsers, Permission.ManageRoles]),
       accessToken: 'tok',
     });
-    vi.mocked(useRoles).mockReturnValue(
-      {
-        data: [
-          { id: 'r1', name: 'organizer', isDefault: false, permissions: [] },
-          { id: 'r2', name: 'core', isDefault: false, permissions: [] },
-        ],
-        isPending: false,
-        isError: false,
-      } as unknown as ReturnType<typeof useRoles>,
-    );
+    vi.mocked(useRoles).mockReturnValue({
+      data: [
+        { id: 'r1', name: 'organizer', isDefault: false, permissions: [] },
+        { id: 'r2', name: 'core', isDefault: false, permissions: [] },
+      ],
+      isPending: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useRoles>);
     mockUsersResult({
       data: [
         makeMember({

--- a/frontend/src/screens/admin/MembersScreen.test.tsx
+++ b/frontend/src/screens/admin/MembersScreen.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { useRoles } from '@/api/roles';
 import { useUsers } from '@/api/users';
 import { useAuthStore } from '@/auth/store';
 import { Permission } from '@/models/permissions';
@@ -22,6 +23,10 @@ vi.mock('@/api/users', () => ({
     isPending: false,
     reset: vi.fn(),
   })),
+}));
+
+vi.mock('@/api/roles', () => ({
+  useRoles: vi.fn(),
 }));
 
 const mockUseUsers = vi.mocked(useUsers);
@@ -91,6 +96,13 @@ function mockUsersResult(overrides: Partial<ReturnType<typeof useUsers>>) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(useRoles).mockReturnValue(
+    {
+      data: [],
+      isPending: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useRoles>,
+  );
   useAuthStore.setState({
     status: 'authed',
     user: adminUser(),
@@ -343,5 +355,86 @@ describe('MembersScreen', () => {
     const links = screen.getAllByRole('link');
     expect(links).toHaveLength(1);
     expect(links[0]?.textContent).toContain('Ada Member');
+  });
+
+  it('shows total count when no filters are active', () => {
+    mockUsersResult({
+      data: [
+        makeMember({ id: 'm1', fullName: 'Ada Lovelace' }),
+        makeMember({ id: 'm2', fullName: 'Grace Hopper' }),
+        makeMember({ id: 'm3', fullName: 'Alan Turing' }),
+      ],
+    });
+
+    renderScreen();
+
+    expect(screen.getByText('3 users')).toBeInTheDocument();
+  });
+
+  it('shows filtered count as "N of M" when search filter is active', async () => {
+    mockUsersResult({
+      data: [
+        makeMember({ id: 'm1', fullName: 'Ada Lovelace' }),
+        makeMember({ id: 'm2', fullName: 'Grace Hopper' }),
+        makeMember({ id: 'm3', fullName: 'Alan Turing' }),
+      ],
+    });
+
+    renderScreen();
+    const user = userEvent.setup();
+    await user.type(screen.getByLabelText(/^search$/i), 'Ada');
+
+    expect(screen.getByText('1 of 3 users')).toBeInTheDocument();
+  });
+
+  it('shows filtered count as "N of M" when role filter is active', async () => {
+    useAuthStore.setState({
+      status: 'authed',
+      user: adminUser([Permission.ManageUsers, Permission.ManageRoles]),
+      accessToken: 'tok',
+    });
+    vi.mocked(useRoles).mockReturnValue(
+      {
+        data: [
+          { id: 'r1', name: 'organizer', isDefault: false, permissions: [] },
+          { id: 'r2', name: 'core', isDefault: false, permissions: [] },
+        ],
+        isPending: false,
+        isError: false,
+      } as unknown as ReturnType<typeof useRoles>,
+    );
+    mockUsersResult({
+      data: [
+        makeMember({
+          id: 'm1',
+          fullName: 'Ada Lovelace',
+          roles: [{ id: 'r1', name: 'organizer', isDefault: false, permissions: [] }],
+        }),
+        makeMember({
+          id: 'm2',
+          fullName: 'Grace Hopper',
+          roles: [{ id: 'r2', name: 'core', isDefault: false, permissions: [] }],
+        }),
+        makeMember({ id: 'm3', fullName: 'Alan Turing', roles: [] }),
+      ],
+    });
+
+    renderScreen();
+    const user = userEvent.setup();
+    // Open the role filter dropdown and select 'organizer'
+    await user.click(screen.getByRole('button', { name: /all roles/i }));
+    await user.click(screen.getByRole('checkbox', { name: 'organizer' }));
+
+    expect(screen.getByText('1 of 3 users')).toBeInTheDocument();
+  });
+
+  it('shows single user count without "of" format', () => {
+    mockUsersResult({
+      data: [makeMember({ id: 'm1', fullName: 'Ada Lovelace' })],
+    });
+
+    renderScreen();
+
+    expect(screen.getByText('1 user')).toBeInTheDocument();
   });
 });

--- a/frontend/src/screens/admin/MembersTab.tsx
+++ b/frontend/src/screens/admin/MembersTab.tsx
@@ -46,6 +46,9 @@ export function MembersTab({ mode }: { mode: MembersMode }) {
     [data, query, sort, selectedRoles],
   );
 
+  const hasFilters = query.trim() !== '' || selectedRoles.size > 0;
+  const countText = formatCountText(visible.length, data.length, hasFilters);
+
   if (isPending) return <ContentLoading />;
   if (isError)
     return (
@@ -115,7 +118,7 @@ export function MembersTab({ mode }: { mode: MembersMode }) {
 
       {data.length > 0 ? (
         <p className="text-foreground-tertiary mb-3 text-sm">
-          {data.length === 1 ? '1 user' : `${String(data.length)} users`}
+          {countText}
         </p>
       ) : null}
 
@@ -308,6 +311,13 @@ function RoleFilter({
       ) : null}
     </div>
   );
+}
+
+function formatCountText(visibleCount: number, totalCount: number, hasFilters: boolean): string {
+  if (hasFilters) {
+    return `${String(visibleCount)} of ${String(totalCount)} ${totalCount === 1 ? 'user' : 'users'}`;
+  }
+  return visibleCount === 1 ? '1 user' : `${String(visibleCount)} users`;
 }
 
 function filterAndSort(

--- a/frontend/src/screens/admin/MembersTab.tsx
+++ b/frontend/src/screens/admin/MembersTab.tsx
@@ -117,9 +117,7 @@ export function MembersTab({ mode }: { mode: MembersMode }) {
       </div>
 
       {data.length > 0 ? (
-        <p className="text-foreground-tertiary mb-3 text-sm">
-          {countText}
-        </p>
+        <p className="text-foreground-tertiary mb-3 text-sm">{countText}</p>
       ) : null}
 
       <MembersList


### PR DESCRIPTION
## Overview

The members list count line (`MembersTab.tsx`) rendered `data.length` — the full fetched list — while the rows below rendered `visible` (post search/role-filter). Searching or filtering left the count stuck at the total, e.g. "83 users" shown above only 2 matching rows.

This adds a `formatCountText` helper that shows `N of M users` when a search query or role filter is active, and falls back to the plain `N users` total otherwise (singular "1 user" preserved in both cases).

## Changes

- Extract `formatCountText` helper (avoids nested ternaries per project style)
- Count `visible.length` against `data.length`, gated on `hasFilters` (search query non-empty or role filter selected)
- Add tests covering: total count with no filters, filtered count with search, filtered count with role filter, singular count

## Test plan

- [x] `npx vitest run src/screens/admin/MembersScreen.test.tsx` — 19 passed
- [ ] Manually verify in the members admin screen: search/filter narrows the list and the count reads "N of M users"

Closes #1280
