### PR TITLE
chore(cron): drop send_attendance_reminders from daily cron

### DIFF
--- a/scripts/cron_daily.sh
+++ b/scripts/cron_daily.sh
@@ -5,6 +5,5 @@ status=0
 timeout 300 uv run --no-dev python manage.py hard_delete_old_events || status=1
 timeout 300 uv run --no-dev python manage.py cleanup_notifications || status=1
 timeout 300 uv run --no-dev python manage.py purge_audit_logs || status=1
-timeout 300 uv run --no-dev python manage.py send_attendance_reminders || status=1
 
 exit $status


### PR DESCRIPTION
## Summary
- Removes the `send_attendance_reminders` step from `scripts/cron_daily.sh` so the daily cron no longer emails members about attendance milestones (10/11/11.5/12 months).
- The management command and `ADMIN_ATTENDANCE_ANALYTICS` feature flag (default off) are left in place — only the cron invocation is removed.

## Test plan
- [ ] Confirm `scripts/cron_daily.sh` no longer references `send_attendance_reminders`
- [ ] Confirm the other cron steps (hard_delete_old_events, cleanup_notifications, purge_audit_logs) are unaffected