### PR TITLE
fix: 1354 - let partiful import mark events as official/club

### DIFF
--- a/backend/community/_attendance_import.py
+++ b/backend/community/_attendance_import.py
@@ -105,6 +105,9 @@ def _require_all_rows_resolved(payload: AttendanceImportCommitIn) -> None:
             )
 
 
+_IMPORTABLE_EVENT_TYPES = {EventType.OFFICIAL, EventType.CLUB}
+
+
 def _resolve_event(payload: AttendanceImportCommitIn, request) -> Event:
     if payload.event_id:
         try:
@@ -115,13 +118,17 @@ def _resolve_event(payload: AttendanceImportCommitIn, request) -> Event:
     if not payload.event_title or not payload.event_date:
         raise_validation(Code.AttendanceImport.EVENT_OR_TITLE_REQUIRED, status_code=400)
 
+    event_type = payload.event_type or EventType.COMMUNITY
+    if event_type not in (*_IMPORTABLE_EVENT_TYPES, EventType.COMMUNITY):
+        raise_validation(Code.AttendanceImport.INVALID_EVENT_TYPE, status_code=400)
+
     start = timezone.make_aware(
         timezone.datetime.combine(payload.event_date, timezone.datetime.min.time())
     )
     return Event.objects.create(
         title=payload.event_title,
         start_datetime=start,
-        event_type=EventType.COMMUNITY,
+        event_type=event_type,
         visibility=PageVisibility.PUBLIC,
         status=EventStatus.ACTIVE,
         rsvp_enabled=True,

--- a/backend/community/_attendance_import_schemas.py
+++ b/backend/community/_attendance_import_schemas.py
@@ -38,6 +38,7 @@ class AttendanceImportCommitIn(BaseModel):
     event_id: str | None = None
     event_title: str | None = None
     event_date: date | None = None
+    event_type: str | None = None
     rows: list[ImportRowResolutionIn]
 
 

--- a/backend/community/_validation.py
+++ b/backend/community/_validation.py
@@ -181,6 +181,7 @@ class Code:
         CSV_EMPTY = "attendance_import.csv_empty"
         CSV_MALFORMED = "attendance_import.csv_malformed"
         EVENT_OR_TITLE_REQUIRED = "attendance_import.event_or_title_required"
+        INVALID_EVENT_TYPE = "attendance_import.invalid_event_type"
         AMBIGUOUS_USER_PICK = "attendance_import.ambiguous_user_pick"  # params: { row_index: int }
 
     class Perm:

--- a/backend/community/validation_codes.json
+++ b/backend/community/validation_codes.json
@@ -760,6 +760,11 @@
         "params": []
       },
       {
+        "name": "INVALID_EVENT_TYPE",
+        "value": "attendance_import.invalid_event_type",
+        "params": []
+      },
+      {
         "name": "AMBIGUOUS_USER_PICK",
         "value": "attendance_import.ambiguous_user_pick",
         "params": [

--- a/backend/openapi_schema.json
+++ b/backend/openapi_schema.json
@@ -147,6 +147,17 @@
             ],
             "title": "Event Title"
           },
