### PR TITLE
ci(railway): add cron-only deploy workflow with selectable ref

### DIFF
--- a/.github/workflows/deploy-railway-cron.yml
+++ b/.github/workflows/deploy-railway-cron.yml
@@ -1,0 +1,81 @@
+name: deploy railway cron (production)
+
+# Deploys ONLY the cron services, so cron changes can ship without releasing
+# whatever else has landed on main. Pick `ref` to control what gets built —
+# `railway up` uploads the checked-out working directory, not a git ref, so the
+# checkout below is what decides the deployed code.
+# Pin matches image pulled 2026-04-20; bump intentionally when upgrading CLI.
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "git ref to deploy (branch, tag, or SHA)"
+        required: true
+        default: main
+      services:
+        description: "comma-separated cron services to deploy"
+        required: true
+        default: cron-daily,cron-checkin-nudges
+
+permissions:
+  contents: read
+
+env:
+  RAILWAY_CLI_IMAGE: ghcr.io/railwayapp/cli@sha256:10ff70f5b1d65e6eee8d8b7839b917bc88631efa5b5eddaa33a585a7891b254c
+
+jobs:
+  deploy-cron:
+    name: deploy cron services to railway (production)
+    runs-on: ubuntu-latest
+    environment: railway-production
+    concurrency:
+      group: railway-deploy-production
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: print deploy context (no token)
+        env:
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+          RAILWAY_ENVIRONMENT: ${{ vars.RAILWAY_ENVIRONMENT_PRODUCTION }}
+          RAILWAY_CRON_SERVICES: ${{ inputs.services }}
+        run: |
+          echo "railway cron deploy context (production target)"
+          echo "  requested_ref=${{ inputs.ref }}"
+          echo "  commit=$(git rev-parse --short=7 HEAD)"
+          echo "  railway_project_id=${RAILWAY_PROJECT_ID}"
+          echo "  railway_environment=${RAILWAY_ENVIRONMENT}"
+          echo "  railway_cron_services=${RAILWAY_CRON_SERVICES}"
+
+      - name: railway up (production token only in this job)
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN_PRODUCTION }}
+          RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
+          RAILWAY_ENVIRONMENT: ${{ vars.RAILWAY_ENVIRONMENT_PRODUCTION }}
+          RAILWAY_CRON_SERVICES: ${{ inputs.services }}
+        run: |
+          set -eu
+          test -n "${RAILWAY_TOKEN}"
+          test -n "${RAILWAY_PROJECT_ID}"
+          test -n "${RAILWAY_ENVIRONMENT}"
+          test -n "${RAILWAY_CRON_SERVICES}"
+          docker_run=(docker run --rm --platform linux/amd64
+            -v "${GITHUB_WORKSPACE}:/workspace"
+            -w /workspace
+            -e RAILWAY_TOKEN
+            "${RAILWAY_CLI_IMAGE}")
+          echo "railway cli version:"
+          "${docker_run[@]}" railway --version
+
+          IFS=',' read -ra services <<< "${RAILWAY_CRON_SERVICES}"
+          for service in "${services[@]}"; do
+            service="$(echo "${service}" | tr -d '[:space:]')"
+            [ -n "${service}" ] || continue
+            echo "railway up (verbose) for service '${service}' — 404 here often means wrong project id, environment id/name, or service slug for this token"
+            "${docker_run[@]}" railway up --ci --verbose \
+              --project "${RAILWAY_PROJECT_ID}" \
+              --environment "${RAILWAY_ENVIRONMENT}" \
+              --service "${service}"
+          done

--- a/.github/workflows/deploy-railway-cron.yml
+++ b/.github/workflows/deploy-railway-cron.yml
@@ -1,10 +1,7 @@
 name: deploy railway cron (production)
 
-# Deploys ONLY the cron services, so cron changes can ship without releasing
-# whatever else has landed on main. Pick `ref` to control what gets built —
 # `railway up` uploads the checked-out working directory, not a git ref, so the
-# checkout below is what decides the deployed code.
-# Pin matches image pulled 2026-04-20; bump intentionally when upgrading CLI.
+# `ref` input is what decides the deployed code.
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -58,8 +58,7 @@ jobs:
           echo "railway cli version:"
           "${docker_run[@]}" railway --version
 
-          # Cron services deploy separately via deploy-railway-cron.yml, so cron
-          # changes can ship without releasing everything else on main.
+          # Cron services deploy separately via deploy-railway-cron.yml.
           echo "railway up (verbose) — 404 here often means wrong project id, environment id/name, or service slug for this token"
           "${docker_run[@]}" railway up --ci --verbose \
             --project "${RAILWAY_PROJECT_ID}" \

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -30,7 +30,6 @@ jobs:
           RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
           RAILWAY_ENVIRONMENT: ${{ vars.RAILWAY_ENVIRONMENT_PRODUCTION }}
           RAILWAY_SERVICE_NAME: ${{ vars.RAILWAY_SERVICE_NAME_PRODUCTION }}
