### PR TITLE
fix(events): stop RSVP status pills from vertical scroll clipping

### DIFF
--- a/frontend/src/components/ui/RsvpStatusPicker.test.tsx
+++ b/frontend/src/components/ui/RsvpStatusPicker.test.tsx
@@ -35,6 +35,15 @@ describe('RsvpStatusPicker', () => {
     expect(row).toHaveClass('justify-center-safe');
   });
 
+  it('should not open a vertical scrollport when nested in a height-capped flex column', () => {
+    // overflow-x-auto alone computes overflow-y to auto, which lets a max-height
+    // flex parent clip the pills into a tiny vertical scroll window.
+    render(<RsvpStatusPicker value={null} onSelect={vi.fn()} />);
+    const row = screen.getByRole('button', { name: 'maybe' }).parentElement;
+    expect(row).toHaveClass('shrink-0');
+    expect(row).toHaveClass('overflow-y-clip');
+  });
+
   it('keeps each pill from shrinking so labels are never truncated', () => {
     render(<RsvpStatusPicker value={null} onSelect={vi.fn()} />);
     expect(screen.getByRole('button', { name: "i'm going" })).toHaveClass('shrink-0');

--- a/frontend/src/components/ui/RsvpStatusPicker.tsx
+++ b/frontend/src/components/ui/RsvpStatusPicker.tsx
@@ -15,7 +15,7 @@ export function RsvpStatusPicker({ value, onSelect, disabled = false, labelFor, 
     ? RSVP_STATUS_LABELS.filter((p) => statuses.includes(p.status))
     : RSVP_STATUS_LABELS;
   return (
-    <div className="-mx-1 flex justify-center-safe gap-2 overflow-x-auto px-1 py-1">
+    <div className="-mx-1 flex shrink-0 justify-center-safe gap-2 overflow-x-auto overflow-y-clip px-1 py-1">
       {options.map((p) => {
         const label = labelFor ? labelFor(p.status, p.label) : p.label;
         const active = value === p.status;

--- a/frontend/src/screens/events/RsvpBox.test.tsx
+++ b/frontend/src/screens/events/RsvpBox.test.tsx
@@ -194,9 +194,15 @@ describe('RsvpBox', () => {
     const scroll = screen.getByTestId('rsvp-details-scroll');
     expect(scroll).toContainElement(screen.getByText('how are you getting there?'));
     expect(scroll).toContainElement(screen.getByLabelText('comment (optional)'));
+    const controls = screen.getByTestId('rsvp-status-controls');
     expect(scroll).not.toContainElement(screen.getByRole('button', { name: /i'm going/i }));
     expect(scroll).not.toContainElement(screen.getByRole('button', { name: /add \+1/i }));
     expect(scroll).not.toContainElement(screen.getByRole('button', { name: /^confirm$/i }));
+    // Status/+1 sit in a shrink-0 shell so the height-capped column cannot clip
+    // the pills into RsvpStatusPicker's overflow-x scrollport.
+    expect(controls).toHaveClass('shrink-0');
+    expect(controls).toContainElement(screen.getByRole('button', { name: /i'm going/i }));
+    expect(controls).toContainElement(screen.getByRole('button', { name: /add \+1/i }));
   });
 
   it('should hide questions when status is can’t go', () => {

--- a/frontend/src/screens/events/RsvpBox.tsx
+++ b/frontend/src/screens/events/RsvpBox.tsx
@@ -129,29 +129,31 @@ export function RsvpBox({
         />
       ) : (
         <div className="flex max-h-[min(70vh,32rem)] flex-col gap-4">
-          <RsvpStatusPicker
-            value={status}
-            onSelect={setStatus}
-            disabled={busy}
-            labelFor={(s, defaultLabel) =>
-              s === RsvpStatus.Attending && atCapacity ? 'join the waitlist' : defaultLabel
-            }
-          />
+          <div data-testid="rsvp-status-controls" className="flex shrink-0 flex-col gap-4">
+            <RsvpStatusPicker
+              value={status}
+              onSelect={setStatus}
+              disabled={busy}
+              labelFor={(s, defaultLabel) =>
+                s === RsvpStatus.Attending && atCapacity ? 'join the waitlist' : defaultLabel
+              }
+            />
 
-          {showPlusOne ? (
-            <div className="flex justify-center">
-              <Button
-                type="button"
-                variant={hasPlusOne ? 'primary' : 'secondary'}
-                onClick={() => {
-                  setHasPlusOne(!hasPlusOne);
-                }}
-                disabled={busy}
-              >
-                {hasPlusOne ? 'remove +1' : 'add +1'}
-              </Button>
-            </div>
-          ) : null}
+            {showPlusOne ? (
+              <div className="flex justify-center">
+                <Button
+                  type="button"
+                  variant={hasPlusOne ? 'primary' : 'secondary'}
+                  onClick={() => {
+                    setHasPlusOne(!hasPlusOne);
+                  }}
+                  disabled={busy}
+                >
+                  {hasPlusOne ? 'remove +1' : 'add +1'}
+                </Button>
+              </div>
+            ) : null}
+          </div>
 
           {showQuestions || showComment ? (
             <div


### PR DESCRIPTION
## Overview

Fixes the RSVP dialog where the status pills ("i'm going" / "maybe" / "can't go") sat inside a tiny vertical scrollport and looked clipped.

Root cause: `RsvpStatusPicker` uses `overflow-x-auto` for narrow viewports; CSS then computes `overflow-y` to `auto`, so a height-capped flex column could shrink the pill row. The earlier change moved status outside the questions scroller, but the picker row itself could still become a scrollport.

This keeps status/+1 in a `shrink-0` shell and sets `overflow-y-clip` on the picker row so only questions/comment scroll.

## Test plan

- [ ] Open an event RSVP dialog with several questionnaire fields
- [ ] Confirm status pills and "+1" are fully visible with no scrollbar on that row
- [ ] Confirm only the questions/comment region scrolls when content is tall
- [ ] Confirm cancel/confirm footer stays pinned
