### PR TITLE
fix(events): rename check-in route from /attendance to /check-in

### DIFF
--- a/backend/community/_checkin_nudge.py
+++ b/backend/community/_checkin_nudge.py
@@ -59,7 +59,7 @@ def send_checkin_nudge(event: Event) -> bool:
     notify_checkin_reminder(event)
 
     sender = get_email_sender()
-    event_url = f"{settings.FRONTEND_BASE_URL}/events/{event.pk}/attendance"
+    event_url = f"{settings.FRONTEND_BASE_URL}/events/{event.pk}/check-in"
     for user in event.co_hosts.all():
         if not user.email:
             continue

--- a/backend/templates/emails/attendance_checkin_reminder.html
+++ b/backend/templates/emails/attendance_checkin_reminder.html
@@ -3,7 +3,7 @@
 <body style="margin: 0; padding: 24px; background: #f5f5f3; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #222;">
   <div style="max-width: 480px; margin: 0 auto; background: #ffffff; border-radius: 8px; padding: 32px;">
     <p style="margin: 0 0 16px;">hi{% if display_name %} {{ display_name|lower }}{% endif %} —</p>
-    <p style="margin: 0 0 24px;"><strong>{{ event_title|lower }}</strong> just started — head to check-in to check people in.</p>
+    <p style="margin: 0 0 24px;"><strong>{{ event_title|lower }}</strong> just started — remember to check people in!</p>
     <p style="margin: 0 0 24px;">
       <a href="{{ event_url }}" style="display: inline-block; background: #3c6939; color: #ffffff; text-decoration: none; padding: 12px 24px; border-radius: 6px; font-weight: 500;">go to check-in</a>
     </p>

--- a/backend/templates/emails/attendance_checkin_reminder.txt
+++ b/backend/templates/emails/attendance_checkin_reminder.txt
@@ -1,6 +1,6 @@
 hi{% if display_name %} {{ display_name|lower }}{% endif %} —
 
-{{ event_title|lower }} just started — head to check-in to check people in.
+{{ event_title|lower }} just started — remember to check people in!
 
 go to check-in:
 

--- a/backend/tests/test_checkin_nudge.py
+++ b/backend/tests/test_checkin_nudge.py
@@ -143,8 +143,8 @@ class TestSendCheckinNudge:
         send_checkin_nudge(event)
 
         sent = fake_email_sender.send.call_args.kwargs
-        assert f"/events/{event.pk}/attendance" in sent["html"]
-        assert f"/events/{event.pk}/attendance" in sent["text"]
+        assert f"/events/{event.pk}/check-in" in sent["html"]
+        assert f"/events/{event.pk}/check-in" in sent["text"]
 
 
 @pytest.mark.django_db

--- a/frontend/src/layout/notificationTarget.ts
+++ b/frontend/src/layout/notificationTarget.ts
@@ -17,7 +17,7 @@ export function notificationTarget(n: AppNotification): string | null {
     case NotificationType.RsvpStatusChanged:
       return n.eventId ? `/events/${n.eventId}` : null;
     case NotificationType.CheckinNudge:
-      return n.eventId ? `/events/${n.eventId}/attendance` : null;
+      return n.eventId ? `/events/${n.eventId}/check-in` : null;
     case NotificationType.EventFlagged:
       return '/admin/flagged-events';
     case NotificationType.JoinRequest:

--- a/frontend/src/router/routes.tsx
+++ b/frontend/src/router/routes.tsx
@@ -112,7 +112,7 @@ export const router = createBrowserRouter([
                   { path: '/events/mine', element: el(<MyEvents />) },
                   { path: '/events/add', element: el(<EventCreate />) },
                   { path: '/events/:id/edit', element: el(<EventEdit />) },
-                  { path: '/events/:id/attendance', element: el(<EventAttendance />) },
+                  { path: '/events/:id/check-in', element: el(<EventAttendance />) },
                   { path: '/events/:id/manage-rsvps', element: el(<EventManageRsvps />) },
                   { path: '/members', element: el(<MembersDirectory />) },
                   { path: '/members/:userId', element: el(<MemberProfile />) },

--- a/frontend/src/screens/events/EventAttendanceScreen.test.tsx
+++ b/frontend/src/screens/events/EventAttendanceScreen.test.tsx
@@ -33,9 +33,9 @@ function renderScreen() {
   const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
   return render(
     <QueryClientProvider client={qc}>
-      <MemoryRouter initialEntries={['/events/ev1/attendance']}>
+      <MemoryRouter initialEntries={['/events/ev1/check-in']}>
         <Routes>
-          <Route path="/events/:id/attendance" element={<EventAttendanceScreen />} />
+          <Route path="/events/:id/check-in" element={<EventAttendanceScreen />} />
           <Route path="/events/:id" element={<div>event detail</div>} />
         </Routes>
       </MemoryRouter>

--- a/frontend/src/screens/events/EventDetailKebabMenu.test.tsx
+++ b/frontend/src/screens/events/EventDetailKebabMenu.test.tsx
@@ -105,7 +105,7 @@ describe('EventDetailKebabMenu', () => {
     await openMenu();
 
     const checkIn = screen.getByRole('menuitem', { name: 'check-in' });
-    expect(checkIn).toHaveAttribute('href', '/events/ev1/attendance');
+    expect(checkIn).toHaveAttribute('href', '/events/ev1/check-in');
   });
 
   it('hides check-in report when the event has not ended', async () => {

--- a/frontend/src/screens/events/EventDetailKebabMenu.tsx
+++ b/frontend/src/screens/events/EventDetailKebabMenu.tsx
@@ -91,7 +91,7 @@ export function EventDetailKebabMenu({ event, eventHasEnded, canManageRsvps }: P
             </MenuLink>
           ) : null}
           <MenuLink
-            to={`/events/${eventId}/attendance`}
+            to={`/events/${eventId}/check-in`}
             onSelect={() => {
               setOpen(false);
             }}


### PR DESCRIPTION
## Summary
- Renames the per-event check-in route from `/events/:id/attendance` to `/events/:id/check-in`, updating all references (kebab menu link, notification target, checkin-nudge email link).
- Updates the check-in nudge email copy to "remember to check people in!".

## Test plan
- [x] `make agent-frontend-typecheck` passes
- [x] Frontend tests pass (EventDetailKebabMenu, EventAttendanceScreen, notificationTarget)
- [x] Backend `test_checkin_nudge.py` passes