### PR TITLE
feat(events): RSVP questionnaire UX and host dialog cache fix

### DIFF
--- a/backend/community/_event_rsvp_answers.py
+++ b/backend/community/_event_rsvp_answers.py
@@ -32,11 +32,8 @@ def find_my_questionnaire_responses(rsvps, user) -> dict:
 
 
 def answers_required_for_status(status: str) -> bool:
-    return status in {
-        RSVPStatus.ATTENDING,
-        RSVPStatus.MAYBE,
-        RSVPStatus.WAITLISTED,
-    }
+    # Waitlisted is the capacity overflow of "going", so it still requires answers.
+    return status in {RSVPStatus.ATTENDING, RSVPStatus.WAITLISTED}
 
 
 def _require_if_needed(q: EventRsvpQuestion, *, require_answers: bool) -> None:

--- a/backend/tests/test_event_rsvp_questions.py
+++ b/backend/tests/test_event_rsvp_questions.py
@@ -111,12 +111,26 @@ class TestRsvpWithAnswers:
         )
         assert response.status_code == 200
 
+    def test_maybe_skips_required_answers(
+        self, api_client, other_headers, auth_headers, rsvp_event
+    ):
+        _create_question(rsvp_event)
+        response = api_client.post(
+            f"/api/community/events/{rsvp_event.id}/rsvp/",
+            {"status": RSVPStatus.MAYBE, "has_plus_one": False},
+            content_type="application/json",
+            **other_headers,
+        )
+        assert response.status_code == 200
+        rsvp = EventRSVP.objects.get(event=rsvp_event)
+        assert rsvp.questionnaire_responses == {}
+
     def test_invalid_option_rejected(self, api_client, other_headers, auth_headers, rsvp_event):
         q = _create_question(rsvp_event)
         response = api_client.post(
             f"/api/community/events/{rsvp_event.id}/rsvp/",
             {
-                "status": RSVPStatus.MAYBE,
+                "status": RSVPStatus.ATTENDING,
                 "questionnaire_responses": {q["id"]: "helicopter"},
             },
             content_type="application/json",

--- a/frontend/src/api/eventRsvpQuestions.test.ts
+++ b/frontend/src/api/eventRsvpQuestions.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { EventRsvpQuestion } from '@/models/event';
+import { makeEvent } from '@/test/fixtures';
 
 import { apiClient } from './client';
 import {
@@ -9,12 +10,19 @@ import {
   newRsvpQuestionId,
   syncEventRsvpQuestions,
 } from './eventRsvpQuestions';
+import { eventKeys } from './events';
+import { queryClient } from './queryClient';
 
-vi.mock('./client', () => ({
-  apiClient: {
-    put: vi.fn(),
-  },
-}));
+vi.mock('./client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./client')>();
+  return {
+    ...actual,
+    apiClient: {
+      ...actual.apiClient,
+      put: vi.fn(),
+    },
+  };
+});
 
 const q = (
   partial: Partial<EventRsvpQuestion> & Pick<EventRsvpQuestion, 'id'>,
@@ -38,6 +46,7 @@ describe('draft RSVP question ids', () => {
 describe('syncEventRsvpQuestions', () => {
   beforeEach(() => {
     vi.mocked(apiClient.put).mockReset();
+    queryClient.clear();
   });
 
   it('should replace all questions in one request', async () => {
@@ -98,5 +107,44 @@ describe('syncEventRsvpQuestions', () => {
       ],
     });
     expect(result.map((question) => question.id)).toEqual(['keep', 'new']);
+  });
+
+  it('should patch cached event detail so the RSVP dialog sees synced questions', async () => {
+    const eventId = 'evt-sync-cache';
+    const slug = 'sync-cache-event';
+    queryClient.setQueryData(
+      eventKeys.detail(slug, true),
+      makeEvent({ id: eventId, slug, rsvpQuestions: [] }),
+    );
+    vi.mocked(apiClient.put).mockResolvedValue({
+      data: [
+        {
+          id: 'q1',
+          label: 'how are you getting there?',
+          field_type: 'select',
+          options: ['transit'],
+          required: true,
+          display_order: 0,
+        },
+      ],
+    });
+
+    await syncEventRsvpQuestions(
+      eventId,
+      [q({ id: `${DRAFT_RSVP_QUESTION_ID_PREFIX}draft`, label: 'how are you getting there?' })],
+      [],
+    );
+
+    expect(queryClient.getQueryData(eventKeys.detail(slug, true))).toMatchObject({
+      rsvpQuestions: [
+        {
+          id: 'q1',
+          label: 'how are you getting there?',
+          fieldType: 'select',
+          options: ['transit'],
+          required: true,
+        },
+      ],
+    });
   });
 });

--- a/frontend/src/api/eventRsvpQuestions.test.ts
+++ b/frontend/src/api/eventRsvpQuestions.test.ts
@@ -14,7 +14,10 @@ import { eventKeys } from './events';
 import { queryClient } from './queryClient';
 
 vi.mock('./client', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('./client')>();
+  const actual = (await importOriginal()) as {
+    apiClient: Record<string, unknown>;
+    [key: string]: unknown;
+  };
   return {
     ...actual,
     apiClient: {

--- a/frontend/src/api/eventRsvpQuestions.ts
+++ b/frontend/src/api/eventRsvpQuestions.ts
@@ -1,6 +1,8 @@
 import type { EventRsvpQuestion } from '@/models/event';
 
 import { apiClient } from './client';
+import { patchEventDetailRsvpQuestions } from './events';
+import { queryClient } from './queryClient';
 import { QuestionType } from './questionTypes';
 import type { components } from './types.gen';
 
@@ -60,5 +62,9 @@ export async function syncEventRsvpQuestions(
       questions: next.map((question) => questionPayload(question, true)),
     },
   );
-  return data.map(mapRsvpQuestion);
+  const questions = data.map(mapRsvpQuestion);
+  // UpdateEvent caches EventOut before this sync runs; without this patch the
+  // RSVP dialog keeps stale/empty questions while the API still requires answers.
+  patchEventDetailRsvpQuestions(queryClient, eventId, questions);
+  return questions;
 }

--- a/frontend/src/api/events.ts
+++ b/frontend/src/api/events.ts
@@ -1,8 +1,7 @@
 import { type QueryClient, useQuery } from '@tanstack/react-query';
 
 import { useAuthStore } from '@/auth/store';
-import type { Event } from '@/models/event';
-import type { EventStatus } from '@/models/event';
+import type { Event, EventRsvpQuestion, EventStatus } from '@/models/event';
 
 import { apiClient } from './client';
 import { mapEvent, type WireEvent } from './eventMapper';
@@ -49,6 +48,19 @@ export function invalidateEventDetail(qc: QueryClient, eventIdOrSlug: string): v
       return cached?.id === eventIdOrSlug || cached?.slug === eventIdOrSlug;
     },
   });