-          RAILWAY_CRON_SERVICE_NAMES: ${{ vars.RAILWAY_CRON_SERVICE_NAMES_PRODUCTION }}
         run: |
           echo "railway deploy context (production target)"
           echo "  github_ref=${GITHUB_REF}"
@@ -38,7 +37,6 @@ jobs:
           echo "  railway_project_id=${RAILWAY_PROJECT_ID}"
           echo "  railway_environment=${RAILWAY_ENVIRONMENT}"
           echo "  railway_service=${RAILWAY_SERVICE_NAME}"
-          echo "  railway_cron_services=${RAILWAY_CRON_SERVICE_NAMES}"
 
       - name: railway up (production token only in this job)
         env:
@@ -46,7 +44,6 @@ jobs:
           RAILWAY_PROJECT_ID: ${{ vars.RAILWAY_PROJECT_ID }}
           RAILWAY_ENVIRONMENT: ${{ vars.RAILWAY_ENVIRONMENT_PRODUCTION }}
           RAILWAY_SERVICE_NAME: ${{ vars.RAILWAY_SERVICE_NAME_PRODUCTION }}
-          RAILWAY_CRON_SERVICE_NAMES: ${{ vars.RAILWAY_CRON_SERVICE_NAMES_PRODUCTION }}
         run: |
           set -eu
           test -n "${RAILWAY_TOKEN}"
@@ -61,21 +58,10 @@ jobs:
           echo "railway cli version:"
           "${docker_run[@]}" railway --version
 
-          deploy_service() {
-            local service="$1"
-            echo "railway up (verbose) for service '${service}' — 404 here often means wrong project id, environment id/name, or service slug for this token"
-            "${docker_run[@]}" railway up --ci --verbose \
-              --project "${RAILWAY_PROJECT_ID}" \
-              --environment "${RAILWAY_ENVIRONMENT}" \
-              --service "${service}"
-          }
-
-          deploy_service "${RAILWAY_SERVICE_NAME}"
-
-          # RAILWAY_CRON_SERVICE_NAMES_PRODUCTION: comma-separated cron service names, e.g. "cron-daily,cron-checkin-nudges"
-          if [ -n "${RAILWAY_CRON_SERVICE_NAMES}" ]; then
-            IFS=',' read -ra cron_services <<< "${RAILWAY_CRON_SERVICE_NAMES}"
-            for service in "${cron_services[@]}"; do
-              deploy_service "${service}"
-            done
-          fi
+          # Cron services deploy separately via deploy-railway-cron.yml, so cron
+          # changes can ship without releasing everything else on main.
+          echo "railway up (verbose) — 404 here often means wrong project id, environment id/name, or service slug for this token"
+          "${docker_run[@]}" railway up --ci --verbose \
+            --project "${RAILWAY_PROJECT_ID}" \
+            --environment "${RAILWAY_ENVIRONMENT}" \
+            --service "${RAILWAY_SERVICE_NAME}"


### PR DESCRIPTION
## Summary

Adds `deploy-railway-cron.yml` so the cron services can be deployed **independently** of the web service — cron changes ship without releasing whatever else has landed on `main`.

Two inputs:

- **`ref`** (default `main`) — branch, tag, or SHA to deploy. This matters: `railway up` uploads the *checked-out working directory*, not a git ref, so deploying a specific commit requires checking it out first. Without this, a "cron-only" run on `main` would still build all of `main`.
- **`services`** (default `cron-daily,cron-checkin-nudges`) — comma-separated, so a single service can be targeted.

Also removes the cron loop from `deploy-railway.yml` (added in #1353). That workflow now deploys only the web service, so the two are cleanly separated and a production release no longer implicitly redeploys cron.

## Usage

To test the cron fix without shipping the rest of `main`:

1. Actions → **deploy railway cron (production)** → Run workflow
2. Set `ref` to the branch/SHA with the cron changes (e.g. #1368's branch)
3. Leave `services` as-is, or narrow to one service

## Notes

Both workflows validated as parseable YAML. `RAILWAY_CRON_SERVICE_NAMES_PRODUCTION` (the repo variable added for #1353) is no longer read by any workflow — the service list is now a workflow input. It can be deleted, or left harmlessly.

## Test plan

- [ ] Run the workflow against #1368's branch and confirm only cron services deploy
- [ ] Confirm `deploy-railway.yml` still deploys the web service correctly