### PR TITLE
fix: 1375 - use calendar picker for partiful import event date

### DIFF
--- a/frontend/src/components/ui/DatePicker.tsx
+++ b/frontend/src/components/ui/DatePicker.tsx
@@ -1,0 +1,97 @@
+import { format } from 'date-fns';
+import { enUS } from 'date-fns/locale/en-US';
+import { useEffect, useRef, useState } from 'react';
+import { DayPicker } from 'react-day-picker';
+
+interface Props {
+  label: string;
+  value: string | null;
+  onChange: (isoDate: string | null) => void;
+  disabled?: boolean;
+  error?: string | undefined;
+}
+
+function isoToDate(iso: string | null): Date | undefined {
+  if (!iso) return undefined;
+  const d = new Date(`${iso}T00:00:00`);
+  return isNaN(d.getTime()) ? undefined : d;
+}
+
+function dateToIso(date: Date): string {
+  return format(date, 'yyyy-MM-dd');
+}
+
+export function DatePicker({ label, value, onChange, disabled, error }: Props) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+  const selectedDate = isoToDate(value);
+
+  useEffect(() => {
+    if (!open) return;
+    function onClick(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', onClick);
+    return () => {
+      document.removeEventListener('mousedown', onClick);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === 'Escape') setOpen(false);
+    }
+    document.addEventListener('keydown', onKey);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+    };
+  }, [open]);
+
+  const display = selectedDate ? format(selectedDate, 'EEEE, MMMM d, yyyy').toLowerCase() : '';
+
+  return (
+    <div ref={ref} className="relative flex flex-col gap-1">
+      <label className="text-foreground text-sm font-medium">{label}</label>
+
+      <button
+        type="button"
+        disabled={disabled}
+        onClick={() => {
+          if (!disabled) setOpen((v) => !v);
+        }}
+        aria-expanded={open}
+        className={[
+          'h-10 w-full rounded-[var(--radius-md)] border px-3 text-left text-sm transition-colors outline-none',
+          display
+            ? 'border-brand-200 bg-brand-50 text-brand-900 font-medium'
+            : 'border-border-strong bg-surface text-muted-foreground',
+          error && 'border-destructive bg-destructive-subtle text-destructive',
+          disabled && 'bg-surface-dim text-muted-foreground',
+        ].join(' ')}
+      >
+        {display || 'pick a date'}
+      </button>
+
+      {open && (
+        <div className="border-brand-100 bg-surface absolute z-50 mt-2 rounded-[var(--radius-md)] border p-3 shadow-(--shadow-lg)">
+          <DayPicker
+            mode="single"
+            selected={selectedDate}
+            onSelect={(day) => {
+              if (!day) return;
+              onChange(dateToIso(day));
+              setOpen(false);
+            }}
+            defaultMonth={selectedDate ?? new Date()}
+            locale={enUS}
+          />
+        </div>
+      )}
+
+      {error ? <p className="text-destructive text-xs">{error}</p> : null}
+    </div>
+  );
+}

--- a/frontend/src/screens/admin/AttendanceImportEventStep.tsx
+++ b/frontend/src/screens/admin/AttendanceImportEventStep.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 
 import { type EventOption, useAttendanceImportEventOptions } from '@/api/attendanceImport';
 import { Button } from '@/components/ui/Button';
+import { DatePicker } from '@/components/ui/DatePicker';
 import { TextField } from '@/components/ui/TextField';
 import { Toggle } from '@/components/ui/Toggle';
 import { EventType } from '@/models/event';
@@ -177,12 +178,11 @@ function NewEventFields({
         }}
         placeholder="e.g. summer potluck"
       />
-      <TextField
+      <DatePicker
         label="event date"
-        type="date"
-        value={date}
-        onChange={(e) => {
-          onDateChange(e.target.value);
+        value={date || null}
+        onChange={(v) => {
+          onDateChange(v ?? '');
         }}
       />
       <div className="flex flex-col gap-1">


### PR DESCRIPTION
## Overview

the "new event" step of the partiful attendance import modal used a raw `type="date"` text field, letting the date just be typed in free-form instead of picked from a calendar. added a date-only `DatePicker` component (mirrors the existing `DateTimePicker`'s calendar popover, minus the time row) and swapped it in.

## Test plan

- [ ] open admin → attendance → import partiful attendance → new event
- [ ] confirm the event date field opens a calendar popover instead of a text input
- [ ] pick a date and confirm the import proceeds with the correct date

Closes #1375