+          "event_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Event Type"
+          },
           "rows": {
             "items": {
               "$ref": "#/components/schemas/ImportRowResolutionIn"

--- a/backend/tests/test_attendance_import.py
+++ b/backend/tests/test_attendance_import.py
@@ -1,5 +1,5 @@
 import pytest
-from community.models import AttendanceStatus, Event, EventRSVP, RSVPStatus
+from community.models import AttendanceStatus, Event, EventRSVP, EventType, RSVPStatus
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils import timezone
 from ninja_jwt.tokens import RefreshToken
@@ -338,6 +338,54 @@ class TestCommitEndpoint:
         event = Event.objects.get(id=body["event_id"])
         assert event.title == "Legacy Mixer"
         assert EventRSVP.objects.filter(event=event, user=alice).exists()
+
+    def test_defaults_to_community_event_type(self, api_client, events_admin, alice):
+        response = api_client.post(
+            "/api/community/events/attendance-import/commit/",
+            {
+                "event_title": "Legacy Mixer",
+                "event_date": "2025-06-13",
+                "rows": [self._row(user_id=str(alice.id), checked_in=True)],
+            },
+            content_type="application/json",
+            **_auth(events_admin),
+        )
+        event = Event.objects.get(id=response.json()["event_id"])
+        assert event.event_type == EventType.COMMUNITY
+
+    @pytest.mark.parametrize("event_type", [EventType.OFFICIAL, EventType.CLUB])
+    def test_creates_event_with_requested_qualifying_type(
+        self, api_client, events_admin, alice, event_type
+    ):
+        response = api_client.post(
+            "/api/community/events/attendance-import/commit/",
+            {
+                "event_title": "Club Mixer",
+                "event_date": "2025-06-13",
+                "event_type": event_type,
+                "rows": [self._row(user_id=str(alice.id), checked_in=True)],
+            },
+            content_type="application/json",
+            **_auth(events_admin),
+        )
+        assert response.status_code == 200
+        event = Event.objects.get(id=response.json()["event_id"])
+        assert event.event_type == event_type
+
+    def test_invalid_event_type_rejected(self, api_client, events_admin, alice):
+        response = api_client.post(
+            "/api/community/events/attendance-import/commit/",
+            {
+                "event_title": "Legacy Mixer",
+                "event_date": "2025-06-13",
+                "event_type": "not_a_real_type",
+                "rows": [self._row(user_id=str(alice.id), checked_in=True)],
+            },
+            content_type="application/json",
+            **_auth(events_admin),
+        )
+        assert response.status_code == 400
+        assert response.json()["detail"][0]["code"] == "attendance_import.invalid_event_type"
 
     def test_missing_event_and_title_rejected(self, api_client, events_admin, alice):
         response = api_client.post(

--- a/frontend/src/api/attendanceImport.ts
+++ b/frontend/src/api/attendanceImport.ts
@@ -133,6 +133,7 @@ export interface CommitAttendanceImportInput {
   eventId?: string;
   eventTitle?: string;
   eventDate?: string;
+  eventType?: string;
   rows: RowResolution[];
 }
 
@@ -154,6 +155,7 @@ export function useCommitAttendanceImport() {
           event_id: input.eventId,
           event_title: input.eventTitle,
           event_date: input.eventDate,
+          event_type: input.eventType,
           rows: input.rows.map((r) => ({
             row_index: r.rowIndex,
             raw_name: r.rawName,

--- a/frontend/src/api/types.gen.ts
+++ b/frontend/src/api/types.gen.ts
@@ -2152,6 +2152,8 @@ export interface components {
             event_id?: string | null;
             /** Event Title */
             event_title?: string | null;
+            /** Event Type */
+            event_type?: string | null;
             /** Rows */
             rows: components["schemas"]["ImportRowResolutionIn"][];
         };

--- a/frontend/src/api/validationCodes.gen.ts
+++ b/frontend/src/api/validationCodes.gen.ts
@@ -177,6 +177,7 @@ export const Code = {
     CsvEmpty: 'attendance_import.csv_empty',
     CsvMalformed: 'attendance_import.csv_malformed',
     EventOrTitleRequired: 'attendance_import.event_or_title_required',
+    InvalidEventType: 'attendance_import.invalid_event_type',
     AmbiguousUserPick: 'attendance_import.ambiguous_user_pick',
   },
   Perm: {
@@ -370,6 +371,7 @@ export type ValidationCode =
   | 'attendance_import.csv_empty'
   | 'attendance_import.csv_malformed'
   | 'attendance_import.event_or_title_required'
+  | 'attendance_import.invalid_event_type'
   | 'attendance_import.ambiguous_user_pick'
   | 'perm.denied'
   | 'rate.limited'
@@ -535,6 +537,7 @@ export const CODE_PARAMS: Record<ValidationCode, readonly string[]> = {
   'attendance_import.csv_empty': [],
   'attendance_import.csv_malformed': [],
   'attendance_import.event_or_title_required': [],
+  'attendance_import.invalid_event_type': [],
   'attendance_import.ambiguous_user_pick': ['row_index'],
   'perm.denied': ['action'],
   'rate.limited': [],

--- a/frontend/src/api/validationCodes.ts
+++ b/frontend/src/api/validationCodes.ts
@@ -404,6 +404,8 @@ function messageForKnownCode(code: KnownCode, err: FieldError): string {
       return "couldn't read that csv — make sure it's the raw partiful export";
     case Code.AttendanceImport.EventOrTitleRequired:
       return 'pick an existing event or give the new event a name and date';
+    case Code.AttendanceImport.InvalidEventType:
+      return 'pick official or club for the new event';
     case Code.AttendanceImport.AmbiguousUserPick:
       return 'pick a member for that row before continuing';
 

--- a/frontend/src/screens/admin/AttendanceImportEventStep.tsx
+++ b/frontend/src/screens/admin/AttendanceImportEventStep.tsx
@@ -4,11 +4,14 @@ import { useState } from 'react';
 import { type EventOption, useAttendanceImportEventOptions } from '@/api/attendanceImport';
 import { Button } from '@/components/ui/Button';
 import { TextField } from '@/components/ui/TextField';
+import { Toggle } from '@/components/ui/Toggle';
+import { EventType } from '@/models/event';
 
 export interface EventTarget {
   eventId?: string;
   eventTitle?: string;
   eventDate?: string;
+  eventType?: (typeof EventType)[keyof typeof EventType];
 }
 
 interface Props {
@@ -20,6 +23,9 @@ export function AttendanceImportEventStep({ onNext }: Props) {
   const [query, setQuery] = useState('');
   const [newTitle, setNewTitle] = useState('');
   const [newDate, setNewDate] = useState('');
+  const [newEventType, setNewEventType] = useState<(typeof EventType)[keyof typeof EventType]>(
+    EventType.Community,
+  );
   const { data: options = [] } = useAttendanceImportEventOptions(query);
 
   return (
@@ -60,10 +66,12 @@ export function AttendanceImportEventStep({ onNext }: Props) {
         <NewEventFields
           title={newTitle}
           date={newDate}
+          eventType={newEventType}
           onTitleChange={setNewTitle}
           onDateChange={setNewDate}
+          onEventTypeChange={setNewEventType}
           onNext={() => {
-            onNext({ eventTitle: newTitle, eventDate: newDate });
+            onNext({ eventTitle: newTitle, eventDate: newDate, eventType: newEventType });
           }}
         />
       )}
@@ -145,14 +153,18 @@ function ExistingEventPicker({
 function NewEventFields({
   title,
   date,
+  eventType,
   onTitleChange,
   onDateChange,
+  onEventTypeChange,
   onNext,
 }: {
   title: string;
   date: string;
+  eventType: (typeof EventType)[keyof typeof EventType];
   onTitleChange: (v: string) => void;
   onDateChange: (v: string) => void;
+  onEventTypeChange: (v: (typeof EventType)[keyof typeof EventType]) => void;
   onNext: () => void;
 }) {
   return (
@@ -173,6 +185,22 @@ function NewEventFields({
           onDateChange(e.target.value);
         }}
       />
+      <div className="flex flex-col gap-1">
+        <Toggle
+          label="official pda event"
+          checked={eventType === EventType.Official}
+          onChange={(checked) => {
+            onEventTypeChange(checked ? EventType.Official : EventType.Community);
+          }}
+        />
+        <Toggle
+          label="pda club event"
+          checked={eventType === EventType.Club}
+          onChange={(checked) => {
+            onEventTypeChange(checked ? EventType.Club : EventType.Community);
+          }}
+        />
+      </div>
       <Button disabled={!title.trim() || !date} onClick={onNext}>
         continue
       </Button>


### PR DESCRIPTION
## Overview

Partiful CSV attendance imports that created a new event always tagged it `event_type=community`, which never counts toward a member's qualifying-event stats (only `official` and `club` events qualify). Adds an official/club toggle to the "new event" step of the import flow so imported attendance can count the same as manually-tracked attendance, per the reporter's request.

- Backend: `event_type` accepted on the import commit payload, validated to `official`/`club`/`community`, used when creating the event (defaults to `community` for backward compat).
- Frontend: two toggles (official / club) on the new-event step of `AttendanceImportDialog`.

## Test plan

- [x] `make agent-frontend-typecheck` — passes
- [x] `make agent-frontend-lint` — passes
- [x] `make agent-typecheck` — passes
- [x] `make agent-lint` — passes
- [x] `make agent-complexity` — passes
- [x] Backend: `pytest backend/tests/test_attendance_import.py` — 28 passed (4 new tests covering default type, official/club creation, and invalid-type rejection)
- [x] Frontend: `make agent-frontend-test` — 143 files / 1180 tests passed
- [ ] Manual check in browser (TODO)

Closes #1354