+}
+
+/** Patch rsvpQuestions on every cached detail entry for this event (uuid or slug keys). */
+export function patchEventDetailRsvpQuestions(
+  qc: QueryClient,
+  eventId: string,
+  rsvpQuestions: EventRsvpQuestion[],
+): void {
+  for (const [key, cached] of qc.getQueriesData<Event>({ queryKey: eventKeys.all })) {
+    if (key[1] !== 'detail' || !cached) continue;
+    if (cached.id !== eventId && key[2] !== eventId) continue;
+    qc.setQueryData(key, { ...cached, rsvpQuestions });
+  }
 }
 
 export async function fetchEvents(status?: EventListStatus): Promise<Event[]> {

--- a/frontend/src/components/questions/QuestionAuthorDialog.test.tsx
+++ b/frontend/src/components/questions/QuestionAuthorDialog.test.tsx
@@ -30,7 +30,7 @@ describe('QuestionAuthorDialog', () => {
     expect(onSave).not.toHaveBeenCalled();
   });
 
-  it('should require options for option-backed types and save parsed values', async () => {
+  it('should require options for option-backed types and save filled rows', async () => {
     const user = userEvent.setup();
     const onSave = vi.fn().mockResolvedValue(undefined);
     render(
@@ -48,7 +48,9 @@ describe('QuestionAuthorDialog', () => {
     await user.click(screen.getByRole('button', { name: 'save' }));
     expect(screen.getByRole('alert')).toHaveTextContent('add at least one option');
 
-    await user.type(screen.getByLabelText('options'), 'vegan\nomni');
+    await user.type(screen.getByLabelText('option 1'), 'vegan');
+    await user.click(screen.getByRole('button', { name: /add option/i }));
+    await user.type(screen.getByLabelText('option 2'), 'omni');
     await user.click(screen.getByRole('button', { name: 'save' }));
     expect(onSave).toHaveBeenCalledWith({
       label: 'Meal',

--- a/frontend/src/components/questions/QuestionAuthorDialog.tsx
+++ b/frontend/src/components/questions/QuestionAuthorDialog.tsx
@@ -6,9 +6,9 @@ import type { QuestionType } from '@/api/questionTypes';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import { Select } from '@/components/ui/Select';
-import { Textarea } from '@/components/ui/Textarea';
 import { TextField } from '@/components/ui/TextField';
 
+import { normalizeQuestionOptions, QuestionOptionsEditor } from './QuestionOptionsEditor';
 import { questionOptionsError, questionTypeWantsOptions } from './questionTypeOptions';
 
 export interface QuestionAuthorValues<T extends string = QuestionType> {
@@ -29,7 +29,7 @@ interface Props<T extends string> {
   title: string;
   initial: QuestionAuthorValues<T>;
   typeOptions: TypeOption<T>[];
-  optionsHint?: string | ((fieldType: T) => string);
+  optionsHint?: string | ((fieldType: T) => string | undefined);
   busy: boolean;
   onSave: (values: QuestionAuthorValues<T>) => Promise<void>;
   errorFallback?: string;
@@ -46,7 +46,7 @@ function QuestionAuthorDialogBody<T extends string>({
   title,
   initial,
   typeOptions,
-  optionsHint = 'one per line',
+  optionsHint,
   busy,
   onSave,
   errorFallback = "couldn't save — try again",
@@ -54,7 +54,9 @@ function QuestionAuthorDialogBody<T extends string>({
   const [label, setLabel] = useState(() => initial.label);
   const [fieldType, setFieldType] = useState<T>(() => initial.fieldType);
   const [required, setRequired] = useState(() => initial.required);
-  const [optionsText, setOptionsText] = useState(() => initial.options.join('\n'));
+  const [options, setOptions] = useState<string[]>(() =>
+    initial.options.length > 0 ? [...initial.options] : [''],
+  );
   const [error, setError] = useState<string | null>(null);
 
   const wantsOptions = questionTypeWantsOptions(fieldType as QuestionType);
@@ -67,13 +69,8 @@ function QuestionAuthorDialogBody<T extends string>({
       setError('label required');
       return;
     }
-    const options = wantsOptions
-      ? optionsText
-          .split('\n')
-          .map((s) => s.trim())
-          .filter(Boolean)
-      : [];
-    const optionsError = questionOptionsError(wantsOptions, options);
+    const normalized = wantsOptions ? normalizeQuestionOptions(options) : [];
+    const optionsError = questionOptionsError(wantsOptions, normalized);
     if (optionsError) {
       setError(optionsError);
       return;
@@ -82,7 +79,7 @@ function QuestionAuthorDialogBody<T extends string>({
       await onSave({
         label: label.trim(),
         fieldType,
-        options,
+        options: normalized,
         required,
       });
       onClose();
@@ -106,20 +103,16 @@ function QuestionAuthorDialogBody<T extends string>({
           label="type"
           value={fieldType}
           onChange={(e) => {
-            setFieldType(e.target.value as T);
+            const next = e.target.value as T;
+            setFieldType(next);
+            if (questionTypeWantsOptions(next as QuestionType) && options.every((o) => !o.trim())) {
+              setOptions(['']);
+            }
           }}
           options={typeOptions}
         />
         {wantsOptions ? (
-          <Textarea
-            label="options"
-            value={optionsText}
-            onChange={(e) => {
-              setOptionsText(e.target.value);
-            }}
-            hint={hint}
-            rows={5}
-          />
+          <QuestionOptionsEditor options={options} onChange={setOptions} hint={hint} />
         ) : null}
         <label className="flex items-center gap-2 text-sm">
           <input

--- a/frontend/src/components/questions/QuestionAuthorDialog.tsx
+++ b/frontend/src/components/questions/QuestionAuthorDialog.tsx
@@ -8,8 +8,12 @@ import { Dialog } from '@/components/ui/Dialog';
 import { Select } from '@/components/ui/Select';
 import { TextField } from '@/components/ui/TextField';
 
-import { normalizeQuestionOptions, QuestionOptionsEditor } from './QuestionOptionsEditor';
-import { questionOptionsError, questionTypeWantsOptions } from './questionTypeOptions';
+import { QuestionOptionsEditor } from './QuestionOptionsEditor';
+import {
+  normalizeQuestionOptions,
+  questionOptionsError,
+  questionTypeWantsOptions,
+} from './questionTypeOptions';
 
 export interface QuestionAuthorValues<T extends string = QuestionType> {
   label: string;

--- a/frontend/src/components/questions/QuestionOptionsEditor.test.tsx
+++ b/frontend/src/components/questions/QuestionOptionsEditor.test.tsx
@@ -1,0 +1,43 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { normalizeQuestionOptions, QuestionOptionsEditor } from './QuestionOptionsEditor';
+
+describe('normalizeQuestionOptions', () => {
+  it('should trim and drop blank options', () => {
+    expect(normalizeQuestionOptions(['  a ', '', 'b', '   '])).toEqual(['a', 'b']);
+  });
+});
+
+describe('QuestionOptionsEditor', () => {
+  it('should render each option as its own field', () => {
+    render(<QuestionOptionsEditor options={['driving', 'transit']} onChange={vi.fn()} />);
+    expect(screen.getByLabelText('option 1')).toHaveValue('driving');
+    expect(screen.getByLabelText('option 2')).toHaveValue('transit');
+    expect(screen.queryByLabelText('options')).not.toBeInTheDocument();
+  });
+
+  it('should add an empty option when + is clicked', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<QuestionOptionsEditor options={['driving']} onChange={onChange} />);
+    await user.click(screen.getByRole('button', { name: /add option/i }));
+    expect(onChange).toHaveBeenCalledWith(['driving', '']);
+  });
+
+  it('should remove an option row', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<QuestionOptionsEditor options={['driving', 'transit']} onChange={onChange} />);
+    await user.click(screen.getByRole('button', { name: /remove option 1/i }));
+    expect(onChange).toHaveBeenCalledWith(['transit']);
+  });
+
+  it('should update a single option value', () => {
+    const onChange = vi.fn();
+    render(<QuestionOptionsEditor options={['driving']} onChange={onChange} />);
+    fireEvent.change(screen.getByLabelText('option 1'), { target: { value: 'bike' } });
+    expect(onChange).toHaveBeenCalledWith(['bike']);
+  });
+});

--- a/frontend/src/components/questions/QuestionOptionsEditor.test.tsx
+++ b/frontend/src/components/questions/QuestionOptionsEditor.test.tsx
@@ -2,13 +2,7 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
-import { normalizeQuestionOptions, QuestionOptionsEditor } from './QuestionOptionsEditor';
-
-describe('normalizeQuestionOptions', () => {
-  it('should trim and drop blank options', () => {
-    expect(normalizeQuestionOptions(['  a ', '', 'b', '   '])).toEqual(['a', 'b']);
-  });
-});
+import { QuestionOptionsEditor } from './QuestionOptionsEditor';
 
 describe('QuestionOptionsEditor', () => {
   it('should render each option as its own field', () => {

--- a/frontend/src/components/questions/QuestionOptionsEditor.tsx
+++ b/frontend/src/components/questions/QuestionOptionsEditor.tsx
@@ -8,10 +8,6 @@ interface Props {
   maxLength?: number;
 }
 
-export function normalizeQuestionOptions(options: readonly string[]): string[] {
-  return options.map((option) => option.trim()).filter(Boolean);
-}
-
 export function QuestionOptionsEditor({ options, onChange, hint, maxLength }: Props) {
   const rows = options.length === 0 ? [''] : [...options];
 

--- a/frontend/src/components/questions/QuestionOptionsEditor.tsx
+++ b/frontend/src/components/questions/QuestionOptionsEditor.tsx
@@ -1,0 +1,71 @@
+import { Button } from '@/components/ui/Button';
+import { TextField } from '@/components/ui/TextField';
+
+interface Props {
+  options: readonly string[];
+  onChange: (options: string[]) => void;
+  hint?: string | undefined;
+  maxLength?: number;
+}
+
+export function normalizeQuestionOptions(options: readonly string[]): string[] {
+  return options.map((option) => option.trim()).filter(Boolean);
+}
+
+export function QuestionOptionsEditor({ options, onChange, hint, maxLength }: Props) {
+  const rows = options.length === 0 ? [''] : [...options];
+
+  function setRow(index: number, value: string) {
+    const next = [...rows];
+    next[index] = value;
+    onChange(next);
+  }
+
+  function addRow() {
+    onChange([...rows, '']);
+  }
+
+  function removeRow(index: number) {
+    onChange(rows.filter((_, i) => i !== index));
+  }
+
+  return (
+    <fieldset className="flex flex-col gap-2">
+      <legend className="text-foreground text-sm font-medium">options</legend>
+      {hint ? <p className="text-foreground-tertiary text-xs">{hint}</p> : null}
+      <ul className="flex flex-col gap-2">
+        {rows.map((option, index) => {
+          const label = `option ${String(index + 1)}`;
+          return (
+            <li key={index} className="flex items-start gap-2">
+              <div className="min-w-0 flex-1">
+                <TextField
+                  label={label}
+                  hideLabel
+                  value={option}
+                  maxLength={maxLength}
+                  onChange={(e) => {
+                    setRow(index, e.target.value);
+                  }}
+                />
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                aria-label={`remove ${label}`}
+                onClick={() => {
+                  removeRow(index);
+                }}
+              >
+                remove
+              </Button>
+            </li>
+          );
+        })}
+      </ul>
+      <Button type="button" variant="secondary" onClick={addRow} className="self-start">
+        + add option
+      </Button>
+    </fieldset>
+  );
+}

--- a/frontend/src/components/questions/questionTypeOptions.test.ts
+++ b/frontend/src/components/questions/questionTypeOptions.test.ts
@@ -8,6 +8,7 @@ import type { components } from '@/api/types.gen';
 
 import {
   JOIN_QUESTION_TYPE_OPTIONS,
+  normalizeQuestionOptions,
   QUESTION_TYPE_OPTIONS,
   questionOptionsError,
   questionTypeWantsOptions,
@@ -54,6 +55,10 @@ describe('question type options', () => {
     expect(questionOptionsError(true, [])).toBe('add at least one option');
     expect(questionOptionsError(true, ['first'])).toBeNull();
     expect(questionOptionsError(false, [])).toBeNull();
+  });
+
+  it('should trim and drop blank options', () => {
+    expect(normalizeQuestionOptions(['  a ', '', 'b', '   '])).toEqual(['a', 'b']);
   });
 
   it('should expose the join subset projected from catalog metadata', () => {

--- a/frontend/src/components/questions/questionTypeOptions.test.ts
+++ b/frontend/src/components/questions/questionTypeOptions.test.ts
@@ -59,7 +59,7 @@ describe('question type options', () => {
   it('should expose the join subset projected from catalog metadata', () => {
     expect(JOIN_QUESTION_TYPE_OPTIONS).toEqual([
       { value: QuestionType.Text, label: 'short text', wantsOptions: false },
-      { value: QuestionType.Textarea, label: 'long text', wantsOptions: false },
+      { value: QuestionType.Textarea, label: 'short answer', wantsOptions: false },
       { value: QuestionType.Select, label: 'select', wantsOptions: true },
     ]);
     expect(JOIN_QUESTION_TYPE_OPTIONS.map(({ value }) => questionTypeWantsOptions(value))).toEqual([
@@ -71,7 +71,7 @@ describe('question type options', () => {
 
   it('should expose the RSVP subset projected from catalog metadata', () => {
     expect(RSVP_QUESTION_TYPE_OPTIONS).toEqual([
-      { value: QuestionType.Textarea, label: 'long text', wantsOptions: false },
+      { value: QuestionType.Textarea, label: 'short answer', wantsOptions: false },
       { value: QuestionType.Select, label: 'select', wantsOptions: true },
       { value: QuestionType.Checkbox, label: 'checkbox', wantsOptions: true },
     ]);

--- a/frontend/src/components/questions/questionTypeOptions.ts
+++ b/frontend/src/components/questions/questionTypeOptions.ts
@@ -11,7 +11,7 @@ export interface QuestionTypeOption {
 /** Labels / option-requirement flags keyed by catalog wire value. */
 const QUESTION_TYPE_META: Record<QuestionType, Omit<QuestionTypeOption, 'value'>> = {
   [QuestionType.Text]: { label: 'short text', wantsOptions: false },
-  [QuestionType.Textarea]: { label: 'long text', wantsOptions: false },
+  [QuestionType.Textarea]: { label: 'short answer', wantsOptions: false },
   [QuestionType.Number]: { label: 'number', wantsOptions: false },
   [QuestionType.Radio]: { label: 'radio', wantsOptions: true },
   [QuestionType.Select]: { label: 'select', wantsOptions: true },

--- a/frontend/src/components/questions/questionTypeOptions.ts
+++ b/frontend/src/components/questions/questionTypeOptions.ts
@@ -68,3 +68,7 @@ export function questionOptionsError(
 ): string | null {
   return wantsOptions && options.length === 0 ? 'add at least one option' : null;
 }
+
+export function normalizeQuestionOptions(options: readonly string[]): string[] {
+  return options.map((option) => option.trim()).filter(Boolean);
+}

--- a/frontend/src/screens/admin/SurveyQuestionDialog.tsx
+++ b/frontend/src/screens/admin/SurveyQuestionDialog.tsx
@@ -41,10 +41,10 @@ function SurveyQuestionDialogBody({ surveyId, open, onClose, existing }: Props) 
       typeOptions={QUESTION_TYPE_OPTIONS.map((t) => ({ value: t.value, label: t.label }))}
       optionsHint={(fieldType) =>
         fieldType === QuestionType.Rating
-          ? 'one label per star (up to 5)'
+          ? 'up to 5 star labels'
           : fieldType === QuestionType.DatetimePoll
-            ? 'one ISO-8601 datetime per line'
-            : 'one option per line'
+            ? 'ISO-8601 datetime values'
+            : undefined
       }
       busy={busy}
       onSave={async (values) => {

--- a/frontend/src/screens/events/EventRsvpResponsesSection.test.tsx
+++ b/frontend/src/screens/events/EventRsvpResponsesSection.test.tsx
@@ -46,7 +46,7 @@ describe('EventRsvpResponsesSection', () => {
         makeGuest({
           userId: 'b',
           name: 'bob',
-          status: RsvpServerStatus.Maybe,
+          status: RsvpServerStatus.Waitlisted,
           questionnaireResponses: {
             q1: { label: 'how are you getting there?', answer: 'transit' },
           },
@@ -54,6 +54,14 @@ describe('EventRsvpResponsesSection', () => {
         makeGuest({
           userId: 'c',
           name: 'cara',
+          status: RsvpServerStatus.Maybe,
+          questionnaireResponses: {
+            q1: { label: 'how are you getting there?', answer: 'bike' },
+          },
+        }),
+        makeGuest({
+          userId: 'd',
+          name: 'dana',
           status: RsvpServerStatus.CantGo,
           questionnaireResponses: {},
         }),
@@ -63,17 +71,19 @@ describe('EventRsvpResponsesSection', () => {
     render(<EventRsvpResponsesSection event={event} />);
 
     expect(screen.getByRole('heading', { name: /question responses/i })).toBeInTheDocument();
-    expect(screen.getByText('2 guests with going / maybe / waitlist')).toBeInTheDocument();
+    expect(screen.getByText('2 guests going or waitlisted')).toBeInTheDocument();
     expect(screen.getByText('alice')).toBeInTheDocument();
     expect(screen.getByText('bob')).toBeInTheDocument();
     expect(screen.queryByText('cara')).not.toBeInTheDocument();
+    expect(screen.queryByText('dana')).not.toBeInTheDocument();
     expect(screen.getByText('bringing chips')).toBeInTheDocument();
     const tallies = screen.getByRole('list');
     expect(tallies).toHaveTextContent(/driving\s*1/);
     expect(tallies).toHaveTextContent(/transit\s*1/);
+    expect(tallies).not.toHaveTextContent(/bike/);
   });
 
-  it('shows empty state when no going/maybe guests', () => {
+  it('shows empty state when no going or waitlisted guests', () => {
     render(
       <EventRsvpResponsesSection
         event={makeEvent({

--- a/frontend/src/screens/events/EventRsvpResponsesSection.tsx
+++ b/frontend/src/screens/events/EventRsvpResponsesSection.tsx
@@ -54,8 +54,8 @@ export function EventRsvpResponsesSection({ event }: Props) {
       <div>
         <h2 className="text-base font-medium">question responses</h2>
         <p className="text-muted text-sm">
-          {String(respondents.length)} guest{respondents.length === 1 ? '' : 's'} with going / maybe
-          / waitlist
+          {String(respondents.length)} guest{respondents.length === 1 ? '' : 's'} going or
+          waitlisted
         </p>
       </div>
 

--- a/frontend/src/screens/events/PublicRsvpCard.test.tsx
+++ b/frontend/src/screens/events/PublicRsvpCard.test.tsx
@@ -73,7 +73,7 @@ describe('PublicRsvpCard', () => {
     );
   });
 
-  it('submits existing question answers when changing status', () => {
+  it('shows questions when attending', () => {
     renderCard({
       status: RsvpServerStatus.Attending,
       event: {
@@ -93,10 +93,54 @@ describe('PublicRsvpCard', () => {
     });
 
     expect(screen.getByLabelText('travel details')).toHaveValue('taking transit');
-    fireEvent.click(screen.getByRole('button', { name: /^maybe$/i }));
+  });
+
+  it('hides questions when status is maybe and allows status change without answers', () => {
+    renderCard({
+      status: RsvpServerStatus.Maybe,
+      event: {
+        rsvpQuestions: [
+          {
+            id: 'q1',
+            label: 'travel details',
+            fieldType: 'textarea',
+            options: [],
+            required: true,
+          },
+        ],
+      },
+    });
+
+    expect(screen.queryByLabelText('travel details')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /can't go/i }));
     expect(updateMutate).toHaveBeenCalledWith(
-      expect.objectContaining({ questionnaireResponses: { q1: 'taking transit' } }),
+      expect.objectContaining({
+        status: RsvpServerStatus.CantGo,
+        questionnaireResponses: {},
+      }),
     );
+  });
+
+  it('requires answers when changing from maybe to going', () => {
+    renderCard({
+      status: RsvpServerStatus.Maybe,
+      event: {
+        rsvpQuestions: [
+          {
+            id: 'q1',
+            label: 'travel details',
+            fieldType: 'textarea',
+            options: [],
+            required: true,
+          },
+        ],
+      },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /i'm going/i }));
+    expect(updateMutate).not.toHaveBeenCalled();
+    expect(screen.getByLabelText('travel details')).toBeInTheDocument();
+    expect(screen.getByText(/required/i)).toBeInTheDocument();
   });
 
   it('renders the comment field', () => {

--- a/frontend/src/screens/events/PublicRsvpCard.tsx
+++ b/frontend/src/screens/events/PublicRsvpCard.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { toast } from 'sonner';
 
@@ -13,7 +13,11 @@ import { buildEventLinks } from '@/utils/eventLinks';
 import { PaymentConfirmStep } from './PaymentConfirmStep';
 import { RsvpCommentField } from './RsvpCommentField';
 import { RsvpQuestionFields } from './RsvpQuestionFields';
-import { missingRequiredQuestionIds, type RsvpAnswerValue } from './rsvpQuestions';
+import {
+  missingRequiredQuestionIds,
+  rsvpQuestionsApplyToStatus,
+  type RsvpAnswerValue,
+} from './rsvpQuestions';
 import { usePaymentGate } from './usePaymentGate';
 
 const UPDATED_TOAST = 'rsvp updated — check your email for an updated link';
@@ -53,27 +57,42 @@ export function PublicRsvpCard({ token, event, status }: Props) {
     ),
   );
   const [answerErrors, setAnswerErrors] = useState<Record<string, string>>({});
+  const [draftStatus, setDraftStatus] = useState(status);
   const [pendingStatus, setPendingStatus] = useState<RsvpInputStatus | null>(null);
   const links = buildEventLinks(event);
   const busy = update.isPending || cancel.isPending;
   const needsPaymentFor = usePaymentGate(event);
+  const showQuestions = event.rsvpQuestions.length > 0 && rsvpQuestionsApplyToStatus(draftStatus);
+
+  useEffect(() => {
+    setDraftStatus(status);
+  }, [status]);
+
+  function filledQuestionnaireResponses(forStatus: string): Record<string, RsvpAnswerValue> {
+    if (!rsvpQuestionsApplyToStatus(forStatus)) return {};
+    const next: Record<string, RsvpAnswerValue> = {};
+    for (const question of event.rsvpQuestions) {
+      const value = answers[question.id];
+      if (value?.trim()) next[question.id] = value;
+    }
+    return next;
+  }
 
   async function applyRsvp(next: RsvpInputStatus, rsvpComment?: string, paidConfirmed?: boolean) {
     setError(null);
-    const missing =
-      next === RsvpServerStatus.CantGo
-        ? []
-        : missingRequiredQuestionIds(event.rsvpQuestions, answers);
+    const requiresAnswers = rsvpQuestionsApplyToStatus(next);
+    const missing = requiresAnswers ? missingRequiredQuestionIds(event.rsvpQuestions, answers) : [];
     if (missing.length > 0) {
       setAnswerErrors(Object.fromEntries(missing.map((id) => [id, 'required'])));
       return;
     }
+    setAnswerErrors({});
     try {
       await update.mutateAsync({
         eventId: event.id,
         status: next,
         hasPlusOne: false,
-        questionnaireResponses: answers,
+        questionnaireResponses: filledQuestionnaireResponses(next),
         ...(rsvpComment !== undefined ? { comment: rsvpComment } : {}),
         ...(paidConfirmed ? { paidConfirmed: true } : {}),
       });
@@ -84,6 +103,14 @@ export function PublicRsvpCard({ token, event, status }: Props) {
   }
 
   function changeStatus(next: RsvpInputStatus) {
+    setDraftStatus(next);
+    if (rsvpQuestionsApplyToStatus(next)) {
+      const missing = missingRequiredQuestionIds(event.rsvpQuestions, answers);
+      if (missing.length > 0) {
+        setAnswerErrors(Object.fromEntries(missing.map((id) => [id, 'required'])));
+        return;
+      }
+    }
     if (next === status) return;
     if (needsPaymentFor(next)) {
       setPendingStatus(next);
@@ -95,7 +122,7 @@ export function PublicRsvpCard({ token, event, status }: Props) {
   function saveComment() {
     const trimmed = comment.trim();
     if (!trimmed) return;
-    void applyRsvp(status as RsvpInputStatus, trimmed);
+    void applyRsvp(draftStatus as RsvpInputStatus, trimmed);
     setComment('');
   }
 
@@ -158,22 +185,24 @@ export function PublicRsvpCard({ token, event, status }: Props) {
           />
         ) : (
           <>
-            <RsvpStatusPicker value={status} onSelect={changeStatus} disabled={busy} />
+            <RsvpStatusPicker value={draftStatus} onSelect={changeStatus} disabled={busy} />
 
-            <RsvpQuestionFields
-              questions={event.rsvpQuestions}
-              answers={answers}
-              onChange={(id, value) => {
-                setAnswers((current) => ({ ...current, [id]: value }));
-                setAnswerErrors((current) => {
-                  if (!(id in current)) return current;
-                  const { [id]: _removed, ...rest } = current;
-                  return rest;
-                });
-              }}
-              errors={answerErrors}
-              disabled={busy}
-            />
+            {showQuestions ? (
+              <RsvpQuestionFields
+                questions={event.rsvpQuestions}
+                answers={answers}
+                onChange={(id, value) => {
+                  setAnswers((current) => ({ ...current, [id]: value }));
+                  setAnswerErrors((current) => {
+                    if (!(id in current)) return current;
+                    const { [id]: _removed, ...rest } = current;
+                    return rest;
+                  });
+                }}
+                errors={answerErrors}
+                disabled={busy}
+              />
+            ) : null}
 
             <RsvpCommentField value={comment} onChange={setComment} disabled={busy} />
             <Button variant="ghost" onClick={saveComment} disabled={busy || !comment.trim()}>

--- a/frontend/src/screens/events/PublicRsvpCard.tsx
+++ b/frontend/src/screens/events/PublicRsvpCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { toast } from 'sonner';
 
@@ -15,8 +15,8 @@ import { RsvpCommentField } from './RsvpCommentField';
 import { RsvpQuestionFields } from './RsvpQuestionFields';
 import {
   missingRequiredQuestionIds,
-  rsvpQuestionsApplyToStatus,
   type RsvpAnswerValue,
+  rsvpQuestionsApplyToStatus,
 } from './rsvpQuestions';
 import { usePaymentGate } from './usePaymentGate';
 
@@ -58,15 +58,16 @@ export function PublicRsvpCard({ token, event, status }: Props) {
   );
   const [answerErrors, setAnswerErrors] = useState<Record<string, string>>({});
   const [draftStatus, setDraftStatus] = useState(status);
+  const [statusFromProps, setStatusFromProps] = useState(status);
   const [pendingStatus, setPendingStatus] = useState<RsvpInputStatus | null>(null);
   const links = buildEventLinks(event);
   const busy = update.isPending || cancel.isPending;
   const needsPaymentFor = usePaymentGate(event);
-  const showQuestions = event.rsvpQuestions.length > 0 && rsvpQuestionsApplyToStatus(draftStatus);
-
-  useEffect(() => {
+  if (status !== statusFromProps) {
+    setStatusFromProps(status);
     setDraftStatus(status);
-  }, [status]);
+  }
+  const showQuestions = event.rsvpQuestions.length > 0 && rsvpQuestionsApplyToStatus(draftStatus);
 
   function filledQuestionnaireResponses(forStatus: string): Record<string, RsvpAnswerValue> {
     if (!rsvpQuestionsApplyToStatus(forStatus)) return {};

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -31,8 +31,8 @@ import { RsvpCommentField } from './RsvpCommentField';
 import { RsvpQuestionFields } from './RsvpQuestionFields';
 import {
   missingRequiredQuestionIds,
-  rsvpQuestionsApplyToStatus,
   type RsvpAnswerValue,
+  rsvpQuestionsApplyToStatus,
 } from './rsvpQuestions';
 import { usePaymentGate } from './usePaymentGate';
 

--- a/frontend/src/screens/events/PublicRsvpForm.tsx
+++ b/frontend/src/screens/events/PublicRsvpForm.tsx
@@ -29,7 +29,11 @@ import { PaymentConfirmStep } from './PaymentConfirmStep';
 import { PublicRsvpPhoneStep } from './PublicRsvpPhoneStep';
 import { RsvpCommentField } from './RsvpCommentField';
 import { RsvpQuestionFields } from './RsvpQuestionFields';
-import { missingRequiredQuestionIds, type RsvpAnswerValue } from './rsvpQuestions';
+import {
+  missingRequiredQuestionIds,
+  rsvpQuestionsApplyToStatus,
+  type RsvpAnswerValue,
+} from './rsvpQuestions';
 import { usePaymentGate } from './usePaymentGate';
 
 const MAX_NAME = 100;
@@ -105,6 +109,9 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
     submitErrorRef.current?.focus();
   }, [submitError]);
 
+  const showQuestions =
+    status !== null && rsvpQuestionsApplyToStatus(status) && questions.length > 0;
+
   function validate(): boolean {
     const next: Record<string, string> = {};
     const firstNameErr = personName(firstName);
@@ -117,8 +124,10 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
     else if (optionalEmail(email)) next.email = 'not a valid email';
     if (!phone.trim()) next.phone = 'phone required';
     else if (!isValidPhoneNumber(phone)) next.phone = 'invalid phone number';
-    for (const id of missingRequiredQuestionIds(questions, answers)) {
-      next[id] = 'required';
+    if (showQuestions) {
+      for (const id of missingRequiredQuestionIds(questions, answers)) {
+        next[id] = 'required';
+      }
     }
     setErrors(next);
     return Object.keys(next).length === 0;
@@ -128,9 +137,11 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
     setSubmitError(null);
     if (!status || !validate()) return;
     const filledAnswers: Record<string, string> = {};
-    for (const q of questions) {
-      const value = answers[q.id];
-      if (value?.trim()) filledAnswers[q.id] = value;
+    if (showQuestions) {
+      for (const q of questions) {
+        const value = answers[q.id];
+        if (value?.trim()) filledAnswers[q.id] = value;
+      }
     }
     try {
       const result = await submit.mutateAsync({
@@ -289,20 +300,22 @@ export function PublicRsvpForm({ event, onSuccess }: Props) {
         />
         <PhoneField label="phone" value={phone} onChange={setPhone} error={errors.phone} />
 
-        <RsvpQuestionFields
-          questions={questions}
-          answers={answers}
-          onChange={(id, value) => {
-            setAnswers((prev) => ({ ...prev, [id]: value }));
-            setErrors((prev) => {
-              if (!(id in prev)) return prev;
-              const { [id]: _removed, ...rest } = prev;
-              return rest;
-            });
-          }}
-          errors={errors}
-          disabled={submit.isPending}
-        />
+        {showQuestions ? (
+          <RsvpQuestionFields
+            questions={questions}
+            answers={answers}
+            onChange={(id, value) => {
+              setAnswers((prev) => ({ ...prev, [id]: value }));
+              setErrors((prev) => {
+                if (!(id in prev)) return prev;
+                const { [id]: _removed, ...rest } = prev;
+                return rest;
+              });
+            }}
+            errors={errors}
+            disabled={submit.isPending}
+          />
+        ) : null}
 
         <RsvpCommentField
           value={comment}

--- a/frontend/src/screens/events/RsvpBox.test.tsx
+++ b/frontend/src/screens/events/RsvpBox.test.tsx
@@ -205,6 +205,22 @@ describe('RsvpBox', () => {
     expect(screen.queryByText('how are you getting there?')).not.toBeInTheDocument();
   });
 
+  it('should hide questions when status is maybe', () => {
+    render(<RsvpBox {...base} mode="create" questions={[requiredSelect]} onConfirm={() => {}} />);
+    fireEvent.click(screen.getByRole('button', { name: /^maybe$/i }));
+    expect(screen.queryByText('how are you getting there?')).not.toBeInTheDocument();
+  });
+
+  it('should allow confirm for maybe without answering required questions', () => {
+    const onConfirm = vi.fn();
+    render(<RsvpBox {...base} mode="create" questions={[requiredSelect]} onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByRole('button', { name: /^maybe$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
+    expect(onConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({ status: RsvpStatus.Maybe, questionnaireResponses: {} }),
+    );
+  });
+
   it('should block confirm when a required question is unanswered', () => {
     const onConfirm = vi.fn();
     render(<RsvpBox {...base} mode="create" questions={[requiredSelect]} onConfirm={onConfirm} />);

--- a/frontend/src/screens/events/RsvpBox.tsx
+++ b/frontend/src/screens/events/RsvpBox.tsx
@@ -10,9 +10,9 @@ import { RsvpCommentField } from './RsvpCommentField';
 import { RsvpQuestionFields } from './RsvpQuestionFields';
 import {
   missingRequiredQuestionIds,
-  rsvpQuestionsApplyToStatus,
   type RsvpAnswerValue,
   type RsvpQuestionDraft,
+  rsvpQuestionsApplyToStatus,
 } from './rsvpQuestions';
 import { usePaymentGate } from './usePaymentGate';
 

--- a/frontend/src/screens/events/RsvpBox.tsx
+++ b/frontend/src/screens/events/RsvpBox.tsx
@@ -10,6 +10,7 @@ import { RsvpCommentField } from './RsvpCommentField';
 import { RsvpQuestionFields } from './RsvpQuestionFields';
 import {
   missingRequiredQuestionIds,
+  rsvpQuestionsApplyToStatus,
   type RsvpAnswerValue,
   type RsvpQuestionDraft,
 } from './rsvpQuestions';
@@ -69,8 +70,7 @@ export function RsvpBox({
   const showComment = allowComment ?? mode === 'create';
   const showPlusOne = allowPlusOnes;
   const joiningWaitlist = status === RsvpStatus.Attending && atCapacity;
-  const showQuestions =
-    questions.length > 0 && (status === RsvpStatus.Attending || status === RsvpStatus.Maybe);
+  const showQuestions = questions.length > 0 && rsvpQuestionsApplyToStatus(status);
 
   function filledQuestionnaireResponses(): Record<string, RsvpAnswerValue> {
     const next: Record<string, RsvpAnswerValue> = {};

--- a/frontend/src/screens/events/form/EventFormQuestions.test.tsx
+++ b/frontend/src/screens/events/form/EventFormQuestions.test.tsx
@@ -31,7 +31,7 @@ describe('EventFormQuestions', () => {
   it('lists questions with type and required marker', () => {
     render(<EventFormQuestions rsvpEnabled questions={[sample]} onQuestionsChange={vi.fn()} />);
     expect(screen.getByText('bring anything?')).toBeInTheDocument();
-    expect(screen.getByText(/long text/)).toBeInTheDocument();
+    expect(screen.getByText(/short answer/)).toBeInTheDocument();
     expect(screen.getByText(/required/)).toBeInTheDocument();
   });
 

--- a/frontend/src/screens/events/form/EventRsvpQuestionDialog.test.tsx
+++ b/frontend/src/screens/events/form/EventRsvpQuestionDialog.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { RsvpQuestionDraft } from '../rsvpQuestions';
@@ -42,7 +43,8 @@ describe('EventRsvpQuestionDialog', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('saves select multiple with parsed options when editing', () => {
+  it('saves select multiple with option rows when editing', async () => {
+    const user = userEvent.setup();
     const existing: RsvpQuestionDraft = {
       id: 'q-existing',
       label: 'help',
@@ -52,8 +54,11 @@ describe('EventRsvpQuestionDialog', () => {
     };
     const onSave = vi.fn();
     render(<EventRsvpQuestionDialog open existing={existing} onClose={() => {}} onSave={onSave} />);
-    fireEvent.change(screen.getByLabelText('options'), { target: { value: 'setup\ncleanup' } });
-    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await user.clear(screen.getByLabelText('option 1'));
+    await user.type(screen.getByLabelText('option 1'), 'setup');
+    await user.click(screen.getByRole('button', { name: /add option/i }));
+    await user.type(screen.getByLabelText('option 2'), 'cleanup');
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
     expect(onSave).toHaveBeenCalledWith({
       id: 'q-existing',
       label: 'help',
@@ -63,40 +68,43 @@ describe('EventRsvpQuestionDialog', () => {
     });
   });
 
-  it('rejects commas in select multiple options', () => {
+  it('rejects commas in select multiple options', async () => {
+    const user = userEvent.setup();
     const onSave = vi.fn();
     render(<EventRsvpQuestionDialog open onClose={() => {}} onSave={onSave} />);
-    fireEvent.change(screen.getByLabelText('question'), { target: { value: 'help' } });
+    await user.type(screen.getByLabelText('question'), 'help');
     fireEvent.change(screen.getByLabelText('type'), { target: { value: 'checkbox' } });
-    fireEvent.change(screen.getByLabelText('options'), { target: { value: 'yes, with a guest' } });
-    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await user.type(screen.getByLabelText('option 1'), 'yes, with a guest');
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
 
     expect(screen.getByRole('alert')).toHaveTextContent(/options cannot contain commas/i);
     expect(onSave).not.toHaveBeenCalled();
   });
 
-  it('allows commas in select one options', () => {
+  it('allows commas in select one options', async () => {
+    const user = userEvent.setup();
     const onSave = vi.fn();
     render(<EventRsvpQuestionDialog open onClose={() => {}} onSave={onSave} />);
-    fireEvent.change(screen.getByLabelText('question'), { target: { value: 'bringing someone?' } });
+    await user.type(screen.getByLabelText('question'), 'bringing someone?');
     fireEvent.change(screen.getByLabelText('type'), { target: { value: 'select' } });
-    fireEvent.change(screen.getByLabelText('options'), {
-      target: { value: 'yes, with a guest\nno' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    await user.type(screen.getByLabelText('option 1'), 'yes, with a guest');
+    await user.click(screen.getByRole('button', { name: /add option/i }));
+    await user.type(screen.getByLabelText('option 2'), 'no');
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
 
     expect(onSave).toHaveBeenCalledWith(
       expect.objectContaining({ options: ['yes, with a guest', 'no'] }),
     );
   });
 
-  it('rejects options over the answer length limit', () => {
+  it('rejects options over the answer length limit', async () => {
+    const user = userEvent.setup();
     const onSave = vi.fn();
     render(<EventRsvpQuestionDialog open onClose={() => {}} onSave={onSave} />);
-    fireEvent.change(screen.getByLabelText('question'), { target: { value: 'pick one' } });
+    await user.type(screen.getByLabelText('question'), 'pick one');
     fireEvent.change(screen.getByLabelText('type'), { target: { value: 'select' } });
-    fireEvent.change(screen.getByLabelText('options'), { target: { value: 'x'.repeat(201) } });
-    fireEvent.click(screen.getByRole('button', { name: /^save$/i }));
+    fireEvent.change(screen.getByLabelText('option 1'), { target: { value: 'x'.repeat(201) } });
+    await user.click(screen.getByRole('button', { name: /^save$/i }));
 
     expect(screen.getByRole('alert')).toHaveTextContent(/options must be 200 characters or fewer/i);
     expect(onSave).not.toHaveBeenCalled();

--- a/frontend/src/screens/events/form/EventRsvpQuestionDialog.tsx
+++ b/frontend/src/screens/events/form/EventRsvpQuestionDialog.tsx
@@ -3,11 +3,11 @@ import { useState } from 'react';
 
 import { DEFAULT_RSVP_QUESTION_TYPE } from '@/api/eventRsvpQuestions';
 import { QuestionType } from '@/api/questionTypes';
+import { QuestionOptionsEditor } from '@/components/questions/QuestionOptionsEditor';
 import {
   normalizeQuestionOptions,
-  QuestionOptionsEditor,
-} from '@/components/questions/QuestionOptionsEditor';
-import { questionOptionsError } from '@/components/questions/questionTypeOptions';
+  questionOptionsError,
+} from '@/components/questions/questionTypeOptions';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import { Select } from '@/components/ui/Select';

--- a/frontend/src/screens/events/form/EventRsvpQuestionDialog.tsx
+++ b/frontend/src/screens/events/form/EventRsvpQuestionDialog.tsx
@@ -3,16 +3,18 @@ import { useState } from 'react';
 
 import { DEFAULT_RSVP_QUESTION_TYPE } from '@/api/eventRsvpQuestions';
 import { QuestionType } from '@/api/questionTypes';
+import {
+  normalizeQuestionOptions,
+  QuestionOptionsEditor,
+} from '@/components/questions/QuestionOptionsEditor';
 import { questionOptionsError } from '@/components/questions/questionTypeOptions';
 import { Button } from '@/components/ui/Button';
 import { Dialog } from '@/components/ui/Dialog';
 import { Select } from '@/components/ui/Select';
-import { Textarea } from '@/components/ui/Textarea';
 import { TextField } from '@/components/ui/TextField';
 
 import {
   newQuestionId,
-  parseOptionsText,
   RSVP_QUESTION_TYPE_OPTIONS,
   type RsvpQuestionDraft,
   type RsvpQuestionType,
@@ -39,7 +41,9 @@ function EventRsvpQuestionDialogBody({ open, onClose, onSave, existing }: Props)
     () => existing?.fieldType ?? DEFAULT_RSVP_QUESTION_TYPE,
   );
   const [required, setRequired] = useState(() => existing?.required ?? false);
-  const [optionsText, setOptionsText] = useState(() => existing?.options.join('\n') ?? '');
+  const [options, setOptions] = useState<string[]>(() =>
+    existing?.options.length ? [...existing.options] : [''],
+  );
   const [error, setError] = useState<string | null>(null);
 
   function onSubmit(e: SyntheticEvent) {
@@ -51,17 +55,17 @@ function EventRsvpQuestionDialogBody({ open, onClose, onSave, existing }: Props)
       return;
     }
     const needsOptions = wantsOptions(fieldType);
-    const options = needsOptions ? parseOptionsText(optionsText) : [];
-    const optionsError = questionOptionsError(needsOptions, options);
+    const normalized = needsOptions ? normalizeQuestionOptions(options) : [];
+    const optionsError = questionOptionsError(needsOptions, normalized);
     if (optionsError) {
       setError(optionsError);
       return;
     }
-    if (options.some((option) => option.length > MAX_OPTION_LENGTH)) {
+    if (normalized.some((option) => option.length > MAX_OPTION_LENGTH)) {
       setError(`options must be ${String(MAX_OPTION_LENGTH)} characters or fewer`);
       return;
     }
-    if (fieldType === QuestionType.Checkbox && options.some((option) => option.includes(','))) {
+    if (fieldType === QuestionType.Checkbox && normalized.some((option) => option.includes(','))) {
       setError('options cannot contain commas');
       return;
     }
@@ -69,7 +73,7 @@ function EventRsvpQuestionDialogBody({ open, onClose, onSave, existing }: Props)
       id: existing?.id ?? newQuestionId(),
       label: label.trim(),
       fieldType,
-      options,
+      options: normalized,
       required,
     });
     onClose();
@@ -90,7 +94,11 @@ function EventRsvpQuestionDialogBody({ open, onClose, onSave, existing }: Props)
           label="type"
           value={fieldType}
           onChange={(e) => {
-            setFieldType(e.target.value as RsvpQuestionType);
+            const next = e.target.value as RsvpQuestionType;
+            setFieldType(next);
+            if (wantsOptions(next) && options.every((option) => !option.trim())) {
+              setOptions(['']);
+            }
           }}
           options={RSVP_QUESTION_TYPE_OPTIONS.map((o) => ({
             value: o.value,
@@ -98,14 +106,10 @@ function EventRsvpQuestionDialogBody({ open, onClose, onSave, existing }: Props)
           }))}
         />
         {wantsOptions(fieldType) ? (
-          <Textarea
-            label="options"
-            value={optionsText}
-            onChange={(e) => {
-              setOptionsText(e.target.value);
-            }}
-            hint="one per line"
-            rows={5}
+          <QuestionOptionsEditor
+            options={options}
+            onChange={setOptions}
+            maxLength={MAX_OPTION_LENGTH}
           />
         ) : null}
         <label className="flex items-center gap-2 text-sm">

--- a/frontend/src/screens/events/rsvpQuestions.test.ts
+++ b/frontend/src/screens/events/rsvpQuestions.test.ts
@@ -1,14 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
 import { QuestionType } from '@/api/questionTypes';
-
 import { RsvpServerStatus } from '@/models/event';
 
 import {
   isAnswerFilled,
   missingRequiredQuestionIds,
-  rsvpQuestionsApplyToStatus,
   type RsvpQuestionDraft,
+  rsvpQuestionsApplyToStatus,
   wantsOptions,
 } from './rsvpQuestions';
 

--- a/frontend/src/screens/events/rsvpQuestions.test.ts
+++ b/frontend/src/screens/events/rsvpQuestions.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from 'vitest';
 
 import { QuestionType } from '@/api/questionTypes';
 
+import { RsvpServerStatus } from '@/models/event';
+
 import {
   isAnswerFilled,
   missingRequiredQuestionIds,
-  parseOptionsText,
+  rsvpQuestionsApplyToStatus,
   type RsvpQuestionDraft,
   wantsOptions,
 } from './rsvpQuestions';
@@ -28,12 +30,6 @@ describe('wantsOptions', () => {
   });
 });
 
-describe('parseOptionsText', () => {
-  it('splits trimmed non-empty lines', () => {
-    expect(parseOptionsText('  a\n\nb  \n')).toEqual(['a', 'b']);
-  });
-});
-
 describe('isAnswerFilled', () => {
   it('treats empty or whitespace as unfilled', () => {
     expect(isAnswerFilled(undefined)).toBe(false);
@@ -52,5 +48,14 @@ describe('missingRequiredQuestionIds', () => {
     ];
     expect(missingRequiredQuestionIds(questions, { a: 'ok', c: '' })).toEqual(['c']);
     expect(missingRequiredQuestionIds(questions, { a: 'ok', c: 'x' })).toEqual([]);
+  });
+});
+
+describe('rsvpQuestionsApplyToStatus', () => {
+  it('should apply only for going and waitlisted statuses', () => {
+    expect(rsvpQuestionsApplyToStatus(RsvpServerStatus.Attending)).toBe(true);
+    expect(rsvpQuestionsApplyToStatus(RsvpServerStatus.Waitlisted)).toBe(true);
+    expect(rsvpQuestionsApplyToStatus(RsvpServerStatus.Maybe)).toBe(false);
+    expect(rsvpQuestionsApplyToStatus(RsvpServerStatus.CantGo)).toBe(false);
   });
 });

--- a/frontend/src/screens/events/rsvpQuestions.ts
+++ b/frontend/src/screens/events/rsvpQuestions.ts
@@ -14,20 +14,12 @@ export { newRsvpQuestionId as newQuestionId };
 
 const RESPONDENT_STATUSES = new Set<string>([
   RsvpServerStatus.Attending,
-  RsvpServerStatus.Maybe,
   RsvpServerStatus.Waitlisted,
 ]);
 
 export const RSVP_QUESTION_TYPE_LABELS: Record<RsvpQuestionType, string> = Object.fromEntries(
   RSVP_QUESTION_TYPE_OPTIONS.map((o) => [o.value, o.label]),
 ) as Record<RsvpQuestionType, string>;
-
-export function parseOptionsText(text: string): string[] {
-  return text
-    .split('\n')
-    .map((s) => s.trim())
-    .filter(Boolean);
-}
 
 export function isAnswerFilled(value: RsvpAnswerValue | undefined): boolean {
   return Boolean(value?.trim());
@@ -41,6 +33,10 @@ export function missingRequiredQuestionIds(
 }
 
 export function isRsvpRespondentStatus(status: string): boolean {
+  return RESPONDENT_STATUSES.has(status);
+}
+
+export function rsvpQuestionsApplyToStatus(status: string): boolean {
   return RESPONDENT_STATUSES.has(status);
 }
 


### PR DESCRIPTION
## Summary
- Only show/require RSVP questionnaire answers when status is going (or waitlisted)
- Rename “long text” to “short answer”, and author select/checkbox options as addable rows instead of a one-per-line box
- Patch the React Query event-detail cache after syncing RSVP questions so hosts don’t get a blank questionnaire dialog with a still-required validation error

## Test plan
- [ ] Edit an event, add RSVP questions, save, RSVP as host — questions appear in the dialog
- [ ] Member/public RSVP: questions show for going; hidden for maybe / can’t go
- [ ] Question authoring: select/checkbox options use + add option rows; type label shows “short answer”


Made with [Cursor](https://cursor.com)