### PR TITLE
fix: prevent duplicate digest emails and report real send counts

### DIFF
--- a/backend/community/management/commands/send_weekly_digest.py
+++ b/backend/community/management/commands/send_weekly_digest.py
@@ -56,6 +56,7 @@ class Command(BaseCommand):
         }
         sender = get_email_sender()
         sent_count = 0
+        failed_count = 0
 
         recipients = (
             User.objects.active_members()
@@ -63,14 +64,19 @@ class Command(BaseCommand):
             .exclude(email="")
         )
         for user in recipients:
-            send_weekly_digest_email(
+            result = send_weekly_digest_email(
                 sender=sender,
                 to=user.email,
                 display_name=user.first_name,
                 events=events,
                 urls=urls,
             )
-            sent_count += 1
+            if result.success:
+                sent_count += 1
+            else:
+                failed_count += 1
 
-        logger.info("send_weekly_digest: sent %d digest(s)", sent_count)
-        self.stdout.write(self.style.SUCCESS(f"Sent {sent_count} digest(s)."))
+        logger.info("send_weekly_digest: sent %d digest(s), %d failed", sent_count, failed_count)
+        summary = f"Sent {sent_count} digest(s); {failed_count} failed."
+        style = self.style.WARNING if failed_count else self.style.SUCCESS
+        self.stdout.write(style(summary))

--- a/backend/notifications/_resend_sender.py
+++ b/backend/notifications/_resend_sender.py
@@ -2,6 +2,7 @@
 
 import logging
 import time
+import uuid
 
 import resend
 from django.conf import settings
@@ -64,13 +65,19 @@ class ResendSender:
         # holds a request thread for up to 30s on a hung connection.
         resend.default_http_client = resend.RequestsClient(timeout=_REQUEST_TIMEOUT_SECONDS)
 
-    def _attempt_send(self, params: dict, masked: str, attempt: int) -> SendResult:
+    def _attempt_send(
+        self, params: dict, masked: str, attempt: int, idempotency_key: str
+    ) -> SendResult:
         """Perform a single send and log success.
 
         Never catches — the caller owns the retry/error policy. Returns a
         successful SendResult; on failure the underlying exception propagates.
         """
-        response = resend.Emails.send(params)
+        # A 5xx/429 can come back after Resend already queued the email, so a
+        # bare retry delivers a duplicate. The key is stable across attempts of
+        # one logical send, so Resend dedupes them (24h window).
+        options: resend.Emails.SendOptions = {"idempotency_key": idempotency_key}
+        response = resend.Emails.send(params, options)
         # SendResponse is a dict subclass; access id via .get() for safety
         message_id = response.get("id") if isinstance(response, dict) else None
         logger.info(
@@ -103,12 +110,13 @@ class ResendSender:
             "text": text,
         }
         masked = mask_recipient(to)
+        idempotency_key = str(uuid.uuid4())
         last_error: Exception | None = None
         attempt = 0
 
         for attempt in range(1, _MAX_ATTEMPTS + 1):
             try:
-                return self._attempt_send(params, masked, attempt)
+                return self._attempt_send(params, masked, attempt, idempotency_key)
             except ResendError as exc:
                 last_error = exc
                 if attempt < _MAX_ATTEMPTS and _is_retryable(exc):

--- a/backend/tests/test_email_sender.py
+++ b/backend/tests/test_email_sender.py
@@ -149,6 +149,29 @@ class TestResendSender:
         assert result.provider_message_id == "msg_after_retry"
         assert mock_send.call_count == 2
 
+    def test_retry_reuses_idempotency_key(self):
+        """Resend can queue the email then 5xx; a fresh key on retry would duplicate it."""
+        transient = RateLimitError(
+            code="429", error_type="rate_limit_exceeded", message="slow down"
+        )
+        with patch.object(_resend_sender.time, "sleep"):
+            with patch(
+                "resend.Emails.send",
+                side_effect=[transient, {"id": "msg_after_retry"}],
+            ) as mock_send:
+                ResendSender().send(to="user@example.com", subject="hi", html="<p>x</p>", text="x")
+        keys = [call.args[1]["idempotency_key"] for call in mock_send.call_args_list]
+        assert len(keys) == 2
+        assert keys[0] == keys[1]
+
+    def test_separate_sends_use_distinct_idempotency_keys(self):
+        with patch("resend.Emails.send", return_value={"id": "m"}) as mock_send:
+            sender = ResendSender()
+            for _ in range(2):
+                sender.send(to="user@example.com", subject="hi", html="<p>x</p>", text="x")
+        keys = [call.args[1]["idempotency_key"] for call in mock_send.call_args_list]
+        assert keys[0] != keys[1]
+
     def test_send_does_not_retry_client_error(self):
         err = ValidationError(code="400", error_type="validation_error", message="bad")
         with patch("resend.Emails.send", side_effect=err) as mock_send:

--- a/backend/tests/test_weekly_digest.py
+++ b/backend/tests/test_weekly_digest.py
@@ -1,6 +1,7 @@
 """Tests for the send_weekly_digest management command."""
 
 from datetime import timedelta
+from io import StringIO
 from unittest.mock import MagicMock
 
 import pytest
@@ -130,3 +131,18 @@ class TestSendWeeklyDigestCommand:
         call_command("send_weekly_digest")
         text = fake_sender.send.call_args.kwargs["text"]
         assert "/settings" in text
+
+    def test_counts_failed_sends_separately(self, fake_sender):
+        fake_sender.send.return_value = SendResult(success=False, error="boom")
+        _make_member("+12025550215")
+        _make_event("potluck", 2)
+        out = StringIO()
+        call_command("send_weekly_digest", stdout=out)
+        assert "Sent 0 digest(s); 1 failed." in out.getvalue()
+
+    def test_reports_zero_failures_on_success(self, fake_sender):
+        _make_member("+12025550216")
+        _make_event("potluck", 2)
+        out = StringIO()
+        call_command("send_weekly_digest", stdout=out)
+        assert "Sent 1 digest(s); 0 failed." in out.getvalue()


### PR DESCRIPTION
## Overview

Two fixes found while test-running the weekly digest cron in production.

### 1. Duplicate emails on retry

Resend can queue an email and *still* return a 429/500, so the sender's bounded retry delivered a second real copy. One recipient received the digest twice during last night's run (`sha256:12c1f8e79781`, a `code=500` retry at 04:05:41).

Fix: generate an idempotency key once per logical send and reuse it across attempts. Resend dedupes on it for 24h.

### 2. Digest reported sends it never made

`sent_count += 1` ran unconditionally, ignoring `SendResult.success`, so the command reported every recipient as sent even when Resend rejected the send. Now tracks failures separately and surfaces both counts.

## Test plan

- [x] `tests/test_email_sender.py` + `tests/test_weekly_digest.py` — 35 passing
- [x] Verified `test_retry_reuses_idempotency_key` fails when the fix is reverted
- [x] Confirmed installed resend SDK (2.30.1) supports `send(params, options)` with `idempotency_key`
- [x] ruff + ty clean

## Notes

Production ran the digest successfully last night (86 recipients) — these fix issues that run surfaced, not a broken feature.
