### PR TITLE
fix: 1360 - stop duplicate privacy prompt after onboarding

### DIFF
--- a/backend/tests/test_onboarding.py
+++ b/backend/tests/test_onboarding.py
@@ -237,6 +237,26 @@ class TestOnboardingConsent:
         assert needs_onboarding_user.guidelines_consent_at is None
         assert needs_onboarding_user.sms_consent_at is None
 
+    def test_contact_privacy_stamped_without_being_requested(
+        self, api_client, needs_onboarding_user, needs_onboarding_auth_headers
+    ):
+        needs_onboarding_user.contact_privacy_consent_at = None
+        needs_onboarding_user.save(update_fields=["contact_privacy_consent_at"])
+        resp = api_client.post(
+            "/api/auth/complete-onboarding/",
+            data={
+                "new_password": "abcd1234ABCD!",
+                "first_name": "Newby",
+                "email": "newby@example.com",
+            },
+            content_type="application/json",
+            **needs_onboarding_auth_headers,
+        )
+        assert resp.status_code == 200, resp.content
+        assert resp.json()["needs_contact_privacy_consent"] is False
+        needs_onboarding_user.refresh_from_db()
+        assert needs_onboarding_user.contact_privacy_consent_at is not None
+
     def test_accept_does_not_overwrite_existing_consent(
         self, api_client, needs_onboarding_user, needs_onboarding_auth_headers
     ):

--- a/backend/users/_auth.py
+++ b/backend/users/_auth.py
@@ -286,8 +286,7 @@ def complete_onboarding(request, payload: OnboardingIn):
         user.onboarded_at = timezone.now()
     user.needs_onboarding = False
     user.needs_password_reset = False
-    # Onboarding's profile step already shows the privacy toggles, so the
-    # retroactive /consent gate would be a duplicate prompt (Issue 1360).
+    # The onboarding profile step already shows the privacy toggles.
     stamp_consents(user, [*payload.consent_types, ConsentType.CONTACT_PRIVACY])
     user.save()
     audit_log(

--- a/backend/users/_auth.py
+++ b/backend/users/_auth.py
@@ -15,7 +15,7 @@ from ninja.responses import Status
 from ninja_jwt.exceptions import TokenError
 from ninja_jwt.tokens import RefreshToken
 
-from users._consents import stamp_consents
+from users._consents import ConsentType, stamp_consents
 from users._helpers import (
     _check_and_set_email,
     _require_first_name,
@@ -286,7 +286,9 @@ def complete_onboarding(request, payload: OnboardingIn):
         user.onboarded_at = timezone.now()
     user.needs_onboarding = False
     user.needs_password_reset = False
-    stamp_consents(user, payload.consent_types)
+    # Onboarding's profile step already shows the privacy toggles, so the
+    # retroactive /consent gate would be a duplicate prompt (Issue 1360).
+    stamp_consents(user, [*payload.consent_types, ConsentType.CONTACT_PRIVACY])
     user.save()
     audit_log(
         logging.INFO,


### PR DESCRIPTION
## Overview

New users already choose their contact-privacy settings during onboarding's profile step, but `complete-onboarding` never stamped the `contact_privacy` consent. `needs_contact_privacy_consent` stayed true, so the retroactive `/consent` gate fired immediately afterward and showed the same "show phone / show email" toggles a second time.

`complete_onboarding` now stamps `ConsentType.CONTACT_PRIVACY` alongside the consents in the payload. The `/consent` gate is unchanged for existing members, who never went through the onboarding profile step and still need the one-time prompt.

## Test plan

- [x] `backend/tests/test_onboarding.py` — new `test_contact_privacy_stamped_without_being_requested` asserts the consent is stamped and `needs_contact_privacy_consent` comes back false (14 passed)
- [x] `backend/tests/test_accept_guidelines.py` — existing `/consent` path for existing members still passes (24 passed together)
- [x] `make agent-lint`, `make agent-typecheck`, `make agent-complexity` clean
- [ ] Manual: log in as a brand-new admin-created user → finish onboarding → should land on `/calendar` with no privacy modal
- [ ] Manual: log in as an existing member with `contact_privacy_consent_at` null → should still see the `/consent` prompt once

Closes #1360
