### PR TITLE
fix(events): RSVP question copy + seed event titles

### DIFF
--- a/backend/community/management/commands/_seed_data.py
+++ b/backend/community/management/commands/_seed_data.py
@@ -15,6 +15,9 @@ from ._seed_shared import SeedEvent, SeedRsvpQuestion
 
 PASSWORD = "testpass123"
 
+# Title includes "rsvp questions" so the event is easy to find when testing questionnaires.
+COOKING_WORKSHOP_TITLE = "Plant-Based Cooking Workshop · rsvp questions"
+
 
 @dataclass
 class SeedUser:
@@ -156,7 +159,7 @@ SEED_EVENTS = [
         max_attendees=3,
     ),
     SeedEvent(
-        title="Plant-Based Cooking Workshop",
+        title=COOKING_WORKSHOP_TITLE,
         description="Learn to make tofu scramble, cashew cheese, and more.",
         delta_days=14,
         duration_hours=2,
@@ -236,7 +239,7 @@ _TRAVEL_Q = "How are you getting there?"
 _NOTES_Q = "Anything we should know?"
 
 SEED_EVENT_RSVP_QUESTIONS: dict[str, list[SeedRsvpQuestion]] = {
-    "Plant-Based Cooking Workshop": [
+    COOKING_WORKSHOP_TITLE: [
         SeedRsvpQuestion(
             label=_TRAVEL_Q,
             field_type=RsvpQuestionType.SELECT,
@@ -261,9 +264,9 @@ SEED_RSVPS = [
     SeedRSVP("Vegan Potluck", _JAMIE, RSVPStatus.WAITLISTED),
     SeedRSVP("Vegan Potluck", _RIN, RSVPStatus.WAITLISTED),
     SeedRSVP("Vegan Potluck", _ASH, RSVPStatus.MAYBE),
-    # Plant-Based Cooking Workshop — uncapped, mixed statuses + questionnaire coverage.
+    # Cooking workshop — uncapped, mixed statuses + questionnaire coverage.
     SeedRSVP(
-        "Plant-Based Cooking Workshop",
+        COOKING_WORKSHOP_TITLE,
         _MEMBER,
         RSVPStatus.ATTENDING,
         has_plus_one=True,
@@ -273,13 +276,13 @@ SEED_RSVPS = [
         },
     ),
     SeedRSVP(
-        "Plant-Based Cooking Workshop",
+        COOKING_WORKSHOP_TITLE,
         _JAMIE,
         RSVPStatus.ATTENDING,
         answers={_TRAVEL_Q: "bike"},
     ),
-    SeedRSVP("Plant-Based Cooking Workshop", _RIN, RSVPStatus.MAYBE),
-    SeedRSVP("Plant-Based Cooking Workshop", _ASH, RSVPStatus.CANT_GO),
+    SeedRSVP(COOKING_WORKSHOP_TITLE, _RIN, RSVPStatus.MAYBE),
+    SeedRSVP(COOKING_WORKSHOP_TITLE, _ASH, RSVPStatus.CANT_GO),
     # Past Potluck — attendance marked (attended / no_show) on attending RSVPs.
     SeedRSVP(
         "Past Potluck (seed)",
@@ -318,8 +321,8 @@ SEED_RSVPS = [
         RSVPStatus.ATTENDING,
         attendance=AttendanceStatus.ATTENDED,
     ),
-    SeedRSVP("Plant-Based Cooking Workshop", _RILEY_NON_MEMBER, RSVPStatus.ATTENDING),
-    SeedRSVP("Plant-Based Cooking Workshop", _TAYLOR_NON_MEMBER, RSVPStatus.ATTENDING),
+    SeedRSVP(COOKING_WORKSHOP_TITLE, _RILEY_NON_MEMBER, RSVPStatus.ATTENDING),
+    SeedRSVP(COOKING_WORKSHOP_TITLE, _TAYLOR_NON_MEMBER, RSVPStatus.ATTENDING),
 ]
 
 SEED_HOME_PAGE = {

--- a/backend/community/management/commands/_seed_staging_data.py
+++ b/backend/community/management/commands/_seed_staging_data.py
@@ -57,7 +57,7 @@ NON_MEMBER_EVENT_TITLE = "[staging] official public rsvp demo"
 
 # Official, RSVP-enabled events the attendance + public-RSVP surfaces read from.
 OFFICIAL_PAST_TITLE = "[staging] official past attendance-marked"
-OFFICIAL_TODAY_TITLE = "[staging] official today rsvp open"
+OFFICIAL_TODAY_TITLE = "[staging] official today · rsvp questions"
 OFFICIAL_FULL_TITLE = "[staging] official over-capacity waitlist"
 
 

--- a/backend/tests/test_seed.py
+++ b/backend/tests/test_seed.py
@@ -1,5 +1,8 @@
 import pytest
-from community.management.commands._seed_data import SEED_EVENT_RSVP_QUESTIONS
+from community.management.commands._seed_data import (
+    COOKING_WORKSHOP_TITLE,
+    SEED_EVENT_RSVP_QUESTIONS,
+)
 from community.models import Event, EventRSVP, JoinRequest, RSVPStatus
 from community.models.choices import AttendanceStatus
 from django.core.management import call_command
@@ -97,7 +100,7 @@ def test_seed_creates_rsvp_questions_on_configured_events():
 def test_seed_rsvps_include_partial_and_complete_questionnaire_responses():
     call_command("seed")
 
-    event = Event.objects.get(title="Plant-Based Cooking Workshop")
+    event = Event.objects.get(title=COOKING_WORKSHOP_TITLE)
     questions = {q.label: q for q in event.rsvp_questions.all()}
     assert len(questions) == 2
 

--- a/frontend/src/screens/events/form/EventFormQuestions.test.tsx
+++ b/frontend/src/screens/events/form/EventFormQuestions.test.tsx
@@ -28,6 +28,12 @@ describe('EventFormQuestions', () => {
     expect(screen.getByRole('button', { name: /add question/i })).toBeInTheDocument();
   });
 
+  it('should explain questions only show for going or waitlisted guests', () => {
+    render(<EventFormQuestions rsvpEnabled questions={[]} onQuestionsChange={vi.fn()} />);
+    expect(screen.getByText('shown when guests rsvp as going or waitlisted')).toBeInTheDocument();
+    expect(screen.queryByText(/going or maybe/i)).not.toBeInTheDocument();
+  });
+
   it('lists questions with type and required marker', () => {
     render(<EventFormQuestions rsvpEnabled questions={[sample]} onQuestionsChange={vi.fn()} />);
     expect(screen.getByText('bring anything?')).toBeInTheDocument();

--- a/frontend/src/screens/events/form/EventFormQuestions.tsx
+++ b/frontend/src/screens/events/form/EventFormQuestions.tsx
@@ -26,7 +26,7 @@ export function EventFormQuestions({ rsvpEnabled, questions, onQuestionsChange }
   return (
     <div className="flex flex-col gap-3">
       <div className="flex flex-wrap items-center justify-between gap-2">
-        <p className="text-muted text-sm">shown when guests rsvp as going or maybe</p>
+        <p className="text-muted text-sm">shown when guests rsvp as going or waitlisted</p>
         <Button
           type="button"
           variant="secondary"


### PR DESCRIPTION
## Overview

Fixes stale host-form copy that still said RSVP questions show for “maybe” after questions were gated to going/waitlisted only.

Also renames the seeded events that include questionnaires so they are easy to spot on local/staging calendars:
- local: `Plant-Based Cooking Workshop · rsvp questions`
- staging: `[staging] official today · rsvp questions`

Re-run `seed` / `seed_staging --reset` after deploy to pick up the new titles (and staging questionnaire fixtures).

## Test plan

- [ ] Event edit → questions helper text says “going or waitlisted”, not “maybe”
- [ ] After reseeding staging, calendar shows `[staging] official today · rsvp questions`
- [ ] That event has travel/notes questions and mixed questionnaire answers
