### PR TITLE
fix: 1372 - allow dev-test event to be both host and guest

### DIFF
--- a/frontend/src/components/DevTestEventOverrides.tsx
+++ b/frontend/src/components/DevTestEventOverrides.tsx
@@ -80,14 +80,14 @@ export function DevTestEventOverrides({ options, onChange }: Props) {
           label="make me a host"
           checked={options.makeMeHost}
           onChange={(v) => {
-            onChange({ ...options, makeMeHost: v, makeMeGuest: v ? false : options.makeMeGuest });
+            set('makeMeHost', v);
           }}
         />
         <Toggle
           label="make me a guest"
           checked={options.makeMeGuest}
           onChange={(v) => {
-            onChange({ ...options, makeMeGuest: v, makeMeHost: v ? false : options.makeMeHost });
+            set('makeMeGuest', v);
           }}
         />
         <Toggle


### PR DESCRIPTION
## Overview

the dev test-events tool's "make me a host" and "make me a guest" toggles were mutually exclusive in the UI — turning one on forced the other off. the backend already applies both independently (co-host membership and RSVP status are unrelated), so this was a UI-only constraint. removed the resets so both toggles can be on at once.

## Test plan

- [ ] toggle "make me a host" on, then "make me a guest" on, and confirm both stay checked
- [ ] create a dev test event with both toggles on and confirm the event shows you as both host and attending guest

Closes #1372
