### PR TITLE
fix(seed): recreate join form questions in seed_staging

### DIFF
--- a/backend/community/management/commands/_seed_data.py
+++ b/backend/community/management/commands/_seed_data.py
@@ -7,10 +7,11 @@ from community.models.choices import (
     AttendanceStatus,
     EventType,
     JoinFormQuestionType,
+    RsvpQuestionType,
     RSVPStatus,
 )
 
-from ._seed_shared import SeedEvent
+from ._seed_shared import SeedEvent, SeedRsvpQuestion
 
 PASSWORD = "testpass123"
 
@@ -43,6 +44,7 @@ class SeedRSVP:
 
     `attendance` only applies to attending RSVPs on a past / in-check-in-window
     event — mirroring the API, which rejects attendance on non-attending RSVPs.
+    `answers` is an explicit label→answer map for that event's RSVP questions.
     """
 
     event_title: str
@@ -50,6 +52,7 @@ class SeedRSVP:
     status: str
     has_plus_one: bool = False
     attendance: str = AttendanceStatus.UNKNOWN
+    answers: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -229,6 +232,27 @@ SEED_NON_MEMBERS = [
     ),
 ]
 
+_TRAVEL_Q = "How are you getting there?"
+_NOTES_Q = "Anything we should know?"
+
+SEED_EVENT_RSVP_QUESTIONS: dict[str, list[SeedRsvpQuestion]] = {
+    "Plant-Based Cooking Workshop": [
+        SeedRsvpQuestion(
+            label=_TRAVEL_Q,
+            field_type=RsvpQuestionType.SELECT,
+            options=["driving", "transit", "bike"],
+            required=True,
+            display_order=0,
+        ),
+        SeedRsvpQuestion(
+            label=_NOTES_Q,
+            field_type=RsvpQuestionType.TEXTAREA,
+            required=False,
+            display_order=1,
+        ),
+    ],
+}
+
 SEED_RSVPS = [
     # Vegan Potluck — max_attendees=3. Admin +1 (2 spots) and Member (1 spot)
     # fill it, so the rest sit on the FIFO waitlist (ordered by insertion below).
@@ -237,9 +261,23 @@ SEED_RSVPS = [
     SeedRSVP("Vegan Potluck", _JAMIE, RSVPStatus.WAITLISTED),
     SeedRSVP("Vegan Potluck", _RIN, RSVPStatus.WAITLISTED),
     SeedRSVP("Vegan Potluck", _ASH, RSVPStatus.MAYBE),
-    # Plant-Based Cooking Workshop — uncapped, mixed statuses.
-    SeedRSVP("Plant-Based Cooking Workshop", _MEMBER, RSVPStatus.ATTENDING, has_plus_one=True),
-    SeedRSVP("Plant-Based Cooking Workshop", _JAMIE, RSVPStatus.ATTENDING),
+    # Plant-Based Cooking Workshop — uncapped, mixed statuses + questionnaire coverage.
+    SeedRSVP(
+        "Plant-Based Cooking Workshop",
+        _MEMBER,
+        RSVPStatus.ATTENDING,
+        has_plus_one=True,
+        answers={
+            _TRAVEL_Q: "transit",
+            _NOTES_Q: "Nut allergy — please avoid shared utensils.",
+        },
+    ),
+    SeedRSVP(
+        "Plant-Based Cooking Workshop",
+        _JAMIE,
+        RSVPStatus.ATTENDING,
+        answers={_TRAVEL_Q: "bike"},
+    ),
     SeedRSVP("Plant-Based Cooking Workshop", _RIN, RSVPStatus.MAYBE),
     SeedRSVP("Plant-Based Cooking Workshop", _ASH, RSVPStatus.CANT_GO),
     # Past Potluck — attendance marked (attended / no_show) on attending RSVPs.

--- a/backend/community/management/commands/_seed_join_requests.py
+++ b/backend/community/management/commands/_seed_join_requests.py
@@ -1,4 +1,4 @@
-"""Join request seeding for the `seed_staging` command."""
+"""Join form question + join request seeding for staging (and shared helpers)."""
 
 from datetime import timedelta
 
@@ -7,11 +7,33 @@ from users.models import User
 
 from community.models import JoinFormQuestion, JoinRequest, JoinRequestStatus
 
+from ._seed_data import SEED_JOIN_FORM_QUESTIONS
 from ._seed_staging_data import JOIN_REQUEST_SPECS, joinreq_email, joinreq_phone
 
 
 def reset_join_requests() -> None:
     JoinRequest.objects.filter(phone_number__startswith="+170255504").delete()
+
+
+def seed_join_form_questions(stdout) -> dict[str, JoinFormQuestion]:
+    """Ensure default join form questions exist. Returns label→question mapping."""
+    questions: dict[str, JoinFormQuestion] = {}
+    for data in SEED_JOIN_FORM_QUESTIONS:
+        question, created = JoinFormQuestion.objects.get_or_create(
+            label=data.label,
+            defaults={
+                "field_type": data.field_type,
+                "required": data.required,
+                "options": data.options,
+                "display_order": data.display_order,
+            },
+        )
+        if not created and question.field_type != data.field_type:
+            question.field_type = data.field_type
+            question.save(update_fields=["field_type"])
+        stdout.write(f"  {'created' if created else 'exists'} question: {question.label}")
+        questions[question.label] = question
+    return questions
 
 
 def _custom_answers(spec) -> dict:
@@ -34,13 +56,14 @@ def seed_join_requests(stdout, reviewer: User | None) -> list[JoinRequest]:
     requests: list[JoinRequest] = []
     for index, spec in enumerate(JOIN_REQUEST_SPECS):
         submitted_at = now - timedelta(days=spec.days_ago)
+        answers = _custom_answers(spec)
         join_request, created = JoinRequest.objects.get_or_create(
             phone_number=joinreq_phone(index),
             defaults={
                 "first_name": spec.first_name,
                 "last_name": spec.last_name,
                 "email": joinreq_email(index) if spec.has_email else "",
-                "custom_answers": _custom_answers(spec),
+                "custom_answers": answers,
                 "status": spec.status,
                 "sms_consent_at": submitted_at,
                 "guidelines_consent_at": submitted_at,
@@ -49,6 +72,9 @@ def seed_join_requests(stdout, reviewer: User | None) -> list[JoinRequest]:
         )
         if created:
             JoinRequest.objects.filter(pk=join_request.pk).update(submitted_at=submitted_at)
+        elif not join_request.custom_answers and answers:
+            join_request.custom_answers = answers
+            join_request.save(update_fields=["custom_answers"])
         requests.append(join_request)
         stdout.write(
             f"  {'created' if created else 'exists'} join request: {join_request.full_name}"

--- a/backend/community/management/commands/_seed_join_requests.py
+++ b/backend/community/management/commands/_seed_join_requests.py
@@ -8,7 +8,7 @@ from users.models import User
 from community.models import JoinFormQuestion, JoinRequest, JoinRequestStatus
 
 from ._seed_data import SEED_JOIN_FORM_QUESTIONS
-from ._seed_staging_data import JOIN_REQUEST_SPECS, joinreq_email, joinreq_phone
+from ._seed_staging_data import JOIN_REQUEST_SPECS, JoinRequestSpec, joinreq_email, joinreq_phone
 
 
 def reset_join_requests() -> None:
@@ -36,25 +36,11 @@ def seed_join_form_questions(stdout) -> dict[str, JoinFormQuestion]:
     return questions
 
 
-def _answer_for_question(spec, question: JoinFormQuestion) -> str:
-    label = question.label.lower()
-    if question.required or "why" in label:
-        return spec.answer
-    if "pronoun" in label:
-        return spec.pronouns
-    if "hear" in label:
-        return "A friend" if "friend" in spec.answer.lower() else "Instagram"
-    return "doing well"
-
-
-def _custom_answers(spec) -> dict:
-    """Snapshot one answer per current join-form question for staging fixtures."""
+def _custom_answers(spec: JoinRequestSpec, questions_by_label: dict[str, JoinFormQuestion]) -> dict:
+    """Map each seeded answer onto the matching join-form question by label."""
     return {
-        str(question.id): {
-            "label": question.label,
-            "answer": _answer_for_question(spec, question),
-        }
-        for question in JoinFormQuestion.objects.order_by("display_order")
+        str(questions_by_label[label].id): {"label": label, "answer": answer}
+        for label, answer in spec.answers.items()
     }
 
 
@@ -66,12 +52,16 @@ def _reviewer_fields(spec, reviewer: User | None, submitted_at) -> dict:
     return {}
 
 
-def seed_join_requests(stdout, reviewer: User | None) -> list[JoinRequest]:
+def seed_join_requests(
+    stdout,
+    reviewer: User | None,
+    questions_by_label: dict[str, JoinFormQuestion],
+) -> list[JoinRequest]:
     now = timezone.now()
     requests: list[JoinRequest] = []
     for index, spec in enumerate(JOIN_REQUEST_SPECS):
         submitted_at = now - timedelta(days=spec.days_ago)
-        answers = _custom_answers(spec)
+        answers = _custom_answers(spec, questions_by_label)
         join_request, created = JoinRequest.objects.get_or_create(
             phone_number=joinreq_phone(index),
             defaults={

--- a/backend/community/management/commands/_seed_join_requests.py
+++ b/backend/community/management/commands/_seed_join_requests.py
@@ -36,11 +36,26 @@ def seed_join_form_questions(stdout) -> dict[str, JoinFormQuestion]:
     return questions
 
 
+def _answer_for_question(spec, question: JoinFormQuestion) -> str:
+    label = question.label.lower()
+    if question.required or "why" in label:
+        return spec.answer
+    if "pronoun" in label:
+        return spec.pronouns
+    if "hear" in label:
+        return "A friend" if "friend" in spec.answer.lower() else "Instagram"
+    return "doing well"
+
+
 def _custom_answers(spec) -> dict:
-    question = JoinFormQuestion.objects.filter(required=True).first()
-    if question is None:
-        return {}
-    return {str(question.id): {"label": question.label, "answer": spec.answer}}
+    """Snapshot one answer per current join-form question for staging fixtures."""
+    return {
+        str(question.id): {
+            "label": question.label,
+            "answer": _answer_for_question(spec, question),
+        }
+        for question in JoinFormQuestion.objects.order_by("display_order")
+    }
 
 
 def _reviewer_fields(spec, reviewer: User | None, submitted_at) -> dict:
@@ -72,7 +87,7 @@ def seed_join_requests(stdout, reviewer: User | None) -> list[JoinRequest]:
         )
         if created:
             JoinRequest.objects.filter(pk=join_request.pk).update(submitted_at=submitted_at)
-        elif not join_request.custom_answers and answers:
+        elif join_request.custom_answers != answers:
             join_request.custom_answers = answers
             join_request.save(update_fields=["custom_answers"])
         requests.append(join_request)

--- a/backend/community/management/commands/_seed_shared.py
+++ b/backend/community/management/commands/_seed_shared.py
@@ -1,11 +1,11 @@
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import timedelta
 
 from django.utils import timezone
 from users.models import User
 from users.roles import Role
 
-from community.models import Event, EventRSVP, EventType, PageVisibility
+from community.models import Event, EventRSVP, EventRsvpQuestion, EventType, PageVisibility
 
 
 @dataclass
@@ -20,6 +20,15 @@ class SeedEvent:
     rsvp_enabled: bool = False
     allow_plus_ones: bool = False
     max_attendees: int | None = None
+
+
+@dataclass
+class SeedRsvpQuestion:
+    label: str
+    field_type: str
+    options: list[str] = field(default_factory=list)
+    required: bool = False
+    display_order: int = 0
 
 
 def seed_events(stdout, events: list[SeedEvent], created_by: User | None) -> dict[str, Event]:
@@ -67,3 +76,49 @@ def apply_rsvp(event: Event, user: User, defaults: dict, *, overwrite: bool = Fa
         EventRSVP.objects.update_or_create(event=event, user=user, defaults=defaults)
     else:
         EventRSVP.objects.get_or_create(event=event, user=user, defaults=defaults)
+
+
+def _sync_seed_rsvp_question(question: EventRsvpQuestion, data: SeedRsvpQuestion) -> None:
+    updates: list[str] = []
+    for attr in ("field_type", "options", "required", "display_order"):
+        value = getattr(data, attr)
+        if getattr(question, attr) != value:
+            setattr(question, attr, value)
+            updates.append(attr)
+    if updates:
+        question.save(update_fields=updates)
+
+
+def seed_event_rsvp_questions(
+    stdout, event: Event, specs: list[SeedRsvpQuestion]
+) -> dict[str, EventRsvpQuestion]:
+    """Ensure RSVP questions exist on an event. Returns label→question mapping."""
+    questions: dict[str, EventRsvpQuestion] = {}
+    for data in specs:
+        question, created = EventRsvpQuestion.objects.get_or_create(
+            event=event,
+            label=data.label,
+            defaults={
+                "field_type": data.field_type,
+                "options": data.options,
+                "required": data.required,
+                "display_order": data.display_order,
+            },
+        )
+        if not created:
+            _sync_seed_rsvp_question(question, data)
+        stdout.write(
+            f"  {'created' if created else 'exists'} rsvp question: {event.title} / {question.label}"
+        )
+        questions[question.label] = question
+    return questions
+
+
+def questionnaire_snapshot(
+    questions_by_label: dict[str, EventRsvpQuestion], answers: dict[str, str]
+) -> dict:
+    """Build {question_id: {label, answer}} from explicit label→answer pairs."""
+    return {
+        str(questions_by_label[label].id): {"label": label, "answer": answer}
+        for label, answer in answers.items()
+    }

--- a/backend/community/management/commands/_seed_staging_data.py
+++ b/backend/community/management/commands/_seed_staging_data.py
@@ -2,13 +2,7 @@
 
 from dataclasses import dataclass
 
-from community.models.choices import (
-    AttendanceStatus,
-    EventType,
-    JoinRequestStatus,
-    PageVisibility,
-    RSVPStatus,
-)
+from community.models.choices import EventType, JoinRequestStatus, PageVisibility
 
 from ._seed_shared import SeedEvent
 
@@ -247,81 +241,6 @@ STAGING_EVENTS = [
         rsvp_enabled=True,
         max_attendees=2,
     ),
-]
-
-
-# Non-member manage-token lifecycle states, controlling what the seed leaves behind.
-TOKEN_VALID = "valid"
-TOKEN_EXPIRED = "expired"
-TOKEN_NONE = "none"
-
-
-_ATTENDED = AttendanceStatus.ATTENDED
-_NO_SHOW = AttendanceStatus.DIDNT_GO
-
-
-@dataclass
-class RsvpOnEvent:
-    """One RSVP row a seeded user should hold on a named event."""
-
-    event_title: str
-    status: str
-    attendance: str = AttendanceStatus.UNKNOWN
-
-
-def _rsvps(*rows: tuple) -> list[RsvpOnEvent]:
-    """Build RsvpOnEvent rows from compact (title, status[, attendance]) tuples."""
-    return [RsvpOnEvent(*row) for row in rows]
-
-
-_A, _M, _C, _W = RSVPStatus.ATTENDING, RSVPStatus.MAYBE, RSVPStatus.CANT_GO, RSVPStatus.WAITLISTED
-
-
-@dataclass
-class MemberRsvpSpec:
-    """RSVPs to attach to the condition member at ``cond_index``."""
-
-    cond_index: int
-    rsvps: list[RsvpOnEvent]
-
-
-# Members across every RSVP state on the official events; the past event carries
-# attendance marks so the attendance report shows a non-trivial member/non-member mix.
-MEMBER_RSVP_SPECS = [
-    MemberRsvpSpec(0, _rsvps((OFFICIAL_PAST_TITLE, _A, _ATTENDED), (OFFICIAL_TODAY_TITLE, _A))),
-    MemberRsvpSpec(1, _rsvps((OFFICIAL_PAST_TITLE, _A, _NO_SHOW), (OFFICIAL_TODAY_TITLE, _M))),
-    MemberRsvpSpec(2, _rsvps((OFFICIAL_PAST_TITLE, _M), (OFFICIAL_TODAY_TITLE, _C))),
-    MemberRsvpSpec(3, _rsvps((OFFICIAL_PAST_TITLE, _A, _ATTENDED), (OFFICIAL_FULL_TITLE, _A))),
-    MemberRsvpSpec(4, _rsvps((OFFICIAL_FULL_TITLE, _A))),
-    MemberRsvpSpec(5, _rsvps((OFFICIAL_FULL_TITLE, _W))),
-]
-
-
-@dataclass
-class NonMemberSpec:
-    label: str
-    rsvps: list[RsvpOnEvent]
-    has_email: bool = True
-    token_state: str = TOKEN_VALID
-
-
-NON_MEMBER_SPECS = [
-    NonMemberSpec("attending (valid token, email)", _rsvps((NON_MEMBER_EVENT_TITLE, _A))),
-    NonMemberSpec(
-        "maybe (valid token, no email)", _rsvps((NON_MEMBER_EVENT_TITLE, _M)), has_email=False
-    ),
-    NonMemberSpec(
-        "can't-go (expired token)",
-        _rsvps((NON_MEMBER_EVENT_TITLE, _C)),
-        token_state=TOKEN_EXPIRED,
-    ),
-    NonMemberSpec(
-        "multi-event attended (past + today)",
-        _rsvps((OFFICIAL_PAST_TITLE, _A, _ATTENDED), (OFFICIAL_TODAY_TITLE, _A)),
-    ),
-    NonMemberSpec("past no-show (attendance report)", _rsvps((OFFICIAL_PAST_TITLE, _A, _NO_SHOW))),
-    NonMemberSpec("waitlisted at capacity", _rsvps((OFFICIAL_FULL_TITLE, _W))),
-    NonMemberSpec("no-rsvp (no token)", [], token_state=TOKEN_NONE),
 ]
 
 

--- a/backend/community/management/commands/_seed_staging_data.py
+++ b/backend/community/management/commands/_seed_staging_data.py
@@ -329,111 +329,155 @@ NON_MEMBER_SPECS = [
 class JoinRequestSpec:
     first_name: str
     last_name: str
-    pronouns: str
     has_email: bool
     status: str
     days_ago: int
-    answer: str
+    answers: dict[str, str]
 
 
 JOIN_REQUEST_SPECS = [
     JoinRequestSpec(
-        "Sage",
-        "Blackwood",
-        "they/them",
-        True,
-        JoinRequestStatus.PENDING,
-        0,
-        "I've been vegan for three years and want to connect with a local community.",
+        first_name="Sage",
+        last_name="Blackwood",
+        has_email=True,
+        status=JoinRequestStatus.PENDING,
+        days_ago=0,
+        answers={
+            "Why do you want to join?": (
+                "I've been vegan for three years and want to connect with a local community."
+            ),
+            "How did you hear about us?": "Instagram",
+            "What are your pronouns?": "they/them",
+        },
     ),
     JoinRequestSpec(
-        "Rowan",
-        "Ashfield",
-        "she/her",
-        True,
-        JoinRequestStatus.PENDING,
-        1,
-        "Looking for like-minded folks to organize with on animal liberation.",
+        first_name="Rowan",
+        last_name="Ashfield",
+        has_email=True,
+        status=JoinRequestStatus.PENDING,
+        days_ago=1,
+        answers={
+            "Why do you want to join?": (
+                "Looking for like-minded folks to organize with on animal liberation."
+            ),
+            "How did you hear about us?": "A friend",
+            "What are your pronouns?": "she/her",
+        },
     ),
     JoinRequestSpec(
-        "Fern",
-        "Whitaker",
-        "he/him",
-        False,
-        JoinRequestStatus.PENDING,
-        2,
-        "A friend recommended this group after I went vegan last month.",
+        first_name="Fern",
+        last_name="Whitaker",
+        has_email=False,
+        status=JoinRequestStatus.PENDING,
+        days_ago=2,
+        answers={
+            "Why do you want to join?": (
+                "A friend recommended this group after I went vegan last month."
+            ),
+            "How did you hear about us?": "A friend",
+            "What are your pronouns?": "he/him",
+        },
     ),
     JoinRequestSpec(
-        "River",
-        "Okafor",
-        "they/them",
-        True,
-        JoinRequestStatus.PENDING,
-        3,
-        "I want to volunteer at events and help with outreach.",
+        first_name="River",
+        last_name="Okafor",
+        has_email=True,
+        status=JoinRequestStatus.PENDING,
+        days_ago=3,
+        answers={
+            "Why do you want to join?": "I want to volunteer at events and help with outreach.",
+            "How did you hear about us?": "Flyer",
+            "What are your pronouns?": "they/them",
+        },
     ),
     JoinRequestSpec(
-        "Wren",
-        "Castellano",
-        "she/her",
-        True,
-        JoinRequestStatus.PENDING,
-        5,
-        "Interested in the intersection of veganism and collective liberation.",
+        first_name="Wren",
+        last_name="Castellano",
+        has_email=True,
+        status=JoinRequestStatus.PENDING,
+        days_ago=5,
+        answers={
+            "Why do you want to join?": (
+                "Interested in the intersection of veganism and collective liberation."
+            ),
+            "How did you hear about us?": "Instagram",
+            "What are your pronouns?": "she/her",
+        },
     ),
     JoinRequestSpec(
-        "Ash",
-        "Delgado",
-        "he/him",
-        False,
-        JoinRequestStatus.PENDING,
-        8,
-        "New to the area and looking for community.",
+        first_name="Ash",
+        last_name="Delgado",
+        has_email=False,
+        status=JoinRequestStatus.PENDING,
+        days_ago=8,
+        answers={
+            "Why do you want to join?": "New to the area and looking for community.",
+            "How did you hear about us?": "Meetup",
+            "What are your pronouns?": "he/him",
+        },
     ),
     JoinRequestSpec(
-        "Juniper",
-        "Osei",
-        "they/them",
-        True,
-        JoinRequestStatus.APPROVED,
-        14,
-        "Been following the group's work for a while and finally ready to join.",
+        first_name="Juniper",
+        last_name="Osei",
+        has_email=True,
+        status=JoinRequestStatus.APPROVED,
+        days_ago=14,
+        answers={
+            "Why do you want to join?": (
+                "Been following the group's work for a while and finally ready to join."
+            ),
+            "How did you hear about us?": "Instagram",
+            "What are your pronouns?": "they/them",
+        },
     ),
     JoinRequestSpec(
-        "Marlowe",
-        "Fontaine",
-        "she/her",
-        True,
-        JoinRequestStatus.APPROVED,
-        20,
-        "A member invited me after a potluck.",
+        first_name="Marlowe",
+        last_name="Fontaine",
+        has_email=True,
+        status=JoinRequestStatus.APPROVED,
+        days_ago=20,
+        answers={
+            "Why do you want to join?": "A member invited me after a potluck.",
+            "How did you hear about us?": "A member",
+            "What are your pronouns?": "she/her",
+        },
     ),
     JoinRequestSpec(
-        "Briar",
-        "Nakamura",
-        "he/him",
-        True,
-        JoinRequestStatus.APPROVED,
-        30,
-        "I run a plant-based cooking blog and want to get more involved locally.",
+        first_name="Briar",
+        last_name="Nakamura",
+        has_email=True,
+        status=JoinRequestStatus.APPROVED,
+        days_ago=30,
+        answers={
+            "Why do you want to join?": (
+                "I run a plant-based cooking blog and want to get more involved locally."
+            ),
+            "How did you hear about us?": "Website",
+            "What are your pronouns?": "he/him",
+        },
     ),
     JoinRequestSpec(
-        "Sparrow",
-        "Reyes",
-        "they/them",
-        False,
-        JoinRequestStatus.REJECTED,
-        12,
-        "Just filling out the form to see what happens.",
+        first_name="Sparrow",
+        last_name="Reyes",
+        has_email=False,
+        status=JoinRequestStatus.REJECTED,
+        days_ago=12,
+        answers={
+            "Why do you want to join?": "Just filling out the form to see what happens.",
+            "How did you hear about us?": "Google",
+            "What are your pronouns?": "they/them",
+        },
     ),
     JoinRequestSpec(
-        "Indigo",
-        "Marchetti",
-        "she/her",
-        True,
-        JoinRequestStatus.REJECTED,
-        25,
-        "not really sure what this group does but sure",
+        first_name="Indigo",
+        last_name="Marchetti",
+        has_email=True,
+        status=JoinRequestStatus.REJECTED,
+        days_ago=25,
+        answers={
+            "Why do you want to join?": "not really sure what this group does but sure",
+            "How did you hear about us?": "TikTok",
+            "What are your pronouns?": "she/her",
+        },
     ),
 ]

--- a/backend/community/management/commands/_seed_staging_rsvps.py
+++ b/backend/community/management/commands/_seed_staging_rsvps.py
@@ -1,0 +1,121 @@
+"""RSVP fixtures for the `seed_staging` command."""
+
+from dataclasses import dataclass, field
+
+from community.models.choices import AttendanceStatus, RsvpQuestionType, RSVPStatus
+
+from ._seed_shared import SeedRsvpQuestion
+from ._seed_staging_data import (
+    NON_MEMBER_EVENT_TITLE,
+    OFFICIAL_FULL_TITLE,
+    OFFICIAL_PAST_TITLE,
+    OFFICIAL_TODAY_TITLE,
+)
+
+TOKEN_VALID = "valid"
+TOKEN_EXPIRED = "expired"
+TOKEN_NONE = "none"
+
+_ATTENDED = AttendanceStatus.ATTENDED
+_NO_SHOW = AttendanceStatus.DIDNT_GO
+_A, _M, _C, _W = RSVPStatus.ATTENDING, RSVPStatus.MAYBE, RSVPStatus.CANT_GO, RSVPStatus.WAITLISTED
+_TRAVEL_Q = "How are you getting there?"
+_NOTES_Q = "Anything we should know?"
+
+
+@dataclass
+class RsvpOnEvent:
+    """One RSVP row a seeded user should hold on a named event."""
+
+    event_title: str
+    status: str
+    attendance: str = AttendanceStatus.UNKNOWN
+    answers: dict[str, str] = field(default_factory=dict)
+
+
+def _rsvps(*rows: tuple) -> list[RsvpOnEvent]:
+    """Build RsvpOnEvent rows from (title, status[, attendance][, answers])."""
+    result: list[RsvpOnEvent] = []
+    for row in rows:
+        if row and isinstance(row[-1], dict):
+            *head, answers = row
+            result.append(RsvpOnEvent(*head, answers=answers))
+        else:
+            result.append(RsvpOnEvent(*row))
+    return result
+
+
+STAGING_EVENT_RSVP_QUESTIONS: dict[str, list[SeedRsvpQuestion]] = {
+    OFFICIAL_TODAY_TITLE: [
+        SeedRsvpQuestion(
+            _TRAVEL_Q, RsvpQuestionType.SELECT, ["driving", "transit", "bike"], True, 0
+        ),
+        SeedRsvpQuestion(_NOTES_Q, RsvpQuestionType.TEXTAREA, display_order=1),
+    ],
+}
+
+
+@dataclass
+class MemberRsvpSpec:
+    """RSVPs to attach to the condition member at ``cond_index``."""
+
+    cond_index: int
+    rsvps: list[RsvpOnEvent]
+
+
+# Members across every RSVP state on the official events; the past event carries
+# attendance marks so the attendance report shows a non-trivial member/non-member mix.
+# OFFICIAL_TODAY also covers questionnaire complete / partial / empty answers.
+MEMBER_RSVP_SPECS = [
+    MemberRsvpSpec(
+        0,
+        _rsvps(
+            (OFFICIAL_PAST_TITLE, _A, _ATTENDED),
+            (
+                OFFICIAL_TODAY_TITLE,
+                _A,
+                {_TRAVEL_Q: "transit", _NOTES_Q: "Bringing a +1 who is gluten-free."},
+            ),
+        ),
+    ),
+    MemberRsvpSpec(
+        1,
+        _rsvps(
+            (OFFICIAL_PAST_TITLE, _A, _NO_SHOW),
+            (OFFICIAL_TODAY_TITLE, _A, {_TRAVEL_Q: "bike"}),
+        ),
+    ),
+    # Can't-go on today has no questionnaire — questions only apply when going.
+    MemberRsvpSpec(2, _rsvps((OFFICIAL_PAST_TITLE, _M), (OFFICIAL_TODAY_TITLE, _C))),
+    MemberRsvpSpec(3, _rsvps((OFFICIAL_PAST_TITLE, _A, _ATTENDED), (OFFICIAL_FULL_TITLE, _A))),
+    MemberRsvpSpec(4, _rsvps((OFFICIAL_FULL_TITLE, _A))),
+    MemberRsvpSpec(5, _rsvps((OFFICIAL_FULL_TITLE, _W))),
+]
+
+
+@dataclass
+class NonMemberSpec:
+    label: str
+    rsvps: list[RsvpOnEvent]
+    has_email: bool = True
+    token_state: str = TOKEN_VALID
+
+
+NON_MEMBER_SPECS = [
+    NonMemberSpec("attending (valid token, email)", _rsvps((NON_MEMBER_EVENT_TITLE, _A))),
+    NonMemberSpec(
+        "maybe (valid token, no email)", _rsvps((NON_MEMBER_EVENT_TITLE, _M)), has_email=False
+    ),
+    NonMemberSpec(
+        "can't-go (expired token)",
+        _rsvps((NON_MEMBER_EVENT_TITLE, _C)),
+        token_state=TOKEN_EXPIRED,
+    ),
+    NonMemberSpec(
+        "multi-event attended (past + today)",
+        _rsvps((OFFICIAL_PAST_TITLE, _A, _ATTENDED), (OFFICIAL_TODAY_TITLE, _A)),
+    ),
+    NonMemberSpec("past no-show (attendance report)", _rsvps((OFFICIAL_PAST_TITLE, _A, _NO_SHOW))),
+    NonMemberSpec("waitlisted at capacity", _rsvps((OFFICIAL_FULL_TITLE, _W))),
+    NonMemberSpec("no-rsvp (no token)", [], token_state=TOKEN_NONE),
+]

--- a/backend/community/management/commands/seed.py
+++ b/backend/community/management/commands/seed.py
@@ -11,6 +11,7 @@ from community.models.join_form import JoinFormQuestion
 
 from ._seed_data import (
     PASSWORD,
+    SEED_EVENT_RSVP_QUESTIONS,
     SEED_EVENTS,
     SEED_FAQ,
     SEED_GUIDELINES,
@@ -22,7 +23,13 @@ from ._seed_data import (
     SeedUser,
 )
 from ._seed_join_requests import seed_join_form_questions
-from ._seed_shared import apply_rsvp, get_or_create_seed_user, seed_events
+from ._seed_shared import (
+    apply_rsvp,
+    get_or_create_seed_user,
+    questionnaire_snapshot,
+    seed_event_rsvp_questions,
+    seed_events,
+)
 
 
 def _seed_singleton(model_cls, seed_data: dict, fields: tuple[str, ...], cmd: "Command") -> None:
@@ -46,7 +53,8 @@ class Command(BaseCommand):
         questions = self._seed_join_form_questions()
         self._seed_event_tags()
         events = self._seed_events(admin_user)
-        self._seed_rsvps(events)
+        rsvp_questions = self._seed_event_rsvp_questions(events)
+        self._seed_rsvps(events, rsvp_questions)
         self._seed_join_requests(questions, admin_user)
         self._seed_content()
         self._print_summary()
@@ -140,7 +148,18 @@ class Command(BaseCommand):
         """Seed events. Returns a title→Event mapping for RSVP seeding."""
         return seed_events(self.stdout, SEED_EVENTS, created_by)
 
-    def _seed_rsvps(self, events: dict[str, Event]) -> None:
+    def _seed_event_rsvp_questions(self, events: dict[str, Event]) -> dict[str, dict]:
+        """Seed RSVP questions on configured events. Returns title→label→question."""
+        by_event: dict[str, dict] = {}
+        for title, specs in SEED_EVENT_RSVP_QUESTIONS.items():
+            event = events.get(title)
+            if event is None:
+                self.stdout.write(f"  Skipped RSVP questions (missing event): {title}")
+                continue
+            by_event[title] = seed_event_rsvp_questions(self.stdout, event, specs)
+        return by_event
+
+    def _seed_rsvps(self, events: dict[str, Event], rsvp_questions: dict[str, dict]) -> None:
         """Seed RSVPs so the roster, waitlist, and stats panel are QA-able."""
         users = {
             u.phone_number: u for u in User.objects.filter(phone_number__startswith="+1702555")
@@ -153,15 +172,17 @@ class Command(BaseCommand):
                     f"  Skipped RSVP (missing event/user): {data.event_title} / {data.phone_number}"
                 )
                 continue
-            apply_rsvp(
-                event,
-                user,
-                {
-                    "status": data.status,
-                    "attendance": data.attendance,
-                    "has_plus_one": data.has_plus_one,
-                },
-            )
+            defaults: dict[str, object] = {
+                "status": data.status,
+                "attendance": data.attendance,
+                "has_plus_one": data.has_plus_one,
+            }
+            questions = rsvp_questions.get(data.event_title)
+            if questions is not None:
+                defaults["questionnaire_responses"] = questionnaire_snapshot(
+                    questions, data.answers
+                )
+            apply_rsvp(event, user, defaults)
             self.stdout.write(f"  RSVP: {user.full_name} → {data.event_title}")
 
     def _seed_join_requests(self, questions: dict[str, JoinFormQuestion], admin_user: User) -> None:

--- a/backend/community/management/commands/seed.py
+++ b/backend/community/management/commands/seed.py
@@ -15,13 +15,13 @@ from ._seed_data import (
     SEED_FAQ,
     SEED_GUIDELINES,
     SEED_HOME_PAGE,
-    SEED_JOIN_FORM_QUESTIONS,
     SEED_JOIN_REQUESTS,
     SEED_NON_MEMBERS,
     SEED_RSVPS,
     SEED_USERS,
     SeedUser,
 )
+from ._seed_join_requests import seed_join_form_questions
 from ._seed_shared import apply_rsvp, get_or_create_seed_user, seed_events
 
 
@@ -128,24 +128,7 @@ class Command(BaseCommand):
 
     def _seed_join_form_questions(self) -> dict[str, JoinFormQuestion]:
         """Seed default join form questions. Returns a label→question mapping."""
-        questions: dict[str, JoinFormQuestion] = {}
-        for data in SEED_JOIN_FORM_QUESTIONS:
-            q, created = JoinFormQuestion.objects.get_or_create(
-                label=data.label,
-                defaults={
-                    "field_type": data.field_type,
-                    "required": data.required,
-                    "options": data.options,
-                    "display_order": data.display_order,
-                },
-            )
-            if not created and q.field_type != data.field_type:
-                q.field_type = data.field_type
-                q.save(update_fields=["field_type"])
-            label = "Created" if created else "Already exists"
-            self.stdout.write(f"  {label} question: {q.label}")
-            questions[q.label] = q
-        return questions
+        return seed_join_form_questions(self.stdout)
 
     def _seed_event_tags(self) -> None:
         for name in ["walk", "restaurant meetup"]:

--- a/backend/community/management/commands/seed_staging.py
+++ b/backend/community/management/commands/seed_staging.py
@@ -15,16 +15,18 @@ from users.roles import Role
 from community.models import Event, EventType, RSVPStatus
 
 from ._seed_join_requests import reset_join_requests, seed_join_form_questions, seed_join_requests
-from ._seed_shared import apply_rsvp, get_or_create_seed_user, seed_events
+from ._seed_shared import (
+    apply_rsvp,
+    get_or_create_seed_user,
+    questionnaire_snapshot,
+    seed_event_rsvp_questions,
+    seed_events,
+)
 from ._seed_staging_data import (
-    MEMBER_RSVP_SPECS,
     NON_MEMBER_EVENT_TITLE,
-    NON_MEMBER_SPECS,
     PASSWORD,
     PRIVACY_SPECS,
     STAGING_EVENTS,
-    TOKEN_EXPIRED,
-    TOKEN_NONE,
     cond_email,
     cond_phone,
     condition_combinations,
@@ -37,6 +39,13 @@ from ._seed_staging_data import (
     privacy_phone,
     reset_member_email,
     reset_member_phone,
+)
+from ._seed_staging_rsvps import (
+    MEMBER_RSVP_SPECS,
+    NON_MEMBER_SPECS,
+    STAGING_EVENT_RSVP_QUESTIONS,
+    TOKEN_EXPIRED,
+    TOKEN_NONE,
 )
 
 
@@ -69,8 +78,9 @@ class Command(BaseCommand):
             self._seed_reset_member()
             admin = perm_users[0] if perm_users else None
             events = self._seed_events(admin)
-            self._seed_member_rsvps(cond_users, events)
-            non_members = self._seed_non_members(events)
+            rsvp_questions = self._seed_event_rsvp_questions(events)
+            self._seed_member_rsvps(cond_users, events, rsvp_questions)
+            non_members = self._seed_non_members(events, rsvp_questions)
             questions = seed_join_form_questions(self.stdout)
             join_requests = seed_join_requests(self.stdout, admin, questions)
         self._print_summary(
@@ -229,23 +239,43 @@ class Command(BaseCommand):
     def _seed_events(self, created_by) -> list[Event]:
         return list(seed_events(self.stdout, STAGING_EVENTS, created_by).values())
 
-    def _apply_rsvps(self, user, rsvps, events_by_title: dict) -> None:
+    def _seed_event_rsvp_questions(self, events: list[Event]) -> dict[str, dict]:
+        events_by_title = {e.title: e for e in events}
+        by_event: dict[str, dict] = {}
+        for title, specs in STAGING_EVENT_RSVP_QUESTIONS.items():
+            event = events_by_title.get(title)
+            if event is None:
+                self.stdout.write(f"  skipped rsvp questions (missing event): {title}")
+                continue
+            by_event[title] = seed_event_rsvp_questions(self.stdout, event, specs)
+        return by_event
+
+    def _apply_rsvps(self, user, rsvps, events_by_title: dict, rsvp_questions: dict) -> None:
         for rsvp in rsvps:
             event = events_by_title.get(rsvp.event_title)
-            if event is not None:
-                apply_rsvp(
-                    event,
-                    user,
-                    {"status": rsvp.status, "attendance": rsvp.attendance},
-                    overwrite=True,
+            if event is None:
+                continue
+            defaults: dict[str, object] = {
+                "status": rsvp.status,
+                "attendance": rsvp.attendance,
+            }
+            questions = rsvp_questions.get(rsvp.event_title)
+            if questions is not None:
+                defaults["questionnaire_responses"] = questionnaire_snapshot(
+                    questions, rsvp.answers
                 )
+            apply_rsvp(event, user, defaults, overwrite=True)
 
-    def _seed_member_rsvps(self, cond_users: list[User], events: list[Event]) -> None:
+    def _seed_member_rsvps(
+        self, cond_users: list[User], events: list[Event], rsvp_questions: dict
+    ) -> None:
         events_by_title = {e.title: e for e in events}
         for spec in MEMBER_RSVP_SPECS:
             if spec.cond_index >= len(cond_users):
                 continue
-            self._apply_rsvps(cond_users[spec.cond_index], spec.rsvps, events_by_title)
+            self._apply_rsvps(
+                cond_users[spec.cond_index], spec.rsvps, events_by_title, rsvp_questions
+            )
         self.stdout.write(f"  seeded member rsvps for {len(MEMBER_RSVP_SPECS)} members")
 
     def _ensure_non_member(self, index: int, spec) -> User:
@@ -281,12 +311,12 @@ class Command(BaseCommand):
             return
         NonMemberRsvpToken.issue_or_extend(user)
 
-    def _seed_non_members(self, events: list[Event]) -> list[User]:
+    def _seed_non_members(self, events: list[Event], rsvp_questions: dict) -> list[User]:
         events_by_title = {e.title: e for e in events}
         users: list[User] = []
         for index, spec in enumerate(NON_MEMBER_SPECS):
             user = self._ensure_non_member(index, spec)
-            self._apply_rsvps(user, spec.rsvps, events_by_title)
+            self._apply_rsvps(user, spec.rsvps, events_by_title, rsvp_questions)
             self._apply_token_state(user, spec.token_state)
             users.append(user)
         return users

--- a/backend/community/management/commands/seed_staging.py
+++ b/backend/community/management/commands/seed_staging.py
@@ -71,8 +71,8 @@ class Command(BaseCommand):
             events = self._seed_events(admin)
             self._seed_member_rsvps(cond_users, events)
             non_members = self._seed_non_members(events)
-            seed_join_form_questions(self.stdout)
-            join_requests = seed_join_requests(self.stdout, admin)
+            questions = seed_join_form_questions(self.stdout)
+            join_requests = seed_join_requests(self.stdout, admin, questions)
         self._print_summary(
             {
                 "roles": roles,

--- a/backend/community/management/commands/seed_staging.py
+++ b/backend/community/management/commands/seed_staging.py
@@ -14,7 +14,7 @@ from users.roles import Role
 
 from community.models import Event, EventType, RSVPStatus
 
-from ._seed_join_requests import reset_join_requests, seed_join_requests
+from ._seed_join_requests import reset_join_requests, seed_join_form_questions, seed_join_requests
 from ._seed_shared import apply_rsvp, get_or_create_seed_user, seed_events
 from ._seed_staging_data import (
     MEMBER_RSVP_SPECS,
@@ -71,6 +71,7 @@ class Command(BaseCommand):
             events = self._seed_events(admin)
             self._seed_member_rsvps(cond_users, events)
             non_members = self._seed_non_members(events)
+            seed_join_form_questions(self.stdout)
             join_requests = seed_join_requests(self.stdout, admin)
         self._print_summary(
             {

--- a/backend/tests/test_seed.py
+++ b/backend/tests/test_seed.py
@@ -1,4 +1,5 @@
 import pytest
+from community.management.commands._seed_data import SEED_EVENT_RSVP_QUESTIONS
 from community.models import Event, EventRSVP, JoinRequest, RSVPStatus
 from community.models.choices import AttendanceStatus
 from django.core.management import call_command
@@ -78,3 +79,43 @@ def test_seed_admin_has_superuser_privileges():
     assert admin.is_superuser
     assert admin.is_staff
     assert admin.roles.filter(name="admin").exists()
+
+
+@pytest.mark.django_db
+def test_seed_creates_rsvp_questions_on_configured_events():
+    call_command("seed")
+
+    for title, specs in SEED_EVENT_RSVP_QUESTIONS.items():
+        event = Event.objects.get(title=title)
+        labels = list(
+            event.rsvp_questions.order_by("display_order").values_list("label", flat=True)
+        )
+        assert labels == [spec.label for spec in specs]
+
+
+@pytest.mark.django_db
+def test_seed_rsvps_include_partial_and_complete_questionnaire_responses():
+    call_command("seed")
+
+    event = Event.objects.get(title="Plant-Based Cooking Workshop")
+    questions = {q.label: q for q in event.rsvp_questions.all()}
+    assert len(questions) == 2
+
+    complete = EventRSVP.objects.get(event=event, user__phone_number="+17025550002")
+    assert set(complete.questionnaire_responses) == {str(q.id) for q in questions.values()}
+    assert {
+        snap["label"]: snap["answer"] for snap in complete.questionnaire_responses.values()
+    } == {
+        "How are you getting there?": "transit",
+        "Anything we should know?": "Nut allergy — please avoid shared utensils.",
+    }
+
+    partial = EventRSVP.objects.get(event=event, user__phone_number="+17025550003")
+    assert set(partial.questionnaire_responses) == {str(questions["How are you getting there?"].id)}
+    assert (
+        partial.questionnaire_responses[str(questions["How are you getting there?"].id)]["answer"]
+        == "bike"
+    )
+
+    unanswered = EventRSVP.objects.get(event=event, user__phone_number="+17025550004")
+    assert unanswered.questionnaire_responses == {}

--- a/backend/tests/test_seed_staging.py
+++ b/backend/tests/test_seed_staging.py
@@ -29,6 +29,7 @@ from community.models import (
     Event,
     EventRSVP,
     EventType,
+    JoinFormQuestion,
     JoinRequest,
     JoinRequestStatus,
     PageVisibility,
@@ -383,6 +384,17 @@ def test_seed_staging_creates_join_requests_matching_specs():
 @pytest.mark.django_db
 def test_seed_staging_join_requests_carry_custom_answers():
     call_command("seed_staging")
+    for index in range(len(JOIN_REQUEST_SPECS)):
+        jr = JoinRequest.objects.get(phone_number=joinreq_phone(index))
+        assert jr.custom_answers
+
+
+@pytest.mark.django_db
+def test_seed_staging_recreates_join_form_questions_when_missing():
+    call_command("seed_staging")
+    JoinFormQuestion.objects.all().delete()
+    call_command("seed_staging", "--reset")
+    assert JoinFormQuestion.objects.filter(required=True).exists()
     for index in range(len(JOIN_REQUEST_SPECS)):
         jr = JoinRequest.objects.get(phone_number=joinreq_phone(index))
         assert jr.custom_answers

--- a/backend/tests/test_seed_staging.py
+++ b/backend/tests/test_seed_staging.py
@@ -384,11 +384,11 @@ def test_seed_staging_creates_join_requests_matching_specs():
 @pytest.mark.django_db
 def test_seed_staging_join_requests_carry_custom_answers():
     call_command("seed_staging")
-    question_ids = {str(q.id) for q in JoinFormQuestion.objects.all()}
-    assert question_ids
-    for index in range(len(JOIN_REQUEST_SPECS)):
+    for index, spec in enumerate(JOIN_REQUEST_SPECS):
         jr = JoinRequest.objects.get(phone_number=joinreq_phone(index))
-        assert set(jr.custom_answers) == question_ids
+        assert {
+            data["label"]: data["answer"] for data in jr.custom_answers.values()
+        } == spec.answers
 
 
 @pytest.mark.django_db

--- a/backend/tests/test_seed_staging.py
+++ b/backend/tests/test_seed_staging.py
@@ -4,16 +4,12 @@ import pytest
 from community.management.commands._seed_staging_data import (
     JOIN_REQUEST_SPECS,
     NON_MEMBER_EVENT_TITLE,
-    NON_MEMBER_SPECS,
     OFFICIAL_FULL_TITLE,
     OFFICIAL_PAST_TITLE,
     OFFICIAL_TODAY_TITLE,
     PASSWORD,
     PRIVACY_SPECS,
     STAGING_EVENTS,
-    TOKEN_EXPIRED,
-    TOKEN_NONE,
-    TOKEN_VALID,
     cond_email,
     cond_phone,
     condition_combinations,
@@ -23,6 +19,13 @@ from community.management.commands._seed_staging_data import (
     perm_email,
     perm_phone,
     privacy_phone,
+)
+from community.management.commands._seed_staging_rsvps import (
+    NON_MEMBER_SPECS,
+    STAGING_EVENT_RSVP_QUESTIONS,
+    TOKEN_EXPIRED,
+    TOKEN_NONE,
+    TOKEN_VALID,
 )
 from community.models import (
     AttendanceStatus,
@@ -441,3 +444,42 @@ def test_seed_staging_reset_removes_join_requests():
     assert JoinRequest.objects.filter(phone_number__startswith="+170255504").count() == len(
         JOIN_REQUEST_SPECS
     )
+
+
+@pytest.mark.django_db
+def test_seed_staging_creates_rsvp_questions_on_configured_events():
+    call_command("seed_staging")
+
+    for title, specs in STAGING_EVENT_RSVP_QUESTIONS.items():
+        event = Event.objects.get(title=title)
+        labels = list(
+            event.rsvp_questions.order_by("display_order").values_list("label", flat=True)
+        )
+        assert labels == [spec.label for spec in specs]
+
+
+@pytest.mark.django_db
+def test_seed_staging_rsvps_include_partial_and_complete_questionnaire_responses():
+    call_command("seed_staging")
+
+    event = Event.objects.get(title=OFFICIAL_TODAY_TITLE)
+    questions = {q.label: q for q in event.rsvp_questions.all()}
+    assert len(questions) == 2
+
+    complete = EventRSVP.objects.get(event=event, user__phone_number=cond_phone(0))
+    assert {
+        snap["label"]: snap["answer"] for snap in complete.questionnaire_responses.values()
+    } == {
+        "How are you getting there?": "transit",
+        "Anything we should know?": "Bringing a +1 who is gluten-free.",
+    }
+
+    partial = EventRSVP.objects.get(event=event, user__phone_number=cond_phone(1))
+    assert set(partial.questionnaire_responses) == {str(questions["How are you getting there?"].id)}
+    assert (
+        partial.questionnaire_responses[str(questions["How are you getting there?"].id)]["answer"]
+        == "bike"
+    )
+
+    unanswered = EventRSVP.objects.get(event=event, user__phone_number=cond_phone(2))
+    assert unanswered.questionnaire_responses == {}

--- a/backend/tests/test_seed_staging.py
+++ b/backend/tests/test_seed_staging.py
@@ -384,9 +384,11 @@ def test_seed_staging_creates_join_requests_matching_specs():
 @pytest.mark.django_db
 def test_seed_staging_join_requests_carry_custom_answers():
     call_command("seed_staging")
+    question_ids = {str(q.id) for q in JoinFormQuestion.objects.all()}
+    assert question_ids
     for index in range(len(JOIN_REQUEST_SPECS)):
         jr = JoinRequest.objects.get(phone_number=joinreq_phone(index))
-        assert jr.custom_answers
+        assert set(jr.custom_answers) == question_ids
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
## Summary
- Staging lost all `JoinFormQuestion` rows, so `/join` showed no questions and `seed_staging --reset` recreated pending join requests with empty answers.
- `seed_staging` now ensures default join-form questions exist (shared with `seed`) and backfills empty seed-request answers.

## Test plan
- [x] `test_seed_staging_recreates_join_form_questions_when_missing`
- [x] Staging join-form API restored and seed join requests refilled manually
- [ ] Confirm `/join` and pending `/join-requests` show questions/answers after deploy


Made with [Cursor](https://cursor.com)